### PR TITLE
fix: thuang-1308-delete-revision-is-slow

### DIFF
--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -259,7 +259,10 @@ export function useDeleteCollection(id = "") {
     onSuccess: () => {
       return Promise.all([
         queryCache.invalidateQueries([USE_COLLECTIONS]),
-        queryCache.invalidateQueries([USE_COLLECTION, id]),
+        queryCache.invalidateQueries([USE_COLLECTION, id], {
+          // (thuang): No need to refetch a deleted private collection
+          refetchActive: false,
+        }),
       ]);
     },
   });


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

![demo](https://user-images.githubusercontent.com/6309723/129986669-5ac69b7d-4163-4018-a503-ae31b565fbf6.gif)

---

## Changes
- modify
Disable refetch after invalidating collection with id, since the private collection is no longer available!

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
