### PR TITLE
feat: 1298 use feature_name column as var_index

### DIFF
--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -340,7 +340,7 @@ def make_cxg(local_filename):
 
     cxg_output_container = local_filename.replace(".h5ad", ".cxg")
     try:
-        h5ad_data_file = H5ADDataFile(local_filename)
+        h5ad_data_file = H5ADDataFile(local_filename, vars_index_column_name="feature_name")
         h5ad_data_file.to_cxg(cxg_output_container, 10.0)
     except Exception as ex:
         msg = "CXG conversion failed."

--- a/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
@@ -149,6 +149,12 @@ class TestH5ADDataFile(unittest.TestCase):
 
         self._validate_cxg_and_h5ad_content_match(self.sample_h5ad_filename, self.sample_output_directory, False)
 
+    def test__to_cxg__simple_anndata_with_corpora_and_dense_using_feature_name_var_index(self):
+        h5ad_file = H5ADDataFile(self.sample_h5ad_filename, vars_index_column_name="feature_name")
+        h5ad_file.to_cxg(self.sample_output_directory, 0)
+
+        self._validate_cxg_and_h5ad_content_match(self.sample_h5ad_filename, self.sample_output_directory, False)
+
     def test__to_cxg__with_sparse_column_encoding(self):
         anndata = self._create_sample_anndata_dataset()
         anndata.X = np.ones((3, 4))
@@ -257,7 +263,15 @@ class TestH5ADDataFile(unittest.TestCase):
         # Create vars
         random_int_category = Series(data=[3, 1, 2, 4], dtype=np.int32)
         random_bool_category = Series(data=[True, True, False, True], dtype=np.bool_)
-        var_dataframe = DataFrame(data={"int_category": random_int_category, "bool_category": random_bool_category})
+        feature_name = Series(data=["a", "b", "c", "d"])
+        var_dataframe = DataFrame(
+            data={
+                "int_category": random_int_category.values,
+                "bool_category": random_bool_category.values,
+                "feature_name": feature_name.values,
+            },
+            index=feature_name,
+        )
         var = var_dataframe
 
         # Create embeddings

--- a/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
@@ -154,6 +154,7 @@ class TestH5ADDataFile(unittest.TestCase):
         h5ad_file.to_cxg(self.sample_output_directory, 0)
 
         self._validate_cxg_and_h5ad_content_match(self.sample_h5ad_filename, self.sample_output_directory, False)
+        self._validate_cxg_var_index_column_match(self.sample_h5ad_filename, self.sample_output_directory, "feature_name")
 
     def test__to_cxg__with_sparse_column_encoding(self):
         anndata = self._create_sample_anndata_dataset()
@@ -241,6 +242,13 @@ class TestH5ADDataFile(unittest.TestCase):
                 x_array = tiledb.DenseArray(main_x_array_location, mode="r")
                 actual_x_data = x_array[:, :]
             self.assertTrue(np.array_equal(expected_x_data, actual_x_data))
+
+    def _validate_cxg_var_index_column_match(self, h5ad_filename, cxg_directory, expected_index_name):
+        anndata_object = anndata.read_h5ad(h5ad_filename)
+        var_array_location = f"{cxg_directory}/var"
+        var_array = tiledb.DenseArray(var_array_location, mode="r")
+        actual_index_name = json.loads(var_array.meta["cxg_schema"])["index"]
+        self.assertEqual(actual_index_name, expected_index_name)
 
     def _write_anndata_to_file(self, anndata):
         temporary_filename = fixture_file_path(f"{uuid4()}.h5ad")

--- a/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
@@ -154,7 +154,10 @@ class TestH5ADDataFile(unittest.TestCase):
         h5ad_file.to_cxg(self.sample_output_directory, 0)
 
         self._validate_cxg_and_h5ad_content_match(self.sample_h5ad_filename, self.sample_output_directory, False)
-        self._validate_cxg_var_index_column_match(self.sample_h5ad_filename, self.sample_output_directory, "feature_name")
+        self._validate_cxg_var_index_column_match(
+            self.sample_output_directory,
+            "feature_name",
+        )
 
     def test__to_cxg__with_sparse_column_encoding(self):
         anndata = self._create_sample_anndata_dataset()
@@ -243,8 +246,7 @@ class TestH5ADDataFile(unittest.TestCase):
                 actual_x_data = x_array[:, :]
             self.assertTrue(np.array_equal(expected_x_data, actual_x_data))
 
-    def _validate_cxg_var_index_column_match(self, h5ad_filename, cxg_directory, expected_index_name):
-        anndata_object = anndata.read_h5ad(h5ad_filename)
+    def _validate_cxg_var_index_column_match(self, cxg_directory, expected_index_name):
         var_array_location = f"{cxg_directory}/var"
         var_array = tiledb.DenseArray(var_array_location, mode="r")
         actual_index_name = json.loads(var_array.meta["cxg_schema"])["index"]


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MDunitz 
@seve 

**Readability:** 
@leslieypark 
---

## Changes
Specify `feature_name` as the `var` index column when creating the H5AD object file.

## Definition of Done (from ticket)
- H5ADDataFile is called with var_index arg when converting H5AD to CXG
- Test that var_index is correctly set on resulting H5ADDataFile obj

## QA steps (optional)
Run this on a real, 2.0.0 compliant H5AD file and inspect the resulting cxg.

## Known Issues
N/A
