### PR TITLE
chore: pin numpy and numba to consistent versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ furl
 h5py<3.0.0
 jsonschema
 moto==1.3.14
-numpy
+numpy==1.20.3
 owlready2
 pandas<1.3.0
 PyMySQL==0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,8 @@ furl
 h5py<3.0.0
 jsonschema
 moto==1.3.14
-numpy==1.20.3
+numba==0.53.1
+numpy==1.21.2
 owlready2
 pandas<1.3.0
 PyMySQL==0.9.3


### PR DESCRIPTION


### Reviewers
**Functional:** 
@MDunitz 

**Readability:** 

---

## Changes
`numba` (which is at least used by `scanpy`) requires `numpy` to be of version `<= 1.20`. On my dev environment 1.21 gets pulled and this causes the app to malfunction. This pins it to a safe version.
