### PR TITLE
feat: 1368 authorization

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -69,8 +69,6 @@ paths:
       tags:
         - collections
       summary: Create a collection
-      security:
-        - cxguserCookie: []
       description: >-
         Creates a new collection in corpora. Once a collection is created it can be linked to datasets.
       operationId: backend.corpora.lambdas.api.v1.collection.create_collection

--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -69,6 +69,8 @@ paths:
       tags:
         - collections
       summary: Create a collection
+      security:
+        - cxguserCookie: []
       description: >-
         Creates a new collection in corpora. Once a collection is created it can be linked to datasets.
       operationId: backend.corpora.lambdas.api.v1.collection.create_collection

--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -19,7 +19,7 @@ paths:
         - collections
       summary: List published collections in Corpora
       security:
-        - cxguserCookie: []
+        - cxguserCookieLenient: []
         - { }
       description: >-
         This lists all collections and their UUIDs that currently exist in the corpora. If a parameter is specified as
@@ -124,7 +124,7 @@ paths:
         - collections
       summary: Get a collection's full details
       security:
-        - cxguserCookie: []
+        - cxguserCookieLenient: []
         - { }
       description: >-
         This will return all datasets and associated attributes.
@@ -1029,6 +1029,11 @@ components:
       in: cookie
       name: cxguser
       x-apikeyInfoFunc: backend.corpora.lambdas.api.v1.authentication.apikey_info_func
+    cxguserCookieLenient:
+      type: apiKey
+      in: cookie
+      name: cxguser
+      x-apikeyInfoFunc: backend.corpora.lambdas.api.v1.authentication.apikey_info_func_lenient
     dummyAuth:
       type: apiKey
       in: header

--- a/backend/corpora/api_server/app.py
+++ b/backend/corpora/api_server/app.py
@@ -98,6 +98,7 @@ def handle_auth_error(ex):
     response.status_code = ex.status_code
     return response
 
+
 @app.errorhandler(ProblemException)
 def handle_corpora_error(exception):
     return FlaskApi.get_response(

--- a/backend/corpora/api_server/app.py
+++ b/backend/corpora/api_server/app.py
@@ -1,9 +1,10 @@
+from backend.corpora.lambdas.api.v1.authorization import AuthError
 import connexion
 import json
 import logging
 import os
 from connexion import FlaskApi, ProblemException, problem
-from flask import g, Response
+from flask import g, Response, jsonify
 from flask_cors import CORS
 from urllib.parse import urlparse
 
@@ -90,6 +91,12 @@ with open(os.path.join(os.path.dirname(__file__), "index.html")) as swagger_ui_f
 def serve_swagger_ui():
     return Response(swagger_ui_html, mimetype="text/html")
 
+
+@app.errorhandler(AuthError)
+def handle_auth_error(ex):
+    response = jsonify(ex.error)
+    response.status_code = ex.status_code
+    return response
 
 @app.errorhandler(ProblemException)
 def handle_corpora_error(exception):

--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from functools import lru_cache
 
@@ -44,7 +43,7 @@ def assert_authorized_token(token: str, audience: str = None) -> dict:
         except ExpiredSignatureError:
             raise
         except JWTClaimsError:
-            raise UnauthorizedError(detail=f"Incorrect claims, please check the audience and issuer.")
+            raise UnauthorizedError(detail="Incorrect claims, please check the audience and issuer.")
         except Exception:
             raise UnauthorizedError(detail="Unable to parse authentication token.")
 

--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -23,8 +23,8 @@ def assert_authorized_token(token: str, audience: str = None) -> dict:
     auth_config = CorporaAuthConfig()
     auth0_domain = auth_config.internal_url
     # If we're using an id_token (for userinfo), we need a difference audience, which gets passed in.
-    # Otherwise use auth_config.audience2
-    use_audience = audience or auth_config.audience2
+    # Otherwise use auth_config.api_audience
+    use_audience = audience or auth_config.api_audience
     public_keys = get_public_keys(auth0_domain)
     public_key = public_keys.get(unverified_header["kid"])
     if public_key:

--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -178,6 +178,8 @@ def check_token(token: dict) -> dict:
 
     :param token: a dictionary that contains the token information.
     """
+    if "access_token" not in token:
+        return {}
     try:
         payload = assert_authorized_token(token.get("access_token"))
     except ExpiredSignatureError:
@@ -209,6 +211,18 @@ def apikey_info_func(tokenstr: str, required_scopes: list) -> dict:
     token = decode_token(tokenstr)
     payload = check_token(token)
     return payload
+
+
+def apikey_info_func_lenient(tokenstr: str, required_scopes: list) -> dict:
+    """
+    Lenient version that allows endpoints to work even if authentication fails.
+    Use this for endpoints that also require public access, so if users end up with a bad token,
+    they won't be locked out.
+    """
+    try:
+        return apikey_info_func(tokenstr, required_scopes)
+    except Exception:
+        return {}
 
 
 def userinfo() -> Response:

--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -49,7 +49,7 @@ def get_oauth_client(config: CorporaAuthConfig) -> FlaskRemoteApp:
         access_token_url=config.api_token_url,
         authorize_url=config.api_authorize_url,
         client_kwargs={"scope": "openid profile email offline_access read:collections write:collections"},
-        authorize_params={"audience": config.audience2}
+        authorize_params={"audience": config.api_audience}
     )
     return oauth_client
 

--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -48,7 +48,7 @@ def get_oauth_client(config: CorporaAuthConfig) -> FlaskRemoteApp:
         refresh_token_url=config.api_token_url,
         access_token_url=config.api_token_url,
         authorize_url=config.api_authorize_url,
-        client_kwargs={"scope": "openid profile email offline_access read:collections write:collections"},
+        client_kwargs={"scope": "openid profile email offline_access write:collections"},
         authorize_params={"audience": config.api_audience},
     )
     return oauth_client

--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -49,7 +49,7 @@ def get_oauth_client(config: CorporaAuthConfig) -> FlaskRemoteApp:
         access_token_url=config.api_token_url,
         authorize_url=config.api_authorize_url,
         client_kwargs={"scope": "openid profile email offline_access read:collections write:collections"},
-        authorize_params={"audience": config.api_audience}
+        authorize_params={"audience": config.api_audience},
     )
     return oauth_client
 

--- a/backend/corpora/lambdas/api/v1/authorization.py
+++ b/backend/corpora/lambdas/api/v1/authorization.py
@@ -38,6 +38,21 @@ def requires_auth(f):
     return decorated
 
 
+def has_scope(required_scope):
+    try:
+        token = get_token_from_session()
+        authorizer.assert_authorized_token(token)
+        unverified_claims = jwt.get_unverified_claims(token)
+        if unverified_claims.get("scope"):
+            token_scopes = unverified_claims["scope"].split()
+            for token_scope in token_scopes:
+                if token_scope == required_scope:
+                    return True
+        return False
+    except Exception:
+        return False
+
+
 def requires_scope(required_scope):
     def actual_decorator(f):
         @wraps(f)

--- a/backend/corpora/lambdas/api/v1/authorization.py
+++ b/backend/corpora/lambdas/api/v1/authorization.py
@@ -1,0 +1,67 @@
+import json
+from six.moves.urllib.request import urlopen
+from functools import wraps
+
+import requests
+
+from flask import Flask, request, jsonify, _request_ctx_stack, session
+from flask_cors import cross_origin
+from jose import jwt
+
+from ....common.authorizer import assert_authorized_token
+from ....common.corpora_config import CorporaAuthConfig
+
+from .authentication import get_token
+
+from backend.corpora.common import authorizer
+
+# Error handler
+class AuthError(Exception):
+    def __init__(self, error, status_code):
+        self.error = error
+        self.status_code = status_code
+
+
+def get_token_from_session():
+    config = CorporaAuthConfig()
+    try:
+        token = get_token(config.cookie_name)
+        return token['access_token']
+    except Exception:
+        raise AuthError({"code": "authorization_header_missing",
+                        "description":
+                            "Authorization header is expected"}, 401)
+
+
+def requires_auth(f):
+    """Determines if the Access Token is valid
+    """
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = get_token_from_session()
+        payload = authorizer.assert_authorized_token(token)
+
+        _request_ctx_stack.top.current_user = payload
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+def requires_scope(required_scope):
+    def actual_decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            token = get_token_from_session()
+            unverified_claims = jwt.get_unverified_claims(token)
+            if unverified_claims.get("scope"):
+                    token_scopes = unverified_claims["scope"].split()
+                    for token_scope in token_scopes:
+                        if token_scope == required_scope:
+                            payload = authorizer.assert_authorized_token(token)
+                            return f(user = payload['sub'], *args, **kwargs)
+            raise AuthError({"code": "invalid_header",
+                        "description": "Missing permissions"}, 401)
+        return wrapper
+    return actual_decorator
+

--- a/backend/corpora/lambdas/api/v1/authorization.py
+++ b/backend/corpora/lambdas/api/v1/authorization.py
@@ -51,5 +51,7 @@ def requires_scope(required_scope):
                         payload = authorizer.assert_authorized_token(token)
                         return f(user=payload["sub"], *args, **kwargs)
             raise AuthError({"code": "invalid_header", "description": "Missing permissions"}, 401)
+
         return wrapper
+
     return actual_decorator

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -66,8 +66,6 @@ def post_collection_revision(collection_uuid: str, user: str):
 
 
 @dbconnect
-@requires_auth
-@requires_scope("write:collections")
 def create_collection(body: object, user: str):
     db_session = g.db_session
     collection = Collection.create(

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -14,14 +14,14 @@ def _is_user_owner_or_allowed(user, owner):
     """
     Check if the user has ownership on a collection, or if it has superuser permissions
     """
-    return (user and user == owner) or (has_scope("read:collections"))
+    return (user and user == owner) or (has_scope("write:collections"))
 
 
 def _owner_or_allowed(user):
     """
     Returns None if the user is superuser, `user` otherwise. Used for where conditions
     """
-    return None if has_scope("read:collections") else user
+    return None if has_scope("write:collections") else user
 
 
 @dbconnect

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -1,3 +1,4 @@
+from backend.corpora.lambdas.api.v1.authorization import requires_auth, requires_scope
 import sqlalchemy
 from typing import Optional
 
@@ -65,6 +66,8 @@ def post_collection_revision(collection_uuid: str, user: str):
 
 
 @dbconnect
+@requires_auth
+@requires_scope("write:collections")
 def create_collection(body: object, user: str):
     db_session = g.db_session
     collection = Collection.create(

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -1,4 +1,3 @@
-from backend.corpora.lambdas.api.v1.authorization import requires_auth, requires_scope
 import sqlalchemy
 from typing import Optional
 

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -7,6 +7,21 @@ from ....common.corpora_orm import DbCollection, CollectionVisibility
 from ....common.entities import Collection
 from ....common.utils.exceptions import ForbiddenHTTPException, ConflictException
 from ....api_server.db import dbconnect
+from backend.corpora.lambdas.api.v1.authorization import has_scope
+
+
+def _is_user_owner_or_allowed(user, owner):
+    """
+    Check if the user has ownership on a collection, or if it has superuser permissions
+    """
+    return (user and user == owner) or (has_scope("read:collections"))
+
+
+def _owner_or_allowed(user):
+    """
+    Returns None if the user is superuser, `user` otherwise. Used for where conditions
+    """
+    return None if has_scope("read:collections") else user
 
 
 @dbconnect
@@ -23,7 +38,7 @@ def get_collections_list(from_date: int = None, to_date: int = None, user: Optio
     for coll_dict in all_collections:
         visibility = coll_dict["visibility"]
         owner = coll_dict["owner"]
-        if visibility == CollectionVisibility.PUBLIC or (user and user == owner):
+        if visibility == CollectionVisibility.PUBLIC or _is_user_owner_or_allowed(user, owner):
             collections.append(dict(id=coll_dict["id"], created_at=coll_dict["created_at"], visibility=visibility.name))
 
     result = {"collections": collections}
@@ -41,16 +56,23 @@ def get_collection_details(collection_uuid: str, visibility: str, user: str):
     collection = Collection.get_collection(db_session, collection_uuid, visibility)
     if not collection:
         raise ForbiddenHTTPException()
-    get_tombstone_datasets = user == collection.owner and collection.visibility == CollectionVisibility.PRIVATE
+    get_tombstone_datasets = (
+        _is_user_owner_or_allowed(user, collection.owner) and collection.visibility == CollectionVisibility.PRIVATE
+    )
     result = collection.reshape_for_api(get_tombstone_datasets)
-    result["access_type"] = "WRITE" if user == collection.owner else "READ"
+    result["access_type"] = "WRITE" if _is_user_owner_or_allowed(user, collection.owner) else "READ"
     return make_response(jsonify(result), 200)
 
 
 @dbconnect
 def post_collection_revision(collection_uuid: str, user: str):
     db_session = g.db_session
-    collection = Collection.get_collection(db_session, collection_uuid, CollectionVisibility.PUBLIC.name, owner=user)
+    collection = Collection.get_collection(
+        db_session,
+        collection_uuid,
+        CollectionVisibility.PUBLIC.name,
+        owner=_owner_or_allowed(user),
+    )
     if not collection:
         raise ForbiddenHTTPException()
     try:
@@ -93,7 +115,11 @@ def delete_collection(collection_uuid: str, visibility: str, user: str):
         return "", 405
     db_session = g.db_session
     priv_collection = Collection.get_collection(
-        db_session, collection_uuid, CollectionVisibility.PRIVATE.name, owner=user, include_tombstones=True
+        db_session,
+        collection_uuid,
+        CollectionVisibility.PRIVATE.name,
+        owner=_owner_or_allowed(user),
+        include_tombstones=True,
     )
     if priv_collection:
         if not priv_collection.tombstone:
@@ -106,7 +132,12 @@ def delete_collection(collection_uuid: str, visibility: str, user: str):
 @dbconnect
 def update_collection(collection_uuid: str, body: dict, user: str):
     db_session = g.db_session
-    collection = Collection.get_collection(db_session, collection_uuid, CollectionVisibility.PRIVATE.name, owner=user)
+    collection = Collection.get_collection(
+        db_session,
+        collection_uuid,
+        CollectionVisibility.PRIVATE.name,
+        owner=_owner_or_allowed(user),
+    )
     if not collection:
         raise ForbiddenHTTPException()
     collection.update(**body)

--- a/oauth/api_scopes.json
+++ b/oauth/api_scopes.json
@@ -3,9 +3,6 @@
     "Name": "test_scope"
   },
   {
-    "Name": "read:collections"
-  },
-  {
     "Name": "write:collections"
   }
 ]

--- a/oauth/api_scopes.json
+++ b/oauth/api_scopes.json
@@ -1,5 +1,11 @@
 [
   {
     "Name": "test_scope"
+  },
+  {
+    "Name": "read:collections"
+  },
+  {
+    "Name": "write:collections"
   }
 ]

--- a/oauth/clients-config.json
+++ b/oauth/clients-config.json
@@ -12,7 +12,7 @@
             "http://backend.corporanet.local:5000/dp/v1/oauth2/callback"
         ],
         "AllowedScopes": [
-           "openid", "profile", "email", "offline_access"
+           "openid", "profile", "email", "offline_access", "read:collections", "write:collections"
         ],
 	"AllowAccessTokensViaBrowser": true,
 	"AlwaysIncludeUserClaimsInIdToken": true,

--- a/oauth/clients-config.json
+++ b/oauth/clients-config.json
@@ -12,7 +12,7 @@
             "http://backend.corporanet.local:5000/dp/v1/oauth2/callback"
         ],
         "AllowedScopes": [
-           "openid", "profile", "email", "offline_access", "read:collections", "write:collections"
+           "openid", "profile", "email", "offline_access", "write:collections"
         ],
 	"AllowAccessTokensViaBrowser": true,
 	"AlwaysIncludeUserClaimsInIdToken": true,

--- a/scripts/setup_dev_data.sh
+++ b/scripts/setup_dev_data.sh
@@ -49,6 +49,7 @@ ${local_aws} secretsmanager update-secret --secret-id corpora/backend/test/auth0
     "client_id": "local-client-id",
     "client_secret": "local-client-secret",
     "audience": "local-client-id",
+    "api_audience": "local-client-id",
     "code_challenge_method": "S256",
     "api_authorize_url": "'"${OIDC_BROWSER_URL}"'/connect/authorize",
     "api_base_url": "'"${OIDC_BROWSER_URL}"'",

--- a/tests/unit/backend/corpora/api_server/base_api_test.py
+++ b/tests/unit/backend/corpora/api_server/base_api_test.py
@@ -90,7 +90,7 @@ class BasicAuthAPITestCurator(BaseAPITest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        (mock_oauth_server, auth_config) = BaseAuthAPITest.get_mock_server_and_auth_config("read:collections")
+        (mock_oauth_server, auth_config) = BaseAuthAPITest.get_mock_server_and_auth_config("write:collections")
         cls.mock_oauth_server = mock_oauth_server
         cls.auth_config = auth_config
 

--- a/tests/unit/backend/corpora/api_server/base_api_test.py
+++ b/tests/unit/backend/corpora/api_server/base_api_test.py
@@ -68,6 +68,7 @@ class BaseAuthAPITest(BaseAPITest):
             "client_id": cls.auth_config.client_id,
             "client_secret": cls.auth_config.client_secret,
             "audience": cls.auth_config.audience,
+            "api_audience": cls.auth_config.api_audience,
             "cookie_name": cls.auth_config.cookie_name,
         }
         cls.auth_config.set(authconfig)

--- a/tests/unit/backend/corpora/api_server/base_api_test.py
+++ b/tests/unit/backend/corpora/api_server/base_api_test.py
@@ -49,29 +49,50 @@ class BaseAPITest(DataPortalTestCase):
 
 
 class BaseAuthAPITest(BaseAPITest):
+    @staticmethod
+    def get_mock_server_and_auth_config(additional_scope=None):
+        mock_oauth_server = MockOauthServer(additional_scope)
+        mock_oauth_server.start()
+        assert mock_oauth_server.server_okay
+
+        # Use the CorporaAuthConfig used by the app
+        auth_config = CorporaAuthConfig()
+
+        os.environ["API_BASE_URL"] = f"http://localhost:{mock_oauth_server.port}"
+        # Overwrite the environment's auth config with our oidc server's config.
+        authconfig = {
+            "api_base_url": f"http://localhost:{mock_oauth_server.port}",
+            "callback_base_url": auth_config.callback_base_url,
+            "redirect_to_frontend": auth_config.redirect_to_frontend,
+            "client_id": auth_config.client_id,
+            "client_secret": auth_config.client_secret,
+            "audience": auth_config.audience,
+            "api_audience": auth_config.api_audience,
+            "cookie_name": auth_config.cookie_name,
+        }
+        auth_config.set(authconfig)
+        return (mock_oauth_server, auth_config)
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.mock_oauth_server = MockOauthServer()
-        cls.mock_oauth_server.start()
-        assert cls.mock_oauth_server.server_okay
+        (mock_oauth_server, auth_config) = BaseAuthAPITest.get_mock_server_and_auth_config()
+        cls.mock_oauth_server = mock_oauth_server
+        cls.auth_config = auth_config
 
-        # Use the CorporaAuthConfig used by the app
-        cls.auth_config = CorporaAuthConfig()
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.mock_oauth_server.terminate()
 
-        os.environ["API_BASE_URL"] = f"http://localhost:{cls.mock_oauth_server.port}"
-        # Overwrite the environment's auth config with our oidc server's config.
-        authconfig = {
-            "api_base_url": f"http://localhost:{cls.mock_oauth_server.port}",
-            "callback_base_url": cls.auth_config.callback_base_url,
-            "redirect_to_frontend": cls.auth_config.redirect_to_frontend,
-            "client_id": cls.auth_config.client_id,
-            "client_secret": cls.auth_config.client_secret,
-            "audience": cls.auth_config.audience,
-            "api_audience": cls.auth_config.api_audience,
-            "cookie_name": cls.auth_config.cookie_name,
-        }
-        cls.auth_config.set(authconfig)
+
+class BasicAuthAPITestCurator(BaseAPITest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        (mock_oauth_server, auth_config) = BaseAuthAPITest.get_mock_server_and_auth_config("read:collections")
+        cls.mock_oauth_server = mock_oauth_server
+        cls.auth_config = auth_config
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/unit/backend/corpora/api_server/mock_auth.py
+++ b/tests/unit/backend/corpora/api_server/mock_auth.py
@@ -48,7 +48,7 @@ class MockOauthApp:
             "access_token": jwt,
             "id_token": jwt,
             "refresh_token": f"random-{time.time()}",
-            "scope": "openid profile email offline read:collections",
+            "scope": "openid profile email offline read:collections write:collections",
             "expires_in": TOKEN_EXPIRES,
             "token_type": "Bearer",
             "expires_at": expires_at,

--- a/tests/unit/backend/corpora/api_server/mock_auth.py
+++ b/tests/unit/backend/corpora/api_server/mock_auth.py
@@ -13,8 +13,9 @@ TOKEN_EXPIRES = 2
 
 # A mocked out oauth server, which serves all the endpoints needed by the oauth type.
 class MockOauthApp:
-    def __init__(self, port):
+    def __init__(self, port, additional_scope=None):
         self.port = port
+        self.additional_scope = additional_scope
 
         # mock flask app
         self.app = Flask("mock_oauth_app")
@@ -34,7 +35,12 @@ class MockOauthApp:
         expires_at = time.time()
         headers = dict(alg="RS256", kid="fake_kid")
         payload = dict(
-            name="Fake User", sub="test_user_id", email="fake_user@email.com", email_verified=True, exp=expires_at
+            name="Fake User",
+            sub="test_user_id",
+            email="fake_user@email.com",
+            email_verified=True,
+            exp=expires_at,
+            scope=self.additional_scope,
         )
 
         jwt = jose.jwt.encode(claims=payload, key="mysecret", algorithm="HS256", headers=headers)
@@ -42,7 +48,7 @@ class MockOauthApp:
             "access_token": jwt,
             "id_token": jwt,
             "refresh_token": f"random-{time.time()}",
-            "scope": "openid profile email offline",
+            "scope": "openid profile email offline read:collections",
             "expires_in": TOKEN_EXPIRES,
             "token_type": "Bearer",
             "expires_at": expires_at,
@@ -68,14 +74,18 @@ class MockOauthApp:
 
 
 class MockOauthServer:
-    def __init__(self):
+    def __init__(self, additional_scope=None):
         self.process = None
         self.port = None
         self.server_okay = False
+        self.additional_scope = additional_scope
 
     def start(self):
         self.port = random.randint(10000, 20000)
-        self.process = subprocess.Popen([sys.executable, __file__, str(self.port)])
+        params = [sys.executable, __file__, str(self.port)]
+        if self.additional_scope:
+            params.append(self.additional_scope)
+        self.process = subprocess.Popen(params)
         # Verify that the mock oauth server is ready (accepting requests) before starting the tests.
         self.server_okay = False
         for _ in range(5):
@@ -114,5 +124,5 @@ def get_auth_token(app):
 
 if __name__ == "__main__":
     port = int(sys.argv[1])
-    mock_app = MockOauthApp(port)
+    mock_app = MockOauthApp(port, *sys.argv[2:])
     mock_app.app.run(port=port, debug=True)

--- a/tests/unit/backend/corpora/api_server/mock_auth.py
+++ b/tests/unit/backend/corpora/api_server/mock_auth.py
@@ -48,7 +48,7 @@ class MockOauthApp:
             "access_token": jwt,
             "id_token": jwt,
             "refresh_token": f"random-{time.time()}",
-            "scope": "openid profile email offline read:collections write:collections",
+            "scope": "openid profile email offline write:collections",
             "expires_in": TOKEN_EXPIRES,
             "token_type": "Bearer",
             "expires_at": expires_at,

--- a/tests/unit/backend/corpora/api_server/mock_auth.py
+++ b/tests/unit/backend/corpora/api_server/mock_auth.py
@@ -39,7 +39,7 @@ class MockOauthApp:
 
         jwt = jose.jwt.encode(claims=payload, key="mysecret", algorithm="HS256", headers=headers)
         r = {
-            "access_token": f"access-{time.time()}",
+            "access_token": jwt,
             "id_token": jwt,
             "refresh_token": f"random-{time.time()}",
             "scope": "openid profile email offline",

--- a/tests/unit/backend/corpora/api_server/test_v1_collection.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_collection.py
@@ -11,7 +11,7 @@ from backend.corpora.common.corpora_orm import (
 )
 from backend.corpora.common.entities import Collection
 from tests.unit.backend.fixtures.mock_aws_test_case import CorporaTestCaseUsingMockAWS
-from tests.unit.backend.corpora.api_server.base_api_test import BaseAuthAPITest
+from tests.unit.backend.corpora.api_server.base_api_test import BaseAuthAPITest, BasicAuthAPITestCurator
 from tests.unit.backend.corpora.api_server.mock_auth import get_auth_token
 
 
@@ -863,3 +863,54 @@ class TestUpdateCollection(BaseAuthAPITest):
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(links, json.loads(response.data)["links"])
+
+
+class TestCollectionsCurators(BasicAuthAPITestCurator):
+    def test_view_non_owned_private_collection__ok(self):
+        # Generate test collection
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="another_test_user_id"
+        )
+
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+        test_url = furl(path=f"/dp/v1/collections/{collection.id}", query_params=dict(visibility="PRIVATE"))
+        response = self.app.get(test_url.url, headers=headers)
+
+        # This will pass even for non curators.
+        # Why are users allowed to view private collections that they don't own?
+        self.assertEqual(response.status_code, 200)
+
+        body = json.loads(response.data)
+        self.assertEqual(body["access_type"], "WRITE")
+
+    def test_update_non_owned_private_collection__ok(self):
+        # Generate test collection
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="another_test_user_id"
+        )
+
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+
+        modified_collection = {
+            "name": "new name",
+            "description": collection.description,
+            "contact_name": collection.contact_name,
+            "contact_email": collection.contact_email,
+            "data_submission_policy_version": collection.data_submission_policy_version,
+            "links": collection.links,
+        }
+        data = json.dumps(modified_collection)
+        response = self.app.put(f"/dp/v1/collections/{collection.id}", data=data, headers=headers)
+        self.assertEqual(200, response.status_code)
+
+    def test_delete_non_owned_private_collection__ok(self):
+        # Generate test collection
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="another_test_user_id"
+        )
+
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+
+        test_url = furl(path=f"/dp/v1/collections/{collection.id}", query_params=dict(visibility="PRIVATE"))
+        response = self.app.delete(test_url.url, headers=headers)
+        self.assertEqual(204, response.status_code)


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MDunitz 

**Readability:** 

---

Issue [1368](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1368)

## Changes
Implements token based authorization. Adds a `requires_auth` and `requires_scope` decorators that can be used to restrict APIs. 
Notes: 
1. The current authentication flow isn't ideal. The proper Oauth2 flow requires the token not to be stored in the cookie, but rather in the FE local storage/memory and sent via the `Authorization` header to each request. The `id_token` is also probably useless for this application and should be replaced with a call to `userinfo`
2. `connexion` (which is currently use to manage secured access to the APIs via the swagger yaml file) does not support scopes unless you use the `Oauth2` flow (currently we're using a custom flow). Therefore, we need to do this manually using decorators. Fixing 1. would allow to do this properly
3. We need two different audiences: one for the `id_token` (currently in configuration) and another for the `access_token` (to be stored in config.audience2 - need to figure out how to do that).
