### PR TITLE
feat: 1368 authorization for curators

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -19,7 +19,7 @@ paths:
         - collections
       summary: List published collections in Corpora
       security:
-        - cxguserCookie: []
+        - cxguserCookieLenient: []
         - { }
       description: >-
         This lists all collections and their UUIDs that currently exist in the corpora. If a parameter is specified as
@@ -124,7 +124,7 @@ paths:
         - collections
       summary: Get a collection's full details
       security:
-        - cxguserCookie: []
+        - cxguserCookieLenient: []
         - { }
       description: >-
         This will return all datasets and associated attributes.
@@ -1029,6 +1029,11 @@ components:
       in: cookie
       name: cxguser
       x-apikeyInfoFunc: backend.corpora.lambdas.api.v1.authentication.apikey_info_func
+    cxguserCookieLenient:
+      type: apiKey
+      in: cookie
+      name: cxguser
+      x-apikeyInfoFunc: backend.corpora.lambdas.api.v1.authentication.apikey_info_func_lenient
     dummyAuth:
       type: apiKey
       in: header

--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -178,6 +178,8 @@ def check_token(token: dict) -> dict:
 
     :param token: a dictionary that contains the token information.
     """
+    if "access_token" not in token:
+        return {}
     try:
         payload = assert_authorized_token(token.get("access_token"))
     except ExpiredSignatureError:

--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -213,6 +213,18 @@ def apikey_info_func(tokenstr: str, required_scopes: list) -> dict:
     return payload
 
 
+def apikey_info_func_lenient(tokenstr: str, required_scopes: list) -> dict:
+    """
+    Lenient version that allows endpoints to work even if authentication fails.
+    Use this for endpoints that also require public access, so if users end up with a bad token,
+    they won't be locked out.
+    """
+    try:
+        return apikey_info_func(tokenstr, required_scopes)
+    except Exception:
+        return {}
+
+
 def userinfo() -> Response:
     """API call: retrieve the user info from the id token stored in the cookie"""
     config = CorporaAuthConfig()

--- a/backend/corpora/lambdas/api/v1/authorization.py
+++ b/backend/corpora/lambdas/api/v1/authorization.py
@@ -49,8 +49,8 @@ def has_scope(required_scope):
                 if token_scope == required_scope:
                     return True
         return False
-    except AuthError:
-        return False 
+    except Exception:
+        return False
 
 
 def requires_scope(required_scope):

--- a/backend/corpora/lambdas/api/v1/authorization.py
+++ b/backend/corpora/lambdas/api/v1/authorization.py
@@ -48,7 +48,7 @@ def has_scope(required_scope):
             for token_scope in token_scopes:
                 if token_scope == required_scope:
                     return True
-            return False
+        return False
     except AuthError:
         return False 
 

--- a/backend/corpora/lambdas/api/v1/authorization.py
+++ b/backend/corpora/lambdas/api/v1/authorization.py
@@ -38,6 +38,18 @@ def requires_auth(f):
     return decorated
 
 
+def has_scope(required_scope):
+    token = get_token_from_session()
+    authorizer.assert_authorized_token(token)
+    unverified_claims = jwt.get_unverified_claims(token)
+    if unverified_claims.get("scope"):
+        token_scopes = unverified_claims["scope"].split()
+        for token_scope in token_scopes:
+            if token_scope == required_scope:
+                return True
+        return False
+
+
 def requires_scope(required_scope):
     def actual_decorator(f):
         @wraps(f)

--- a/backend/corpora/lambdas/api/v1/authorization.py
+++ b/backend/corpora/lambdas/api/v1/authorization.py
@@ -39,15 +39,18 @@ def requires_auth(f):
 
 
 def has_scope(required_scope):
-    token = get_token_from_session()
-    authorizer.assert_authorized_token(token)
-    unverified_claims = jwt.get_unverified_claims(token)
-    if unverified_claims.get("scope"):
-        token_scopes = unverified_claims["scope"].split()
-        for token_scope in token_scopes:
-            if token_scope == required_scope:
-                return True
-        return False
+    try:
+        token = get_token_from_session()
+        authorizer.assert_authorized_token(token)
+        unverified_claims = jwt.get_unverified_claims(token)
+        if unverified_claims.get("scope"):
+            token_scopes = unverified_claims["scope"].split()
+            for token_scope in token_scopes:
+                if token_scope == required_scope:
+                    return True
+            return False
+    except AuthError:
+        return False 
 
 
 def requires_scope(required_scope):

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -1,4 +1,3 @@
-from backend.corpora.lambdas.api.v1.authorization import has_scope
 import sqlalchemy
 from typing import Optional
 
@@ -8,6 +7,7 @@ from ....common.corpora_orm import DbCollection, CollectionVisibility
 from ....common.entities import Collection
 from ....common.utils.exceptions import ForbiddenHTTPException, ConflictException
 from ....api_server.db import dbconnect
+from backend.corpora.lambdas.api.v1.authorization import has_scope
 
 
 def _is_user_owner_or_allowed(user, owner):

--- a/tests/unit/backend/corpora/api_server/base_api_test.py
+++ b/tests/unit/backend/corpora/api_server/base_api_test.py
@@ -49,9 +49,8 @@ class BaseAPITest(DataPortalTestCase):
 
 
 class BaseAuthAPITest(BaseAPITest):
-
     @staticmethod
-    def get_mock_server_and_auth_config(additional_scope = None):
+    def get_mock_server_and_auth_config(additional_scope=None):
         mock_oauth_server = MockOauthServer(additional_scope)
         mock_oauth_server.start()
         assert mock_oauth_server.server_okay
@@ -85,7 +84,7 @@ class BaseAuthAPITest(BaseAPITest):
     def tearDownClass(cls):
         super().tearDownClass()
         cls.mock_oauth_server.terminate()
-        
+
 
 class BasicAuthAPITestCurator(BaseAPITest):
     @classmethod

--- a/tests/unit/backend/corpora/api_server/base_api_test.py
+++ b/tests/unit/backend/corpora/api_server/base_api_test.py
@@ -49,59 +49,51 @@ class BaseAPITest(DataPortalTestCase):
 
 
 class BaseAuthAPITest(BaseAPITest):
+
+    @staticmethod
+    def get_mock_server_and_auth_config(additional_scope = None):
+        mock_oauth_server = MockOauthServer(additional_scope)
+        mock_oauth_server.start()
+        assert mock_oauth_server.server_okay
+
+        # Use the CorporaAuthConfig used by the app
+        auth_config = CorporaAuthConfig()
+
+        os.environ["API_BASE_URL"] = f"http://localhost:{mock_oauth_server.port}"
+        # Overwrite the environment's auth config with our oidc server's config.
+        authconfig = {
+            "api_base_url": f"http://localhost:{mock_oauth_server.port}",
+            "callback_base_url": auth_config.callback_base_url,
+            "redirect_to_frontend": auth_config.redirect_to_frontend,
+            "client_id": auth_config.client_id,
+            "client_secret": auth_config.client_secret,
+            "audience": auth_config.audience,
+            "api_audience": auth_config.api_audience,
+            "cookie_name": auth_config.cookie_name,
+        }
+        auth_config.set(authconfig)
+        return (mock_oauth_server, auth_config)
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.mock_oauth_server = MockOauthServer()
-        cls.mock_oauth_server.start()
-        assert cls.mock_oauth_server.server_okay
-
-        # Use the CorporaAuthConfig used by the app
-        cls.auth_config = CorporaAuthConfig()
-
-        os.environ["API_BASE_URL"] = f"http://localhost:{cls.mock_oauth_server.port}"
-        # Overwrite the environment's auth config with our oidc server's config.
-        authconfig = {
-            "api_base_url": f"http://localhost:{cls.mock_oauth_server.port}",
-            "callback_base_url": cls.auth_config.callback_base_url,
-            "redirect_to_frontend": cls.auth_config.redirect_to_frontend,
-            "client_id": cls.auth_config.client_id,
-            "client_secret": cls.auth_config.client_secret,
-            "audience": cls.auth_config.audience,
-            "api_audience": cls.auth_config.api_audience,
-            "cookie_name": cls.auth_config.cookie_name,
-        }
-        cls.auth_config.set(authconfig)
+        (mock_oauth_server, auth_config) = BaseAuthAPITest.get_mock_server_and_auth_config()
+        cls.mock_oauth_server = mock_oauth_server
+        cls.auth_config = auth_config
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
         cls.mock_oauth_server.terminate()
+        
 
 class BasicAuthAPITestCurator(BaseAPITest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.mock_oauth_server = MockOauthServer("read:collections")
-        cls.mock_oauth_server.start()
-        assert cls.mock_oauth_server.server_okay
-
-        # Use the CorporaAuthConfig used by the app
-        cls.auth_config = CorporaAuthConfig()
-
-        os.environ["API_BASE_URL"] = f"http://localhost:{cls.mock_oauth_server.port}"
-        # Overwrite the environment's auth config with our oidc server's config.
-        authconfig = {
-            "api_base_url": f"http://localhost:{cls.mock_oauth_server.port}",
-            "callback_base_url": cls.auth_config.callback_base_url,
-            "redirect_to_frontend": cls.auth_config.redirect_to_frontend,
-            "client_id": cls.auth_config.client_id,
-            "client_secret": cls.auth_config.client_secret,
-            "audience": cls.auth_config.audience,
-            "api_audience": cls.auth_config.api_audience,
-            "cookie_name": cls.auth_config.cookie_name,
-        }
-        cls.auth_config.set(authconfig)
+        (mock_oauth_server, auth_config) = BaseAuthAPITest.get_mock_server_and_auth_config("read:collections")
+        cls.mock_oauth_server = mock_oauth_server
+        cls.auth_config = auth_config
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/unit/backend/corpora/api_server/base_api_test.py
+++ b/tests/unit/backend/corpora/api_server/base_api_test.py
@@ -77,3 +77,33 @@ class BaseAuthAPITest(BaseAPITest):
     def tearDownClass(cls):
         super().tearDownClass()
         cls.mock_oauth_server.terminate()
+
+class BasicAuthAPITestCurator(BaseAPITest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mock_oauth_server = MockOauthServer("read:collections")
+        cls.mock_oauth_server.start()
+        assert cls.mock_oauth_server.server_okay
+
+        # Use the CorporaAuthConfig used by the app
+        cls.auth_config = CorporaAuthConfig()
+
+        os.environ["API_BASE_URL"] = f"http://localhost:{cls.mock_oauth_server.port}"
+        # Overwrite the environment's auth config with our oidc server's config.
+        authconfig = {
+            "api_base_url": f"http://localhost:{cls.mock_oauth_server.port}",
+            "callback_base_url": cls.auth_config.callback_base_url,
+            "redirect_to_frontend": cls.auth_config.redirect_to_frontend,
+            "client_id": cls.auth_config.client_id,
+            "client_secret": cls.auth_config.client_secret,
+            "audience": cls.auth_config.audience,
+            "api_audience": cls.auth_config.api_audience,
+            "cookie_name": cls.auth_config.cookie_name,
+        }
+        cls.auth_config.set(authconfig)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.mock_oauth_server.terminate()

--- a/tests/unit/backend/corpora/api_server/mock_auth.py
+++ b/tests/unit/backend/corpora/api_server/mock_auth.py
@@ -13,8 +13,9 @@ TOKEN_EXPIRES = 2
 
 # A mocked out oauth server, which serves all the endpoints needed by the oauth type.
 class MockOauthApp:
-    def __init__(self, port):
+    def __init__(self, port, additional_scope = None):
         self.port = port
+        self.additional_scope = additional_scope
 
         # mock flask app
         self.app = Flask("mock_oauth_app")
@@ -34,7 +35,7 @@ class MockOauthApp:
         expires_at = time.time()
         headers = dict(alg="RS256", kid="fake_kid")
         payload = dict(
-            name="Fake User", sub="test_user_id", email="fake_user@email.com", email_verified=True, exp=expires_at
+            name="Fake User", sub="test_user_id", email="fake_user@email.com", email_verified=True, exp=expires_at, scope=self.additional_scope
         )
 
         jwt = jose.jwt.encode(claims=payload, key="mysecret", algorithm="HS256", headers=headers)
@@ -42,7 +43,7 @@ class MockOauthApp:
             "access_token": jwt,
             "id_token": jwt,
             "refresh_token": f"random-{time.time()}",
-            "scope": "openid profile email offline",
+            "scope": "openid profile email offline read:collections",
             "expires_in": TOKEN_EXPIRES,
             "token_type": "Bearer",
             "expires_at": expires_at,
@@ -68,14 +69,18 @@ class MockOauthApp:
 
 
 class MockOauthServer:
-    def __init__(self):
+    def __init__(self, additional_scope = None):
         self.process = None
         self.port = None
         self.server_okay = False
+        self.additional_scope = additional_scope
 
     def start(self):
         self.port = random.randint(10000, 20000)
-        self.process = subprocess.Popen([sys.executable, __file__, str(self.port)])
+        params = [sys.executable, __file__, str(self.port)]
+        if self.additional_scope:
+            params.append(self.additional_scope)
+        self.process = subprocess.Popen(params)
         # Verify that the mock oauth server is ready (accepting requests) before starting the tests.
         self.server_okay = False
         for _ in range(5):
@@ -114,5 +119,5 @@ def get_auth_token(app):
 
 if __name__ == "__main__":
     port = int(sys.argv[1])
-    mock_app = MockOauthApp(port)
+    mock_app = MockOauthApp(port, *sys.argv[2:])
     mock_app.app.run(port=port, debug=True)

--- a/tests/unit/backend/corpora/api_server/mock_auth.py
+++ b/tests/unit/backend/corpora/api_server/mock_auth.py
@@ -13,7 +13,7 @@ TOKEN_EXPIRES = 2
 
 # A mocked out oauth server, which serves all the endpoints needed by the oauth type.
 class MockOauthApp:
-    def __init__(self, port, additional_scope = None):
+    def __init__(self, port, additional_scope=None):
         self.port = port
         self.additional_scope = additional_scope
 
@@ -35,7 +35,12 @@ class MockOauthApp:
         expires_at = time.time()
         headers = dict(alg="RS256", kid="fake_kid")
         payload = dict(
-            name="Fake User", sub="test_user_id", email="fake_user@email.com", email_verified=True, exp=expires_at, scope=self.additional_scope
+            name="Fake User",
+            sub="test_user_id",
+            email="fake_user@email.com",
+            email_verified=True,
+            exp=expires_at,
+            scope=self.additional_scope,
         )
 
         jwt = jose.jwt.encode(claims=payload, key="mysecret", algorithm="HS256", headers=headers)
@@ -69,7 +74,7 @@ class MockOauthApp:
 
 
 class MockOauthServer:
-    def __init__(self, additional_scope = None):
+    def __init__(self, additional_scope=None):
         self.process = None
         self.port = None
         self.server_okay = False

--- a/tests/unit/backend/corpora/api_server/test_v1_collection.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_collection.py
@@ -891,14 +891,15 @@ class TestCollectionsCurators(BasicAuthAPITestCurator):
 
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
 
-        data = json.dumps({
+        modified_collection = {
             "name": "new name",
             "description": collection.description,
             "contact_name": collection.contact_name,
             "contact_email": collection.contact_email,
             "data_submission_policy_version": collection.data_submission_policy_version,
             "links": collection.links,
-            })
+        }
+        data = json.dumps(modified_collection)
         response = self.app.put(f"/dp/v1/collections/{collection.id}", data=data, headers=headers)
         self.assertEqual(200, response.status_code)
 

--- a/tests/unit/backend/corpora/api_server/test_v1_collection.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_collection.py
@@ -11,7 +11,7 @@ from backend.corpora.common.corpora_orm import (
 )
 from backend.corpora.common.entities import Collection
 from tests.unit.backend.fixtures.mock_aws_test_case import CorporaTestCaseUsingMockAWS
-from tests.unit.backend.corpora.api_server.base_api_test import BaseAuthAPITest
+from tests.unit.backend.corpora.api_server.base_api_test import BaseAuthAPITest, BasicAuthAPITestCurator
 from tests.unit.backend.corpora.api_server.mock_auth import get_auth_token
 
 
@@ -863,3 +863,53 @@ class TestUpdateCollection(BaseAuthAPITest):
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(links, json.loads(response.data)["links"])
+
+
+class TestCollectionsCurators(BasicAuthAPITestCurator):
+    def test_view_non_owned_private_collection__ok(self):
+        # Generate test collection
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="another_test_user_id"
+        )
+
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+        test_url = furl(path=f"/dp/v1/collections/{collection.id}", query_params=dict(visibility="PRIVATE"))
+        response = self.app.get(test_url.url, headers=headers)
+
+        # This will pass even for non curators.
+        # Why are users allowed to view private collections that they don't own?
+        self.assertEqual(response.status_code, 200)
+
+        body = json.loads(response.data)
+        self.assertEqual(body["access_type"], "WRITE")
+
+    def test_update_non_owned_private_collection__ok(self):
+        # Generate test collection
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="another_test_user_id"
+        )
+
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+
+        data = json.dumps({
+            "name": "new name",
+            "description": collection.description,
+            "contact_name": collection.contact_name,
+            "contact_email": collection.contact_email,
+            "data_submission_policy_version": collection.data_submission_policy_version,
+            "links": collection.links,
+            })
+        response = self.app.put(f"/dp/v1/collections/{collection.id}", data=data, headers=headers)
+        self.assertEqual(200, response.status_code)
+
+    def test_delete_non_owned_private_collection__ok(self):
+        # Generate test collection
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="another_test_user_id"
+        )
+
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+
+        test_url = furl(path=f"/dp/v1/collections/{collection.id}", query_params=dict(visibility="PRIVATE"))
+        response = self.app.delete(test_url.url, headers=headers)
+        self.assertEqual(204, response.status_code)


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MDunitz 

**Readability:** 
@seve 

---

Ticket [#1368 ](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1368)

## Changes
- Changes all the collections endpoints to behave differently depending on the user's permissions

## Definition of Done (from ticket)
- Curators can view all the private collections, even if they belong to other users
- Curators can delete any private collection
- Curators can update any private collection
- Curators can start revisions on every private collection.

## Known issues
Verify if this doesn't introduce new authentication issues that might impact non logged in users.
