### PR TITLE
feat: Add withdrawn dataset toast (#1237)

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -42,6 +42,8 @@ module.exports = {
     camelcase: "off",
     "react/jsx-no-target-blank": 0,
     "react/prop-types": "off",
+    // (thuang): We use nested template literals extensively
+    "sonarjs/no-nested-template-literals": "off",
     "sort-keys": [
       "error",
       "asc",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,7 +55,7 @@
         "eslint-plugin-prettier": "^3.3.1",
         "eslint-plugin-react": "^7.22.0",
         "eslint-plugin-react-hooks": "^4.2.0",
-        "eslint-plugin-sonarjs": "^0.6.0",
+        "eslint-plugin-sonarjs": "^0.10.0",
         "expect-playwright": "^0.7.2",
         "jest": "^26.6.3",
         "jest-playwright-preset": "^1.4.5",
@@ -4163,9 +4163,13 @@
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001204",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-      "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ=="
+      "version": "1.0.30001255",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -5849,12 +5853,16 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.6.0.tgz",
-      "integrity": "sha512-y+sXXWsYVW2kNEjmZI87laFspwC/hic7wyMjsPFoST8aQ2hESUVavkZjnTeVdHMOmlmcloKkyX/GJJetmfBY4Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.10.0.tgz",
+      "integrity": "sha512-FBRIBmWQh2UAfuLSnuYEfmle33jIup9hfkR0X8pkfjeCKNpHUG8qyZI63ahs3aw8CJrv47QJ9ccdK3ZxKH016A==",
       "dev": true,
+      "license": "LGPL-3.0",
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -11508,6 +11516,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-5.0.0.tgz",
       "integrity": "sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==",
+      "hasInstallScript": true,
       "dependencies": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -20885,9 +20894,9 @@
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-lite": {
-      "version": "1.0.30001204",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-      "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ=="
+      "version": "1.0.30001255",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -22395,10 +22404,11 @@
       "dev": true
     },
     "eslint-plugin-sonarjs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.6.0.tgz",
-      "integrity": "sha512-y+sXXWsYVW2kNEjmZI87laFspwC/hic7wyMjsPFoST8aQ2hESUVavkZjnTeVdHMOmlmcloKkyX/GJJetmfBY4Q==",
-      "dev": true
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.10.0.tgz",
+      "integrity": "sha512-FBRIBmWQh2UAfuLSnuYEfmle33jIup9hfkR0X8pkfjeCKNpHUG8qyZI63ahs3aw8CJrv47QJ9ccdK3ZxKH016A==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-sonarjs": "^0.6.0",
+    "eslint-plugin-sonarjs": "^0.10.0",
     "expect-playwright": "^0.7.2",
     "jest": "^26.6.3",
     "jest-playwright-preset": "^1.4.5",

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/utils.ts
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/utils.ts
@@ -178,9 +178,7 @@ function useCheckCollection({
 
     if (!intervalId && shouldFetch) {
       intervalId = window?.setInterval(() => {
-        if (shouldFetch) {
-          invalidateCollectionQuery();
-        }
+        invalidateCollectionQuery();
       }, FETCH_COLLECTION_INTERVAL_MS);
     }
 

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -77,7 +77,7 @@ const Collection: FC = () => {
       return;
 
     let message = "";
-    // TODO: Verify that contact_name is required and won't be the default empty string.
+    // TODO: Remove empty string check after re-curation is complete. Contact name should always be populated.
     if (collectionContactName) {
       message = `A dataset was withdrawn by ${collectionContactName}. You've been redirected to the parent collection.`;
     } else {

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -83,7 +83,7 @@ const Collection: FC = () => {
     } else {
       message =
         "A dataset was withdrawn. You've been redirected to the parent collection.";
-    };
+    }
 
     Toast.show({
       icon: IconNames.ISSUE,

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -2,7 +2,7 @@ import { H3, Intent, Tab, Tabs } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import React, { FC, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import { ACCESS_TYPE, VISIBILITY_TYPE } from "src/common/entities";
 import { get } from "src/common/featureFlags";
 import { FEATURES } from "src/common/featureFlags/features";
@@ -38,17 +38,24 @@ enum TABS {
 
 const Collection: FC = () => {
   const router = useRouter();
+  const [hasTombstoneToastBeenShown, setHasTombestoneToastBeenShow] = useState(false);
   const { params } = router.query;
 
   let id = "";
   let isPrivate = false;
+  let tombstonedDatasetId;
 
   if (Array.isArray(params)) {
     id = params[0];
-    isPrivate = params[1] === "private";
+    isPrivate = params[1] === "private";  // Is this always passed in?
+    tombstonedDatasetId = params[2];  // Need to verify this indexing
   } else if (params) {
     id = params;
   }
+
+  useEffect(() => {
+    setHasTombestoneToastBeenShow(true)
+  }, [])
 
   const visibility = isPrivate
     ? VISIBILITY_TYPE.PRIVATE
@@ -118,6 +125,15 @@ const Collection: FC = () => {
   const shouldShowPrivateWriteAction =
     collection.access_type === ACCESS_TYPE.WRITE && isPrivate;
 
+  // const showTombstoneToast = () => {
+  //   Toast.show({
+  //     icon: IconNames.TICK,
+  //     intent: Intent.PRIMARY,
+  //     message:
+  //       "Your file is being uploaded which will continue in the background, even if you close this window.",
+  //   });
+  // };
+
   return (
     <>
       <Head>
@@ -133,6 +149,13 @@ const Collection: FC = () => {
             </span>
           </StyledCallout>
         )}
+        {!hasTombstoneToastBeenShown &&
+          Toast.show({
+          icon: IconNames.TICK,
+          intent: Intent.PRIMARY,
+          message:
+            "Your file is being uploaded which will continue in the background, even if you close this window.",
+        })}
         <CollectionInfo>
           <H3 data-test-id="collection-name">{collection.name}</H3>
           <Description data-test-id="collection-description">
@@ -147,6 +170,15 @@ const Collection: FC = () => {
             {renderLinks(collection.links)}
           </LinkContainer>
         </CollectionInfo>
+
+        {/* {tombstonedDatasetId && (
+          Toast.show({
+            icon: IconNames.TICK,
+            intent: Intent.PRIMARY,
+            message:
+              "Your file is being uploaded which will continue in the background, even if you close this window.",
+          })
+        )} */}
 
         {shouldShowPrivateWriteAction && (
           <ActionButtons

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -76,11 +76,19 @@ const Collection: FC = () => {
     if (!tombstoned_dataset_id || typeof collectionContactName === "undefined")
       return;
 
+    let message = "";
     // TODO: Verify that contact_name is required and won't be the default empty string.
+    if (collectionContactName) {
+      message = `A dataset was withdrawn by ${collectionContactName}. You've been redirected to the parent collection.`;
+    } else {
+      message =
+        "A dataset was withdrawn. You've been redirected to the parent collection.";
+    };
+
     Toast.show({
       icon: IconNames.ISSUE,
       intent: Intent.PRIMARY,
-      message: `A dataset was withdrawn by ${collectionContactName}. You've been redirected to the parent collection.`,
+      message,
     });
   }, [tombstoned_dataset_id, collectionContactName]);
 


### PR DESCRIPTION
### Reviewers
**Functional:** 
@tihuan 

**Readability:** 
@seve

---

## Changes
- Add withdrawn dataset toast to collections page. When a user goes to an explorer link for a tombstoned dataset, the explorer will redirect the user back to the parent collections page with the URL query param of `tombstoned_dataset_id`.

<img width="1533" alt="Screen Shot 2021-09-08 at 10 02 10" src="https://user-images.githubusercontent.com/75650148/132566978-e56ce86c-afad-4a6c-91e0-0be386ad7f6f.png">


## Definition of Done (from ticket)
Navigating to a tombstoned dataset result in a withdrawn dataset toast.

## QA steps (optional)
Run data portal locally and go to a collection. Add `?tombstoned_dataset_id=asdfasdf` to the URL and press enter. You should see the toast.

## Known Issues
The explorer side of this ticket (redirection) is being completed by @MDunitz.