### PR TITLE
fix: remove git-secrets from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,6 @@ repos:
       - id: flake8
         stages: [commit]
         files: ^(backend|tests|scripts)/
-  - repo: https://github.com/awslabs/git-secrets
-    rev: 1.3.0
-    hooks:
-      - id: git-secrets
-        stages: [ commit ]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.2
     hooks:
@@ -25,8 +20,3 @@ repos:
           - prettier@2.3.2
           - prettier-plugin-organize-imports@2.2.0
           - typescript@3.9.9
-  - repo: https://github.com/awslabs/git-secrets
-    rev: 80230afa8c8bdeac766a0fece36f95ffaa0be778
-    hooks:
-      - id: git-secrets
-        stages: [commit]

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ well-labeled repository of interoperable datasets.
 ## Developers
 
 ### Development quickstart
+
 See [DEV_ENV.md](DEV_ENV.md) for the local development guide.
 
 See [REMOTE_DEV.md](REMOTE_DEV.md) for personal remote deployment guide.
 
 ### Pre-requisites
 
+1. Install pre-commit: `pre-commit install` or check doc [here](https://pre-commit.com/)
 1. [Install and configure awscli](docs/awscli.md)
 1. [Configure ssh access](https://github.com/chanzuckerberg/single-cell-infra#ssh)
 
@@ -48,6 +50,7 @@ See [REMOTE_DEV.md](REMOTE_DEV.md) for personal remote deployment guide.
 1. [Deploy Frontend](frontend/README.md#Deployment)
 
 ### Database Procedures
+
 see [Data Portal Database Procedures](backend/database/README.md)
 
 ### Running unittests
@@ -56,6 +59,7 @@ see [Data Portal Database Procedures](backend/database/README.md)
 1. Run the tests `$ make unit-test`
 
 ### Installing Chamber
+
 For running functional tests below, you will need to install Chamber on your machine. Chamber
 is a tool for reading secrets stored in AWS Secret Store and Parameter Store.
 
@@ -63,6 +67,7 @@ On Linux, go to https://github.com/segmentio/chamber/releases to download the la
 and add it somewhere on your path.
 
 On Mac, run
+
 ```
 brew install chamber
 ```
@@ -81,6 +86,7 @@ brew install chamber
 1. Run `make functional-test`
 
 ### Upload processing container
+
 The upload processing container is split into 2 parts: a base container that contains R
 libraries, and the Data Portal upload application code that build on top of this.
 
@@ -88,6 +94,7 @@ Because the base container takes a long time to build and is expected to change
 infrequently, the container is built separately from the standard release process.
 
 #### Building the image
+
 The base image is built using Github actions. It is built both nightly, and whenever
 the Dockerfile.processing_base file is changed.
 


### PR DESCRIPTION
I removed `https://github.com/awslabs/git-secrets` from the config, since it keeps failing at pre-commit installing stage

And also added a line in the README to remind people to run `pre-commit install` to add precommit hook, such as prettier!

PTAL thank you 🙆‍♂️ 
---

## Changes
- add
- remove
- modify

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
