### PR TITLE
fix: fix-flaky-revision-test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.8b0
     hooks:
       - id: black
         stages: [commit]

--- a/frontend/tests/features/collection/revision.test.ts
+++ b/frontend/tests/features/collection/revision.test.ts
@@ -21,7 +21,7 @@ describeIfDeployed("Collection Revision", () => {
 
     await expect(publishButton).toBeDisabled();
 
-    await goToPage(TEST_URL + ROUTES.MY_COLLECTIONS);
+    await page.click(getText("My Collections"));
 
     const COLLECTION_ROW_SELECTOR_CONTINUE = `*${getTestID(
       COLLECTION_ROW_ID
@@ -33,18 +33,20 @@ describeIfDeployed("Collection Revision", () => {
     );
 
     const collectionRowContinue = await page.$(
-      `*${getTestID(COLLECTION_ROW_ID)} >> text="${collectionName}"`
+      COLLECTION_ROW_SELECTOR_CONTINUE
     );
 
     expect(collectionRowContinue).not.toBe(null);
 
-    const revisionTag = await collectionRowContinue?.$(
-      getTestID("revision-tag")
-    );
+    await tryUntil(async () => {
+      const revisionTag = await collectionRowContinue?.$(
+        getTestID("revision-tag")
+      );
 
-    await tryUntil(async () => await expect(revisionTag).not.toBe(null));
+      await expect(revisionTag).not.toBe(null);
 
-    await expect(revisionTag).toMatchText("Revision Pending");
+      await expect(revisionTag).toMatchText("Revision Pending");
+    });
 
     const actionButtonContinue = await collectionRowContinue?.$(
       getTestID("revision-action-button")


### PR DESCRIPTION
This PR updates pre-commit black version and fix FE E2E revision test that was flaky when FE had to fetch lots of collections