### PR TITLE
fix: make X_approximate_distribution optional in h5ad_data_file.py

### DIFF
--- a/backend/corpora/common/utils/corpora_constants.py
+++ b/backend/corpora/common/utils/corpora_constants.py
@@ -83,7 +83,6 @@ class CorporaConstants(object):
         "schema_version",
         "title",
         "X_normalization",
-        "X_approximate_distribution",
     ]
 
     # The Corpora specification requires some values encoded as JSON due to the inability of AnnData to store complex
@@ -98,6 +97,7 @@ class CorporaConstants(object):
         "tags",
         "project_name",
         "project_description",
+        "X_approximate_distribution",
     ]
 
     # Constants related to the dataset format of which a submission to Corpora must be.

--- a/frontend/src/common/entities.ts
+++ b/frontend/src/common/entities.ts
@@ -96,7 +96,7 @@ export interface Dataset {
   cell_type: Ontology[];
   is_primary_data: IS_PRIMARY_DATA;
   x_normalization: string;
-  x_approximate_distribution: X_APPROXIMATE_DISTRIBUTION;
+  x_approximate_distribution?: X_APPROXIMATE_DISTRIBUTION;
   schema_version: string;
   // source_data_location: string;
   // revision: number;


### PR DESCRIPTION
### Reviewers
**Functional:** 
@leslieypark 

**Readability:** 

---

## Changes
- More requirements to make `X_approximate_distribution` optional
