### PR TITLE
chore: relaxed assertion for expected conversion status

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -241,7 +241,7 @@ paths:
 
   /dp/v1/collections/{collection_uuid}/upload-links:
     post:
-      summary: Start an dataset upload
+      summary: Start a dataset upload
       tags:
         - collections
         - datasets

--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -98,7 +98,7 @@ If a conversion fails the processing_status will indicated it as follow:
     conversion_anndata_status = ConversionStatus.CONVERTING
 }
 
-Once all conversion are compelete, the conversion status for each file will be either CONVERTED or FAILED:
+Once all conversion are complete, the conversion status for each file will be either CONVERTED or FAILED:
 {
     processing_status = ProcessingStatus.SUCCESS
     upload_status = UploadStatus.UPLOADED

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -209,7 +209,9 @@ class TestApi(BaseFunctionalTestCase):
                 res.raise_for_status()
                 data = json.loads(res.content)
                 upload_status = data["upload_status"]
-                self.assertIn(upload_status, expected_upload_statuses)
+                if upload_status:
+                    self.assertIn(upload_status, expected_upload_statuses)
+
                 # conversion statuses only returned once uploaded
                 if upload_status == "UPLOADED":
                     conversion_cxg_status = data.get("conversion_cxg_status")

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -199,8 +199,9 @@ class TestApi(BaseFunctionalTestCase):
 
         with self.subTest("Test dataset conversion"):
             keep_trying = True
-            upload_statuses = ["WAITING", "UPLOADING", "UPLOADED"]
-            conversion_statuses = ["CONVERTING", "CONVERTED", "FAILED"]
+            expected_upload_statuses = ["WAITING", "UPLOADING", "UPLOADED"]
+            # conversion statuses can be `None` when/if we hit the status endpoint too early after an upload
+            expected_conversion_statuses = ["CONVERTING", "CONVERTED", "FAILED", None]
             timer = time.time()
             while keep_trying:
                 data = None
@@ -208,14 +209,14 @@ class TestApi(BaseFunctionalTestCase):
                 res.raise_for_status()
                 data = json.loads(res.content)
                 upload_status = data["upload_status"]
-                self.assertIn(upload_status, upload_statuses)
+                self.assertIn(upload_status, expected_upload_statuses)
                 # conversion statuses only returned once uploaded
                 if upload_status == "UPLOADED":
                     conversion_cxg_status = data.get("conversion_cxg_status")
                     conversion_loom_status = data.get("conversion_loom_status")
                     conversion_rds_status = data.get("conversion_rds_status")
                     conversion_anndata_status = data.get("conversion_anndata_status")
-                    self.assertIn(data.get("conversion_cxg_status"), conversion_statuses)
+                    self.assertIn(data.get("conversion_cxg_status"), expected_conversion_statuses)
                     if conversion_cxg_status == "FAILED":
                         self.fail(f"CXG CONVERSION FAILED. Status: {data}, Check logs for dataset: {dataset_uuid}")
                     if conversion_loom_status == "FAILED":


### PR DESCRIPTION
### Reviewers
**Functional:** 
@ebezzi 

**Readability:** 
@leslieypark 

---

## Changes
- modify: relaxed the assertion for expected conversion status since we can hit the status endoint too early which was resulting in the test flakiness

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
