### PR TITLE
fix: rename final h5ad file to local.h5ad

### DIFF
--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -443,7 +443,7 @@ def process_cxg(local_filename, dataset_id, cellxgene_bucket):
 
 def validate_h5ad_file_and_add_labels(dataset_id, local_filename):
     update_db(dataset_id, processing_status=dict(validation_status=ValidationStatus.VALIDATING))
-    output_filename = f"withlabels.{local_filename}"
+    output_filename = "local.h5ad"
     commands = ["cellxgene-schema", "validate", "--add-labels", output_filename, local_filename]
     val_proc = subprocess.run(commands, capture_output=True)
     if val_proc.returncode != 0:
@@ -499,7 +499,7 @@ def process(dataset_id, dropbox_url, cellxgene_bucket, artifact_bucket):
     local_filename = download_from_dropbox_url(
         dataset_id,
         dropbox_url,
-        "local.h5ad",
+        "raw.h5ad",
     )
 
     # No file cleanup needed due to docker run-time environment.

--- a/tests/unit/backend/corpora/dataset_processing/test_process.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_process.py
@@ -593,7 +593,7 @@ class TestDatasetProcessing(DataPortalTestCase):
             download_from_dropbox_url(
                 self.dataset_id,
                 "dropbox.com",
-                "local.h5ad",
+                "raw.h5ad",
             )
         end = time.time()
         # check that tombstoning ends the download thread early

--- a/tests/unit/processing_container/test_process.py
+++ b/tests/unit/processing_container/test_process.py
@@ -59,7 +59,7 @@ class TestDatasetProcessing(CorporaTestCaseUsingMockAWS):
     # TODO: Remove mocking of validate_h5ad_file after validation process is updated to be 2.0 compliant.
     @patch("backend.corpora.dataset_processing.process.validate_h5ad_file_and_add_labels")
     def test_main(self, mock_validate_h5ad):
-        mock_validate_h5ad.return_value = "local.h5ad"
+        mock_validate_h5ad.return_value = "raw.h5ad"
         url = self.presigned_url
         dataset = self.generate_dataset(
             self.session, collection_id="test_collection_id", collection_visibility=CollectionVisibility.PUBLIC.name


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MDunitz 

**Readability:** 
@leslieypark 

Ticket [#1432](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1432)

---

## Changes
Since `cellxgene-schema` now ouputs a file, the final h5ad file that gets uploaded was renamed. This reverts it back to `local.h5ad`
