### PR TITLE
test: add tiledb regression test

### DIFF
--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -21,7 +21,7 @@ RUN git clone https://github.com/chanzuckerberg/single-cell-explorer.git \
  && rm -rf single-cell-explorer client build/client /usr/bin/npm
 
 # Install python dependencies
-RUN pip3 install loompy==3.0.6 scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 tiledb==0.7.4 awscli
+RUN pip3 install loompy==3.0.6 scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 awscli
 RUN pip3 install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple cellxgene-schema==2.0.0rc1
 
 ADD requirements.txt requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,7 @@ pytest
 requests>=2.22.0
 s3fs==0.4.2
 scanpy
-# tiledb==0.10.1
-tiledb==0.8.0
+tiledb==0.10.1
 click==7.1.2
 -r ./backend/corpora/api_server/requirements.txt
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,8 @@ pytest
 requests>=2.22.0
 s3fs==0.4.2
 scanpy
-tiledb==0.10.1
+# tiledb==0.10.1
+tiledb==0.8.0
 click==7.1.2
 -r ./backend/corpora/api_server/requirements.txt
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
@@ -193,6 +193,7 @@ class TestH5ADDataFile(unittest.TestCase):
             value[col_name] = np.zeros((100,), dtype=np.int)
             A[:] = value        # if there's a regression, this statement will throw a TileDBError
 
+        rmtree("foo")
         # if we get here we're good
 
     def _validate_cxg_and_h5ad_content_match(self, h5ad_filename, cxg_directory, is_sparse, has_column_encoding=False):

--- a/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
@@ -182,15 +182,16 @@ class TestH5ADDataFile(unittest.TestCase):
 
         attrs = [tiledb.Attr(name=col_name, dtype=np.int)]
         domain = tiledb.Domain(tiledb.Dim(domain=(0, 99), tile=100, dtype=np.uint32))
-        schema = tiledb.ArraySchema(domain=domain, sparse=False, attrs=attrs, cell_order="row-major",
-                                    tile_order="row-major")
+        schema = tiledb.ArraySchema(
+            domain=domain, sparse=False, attrs=attrs, cell_order="row-major", tile_order="row-major"
+        )
         tiledb.DenseArray.create("foo", schema)
 
         try:
             with tiledb.DenseArray("foo", mode="w") as A:
                 value = {}
                 value[col_name] = np.zeros((100,), dtype=np.int)
-                A[:] = value        # if there's a regression, this statement will throw a TileDBError
+                A[:] = value  # if there's a regression, this statement will throw a TileDBError
                 # if we get here we're good
         finally:
             rmtree("foo")

--- a/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_h5ad_data_file.py
@@ -177,8 +177,6 @@ class TestH5ADDataFile(unittest.TestCase):
     def test__slash_in_attribute_name(self):
         # tiledb failure repro code from https://github.com/TileDB-Inc/TileDB-Py/issues/294
         # this fails (throws a TileDBError) for 0.8.0 and below but works for 0.8.1+
-        import numpy as np
-        import tiledb
 
         col_name = "fo/o"
 
@@ -188,13 +186,14 @@ class TestH5ADDataFile(unittest.TestCase):
                                     tile_order="row-major")
         tiledb.DenseArray.create("foo", schema)
 
-        with tiledb.DenseArray("foo", mode="w") as A:
-            value = {}
-            value[col_name] = np.zeros((100,), dtype=np.int)
-            A[:] = value        # if there's a regression, this statement will throw a TileDBError
-
-        rmtree("foo")
-        # if we get here we're good
+        try:
+            with tiledb.DenseArray("foo", mode="w") as A:
+                value = {}
+                value[col_name] = np.zeros((100,), dtype=np.int)
+                A[:] = value        # if there's a regression, this statement will throw a TileDBError
+                # if we get here we're good
+        finally:
+            rmtree("foo")
 
     def _validate_cxg_and_h5ad_content_match(self, h5ad_filename, cxg_directory, is_sparse, has_column_encoding=False):
         anndata_object = anndata.read_h5ad(h5ad_filename)


### PR DESCRIPTION
### Reviewers
**Functional:** 
@bkmartinjr @MDunitz 

**Readability:** 
@leslieypark 

---

## Changes
- add: tiledb regression test
- remove: superfluous tiledb version spec in `Dockerfile.processing_image`

## Definition of Done (from ticket)

## QA steps (optional)
* ran `test__slash_in_attribute_name` locally using a known version of tiledb that would fail (tiledb==0.8.0)
* also ran via CI to demonstrate: https://github.com/chanzuckerberg/single-cell-data-portal/pull/1434/checks?check_run_id=3678016085#step:5:3314

## Known Issues
* This added unit test is a regression test of tiledb and contains no cellxgene code, so arguably doesn't belong in our unit tests, but it was requested, so here it is 😄 