### PR TITLE
(#1093) show verbose errors only in dev env

### DIFF
--- a/backend/chalice/api_server/app.py
+++ b/backend/chalice/api_server/app.py
@@ -37,11 +37,10 @@ def get_chalice_app(flask_app):
     deployment = os.environ["DEPLOYMENT_STAGE"]
     allowed_origins = []
 
-    if deployment in ["dev"]:
+    if deployment not in ["prod", "stage"]:
         flask_app.debug = True
         app.debug = flask_app.debug
         app.log.setLevel(logging.DEBUG)
-        app.log.debug("RUNNING IN DEBUG MODE. YAY!")
 
     if deployment not in ["prod"]:
         allowed_origins.extend(

--- a/backend/chalice/api_server/app.py
+++ b/backend/chalice/api_server/app.py
@@ -31,14 +31,18 @@ def create_flask_app():
 
 def get_chalice_app(flask_app):
     app = Chalice(app_name=flask_app.name)
-    flask_app.debug = True
-    app.debug = flask_app.debug
-    app.log.setLevel(logging.DEBUG)
 
     # set the flask secret key, needed for session cookies
     flask_secret_key = "OpenSesame"
     deployment = os.environ["DEPLOYMENT_STAGE"]
     allowed_origins = []
+
+    if deployment in ["dev"]:
+        flask_app.debug = True
+        app.debug = flask_app.debug
+        app.log.setLevel(logging.DEBUG)
+        app.log.debug("RUNNING IN DEBUG MODE. YAY!")
+
     if deployment not in ["prod"]:
         allowed_origins.extend(
             [


### PR DESCRIPTION
addresses security vulnerability on prod/staging

### Reviewers
**Functional:** 
@MDunitz 

**Readability:** 
@blrnw3 

---

## Changes
only enable debug logging and and flask debug mode when in dev mode (more precisely, when not in "prod" or "stage" mode).

## Definition of Done (from ticket)
N/A.

## QA steps (optional)
Ran local stack and manually smoke tested data portal to ensure server came up.
But not sure how to re-test the specific error generated during the security audit.

## Known Issues
