### PR TITLE
Use auth0's userinfo endpoint

### DIFF
--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -2,6 +2,7 @@ import os
 from functools import lru_cache
 
 import requests
+from requests.api import head
 from jose import jwt
 from jose.exceptions import ExpiredSignatureError, JWTError, JWTClaimsError
 
@@ -101,6 +102,14 @@ def get_userinfo(token: str) -> dict:
         email_verified=payload.get("email_verified"),
     )
     return userinfo
+
+
+def get_userinfo_from_auth0(token: str) -> dict:
+    auth_config = CorporaAuthConfig()
+    auth0_domain = auth_config.internal_url
+    res = requests.get(f"{auth0_domain}/userinfo", headers={"Authorization": f"Bearer {token}"})
+    res.raise_for_status()
+    return res.json()
 
 
 @lru_cache(maxsize=32)

--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -11,7 +11,7 @@ from flask import make_response, jsonify, current_app, request, redirect, after_
 from jose.exceptions import ExpiredSignatureError
 
 
-from ....common.authorizer import get_userinfo, assert_authorized_token
+from ....common.authorizer import get_userinfo, assert_authorized_token, get_userinfo_from_auth0
 from ....common.corpora_config import CorporaAuthConfig
 
 # global oauth client
@@ -227,7 +227,7 @@ def userinfo() -> Response:
     """API call: retrieve the user info from the id token stored in the cookie"""
     config = CorporaAuthConfig()
     token = get_token(config.cookie_name)
-    userinfo = get_userinfo(token.get("id_token"))
+    userinfo = get_userinfo_from_auth0(token.get("access_token"))
     return make_response(jsonify(userinfo))
 
 


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MDunitz @seve 

**Readability:** 


Ticket [1430](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1430)
---

## Changes
- Uses `/userinfo` instead of the `id_token`.
