### PR TITLE
feat: migrate data_submission_policy_version to be nullable

### DIFF
--- a/backend/corpora/common/corpora_orm.py
+++ b/backend/corpora/common/corpora_orm.py
@@ -235,7 +235,7 @@ class DbCollection(Base, AuditMixin, TimestampMixin):
     obfuscated_uuid = Column(String, default="")
     contact_name = Column(StrippedString, default="")
     contact_email = Column(StrippedString, default="")
-    data_submission_policy_version = Column(StrippedString, nullable=False)
+    data_submission_policy_version = Column(StrippedString, nullable=True)
     tombstone = Column(Boolean, default=False, nullable=False)
 
     # Relationships

--- a/backend/database/versions/23bade351f23_update_data_submission_policy_version.py
+++ b/backend/database/versions/23bade351f23_update_data_submission_policy_version.py
@@ -1,0 +1,30 @@
+"""update_data_submission_policy_version
+
+Revision ID: 23bade351f23
+Revises: 424e875043d3
+Create Date: 2021-09-24 16:41:33.297342
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '23bade351f23'
+down_revision = '424e875043d3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('project', 'data_submission_policy_version',
+               existing_type=sa.VARCHAR(),
+               nullable=True)
+
+
+def downgrade():
+    op.execute("UPDATE project SET data_submission_policy_version='' WHERE data_submission_policy_version=null")
+
+    op.alter_column('project', 'data_submission_policy_version',
+               existing_type=sa.VARCHAR(),
+               nullable=False)

--- a/backend/database/versions/23bade351f23_update_data_submission_policy_version.py
+++ b/backend/database/versions/23bade351f23_update_data_submission_policy_version.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '23bade351f23'
-down_revision = '424e875043d3'
+down_revision = 'a8cd0dc08805'
 branch_labels = None
 depends_on = None
 

--- a/backend/database/versions/23bade351f23_update_data_submission_policy_version.py
+++ b/backend/database/versions/23bade351f23_update_data_submission_policy_version.py
@@ -17,14 +17,10 @@ depends_on = None
 
 
 def upgrade():
-    op.alter_column('project', 'data_submission_policy_version',
-               existing_type=sa.VARCHAR(),
-               nullable=True)
+    op.alter_column('project', 'data_submission_policy_version', existing_type=sa.VARCHAR(), nullable=True)
 
 
 def downgrade():
     op.execute("UPDATE project SET data_submission_policy_version='' WHERE data_submission_policy_version=null")
 
-    op.alter_column('project', 'data_submission_policy_version',
-               existing_type=sa.VARCHAR(),
-               nullable=False)
+    op.alter_column('project', 'data_submission_policy_version', existing_type=sa.VARCHAR(), nullable=False)

--- a/backend/database/versions/23bade351f23_update_data_submission_policy_version.py
+++ b/backend/database/versions/23bade351f23_update_data_submission_policy_version.py
@@ -10,17 +10,17 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '23bade351f23'
-down_revision = 'a8cd0dc08805'
+revision = "23bade351f23"
+down_revision = "a8cd0dc08805"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.alter_column('project', 'data_submission_policy_version', existing_type=sa.VARCHAR(), nullable=True)
+    op.alter_column("project", "data_submission_policy_version", existing_type=sa.VARCHAR(), nullable=True)
 
 
 def downgrade():
     op.execute("UPDATE project SET data_submission_policy_version='' WHERE data_submission_policy_version=null")
 
-    op.alter_column('project', 'data_submission_policy_version', existing_type=sa.VARCHAR(), nullable=False)
+    op.alter_column("project", "data_submission_policy_version", existing_type=sa.VARCHAR(), nullable=False)

--- a/backend/database/versions/23bade351f23_update_data_submission_policy_version.py
+++ b/backend/database/versions/23bade351f23_update_data_submission_policy_version.py
@@ -1,7 +1,7 @@
 """update_data_submission_policy_version
 
 Revision ID: 23bade351f23
-Revises: 424e875043d3
+Revises: a8cd0dc08805
 Create Date: 2021-09-24 16:41:33.297342
 
 """


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MDunitz 

**Readability:** 
@MDunitz 

---

## Changes
- modify

## Definition of Done (from ticket)
Adding migration to change `data_submission_policy_version` to nullable.
