### PR TITLE
fix: safely handle explorer_url=None in revisions

### DIFF
--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -113,6 +113,8 @@ class Dataset(Entity):
         return None if not asset else DatasetAsset(asset[0])
 
     def _create_new_explorer_url(self, new_uuid: str) -> str:
+        if self.explorer_url is None:
+            return None
         original_url = urlparse(self.explorer_url)
         original_path = PurePosixPath(original_url.path)
         new_path = str(original_path.parent / f"{new_uuid}.cxg")


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MDunitz 

**Readability:** 

Ticket [#1472 ](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1472)

---

## Changes
- If `explorer_url` is None on the cloned dataset, the revision will break. This will just keep the url as None.
