### PR TITLE
fix: use list diffing instead of incorrect object equality check

### DIFF
--- a/frontend/src/common/utils/checkForRevisionChange.ts
+++ b/frontend/src/common/utils/checkForRevisionChange.ts
@@ -107,13 +107,7 @@ export default function checkForRevisionChange(
   }
   if (publishedCollection.links.length !== revision.links.length) return true;
   //Check links for differences
-  if (
-    publishedCollection.links.some((link, index) => {
-      if (link !== revision.links[index]) {
-        return true;
-      }
-    })
-  )
+  if (checkListForChanges(revision.links, publishedCollection.links))
     return true;
 
   if (


### PR DESCRIPTION
### Reviewers
**Functional:** @tihuan 

---

There were two bugs, last PR only caught the returning true in `Array.forEach()` this catches the `object === object`