### PR TITLE
fix: 1525 Learn Button popper position

### DIFF
--- a/frontend/src/components/Header/components/LearnButton/index.tsx
+++ b/frontend/src/components/Header/components/LearnButton/index.tsx
@@ -1,10 +1,17 @@
-import { Button, Intent, Menu, MenuItem, Popover } from "@blueprintjs/core";
+import {
+  Button,
+  Intent,
+  Menu,
+  MenuItem,
+  Popover,
+  Position,
+} from "@blueprintjs/core";
 import { EXTERNAL_LINKS } from "src/common/constants/routes";
 import { MenuWrapper } from "./style";
 
 const LearnButton = (): JSX.Element => {
   return (
-    <Popover content={<Content />}>
+    <Popover position={Position.BOTTOM} content={<Content />}>
       <Button minimal intent={Intent.PRIMARY}>
         Help & Documentation
       </Button>


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- add
- remove
- modify
Force popper position to be `BOTTOM`

<img width="246" alt="Screen Shot 2021-10-08 at 3 59 38 PM" src="https://user-images.githubusercontent.com/6309723/136632929-0aac1952-fdf2-4ccd-919e-b0c6a959f03e.png">


## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
