### PR TITLE
fix: cache userinfo call

### DIFF
--- a/frontend/src/common/queries/auth.ts
+++ b/frontend/src/common/queries/auth.ts
@@ -34,8 +34,12 @@ async function fetchUserInfo(
   return result;
 }
 
+const AUTH_TOKEN_CACHE_TIME_MS = 8 * 60 * 60 * 1000;
+
 export function useUserInfo(hasAuth: boolean) {
   return useQuery([USE_USER_INFO, { hasAuth }], fetchUserInfo, {
+    refetchOnMount: false,
     retry: false,
+    staleTime: AUTH_TOKEN_CACHE_TIME_MS,
   });
 }


### PR DESCRIPTION
### Reviewers
**Functional:** 
@danieljhegeman 

**Readability:** 
@ebezzi 
---

## Changes
- modify
This limits the amount of `/userinfo` call to just once when the app starts, and then when the window refocuses!

Hopefully this means we won't hit Auth0 rate limiting as often 🤞 

Thank you!

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
