### PR TITLE
feat: delete published collection

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -145,6 +145,8 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
+        "410":
+          description: Gone
     post:
       tags:
         - collections

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -53,15 +53,20 @@ def get_collections_list(from_date: int = None, to_date: int = None, user: Optio
 @dbconnect
 def get_collection_details(collection_uuid: str, visibility: str, user: str):
     db_session = g.db_session
-    collection = Collection.get_collection(db_session, collection_uuid, visibility)
+    collection = Collection.get_collection(db_session, collection_uuid, visibility, include_tombstones=True)
     if not collection:
         raise ForbiddenHTTPException()
-    get_tombstone_datasets = (
-        _is_user_owner_or_allowed(user, collection.owner) and collection.visibility == CollectionVisibility.PRIVATE
-    )
-    result = collection.reshape_for_api(get_tombstone_datasets)
+    if collection.tombstone == True and visibility == CollectionVisibility.PUBLIC.name:
+        result = ""
+        response = 410
+    else:
+        get_tombstone_datasets = (
+            _is_user_owner_or_allowed(user, collection.owner) and collection.visibility == CollectionVisibility.PRIVATE
+        )
+        result = collection.reshape_for_api(get_tombstone_datasets)
+        response = 200
     result["access_type"] = "WRITE" if _is_user_owner_or_allowed(user, collection.owner) else "READ"
-    return make_response(jsonify(result), 200)
+    return make_response(jsonify(result), response)
 
 
 @dbconnect
@@ -110,23 +115,43 @@ def get_collection_dataset(dataset_uuid: str):
 
 @dbconnect
 def delete_collection(collection_uuid: str, visibility: str, user: str):
-    if visibility != CollectionVisibility.PRIVATE.name:
-        # Only allowed to delete private collections
-        return "", 405
     db_session = g.db_session
-    priv_collection = Collection.get_collection(
-        db_session,
-        collection_uuid,
-        CollectionVisibility.PRIVATE.name,
-        owner=_owner_or_allowed(user),
-        include_tombstones=True,
-    )
-    if priv_collection:
-        if not priv_collection.tombstone:
-            priv_collection.delete()
-        return "", 204
+    if visibility == CollectionVisibility.PUBLIC.name:
+        pub_collection = Collection.get_collection(
+            db_session,
+            collection_uuid,
+            visibility,
+            owner=_owner_or_allowed(user),
+            include_tombstones=True,
+        )
+        priv_collection = Collection.get_collection(
+            db_session,
+            collection_uuid,
+            CollectionVisibility.PRIVATE.name,
+            owner=_owner_or_allowed(user),
+            include_tombstones=True,
+        )
+
+        if pub_collection:
+            if not pub_collection.tombstone:
+                pub_collection.tombstone_collection()
+            if priv_collection:
+                if not priv_collection.tombstone:
+                    priv_collection.delete()
+            return "", 204
     else:
-        return "", 403
+        priv_collection = Collection.get_collection(
+            db_session,
+            collection_uuid,
+            CollectionVisibility.PRIVATE.name,
+            owner=_owner_or_allowed(user),
+            include_tombstones=True,
+        )
+        if priv_collection:
+            if not priv_collection.tombstone:
+                priv_collection.delete()
+            return "", 204
+    return "", 403
 
 
 @dbconnect

--- a/tests/unit/backend/corpora/api_server/test_v1_collection.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_collection.py
@@ -2,7 +2,6 @@ import itertools
 import json
 from datetime import datetime
 from furl import furl
-import unittest
 
 from backend.corpora.common.corpora_orm import (
     CollectionVisibility,
@@ -651,8 +650,7 @@ class TestCollectionDeletion(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         for bucket, key in s3_objects:
             self.assertS3FileDoesNotExist(bucket, key)
 
-    @unittest.skip("Tombstone not supported through API.")
-    def test_tombstone_collection__ok(self):
+    def test_tombstone_collection_revision__ok(self):
         # Generate test collection
         collection = self.generate_collection(
             self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id"
@@ -668,9 +666,9 @@ class TestCollectionDeletion(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         dataset_1 = self.generate_dataset(self.session, collection=collection, processing_status=processing_status_1)
         dataset_2 = self.generate_dataset(self.session, collection=collection, processing_status=processing_status_2)
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
-        test_url = furl(path=f"/dp/v1/collections/{collection.id}", query_params=dict(visibility="PRIVATE"))
-
-        response = self.app.get(test_url.url, headers=headers)
+        test_private_url = furl(path=f"/dp/v1/collections/{collection.id}", query_params=dict(visibility="PRIVATE"))
+        test_public_url = furl(path=f"/dp/v1/collections/{collection.id}", query_params=dict(visibility="PUBLIC"))
+        response = self.app.get(test_private_url.url, headers=headers)
         self.assertEqual(200, response.status_code)
 
         body = json.loads(response.data)
@@ -679,22 +677,73 @@ class TestCollectionDeletion(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         self.assertIn(dataset_2.id, dataset_ids)
 
         # delete collection
-        response = self.app.delete(test_url.url, headers=headers)
+        response = self.app.delete(test_private_url.url, headers=headers)
 
-        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.status_code, 204)
 
         # check collection and datasets delete
-        self.session.expire_all()
-        collection = Collection.get_collection(
-            self.session, collection.id, CollectionVisibility.PRIVATE.name, include_tombstones=True
+        response = self.app.get(test_private_url.url, headers=headers)
+        self.assertEqual(response.status_code, 403)
+
+        # Public collection still exists
+        response = self.app.get(test_public_url.url, headers=headers)
+        self.assertEqual(response.status_code, 200)
+
+    def test_tombstone_published_collection_with_revision__ok(self):
+        """Both the published and revised collections are tombstoned."""
+        # Generate test collection
+        collection_rev = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id"
+        )
+        # Generate the public collection with the same id as the private so a tombstone is created
+        collection_pub = self.generate_collection(
+            self.session, id=collection_rev.id, visibility=CollectionVisibility.PUBLIC.name, owner="test_user_id"
         )
 
-        self.assertTrue(collection.tombstone)
-        self.assertTrue(dataset_1.tombstone)
-        self.assertTrue(dataset_2.tombstone)
+        processing_status = {"upload_status": UploadStatus.UPLOADED, "upload_progress": 100.0}
 
-        response = self.app.get(test_url.url, headers=headers)
+        dataset_rev = self.generate_dataset(
+            self.session, collection=collection_rev, processing_status=processing_status
+        )
+        dataset_pub = self.generate_dataset(
+            self.session, collection=collection_pub, processing_status=processing_status
+        )
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+
+        # Verify private collections exist
+        test_private_url = furl(path=f"/dp/v1/collections/{collection_rev.id}", query_params=dict(visibility="PRIVATE"))
+        response = self.app.get(test_private_url.url, headers=headers)
+        self.assertEqual(200, response.status_code)
+        body = json.loads(response.data)
+        dataset_ids = [dataset["id"] for dataset in body["datasets"]]
+        self.assertIn(dataset_rev.id, dataset_ids)
+
+        # Verify public collections exist
+        test_public_url = furl(path=f"/dp/v1/collections/{collection_pub.id}", query_params=dict(visibility="PUBLIC"))
+        response = self.app.get(test_public_url.url, headers=headers)
+        self.assertEqual(200, response.status_code)
+        body = json.loads(response.data)
+        dataset_ids = [dataset["id"] for dataset in body["datasets"]]
+        self.assertIn(dataset_pub.id, dataset_ids)
+
+        # delete public collection
+        response = self.app.delete(test_public_url.url, headers=headers)
+        self.assertEqual(response.status_code, 204)
+
+        # check collection revision and datasets tombstoned
+        response = self.app.get(test_private_url.url, headers=headers)
         self.assertEqual(response.status_code, 403)
+
+        # check public collection is tombstoned and datasets deleted.
+        response = self.app.get(test_public_url.url, headers=headers)
+        self.assertEqual(response.status_code, 410)
+
+        self.session.expire_all()
+        collection = Collection.get_collection(
+            self.session, collection_pub.id, CollectionVisibility.PUBLIC.name, include_tombstones=True
+        )
+        self.assertTrue(collection.tombstone)
+        self.assertTrue(dataset_pub.tombstone)
 
     def test_delete_collection__dataset_not_available(self):
         # Generate test collection
@@ -721,7 +770,7 @@ class TestCollectionDeletion(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         response = self.app.get(dataset_url.url, headers=headers)
         self.assertEqual(response.status_code, 403)
 
-    def test_delete_collection__already_tombstoned__403(self):
+    def test_delete_collection__already_tombstoned__ok(self):
         collection = self.generate_collection(
             self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id", tombstone=True
         )
@@ -734,7 +783,7 @@ class TestCollectionDeletion(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         response = self.app.delete(test_url.url, headers=headers)
         self.assertEqual(response.status_code, 204)
 
-    def test_delete_collection__public__405(self):
+    def test_delete_collection__public__ok(self):
         collection = self.generate_collection(
             self.session, visibility=CollectionVisibility.PUBLIC.name, owner="test_user_id"
         )
@@ -747,7 +796,10 @@ class TestCollectionDeletion(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         for test_url in test_urls:
             with self.subTest(test_url.url):
                 response = self.app.delete(test_url.url, headers=headers)
-                self.assertEqual(response.status_code, 405)
+                self.assertEqual(response.status_code, 204)
+
+                response = self.app.get(test_url.url, headers=headers)
+                self.assertEqual(response.status_code, 410)
 
     def test_delete_collection__not_owner(self):
         collection = self.generate_collection(


### PR DESCRIPTION
### Reviewers
**Functional:** @seve 

**Readability:** 

---

## Changes
- modify DELETE collection/{collection_uuid} endpoint to allow the owner of a collection to tombstone a published collection. If an active revision exists for the collection, it will be deleted.
- modified GET collection/{collection_uuid} to return a gone<410> response with the contact_name and contact_email in the response body.

## Definition of Done (from ticket)
https://github.com/chanzuckerberg/single-cell-data-portal/issues/1577

## QA steps (optional)

## Known Issues
