### PR TITLE
fix: pin packaging version in dockerfile.processing_image to fix smoke tests

### DIFF
--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -19,7 +19,7 @@ RUN git clone https://github.com/chanzuckerberg/single-cell-explorer.git \
  && rm -rf single-cell-explorer client build/client /usr/bin/npm
 
 # Install python dependencies
-RUN pip3 install scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 cython==0.29.24 awscli
+RUN pip3 install scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 pyparsing<3,>=2.0.2 awscli
 RUN pip3 install cellxgene-schema==2.0.3
 
 ADD requirements.txt requirements.txt

--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -19,7 +19,7 @@ RUN git clone https://github.com/chanzuckerberg/single-cell-explorer.git \
  && rm -rf single-cell-explorer client build/client /usr/bin/npm
 
 # Install python dependencies
-RUN pip3 install scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 pyparsing==2.4.7 awscli
+RUN pip3 install scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 packaging==21.0 awscli
 RUN pip3 install cellxgene-schema==2.0.3
 
 ADD requirements.txt requirements.txt

--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -19,7 +19,7 @@ RUN git clone https://github.com/chanzuckerberg/single-cell-explorer.git \
  && rm -rf single-cell-explorer client build/client /usr/bin/npm
 
 # Install python dependencies
-RUN pip3 install scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 awscli
+RUN pip3 install scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 cython==0.29.24 awscli
 RUN pip3 install cellxgene-schema==2.0.3
 
 ADD requirements.txt requirements.txt

--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -19,6 +19,7 @@ RUN git clone https://github.com/chanzuckerberg/single-cell-explorer.git \
  && rm -rf single-cell-explorer client build/client /usr/bin/npm
 
 # Install python dependencies
+# Remove packaging dependency once pyparser>3 is supported.
 RUN pip3 install scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 packaging==21.0 awscli
 RUN pip3 install cellxgene-schema==2.0.3
 

--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -19,7 +19,7 @@ RUN git clone https://github.com/chanzuckerberg/single-cell-explorer.git \
  && rm -rf single-cell-explorer client build/client /usr/bin/npm
 
 # Install python dependencies
-RUN pip3 install scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 pyparsing<3,>=2.0.2 awscli
+RUN pip3 install scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 pyparsing==2.4.7 awscli
 RUN pip3 install cellxgene-schema==2.0.3
 
 ADD requirements.txt requirements.txt


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

---
This is the original failing [smoke test](https://github.com/chanzuckerberg/single-cell-data-portal/runs/4072903438?check_suite_focus=true#step:5:339). Here is the error in our smoke test.
> ERROR: packaging 21.2 has requirement pyparsing<3,>=2.0.2, but you'll have pyparsing 3.0.4 which is incompatible.

The python library Packaging is failing during install do to conflicting requirements. Packaging's version 21.2 locks down the version of pyparsing to resolve this https://github.com/pypa/packaging/pull/471. 

There is also an error installing the requirements for Owlready2==0.34. This is pinned in [chanzuckerberg/single-cell-curation](https://github.com/chanzuckerberg/single-cell-curation/blob/37d8a199c4017d743694ad9ff47f8ccca555efd0/cellxgene_schema_cli/requirements.txt#L7)


## Changes
- pin packaging version in dockerfile.processing_image to one that does not lock the pyparsing library version to >3.
