### PR TITLE
fix: pin SeuratObject to version 4.0.2

### DIFF
--- a/backend/corpora/dataset_processing/make_seurat.R
+++ b/backend/corpora/dataset_processing/make_seurat.R
@@ -1,5 +1,8 @@
 library(sceasy)
 
+require(devtools)
+install_version("SeuratObject", version = "4.0.2", repos = "http://cran.rstudio.com/")
+
 h5adPath <- commandArgs(trailingOnly = TRUE)[1]
 
 sceasy::convertFormat(h5adPath, from="anndata", to="seurat", outFile = gsub(".h5ad", ".rds", h5adPath), main_layer = "data")


### PR DESCRIPTION
### Reviewers
**Functional:** 
@pablo-gar @maniarathi 

Ticket [#1657](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1657)

---

## Changes
- Pins `SeuratObject` to version 4.0.2. The latest version (4.0.3) is causing the issue documented in the ticket. 
