### PR TITLE
feat: add is_primary_data to datasets/index endpoint

### DIFF
--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -156,6 +156,7 @@ class Dataset(Entity):
             DbDataset.sex,
             DbDataset.ethnicity,
             DbDataset.development_stage,
+            DbDataset.is_primary_data,
             DbDataset.schema_version,  # Required for schema manipulation
         ]
         table = cls.table

--- a/tests/unit/backend/corpora/api_server/test_v1_dataset.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_dataset.py
@@ -141,6 +141,7 @@ class TestDataset(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         self.assertEqual(actual_dataset["development_stage"], dataset.development_stage)
         self.assertEqual(actual_dataset["cell_count"], dataset.cell_count)
         self.assertEqual(actual_dataset["cell_type"], dataset.cell_type)
+        self.assertEqual(actual_dataset["is_primary_data"], dataset.is_primary_data)
 
     def test__cancel_dataset_download__ok(self):
         # Test pre upload

--- a/tests/unit/backend/corpora/api_server/test_v1_dataset.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_dataset.py
@@ -141,7 +141,7 @@ class TestDataset(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         self.assertEqual(actual_dataset["development_stage"], dataset.development_stage)
         self.assertEqual(actual_dataset["cell_count"], dataset.cell_count)
         self.assertEqual(actual_dataset["cell_type"], dataset.cell_type)
-        self.assertEqual(actual_dataset["is_primary_data"], dataset.is_primary_data)
+        self.assertEqual(actual_dataset["is_primary_data"], dataset.is_primary_data.name)
 
     def test__cancel_dataset_download__ok(self):
         # Test pre upload


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MillenniumFalconMechanic 

**Readability:** 
N/A
---

## Changes
- Add `is_primary_data` to `datasets/index` endpoint
