### PR TITLE
feat: update +n tag to include all values (#1603)

### DIFF
--- a/frontend/src/common/constants/metadata.ts
+++ b/frontend/src/common/constants/metadata.ts
@@ -1,0 +1,6 @@
+export enum PluralizedMetadataLabel {
+  ASSAY = "assays",
+  DISEASE = "diseases",
+  ORGANISM = "organisms",
+  TISSUE = "tissues",
+}

--- a/frontend/src/components/Collections/components/Grid/components/Popover/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Popover/index.tsx
@@ -5,26 +5,29 @@ import {
   Tag,
 } from "@blueprintjs/core";
 import { FC } from "react";
+import { PluralizedMetadataLabel } from "src/common/constants/metadata";
 import { LeftAlignedDetailsCell } from "../Row/common/style";
 import { ContentColumn, ContentWrapper, FieldValues } from "./style";
 
 interface Props {
+  label: PluralizedMetadataLabel;
   values: string[];
 }
 const CHUNK_SIZE = 25;
-const Popover: FC<Props> = ({ values }) => {
+const Popover: FC<Props> = ({ label, values }) => {
   const chunkedValues = Array(Math.ceil(values.length / CHUNK_SIZE))
     .fill("")
     .map((_, index) => index * CHUNK_SIZE)
     .map((begin) => values.slice(begin, begin + CHUNK_SIZE));
   return (
     <LeftAlignedDetailsCell>
-      <FieldValues>
-        {values[0]}
-        <br />
-        {values[1]}
-      </FieldValues>
-      {values.length > 2 && (
+      {values.length <= 2 ? (
+        <FieldValues>
+          {values[0]}
+          <br />
+          {values[1]}
+        </FieldValues>
+      ) : (
         <PopoverRaw
           interactionKind={PopoverInteractionKind.HOVER}
           placement={Position.RIGHT}
@@ -48,7 +51,9 @@ const Popover: FC<Props> = ({ values }) => {
             </ContentWrapper>
           }
         >
-          <Tag minimal>+{values.length - 2}</Tag>
+          <Tag minimal>
+            {values.length} {label}
+          </Tag>
         </PopoverRaw>
       )}
     </LeftAlignedDetailsCell>

--- a/frontend/src/components/Collections/components/Grid/components/Row/CollectionRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/CollectionRow/index.tsx
@@ -3,6 +3,7 @@ import loadable from "@loadable/component";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { FC } from "react";
+import { PluralizedMetadataLabel } from "src/common/constants/metadata";
 import { ROUTES } from "src/common/constants/routes";
 import { ACCESS_TYPE, VISIBILITY_TYPE } from "src/common/entities";
 import {
@@ -34,12 +35,15 @@ const AsyncPopover = loadable(
     )
 );
 
-const conditionalPopover = (values: string[]) => {
+const conditionalPopover = (
+  label: PluralizedMetadataLabel,
+  values: string[]
+) => {
   if (!values || values.length === 0) {
     return <LeftAlignedDetailsCell>-</LeftAlignedDetailsCell>;
   }
 
-  return <AsyncPopover values={values} />;
+  return <AsyncPopover label={label} values={values} />;
 };
 
 const CollectionRow: FC<Props> = (props) => {
@@ -107,10 +111,10 @@ const CollectionRow: FC<Props> = (props) => {
           </TagContainer>
         )}
       </StyledCell>
-      {conditionalPopover(tissue)}
-      {conditionalPopover(assay)}
-      {conditionalPopover(disease)}
-      {conditionalPopover(organism)}
+      {conditionalPopover(PluralizedMetadataLabel.TISSUE, tissue)}
+      {conditionalPopover(PluralizedMetadataLabel.ASSAY, assay)}
+      {conditionalPopover(PluralizedMetadataLabel.DISEASE, disease)}
+      {conditionalPopover(PluralizedMetadataLabel.ORGANISM, organism)}
       <RightAlignedDetailsCell>{cell_count || "-"}</RightAlignedDetailsCell>
       {props.revisionsEnabled && visibility === VISIBILITY_TYPE.PUBLIC ? (
         <RevisionCell

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Popover/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Popover/index.tsx
@@ -1,5 +1,6 @@
 import loadable from "@loadable/component";
 import { FC } from "react";
+import { PluralizedMetadataLabel } from "src/common/constants/metadata";
 import { LeftAlignedDetailsCell } from "../../../common/style";
 import { Skeleton } from "../common/Skeleton";
 
@@ -11,11 +12,12 @@ const AsyncPopover = loadable(
 );
 
 interface Props {
+  label: PluralizedMetadataLabel;
   values: string[];
   isLoading: boolean;
 }
 
-const Popover: FC<Props> = ({ values, isLoading }) => {
+const Popover: FC<Props> = ({ label, values, isLoading }) => {
   if (isLoading) {
     return (
       <td>
@@ -28,7 +30,7 @@ const Popover: FC<Props> = ({ values, isLoading }) => {
     return <LeftAlignedDetailsCell>-</LeftAlignedDetailsCell>;
   }
 
-  return <AsyncPopover values={values} />;
+  return <AsyncPopover label={label} values={values} />;
 };
 
 export default Popover;

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
@@ -2,6 +2,7 @@ import { AnchorButton, Classes, Intent, Tooltip } from "@blueprintjs/core";
 import loadable from "@loadable/component";
 import { FC } from "react";
 import { CancelledError, useQueryCache } from "react-query";
+import { PluralizedMetadataLabel } from "src/common/constants/metadata";
 import {
   ACCESS_TYPE,
   Collection,
@@ -183,10 +184,26 @@ const DatasetRow: FC<Props> = ({
           {revisionsEnabled && <RevisionStatusTag dataset={dataset} />}
         </TitleContainer>
       </DetailsCell>
-      <Popover values={tissue} isLoading={isMetadataLoading} />
-      <Popover values={assay} isLoading={isMetadataLoading} />
-      <Popover values={disease} isLoading={isMetadataLoading} />
-      <Popover values={organism} isLoading={isMetadataLoading} />
+      <Popover
+        label={PluralizedMetadataLabel.TISSUE}
+        values={tissue}
+        isLoading={isMetadataLoading}
+      />
+      <Popover
+        label={PluralizedMetadataLabel.ASSAY}
+        values={assay}
+        isLoading={isMetadataLoading}
+      />
+      <Popover
+        label={PluralizedMetadataLabel.DISEASE}
+        values={disease}
+        isLoading={isMetadataLoading}
+      />
+      <Popover
+        label={PluralizedMetadataLabel.ORGANISM}
+        values={organism}
+        isLoading={isMetadataLoading}
+      />
       <CellCount cellCount={cell_count} isLoading={isMetadataLoading} />
       <ActionCell>
         <ActionButtonsContainer>

--- a/frontend/src/components/Collections/components/Grid/components/Row/common/style.ts
+++ b/frontend/src/components/Collections/components/Grid/components/Row/common/style.ts
@@ -10,7 +10,9 @@ export const StyledCell = styled.td`
     :not(.${Classes.TAG}) {
       display: block;
     }
-    margin-top: ${PT_GRID_SIZE_PX / 2}px;
+    :not(.${Classes.POPOVER_WRAPPER}) {
+      margin-top: ${PT_GRID_SIZE_PX / 2}px;
+    }
   }
 `;
 


### PR DESCRIPTION
### Reviewers
**Functional:** 
@tihuan 

---

## Changes
Updated n+ tag to render only when there are 2 or more field values. The first two values are no longer displayed alongside the tag.  Pluralized metadata name is added to tag and + is removed (see [mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=1670%3A25035)).