### PR TITLE
chore: Remove revision from batch job definitions

### DIFF
--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -3,6 +3,8 @@
 
 data aws_region current {}
 
+data aws_caller_identity current {}
+
 resource aws_batch_job_definition batch_job_def {
   type = "container"
   name = "dp-${var.deployment_stage}-${var.custom_stack_name}-upload"

--- a/.happy/terraform/modules/batch/outputs.tf
+++ b/.happy/terraform/modules/batch/outputs.tf
@@ -2,3 +2,8 @@ output batch_job_definition {
   value       = aws_batch_job_definition.batch_job_def.id
   description = "ARN for the batch job definition"
 }
+
+output batch_job_definition_no_revision {
+  value       = "arn:aws:batch:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:job-definition/${aws_batch_job_definition.batch_job_def.name}"
+  description = "ARN for the batch job definition"
+}

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -177,7 +177,7 @@ module upload_error_lambda {
 
 module upload_sfn {
   source               = "../sfn"
-  job_definition_arn   = module.upload_batch.batch_job_definition
+  job_definition_arn   = module.upload_batch.batch_job_definition_no_revision
   job_queue_arn        = local.job_queue_arn
   role_arn             = local.sfn_role_arn
   custom_stack_name    = local.custom_stack_name


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@metakuni 

**Readability:** 

Companion PR: https://github.com/chanzuckerberg/single-cell-infra/pull/472

---

## Changes
- Removes the revision from the batch job definitions used by the step function. This is useful because if a deployment happens, the definition will be marked as INACTIVE, causing existing jobs to fail. This should allow to always pick up the latest revision available.
