### PR TITLE
fix: add display state to prevent multiple renders of toast

### DIFF
--- a/frontend/src/components/Collections/index.tsx
+++ b/frontend/src/components/Collections/index.tsx
@@ -1,7 +1,7 @@
 import { Intent } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { useRouter } from "next/router";
-import { FC, useEffect } from "react";
+import { FC, useEffect, useState } from "react";
 import { VISIBILITY_TYPE } from "src/common/entities";
 import { useExplainNewTab } from "src/common/hooks/useExplainNewTab";
 import { useCollections } from "src/common/queries/collections";
@@ -23,8 +23,10 @@ const Collections: FC = () => {
 
   const { tombstoned_collection_id } = router.query;
 
+  const [hasShownWithdrawToast, setHasShownWithdrawToast] = useState(false);
+
   useEffect(() => {
-    if (!tombstoned_collection_id) return;
+    if (!tombstoned_collection_id || hasShownWithdrawToast) return;
 
     Toast.show({
       icon: IconNames.ISSUE,
@@ -33,7 +35,8 @@ const Collections: FC = () => {
         "This collection was withdrawn. You’ve been redirected to the cellxgene Data Portal homepage.",
     });
     removeParams("tombstoned_collection_id");
-  }, [tombstoned_collection_id]);
+    setHasShownWithdrawToast(true);
+  }, [tombstoned_collection_id, hasShownWithdrawToast]);
 
   if (isFetching && !collections) return <div>Loading collections...</div>;
 

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -72,6 +72,8 @@ const Collection: FC = () => {
     visibility,
   });
 
+  const [hasShownWithdrawToast, setHasShownWithdrawToast] = useState(false);
+
   const { data: collection, isError, isFetching } = collectionState;
 
   const [deleteMutation, { isLoading }] = useDeleteCollection(id, visibility);
@@ -82,6 +84,7 @@ const Collection: FC = () => {
 
   useEffect(() => {
     if (
+      hasShownWithdrawToast ||
       !tombstoned_dataset_id ||
       !collection ||
       isTombstonedCollection(collection)
@@ -95,7 +98,8 @@ const Collection: FC = () => {
         "A dataset was withdrawn. You've been redirected to the parent collection.",
     });
     removeParams("tombstoned_dataset_id");
-  }, [tombstoned_dataset_id, collection]);
+    setHasShownWithdrawToast(true);
+  }, [tombstoned_dataset_id, collection, hasShownWithdrawToast]);
 
   useEffect(() => {
     if (!userWithdrawn && isTombstonedCollection(collection)) {


### PR DESCRIPTION
### Reviewers
**Functional:** @tihuan 

**Readability:** @atolopko-czi / @Bento007 

---

React Router was preserving the query param even though we were deleting it off the URL.  The collection object would change, triggering a call of the effect hook which would pop the toast again.