### PR TITLE
feat: hooked up /datasets/index and collections/index. (#1609)

### DIFF
--- a/frontend/src/common/hooks/useCategoryFilter.ts
+++ b/frontend/src/common/hooks/useCategoryFilter.ts
@@ -99,8 +99,8 @@ export function useCategoryFilter<T extends Categories>(
 
   // Set up original, full set of categories and their values.
   useMemo(() => {
-    // Only build category set once on load.
-    if (categorySet) {
+    // Only build category set if there are rows to parse category values from. Only build category set once on load.
+    if (!originalRows.length || categorySet) {
       return;
     }
     setCategorySet(buildCategorySet(originalRows));

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -23,7 +23,7 @@ import SideBar from "src/components/common/SideBar";
 import { View } from "src/views/globalStyle";
 
 // Collection ID object key
-const COLLECTION_ID = "collection_id";
+const COLLECTION_ID = "id";
 
 // Collection name object key
 const COLLECTION_NAME = "name";
@@ -38,13 +38,6 @@ export default function Collections(): JSX.Element {
   // Column configuration backing table.
   const columnConfig: Column<CollectionRow>[] = useMemo(
     () => [
-      // Hidden, required for sorting
-      {
-        // Sort by revised_at if specified otherwise published_at.
-        accessor: (dataset: CollectionRow): number =>
-          dataset.revised_at ?? dataset.published_at,
-        id: COLUMN_ID_RECENCY,
-      },
       {
         Cell: ({ row }: RowPropsValue) => {
           return (
@@ -85,21 +78,36 @@ export default function Collections(): JSX.Element {
         filter: "includesSome",
         id: CATEGORY_KEY.ORGANISM,
       },
+      // Hidden, required for sorting
+      {
+        // Sort by revised_at if specified otherwise published_at.
+        accessor: (dataset: CollectionRow): number =>
+          dataset.revised_at ?? dataset.published_at,
+        id: COLUMN_ID_RECENCY,
+      },
+      // Hidden, required for accessing collection ID via row.values, for building link to collection detail page.
+      {
+        accessor: COLLECTION_ID,
+      },
+      // Hidden, required for filter.
       {
         accessor: ontologyCellAccessorFn(CATEGORY_KEY.ASSAY),
         filter: "includesSome",
         id: CATEGORY_KEY.ASSAY,
       },
+      // Hidden, required for filter.
       {
         accessor: ontologyCellAccessorFn(CATEGORY_KEY.CELL_TYPE),
         filter: "includesSome",
         id: CATEGORY_KEY.CELL_TYPE,
       },
+      // Hidden, required for filter.
       {
         accessor: (dataset: CollectionRow) => dataset.is_primary_data,
         filter: "includesSome",
         id: CATEGORY_KEY.IS_PRIMARY_DATA,
       },
+      // Hidden, required for filter.
       {
         accessor: ontologyCellAccessorFn(CATEGORY_KEY.SEX),
         filter: "includesSome",

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -20,16 +20,19 @@ import {
 import { ontologyCellAccessorFn } from "src/components/common/Filter/common/utils";
 import DatasetsGrid from "src/components/Datasets/components/Grid/components/DatasetsGrid";
 
-// Collection name object key
+// Collection ID object key.
+const COLLECTION_ID = "collection_id";
+
+// Collection name object key.
 const COLLECTION_NAME = "collection_name";
 
-// Dataset ID object key
+// Dataset ID object key.
 const DATASET_ID = "id";
 
-// Dataset name object key
+// Dataset name object key.
 const DATASET_NAME = "name";
 
-// Key identifying recency sort by column
+// Key identifying recency sort by column.
 const COLUMN_ID_RECENCY = "recency";
 
 export default function Datasets(): JSX.Element {
@@ -39,16 +42,6 @@ export default function Datasets(): JSX.Element {
   // Column configuration backing table.
   const columnConfig: Column<DatasetRow>[] = useMemo(
     () => [
-      // Hidden, required for sorting by recency.
-      {
-        accessor: (dataset: DatasetRow): number =>
-          dataset.revised_at ?? dataset.published_at,
-        id: COLUMN_ID_RECENCY,
-      },
-      // Hidden, required for accessing collection name via row.values, for display.
-      {
-        accessor: COLLECTION_NAME,
-      },
       {
         Cell: DatasetNameCell,
         Header: "Dataset",
@@ -79,23 +72,41 @@ export default function Datasets(): JSX.Element {
         Header: "Cells",
         accessor: "cell_count",
       },
+      // Hidden, required for sorting by recency.
+      {
+        accessor: (dataset: DatasetRow): number =>
+          dataset.revised_at ?? dataset.published_at,
+        id: COLUMN_ID_RECENCY,
+      },
+      // Hidden, required for accessing collection ID via row.values, for building link to collection detail page.
+      {
+        accessor: COLLECTION_ID,
+      },
+      // Hidden, required for accessing collection name via row.values, for display.
+      {
+        accessor: COLLECTION_NAME,
+      },
+      // Hidden, required for filter.
       {
         Header: "Assay",
         accessor: ontologyCellAccessorFn(CATEGORY_KEY.ASSAY),
         filter: "includesSome",
         id: CATEGORY_KEY.ASSAY,
       },
+      // Hidden, required for filter.
       {
         Header: "Cell Type",
         accessor: ontologyCellAccessorFn(CATEGORY_KEY.CELL_TYPE),
         filter: "includesSome",
         id: CATEGORY_KEY.CELL_TYPE,
       },
+      // Hidden, required for filter.
       {
         Header: "Primary Data",
         accessor: CATEGORY_KEY.IS_PRIMARY_DATA,
         filter: "includesSome",
       },
+      // Hidden, required for filter.
       {
         Header: "Sex",
         accessor: ontologyCellAccessorFn(CATEGORY_KEY.SEX),
@@ -114,6 +125,7 @@ export default function Datasets(): JSX.Element {
       initialState: {
         hiddenColumns: [
           DATASET_ID,
+          COLLECTION_ID,
           COLLECTION_NAME,
           COLUMN_ID_RECENCY,
           // CATEGORY_KEY.CELL_TYPE,

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import {
   CellProps,
   Column,
@@ -11,7 +11,7 @@ import { ROUTES } from "src/common/constants/routes";
 import { FEATURES } from "src/common/featureFlags/features";
 import { useCategoryFilter } from "src/common/hooks/useCategoryFilter";
 import { useFeatureFlag } from "src/common/hooks/useFeatureFlag";
-import { fetchDatasetRows } from "src/common/queries/filter";
+import { useFetchDatasetRows } from "src/common/queries/filter";
 import Categories from "src/components/Categories";
 import {
   CATEGORY_KEY,
@@ -33,8 +33,8 @@ const DATASET_NAME = "name";
 const COLUMN_ID_RECENCY = "recency";
 
 export default function Datasets(): JSX.Element {
-  // Filterable datasets joined from datasets index and collections index responses.
-  const [filterableDatasets] = useState<DatasetRow[]>(fetchDatasetRows());
+  // Filterable datasets joined from datasets and collections responses.
+  const { error, loading, rows: datasetRows } = useFetchDatasetRows();
 
   // Column configuration backing table.
   const columnConfig: Column<DatasetRow>[] = useMemo(
@@ -80,14 +80,12 @@ export default function Datasets(): JSX.Element {
         accessor: "cell_count",
       },
       {
-        Cell: Cell,
         Header: "Assay",
         accessor: ontologyCellAccessorFn(CATEGORY_KEY.ASSAY),
         filter: "includesSome",
         id: CATEGORY_KEY.ASSAY,
       },
       {
-        Cell: Cell,
         Header: "Cell Type",
         accessor: ontologyCellAccessorFn(CATEGORY_KEY.CELL_TYPE),
         filter: "includesSome",
@@ -99,7 +97,6 @@ export default function Datasets(): JSX.Element {
         filter: "includesSome",
       },
       {
-        Cell: Cell,
         Header: "Sex",
         accessor: ontologyCellAccessorFn(CATEGORY_KEY.SEX),
         filter: "includesSome",
@@ -113,7 +110,7 @@ export default function Datasets(): JSX.Element {
   const tableInstance = useTable<DatasetRow>(
     {
       columns: columnConfig,
-      data: filterableDatasets,
+      data: datasetRows,
       initialState: {
         hiddenColumns: [
           DATASET_ID,
@@ -157,8 +154,12 @@ export default function Datasets(): JSX.Element {
         <title>cellxgene | Datasets</title>
       </Head>
       <div style={{ display: "flex" }}>
-        <Categories {...filterInstance} />
-        <DatasetsGrid tableInstance={tableInstance} />
+        {error || loading ? null : (
+          <>
+            <Categories {...filterInstance} />
+            <DatasetsGrid tableInstance={tableInstance} />
+          </>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Changes
* Added react-query-based fetch of datasets from `datasets/index`.
* Added react-query-based fetch of collections from `collections/index`.
* Hooked up responses to filter view model builder functionality.
 
## Definition of Done (from ticket)
* Set of datasets, joined with collection information, sorted by publication date is available to display components.
* Set of collections, with rolled up dataset metadata, sorted by recency is available to display components.

## Known Issues
* A possible improvement would be to cache the built view models via react-query rather than just the response themselves. Alternatively, built view models could be cached at the application level.
* There is some duplication between the sequencing of the fetch and build of datasets and the fetch and build of collections. This could be possibly refactored into a single, shared hook.