### PR TITLE
feat: add explorer_url to dataset/index

### DIFF
--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -158,6 +158,7 @@ class Dataset(Entity):
             DbDataset.development_stage,
             DbDataset.is_primary_data,
             DbDataset.schema_version,  # Required for schema manipulation
+            DbDataset.explorer_url,
             DbDataset.published_at,
             DbDataset.revised_at,
         ]

--- a/tests/unit/backend/corpora/api_server/test_v1_dataset.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_dataset.py
@@ -150,6 +150,7 @@ class TestDataset(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         self.assertEqual(actual_dataset["cell_count"], dataset.cell_count)
         self.assertEqual(actual_dataset["cell_type"], dataset.cell_type)
         self.assertEqual(actual_dataset["is_primary_data"], dataset.is_primary_data.name)
+        self.assertEqual(actual_dataset["explorer_url"], dataset.explorer_url)
         self.assertEqual(actual_dataset["published_at"], dataset.published_at.timestamp())
         self.assertEqual(actual_dataset["revised_at"], dataset.revised_at.timestamp())
 


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MillenniumFalconMechanic 

Ticket [#1721](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1721)

---

## Changes
- Adds `explorer_url` to the `dataset/index` endpoint
