### PR TITLE
fix: behavior of download radio buttons

### DIFF
--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
@@ -33,6 +33,40 @@ const DataFormat: FC<Props> = ({
     handleChangeRaw(value);
   };
 
+  const renderH5adRadio = (): React.ReactElement => {
+    return (
+      <Radio
+        disabled={!availableFormats.includes(DATASET_ASSET_FORMAT.H5AD)}
+        label=".h5ad (AnnData v0.7)"
+        value={DATASET_ASSET_FORMAT.H5AD}
+      />
+    );
+  };
+
+  const renderRdsButton = (): React.ReactElement => {
+    return (
+      <Radio
+        disabled={!availableFormats.includes(DATASET_ASSET_FORMAT.RDS)}
+        label=".rds (Seurat v3)"
+        value={DATASET_ASSET_FORMAT.RDS}
+      />
+    );
+  };
+
+  const renderTooltip = (): React.ReactElement => {
+    return (
+      <Tooltip
+        disabled={!isRDSSkipped}
+        interactionKind={PopoverInteractionKind.HOVER}
+        content="A .rds (Seurat v3) download is unavailable due to limitations in the R dgCMatrix sparse matrix class."
+        intent={Intent.DANGER}
+        position={Position.TOP}
+      >
+        {renderRdsButton()}
+      </Tooltip>
+    );
+  };
+
   return (
     <Section>
       <Title>DATA FORMAT</Title>
@@ -43,24 +77,9 @@ const DataFormat: FC<Props> = ({
         onChange={handleChange}
         selectedValue={selectedFormat}
       >
-        <Radio
-          disabled={!availableFormats.includes(DATASET_ASSET_FORMAT.H5AD)}
-          label=".h5ad (AnnData v0.7)"
-          value={DATASET_ASSET_FORMAT.H5AD}
-        />
-        <Tooltip
-          disabled={!isRDSSkipped}
-          interactionKind={PopoverInteractionKind.HOVER}
-          content="A .rds (Seurat v3) download is unavailable due to limitations in the R dgCMatrix sparse matrix class."
-          intent={Intent.DANGER}
-          position={Position.TOP}
-        >
-          <Radio
-            disabled={!availableFormats.includes(DATASET_ASSET_FORMAT.RDS)}
-            label=".rds (Seurat v3)"
-            value={DATASET_ASSET_FORMAT.RDS}
-          />
-        </Tooltip>
+        {renderH5adRadio()}
+        {isRDSSkipped && renderTooltip()}
+        {!isRDSSkipped && renderRdsButton()}
       </RadioGroup>
     </Section>
   );

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
@@ -43,7 +43,7 @@ const DataFormat: FC<Props> = ({
     );
   };
 
-  const renderRdsButton = (): React.ReactElement => {
+  const renderRdsRadio = (): React.ReactElement => {
     return (
       <Radio
         disabled={!availableFormats.includes(DATASET_ASSET_FORMAT.RDS)}
@@ -53,16 +53,16 @@ const DataFormat: FC<Props> = ({
     );
   };
 
-  const renderTooltip = (): React.ReactElement => {
+  const renderDisabledRdsRadio = (): React.ReactElement => {
     return (
       <Tooltip
-        disabled={!isRDSSkipped}
+        disabled={false}
         interactionKind={PopoverInteractionKind.HOVER}
         content="A .rds (Seurat v3) download is unavailable due to limitations in the R dgCMatrix sparse matrix class."
         intent={Intent.DANGER}
         position={Position.TOP}
       >
-        {renderRdsButton()}
+        {renderRdsRadio()}
       </Tooltip>
     );
   };
@@ -78,8 +78,7 @@ const DataFormat: FC<Props> = ({
         selectedValue={selectedFormat}
       >
         {renderH5adRadio()}
-        {isRDSSkipped && renderTooltip()}
-        {!isRDSSkipped && renderRdsButton()}
+        {isRDSSkipped ? renderDisabledRdsRadio() : renderRdsRadio()}
       </RadioGroup>
     </Section>
   );

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
@@ -62,6 +62,8 @@ const DataFormat: FC<Props> = ({
         intent={Intent.DANGER}
         position={Position.TOP}
       >
+        {/* Logically renders only when rds format not available, but a Tooltip wrapper also happens to prevent 
+        proper functioning of radio buttons with a larger radio group outside of the Tooltip wrapper */}
         {renderRdsRadio()}
       </Tooltip>
     );


### PR DESCRIPTION
This commit rearranges the rendering logic for the DataFormat component
so that the Tooltip, which breaks the radio button grouping
functionality, only renders when the rds radio button is not needed.

### Reviewers
**Functional:** 
@seve 
**Readability:** 
@tihuan 
---

## Changes
- add
- remove
- modify

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
