### PR TITLE
fix: Correctly update revised_at when publishing Collection revision

### DIFF
--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -208,7 +208,9 @@ class Collection(Entity):
             revision = Dataset(dataset)
             original = Dataset.get(self.session, revision.original_id) if revision.original_id else None
             if original and public_collection.check_has_dataset(original):
-                has_dataset_changes = original.publish_revision(revision, now)
+                dataset_is_changed = original.publish_revision(revision, now)
+                if dataset_is_changed:
+                    has_dataset_changes = True
             else:
                 # The dataset is new
                 revision.publish_new(now)


### PR DESCRIPTION
This commit fixes a bug that allowed the revised_at column to sometimes
not be updated even when there were changes (revisions) to a
Collection's datasets.

### Reviewers
**Functional:** 
@ebezzi 
**Readability:** 
@metakuni 
---

## Changes
- add
- remove
- modify

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
