### PR TITLE
fix: seurat reprocessing change

### DIFF
--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -195,22 +195,7 @@ resource "aws_sfn_state_machine" "state_machine_seurat" {
           ]
         }
       },
-      "TimeoutSeconds": 36000,
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "Next": "HandleErrors",
-          "ResultPath": "$.error"
-        }
-      ]
-    },
-    "HandleErrors": {
-      "Type": "Task",
-      "InputPath": "$",
-      "Resource": "${var.lambda_error_handler}",
-      "End": true
+      "TimeoutSeconds": 36000
     }
   }
 }

--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -196,6 +196,7 @@ def create_artifact(
         update_db(dataset_id, processing_status={processing_status_type: ConversionStatus.FAILED})
         raise e
 
+
 def replace_artifact(
     file_name: str,
     bucket_prefix: str,
@@ -203,6 +204,7 @@ def replace_artifact(
 ):
     logger.info(f"Uploading [{bucket_prefix}/{file_name}] to S3 bucket: [{artifact_bucket}].")
     DatasetAsset.upload(file_name, bucket_prefix, artifact_bucket)
+
 
 def create_artifacts(local_filename: str, dataset_id: str, artifact_bucket: str, can_convert_to_seurat: bool = False):
     bucket_prefix = get_bucket_prefix(dataset_id)

--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -196,6 +196,13 @@ def create_artifact(
         update_db(dataset_id, processing_status={processing_status_type: ConversionStatus.FAILED})
         raise e
 
+def replace_artifact(
+    file_name: str,
+    bucket_prefix: str,
+    artifact_bucket: str,
+):
+    logger.info(f"Uploading [{bucket_prefix}/{file_name}] to S3 bucket: [{artifact_bucket}].")
+    DatasetAsset.upload(file_name, bucket_prefix, artifact_bucket)
 
 def create_artifacts(local_filename: str, dataset_id: str, artifact_bucket: str, can_convert_to_seurat: bool = False):
     bucket_prefix = get_bucket_prefix(dataset_id)

--- a/backend/corpora/dataset_processing/process_seurat.py
+++ b/backend/corpora/dataset_processing/process_seurat.py
@@ -45,58 +45,81 @@ def process(dataset_id: str, artifact_bucket: str):
         # 1. newly processed dataset: h5ad will exist with key == dataset_id, rds will not exist
         # 2. non-revised reprocessed dataset with seurat
         # 3. revised reprocessed dataset with no seurat: h5ad will exist with key != dataset_id, rds will not exist
-        # 4. revised reprocessed dataset with "to be replaced" seurat: h5ad will exist with key != dataset_id, rds will exist
+        # 4. revised reprocessed dataset with "to be replaced" seurat: h5ad will exist with key ≠ dataset_id,
+        #    rds will exist
 
         h5ad_uri = next(a.s3_uri for a in dataset.artifacts if a.filetype == DatasetArtifactFileType.H5AD)
         rds_artifacts = [a for a in dataset.artifacts if a.filetype == DatasetArtifactFileType.RDS]
         artifact_key = h5ad_uri.split("/")[-2]
 
-        if artifact_key == dataset_id and not rds_artifacts: # Case 1
+        if artifact_key == dataset_id and not rds_artifacts:  # Case 1
 
             bucket_prefix = get_bucket_prefix(dataset_id)
             object_key = f"{bucket_prefix}/{labeled_h5ad_filename}"
             download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
 
             seurat_filename = convert_file_ignore_exceptions(
-                make_seurat, labeled_h5ad_filename, "Failed to convert dataset to Seurat format.", dataset_id, "rds_status"
+                make_seurat,
+                labeled_h5ad_filename,
+                "Failed to convert dataset to Seurat format.",
+                dataset_id,
+                "rds_status",
             )
 
             if seurat_filename:
                 create_artifact(
-                    seurat_filename, DatasetArtifactFileType.RDS, bucket_prefix, dataset_id, artifact_bucket, "rds_status"
+                    seurat_filename,
+                    DatasetArtifactFileType.RDS,
+                    bucket_prefix,
+                    dataset_id,
+                    artifact_bucket,
+                    "rds_status",
                 )
 
-        elif artifact_key == dataset_id and rds_artifacts: # Case 2
+        elif artifact_key == dataset_id and rds_artifacts:  # Case 2
             logger.warning(f"Reprocessing Seurat for existing dataset {artifact_key}, will replace the S3 file only")
             bucket_prefix = get_bucket_prefix(dataset_id)
             object_key = f"{bucket_prefix}/{labeled_h5ad_filename}"
             download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
 
             seurat_filename = convert_file_ignore_exceptions(
-                make_seurat, labeled_h5ad_filename, "Failed to convert dataset to Seurat format.", dataset_id, "rds_status"
+                make_seurat,
+                labeled_h5ad_filename,
+                "Failed to convert dataset to Seurat format.",
+                dataset_id,
+                "rds_status",
             )
 
             if seurat_filename:
                 replace_artifact(seurat_filename, bucket_prefix, artifact_bucket)
-                rds_artifact = rds_artifacts[0] # Only one RDS artifact for dataset will ever exist
+                rds_artifact = rds_artifacts[0]  # Only one RDS artifact for dataset will ever exist
                 rds_artifact.updated_at = datetime.utcnow()
-        
-        elif artifact_key != dataset_id and not rds_artifacts: # Case 3
+
+        elif artifact_key != dataset_id and not rds_artifacts:  # Case 3
             logger.warning(f"Found existing artifacts in {artifact_key} but no RDS, creating a new artifact")
             bucket_prefix = get_bucket_prefix(artifact_key)
             object_key = f"{bucket_prefix}/{labeled_h5ad_filename}"
             download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
 
             seurat_filename = convert_file_ignore_exceptions(
-                make_seurat, labeled_h5ad_filename, "Failed to convert dataset to Seurat format.", dataset_id, "rds_status"
+                make_seurat,
+                labeled_h5ad_filename,
+                "Failed to convert dataset to Seurat format.",
+                dataset_id,
+                "rds_status",
             )
 
             if seurat_filename:
                 create_artifact(
-                    seurat_filename, DatasetArtifactFileType.RDS, bucket_prefix, dataset_id, artifact_bucket, "rds_status"
+                    seurat_filename,
+                    DatasetArtifactFileType.RDS,
+                    bucket_prefix,
+                    dataset_id,
+                    artifact_bucket,
+                    "rds_status",
                 )
-        
-        else: # Case 4
+
+        else:  # Case 4
             logger.warning(f"Found existing artifacts in {artifact_key} including an RDS, replacing it")
 
             bucket_prefix = get_bucket_prefix(artifact_key)
@@ -104,10 +127,14 @@ def process(dataset_id: str, artifact_bucket: str):
             download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
 
             seurat_filename = convert_file_ignore_exceptions(
-                make_seurat, labeled_h5ad_filename, "Failed to convert dataset to Seurat format.", dataset_id, "rds_status"
+                make_seurat,
+                labeled_h5ad_filename,
+                "Failed to convert dataset to Seurat format.",
+                dataset_id,
+                "rds_status",
             )
 
             if seurat_filename:
                 replace_artifact(seurat_filename, bucket_prefix, artifact_bucket)
-                rds_artifact = rds_artifacts[0] # Only one RDS artifact for dataset will ever exist
+                rds_artifact = rds_artifacts[0]  # Only one RDS artifact for dataset will ever exist
                 rds_artifact.updated_at = datetime.utcnow()

--- a/backend/corpora/dataset_processing/process_seurat.py
+++ b/backend/corpora/dataset_processing/process_seurat.py
@@ -72,6 +72,7 @@ def process(dataset_id: str, artifact_bucket: str):
                 )
 
         elif artifact_key == dataset_id and rds_uri: # Case 2
+            logger.warning(f"Reprocessing Seurat for existing dataset {artifact_key}, will replace the S3 file only")
             bucket_prefix = get_bucket_prefix(dataset_id)
             object_key = f"{bucket_prefix}/{labeled_h5ad_filename}"
             download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)

--- a/backend/corpora/dataset_processing/process_seurat.py
+++ b/backend/corpora/dataset_processing/process_seurat.py
@@ -38,39 +38,63 @@ def process(dataset_id: str, artifact_bucket: str):
             logger.info("Skipping Seurat conversion")
             return
 
-    labeled_h5ad_filename = "local.h5ad"
+        labeled_h5ad_filename = "local.h5ad"
 
-    # Check for existing artifacts
-    # If this is a new dataset, no artifacts will exist and this won't do anything
-    # If we're reprocessing a new dataset and this dataset has been revised, we need to download
-    # the h5ad from its specified artifact location
-    if dataset.artifacts:
-        h5ad_uri = next(a["s3_uri"] for a in dataset.artifacts if a.filetype == DatasetArtifactFileType.H5AD)
+        # Check for existing artifacts
+        # If this is a new dataset, no artifacts will exist and this won't do anything
+        # If we're reprocessing a new dataset and this dataset has been revised, we need to download
+        # the h5ad from its specified artifact location
+        # if dataset.artifacts:
+
+        # Three cases:
+        # 1. newly processed dataset: h5ad will exist with key == dataset_id, rds will not exist
+        # 2. reprocessed dataset with no seurat: h5ad will exist with key != dataset_id, rds will not exist
+        # 3. reprocessed dataset with "to be replaced" seurat: h5ad will exist with key != dataset_id, rds will exist
+
+        h5ad_uri = next(a.s3_uri for a in dataset.artifacts if a.filetype == DatasetArtifactFileType.H5AD)
+        rds_uri = [a for a in dataset.artifacts if a.filetype == DatasetArtifactFileType.RDS]
         artifact_key = h5ad_uri.split("/")[-2]
-        
-        logger.warning(f"Found an existing h5ad artifact with key {artifact_key}, downloading from there")
 
-        bucket_prefix = get_bucket_prefix(artifact_key)
-        object_key = f"{bucket_prefix}/{labeled_h5ad_filename}"
-        download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
+        if artifact_key == dataset_id: # Case 1
 
-        seurat_filename = convert_file_ignore_exceptions(
-            make_seurat, labeled_h5ad_filename, "Failed to convert dataset to Seurat format.", dataset_id, "rds_status"
-        )
+            bucket_prefix = get_bucket_prefix(dataset_id)
+            object_key = f"{bucket_prefix}/{labeled_h5ad_filename}"
+            download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
 
-        if seurat_filename:
-            replace_artifact(seurat_filename, bucket_prefix, artifact_bucket)
-
-    else:
-        bucket_prefix = get_bucket_prefix(dataset_id)
-        object_key = f"{bucket_prefix}/{labeled_h5ad_filename}"
-        download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
-
-        seurat_filename = convert_file_ignore_exceptions(
-            make_seurat, labeled_h5ad_filename, "Failed to convert dataset to Seurat format.", dataset_id, "rds_status"
-        )
-
-        if seurat_filename:
-            create_artifact(
-                seurat_filename, DatasetArtifactFileType.RDS, bucket_prefix, dataset_id, artifact_bucket, "rds_status"
+            seurat_filename = convert_file_ignore_exceptions(
+                make_seurat, labeled_h5ad_filename, "Failed to convert dataset to Seurat format.", dataset_id, "rds_status"
             )
+
+            if seurat_filename:
+                create_artifact(
+                    seurat_filename, DatasetArtifactFileType.RDS, bucket_prefix, dataset_id, artifact_bucket, "rds_status"
+                )
+        
+        elif artifact_key != dataset_id and not rds_uri: # Case 2
+            logger.warning(f"Found existing artifacts in {artifact_key} but no RDS, creating a new artifact")
+            bucket_prefix = get_bucket_prefix(artifact_key)
+            object_key = f"{bucket_prefix}/{labeled_h5ad_filename}"
+            download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
+
+            seurat_filename = convert_file_ignore_exceptions(
+                make_seurat, labeled_h5ad_filename, "Failed to convert dataset to Seurat format.", dataset_id, "rds_status"
+            )
+
+            if seurat_filename:
+                create_artifact(
+                    seurat_filename, DatasetArtifactFileType.RDS, bucket_prefix, dataset_id, artifact_bucket, "rds_status"
+                )
+        
+        else: # Case 3
+            logger.warning(f"Found existing artifacts in {artifact_key} including an RDS, replacing it")
+
+            bucket_prefix = get_bucket_prefix(artifact_key)
+            object_key = f"{bucket_prefix}/{labeled_h5ad_filename}"
+            download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
+
+            seurat_filename = convert_file_ignore_exceptions(
+                make_seurat, labeled_h5ad_filename, "Failed to convert dataset to Seurat format.", dataset_id, "rds_status"
+            )
+
+            if seurat_filename:
+                replace_artifact(seurat_filename, bucket_prefix, artifact_bucket)

--- a/backend/corpora/dataset_processing/process_seurat.py
+++ b/backend/corpora/dataset_processing/process_seurat.py
@@ -41,12 +41,6 @@ def process(dataset_id: str, artifact_bucket: str):
 
         labeled_h5ad_filename = "local.h5ad"
 
-        # Check for existing artifacts
-        # If this is a new dataset, no artifacts will exist and this won't do anything
-        # If we're reprocessing a new dataset and this dataset has been revised, we need to download
-        # the h5ad from its specified artifact location
-        # if dataset.artifacts:
-
         # Four cases:
         # 1. newly processed dataset: h5ad will exist with key == dataset_id, rds will not exist
         # 2. non-revised reprocessed dataset with seurat
@@ -84,7 +78,7 @@ def process(dataset_id: str, artifact_bucket: str):
 
             if seurat_filename:
                 replace_artifact(seurat_filename, bucket_prefix, artifact_bucket)
-                rds_artifact = next(rds_artifacts)
+                rds_artifact = rds_artifacts[0] # Only one RDS artifact for dataset will ever exist
                 rds_artifact.updated_at = datetime.utcnow()
         
         elif artifact_key != dataset_id and not rds_artifacts: # Case 3
@@ -115,5 +109,5 @@ def process(dataset_id: str, artifact_bucket: str):
 
             if seurat_filename:
                 replace_artifact(seurat_filename, bucket_prefix, artifact_bucket)
-                rds_artifact = next(rds_artifacts)
+                rds_artifact = rds_artifacts[0] # Only one RDS artifact for dataset will ever exist
                 rds_artifact.updated_at = datetime.utcnow()


### PR DESCRIPTION
### Reviewers
**Functional:** 
@metakuni 

**Readability:** 

Ticket [#1761](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1761)

---

## Changes
- Enhances the Seurat reprocessing logic so that it will work for every type of dataset. In particular:
1. Datasets that are revised will not have their RDS artifact in a bucket with a matching name, therefore we need to read the S3 path from the database.
2. Datasets with an existing RDS artifact should not create a new database record, but they should replace the S3 file in place.
