### PR TITLE
fix: do not update curator_name when revising a collection

### DIFF
--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -252,6 +252,8 @@ const Content: FC<Props> = (props) => {
   async function submitEditCollection() {
     const payload = createPayload();
 
+    delete payload?.curator_name; // Do not update curator name when revising a collection
+
     if (!payload) return;
 
     setIsLoading(true);


### PR DESCRIPTION
### Reviewers
**Functional:** 
@Bento007 
**Readability:** 
@seve 
---

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1748

## Changes
- delete `curator_name` from list of attributes sent from FE to BE when editing the details for a private collection

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
