### PR TITLE
fix: detect duplicate H5AD files

### DIFF
--- a/backend/corpora/lambdas/api/v1/collection_uuid/publish.py
+++ b/backend/corpora/lambdas/api/v1/collection_uuid/publish.py
@@ -19,7 +19,7 @@ def check_for_duplicate_datasets(collection: Collection) -> bool:
     for dataset in collection.datasets:
         if not dataset.tombstone:
             for artifact in dataset.artifacts:
-                if artifact.file_type == DatasetArtifactFileType.H5AD:
+                if artifact.filetype == DatasetArtifactFileType.H5AD:
                     _artifact = DatasetAsset(artifact)
                     metadata = _artifact.get_s3_metadata()
                     if not metadata:

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -2,6 +2,7 @@ import json
 import os
 import time
 import unittest
+
 import requests
 from requests import HTTPError
 
@@ -60,6 +61,10 @@ class TestApi(BaseFunctionalTestCase):
         res.raise_for_status()
         data = json.loads(res.content)
         collection_uuid = data["collection_uuid"]
+        self.addCleanup(requests.delete, f"{self.api}/dp/v1/collections/{collection_uuid}", headers=headers)
+        self.addCleanup(
+            requests.delete, f"{self.api}/dp/v1/collections/{collection_uuid}?visibility=PRIVATE", headers=headers
+        )
         self.assertEqual(res.status_code, requests.codes.created)
         self.assertIn("collection_uuid", data)
 

--- a/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
+++ b/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
@@ -189,7 +189,7 @@ class TestPublish(BaseAuthAPITest):
             dataset = self.generate_dataset(
                 self.session, collection_id=collection.id, collection_visibility=collection.visibility
             )
-            self.generate_asset(self.session, dataset.id, file_type=DatasetArtifactFileType.CXG)
+            self.generate_asset(self.session, dataset.id, filetype=DatasetArtifactFileType.CXG)
 
         path = f"/dp/v1/collections/{collection.id}/publish"
         response = self.app.post(path, headers=self.headers_authed, data=json.dumps(self.publish_body))

--- a/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
+++ b/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime
 from mock import Mock, patch
 
-from backend.corpora.common.corpora_orm import CollectionVisibility, CollectionLinkType
+from backend.corpora.common.corpora_orm import CollectionVisibility, CollectionLinkType, DatasetArtifactFileType
 from tests.unit.backend.corpora.api_server.base_api_test import BaseAuthAPITest, BasicAuthAPITestCurator
 from tests.unit.backend.corpora.api_server.mock_auth import get_auth_token
 
@@ -179,6 +179,21 @@ class TestPublish(BaseAuthAPITest):
         path = f"/dp/v1/collections/{collection.id}/publish"
         response = self.app.post(path, headers=self.headers_authed, data=json.dumps(self.publish_body))
         self.assertEqual(409, response.status_code)
+
+    @patch("backend.corpora.common.entities.dataset_asset.s3_client.head_object")
+    def test__publish_with_Duplicate_dataset__200(self, mocked):
+        """Only H5AD files are checked."""
+        mocked.return_value = {"ETag": "ABCDEF"}
+        collection = self.generate_collection(self.session)
+        for i in range(2):
+            dataset = self.generate_dataset(
+                self.session, collection_id=collection.id, collection_visibility=collection.visibility
+            )
+            self.generate_asset(self.session, dataset.id, file_type=DatasetArtifactFileType.CXG)
+
+        path = f"/dp/v1/collections/{collection.id}/publish"
+        response = self.app.post(path, headers=self.headers_authed, data=json.dumps(self.publish_body))
+        self.assertEqual(201, response.status_code)
 
 
 class TestPublishCurators(BasicAuthAPITestCurator):

--- a/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
+++ b/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
@@ -193,7 +193,7 @@ class TestPublish(BaseAuthAPITest):
 
         path = f"/dp/v1/collections/{collection.id}/publish"
         response = self.app.post(path, headers=self.headers_authed, data=json.dumps(self.publish_body))
-        self.assertEqual(201, response.status_code)
+        self.assertEqual(202, response.status_code)
 
 
 class TestPublishCurators(BasicAuthAPITestCurator):


### PR DESCRIPTION
Only check h5ad File for duplication across datasets in a collection. Don't check derived files for duplication. This was added because smoke tests were failing with a 500 error when publishing a collection. This was caused by the way were are retrieving metadata from S3. When parsing the file name from the S3 URI we were not taking into account that the URI for the CXG artifact was to a directory. Thus when requesting metadata for a directory, S3 return 404. Rather than retrieving all of the files from the CXG directory and check for duplication it's faster and easier to check if the source H5AD file is duplicated across the datasets in the collection. Since the H5AD file is used to generate the other artifacts, it's safe to assume if the H5AD file are unique, then the derived artifacts must also be unique.

**This currently blocks publishing a collection.**

### Reviewers
**Functional:** @danieljhegeman 

**Readability:** @seve 

---

## Changes
- modify duplication detection during publication to only check H5AD files.
- add collection clean up for smoke-tests. 
- add a test that we are only duplication check H5AD files.

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
