### PR TITLE
feat: create DOI normalization function

### DIFF
--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -1,11 +1,12 @@
 import typing
 from datetime import datetime
+from urllib.parse import urlparse
 from sqlalchemy import and_
 
 from . import Dataset
 from .entity import Entity
 from .geneset import Geneset
-from ..corpora_orm import DbCollection, DbCollectionLink, CollectionVisibility
+from ..corpora_orm import CollectionLinkType, DbCollection, DbCollectionLink, CollectionVisibility
 from ..utils.db_helpers import clone
 
 
@@ -280,3 +281,18 @@ class Collection(Entity):
     def check_has_dataset(self, dataset: Dataset) -> bool:
         """Check that a dataset is part of the collection"""
         return all([self.id == dataset.collection_id, self.visibility == dataset.collection_visibility])
+
+    @staticmethod
+    def _normalize_doi(doi_url) -> str:
+        try:
+            return urlparse(doi_url.strip()).path.strip("/")
+        except Exception:
+            return None
+
+    def get_normalized_doi(self) -> str:
+        """Returns a normalized DOI if it exists, None otherwise"""
+        doi = [link for link in self.links if link.link_type == CollectionLinkType.DOI]
+        if doi:
+            return self._normalize_doi(doi[0].link_url)
+        else:
+            return None

--- a/tests/unit/backend/corpora/common/entities/test_collection.py
+++ b/tests/unit/backend/corpora/common/entities/test_collection.py
@@ -46,6 +46,31 @@ class TestCollection(DataPortalTestCase):
         with self.assertRaises(SQLAlchemyError):
             Collection.get(self.session, invalid_visibility_key)
 
+    def test__normalize_doi(self):
+        # Removes doi.org
+        normalized_doi = Collection._normalize_doi("http://doi.org/part1/part2")
+        self.assertEqual("part1/part2", normalized_doi)
+
+        # Removes www.doi.org
+        normalized_doi = Collection._normalize_doi("http://www.doi.org/part1/part2")
+        self.assertEqual("part1/part2", normalized_doi)
+
+        # Handes whitespaces correctly
+        normalized_doi = Collection._normalize_doi(" https://doi.org/part1/part2 ")
+        self.assertEqual("part1/part2", normalized_doi)
+
+        # If a plain DOI (no URL) is passed, return it
+        normalized_doi = Collection._normalize_doi("part1/part2")
+        self.assertEqual("part1/part2", normalized_doi)
+
+    def test__get_normalized_doi(self):
+        key = (self.uuid, self.visibility)
+        collection = Collection.get(self.session, key)
+        normalized_doi = collection.get_normalized_doi()
+        # The mocked DOI for the test collection is http://test_doi_url.place, 
+        # so the normalized DOI is an empty string
+        self.assertEqual(normalized_doi, "")
+
     def test__create_collection_creates_associated_links(self):
         """
         Create a collection with a variable number of links.

--- a/tests/unit/backend/corpora/common/entities/test_collection.py
+++ b/tests/unit/backend/corpora/common/entities/test_collection.py
@@ -67,7 +67,7 @@ class TestCollection(DataPortalTestCase):
         key = (self.uuid, self.visibility)
         collection = Collection.get(self.session, key)
         normalized_doi = collection.get_normalized_doi()
-        # The mocked DOI for the test collection is http://test_doi_url.place, 
+        # The mocked DOI for the test collection is http://test_doi_url.place,
         # so the normalized DOI is an empty string
         self.assertEqual(normalized_doi, "")
 


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MDunitz 

**Readability:** 

Ticket [#1803](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1803)

---

## Changes
- Adds a function that returns a normalized DOI for a collection. This DOI doesn't have an URL format and will be used to call the Crossref API to retrieve the metadata.
