### PR TITLE
fix: updated staleTime for filter queries. (#1773)

### DIFF
--- a/frontend/src/common/queries/filter.ts
+++ b/frontend/src/common/queries/filter.ts
@@ -15,6 +15,13 @@ import { checkIsOverMaxCellCount } from "src/components/common/Grid/common/utils
 import { API_URL } from "src/configs/configs";
 
 /**
+ * Never expire cached collections and datasets. TODO revisit once state management approach is confirmed (#1809).
+ */
+const DEFAULT_QUERY_OPTIONS = {
+  staleTime: Infinity,
+};
+
+/**
  * Query key for /collections/index
  */
 const QUERY_ID_COLLECTIONS = "collectionsIndex";
@@ -152,7 +159,10 @@ export function useFetchCollections(): UseQueryResult<
 > {
   return useQuery<Map<string, CollectionResponse>>(
     [USE_COLLECTIONS_INDEX],
-    fetchCollections
+    fetchCollections,
+    {
+      ...DEFAULT_QUERY_OPTIONS,
+    }
   );
 }
 
@@ -199,7 +209,9 @@ export function useFetchDatasetRows(): FetchCategoriesRows<DatasetRow> {
  * fields.
  */
 export function useFetchDatasets(): UseQueryResult<DatasetResponse[]> {
-  return useQuery<DatasetResponse[]>([USE_DATASETS_INDEX], fetchDatasets);
+  return useQuery<DatasetResponse[]>([USE_DATASETS_INDEX], fetchDatasets, {
+    ...DEFAULT_QUERY_OPTIONS,
+  });
 }
 
 /**


### PR DESCRIPTION
### Reviewers
**Functional:** 
@tihuan 

---

## Changes
* Updated `stateTime` of filter-related queries to never expire.
* Note: data refresh-management will not be handled in Q1 2022. `staleTime` could be replaced with `refetchOnWindowFocus` during update of filter state management in _[Remember filter while navigating within the Portal](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1811)_ (if data re-fetching without clearing selected filters is supported).

## Definition of Done (from ticket)
* Any selected filters remain selected on blur and refocus of browser tab.

## QA steps
1. View collections page.
1. Select at least one category value from the filter sidebar.
1. Click to different browser tab.
1. Click back to tab containing collections page.

 => Selected filter should still be selected.

