### PR TITLE
chore: set rdev instance_count to 1

### DIFF
--- a/.happy/terraform/envs/rdev/main.tf
+++ b/.happy/terraform/envs/rdev/main.tf
@@ -12,6 +12,8 @@ module stack {
   require_okta                 = true
   stack_prefix                 = "/${var.stack_name}"
   batch_container_memory_limit = 28000
+  backend_instance_count       = 1
+  frontend_instance_count      = 1
 
   wait_for_steady_state        = var.wait_for_steady_state
 }

--- a/.happy/terraform/modules/ecs-stack/variables.tf
+++ b/.happy/terraform/modules/ecs-stack/variables.tf
@@ -85,11 +85,11 @@ variable batch_container_memory_limit {
 variable frontend_instance_count {
   type        = number
   description = "How many frontend tasks to run"
-  default     = 1
+  default     = 2
 }
 
 variable backend_instance_count {
   type        = number
   description = "How many backend tasks to run"
-  default     = 1
+  default     = 2
 }

--- a/.happy/terraform/modules/ecs-stack/variables.tf
+++ b/.happy/terraform/modules/ecs-stack/variables.tf
@@ -85,11 +85,11 @@ variable batch_container_memory_limit {
 variable frontend_instance_count {
   type        = number
   description = "How many frontend tasks to run"
-  default     = 2
+  default     = 1
 }
 
 variable backend_instance_count {
   type        = number
   description = "How many backend tasks to run"
-  default     = 2
+  default     = 1
 }


### PR DESCRIPTION
### Reviewers
**Functional:** 
@metakuni 

**Readability:** 

---

## Changes
- Set rdev instance_count to 1. This will help us save some memory and avoid adding EC2 machines.
