### PR TITLE
fix: removed flash of no results for filtered grids. (#1797)

### DIFF
--- a/frontend/src/common/queries/filter.ts
+++ b/frontend/src/common/queries/filter.ts
@@ -120,6 +120,10 @@ export function useFetchCollectionRows(): FetchCategoriesRows<CollectionRow> {
   // View model built from join of collections response and aggregated metadata of dataset rows.
   const [collectionRows, setCollectionRows] = useState<CollectionRow[]>([]);
 
+  // Fetch states
+  const [isError, setIsError] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
   // Fetch datasets.
   const {
     data: datasets,
@@ -134,18 +138,28 @@ export function useFetchCollectionRows(): FetchCategoriesRows<CollectionRow> {
     isLoading: collectionsLoading,
   } = useFetchCollections();
 
-  // Build dataset rows once datasets and collections responses have resolved.
+  // Build collection rows once datasets and collections responses have resolved. Update loading and error fetch states.
   useEffect(() => {
+    setIsLoading(datasetsLoading || collectionsLoading);
+    setIsError(datasetsError || collectionsError);
+
     if (!datasets || !collectionsById) {
       return;
     }
     const datasetRows = buildDatasetRows(collectionsById, datasets);
     setCollectionRows(buildCollectionRows(collectionsById, datasetRows));
-  }, [datasets, collectionsById]);
+  }, [
+    collectionsById,
+    collectionsError,
+    collectionsLoading,
+    datasets,
+    datasetsError,
+    datasetsLoading,
+  ]);
 
   return {
-    isError: datasetsError || collectionsError,
-    isLoading: datasetsLoading || collectionsLoading,
+    isError,
+    isLoading,
     rows: collectionRows,
   };
 }
@@ -174,6 +188,10 @@ export function useFetchDatasetRows(): FetchCategoriesRows<DatasetRow> {
   // View model built from join of datasets and collections responses.
   const [datasetRows, setDatasetRows] = useState<DatasetRow[]>([]);
 
+  // Fetch states
+  const [isError, setIsError] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
   // Fetch datasets.
   const {
     data: datasets,
@@ -188,17 +206,27 @@ export function useFetchDatasetRows(): FetchCategoriesRows<DatasetRow> {
     isLoading: collectionsLoading,
   } = useFetchCollections();
 
-  // Build dataset rows once datasets and collections responses have resolved.
+  // Build dataset rows once datasets and collections responses have resolved. Update loading and error fetch states.
   useEffect(() => {
+    setIsLoading(datasetsLoading || collectionsLoading);
+    setIsError(datasetsError || collectionsError);
+
     if (!datasets || !collectionsById) {
       return;
     }
     setDatasetRows(buildDatasetRows(collectionsById, datasets));
-  }, [datasets, collectionsById]);
+  }, [
+    collectionsById,
+    collectionsError,
+    collectionsLoading,
+    datasets,
+    datasetsError,
+    datasetsLoading,
+  ]);
 
   return {
-    isError: datasetsError || collectionsError,
-    isLoading: datasetsLoading || collectionsLoading,
+    isError,
+    isLoading,
     rows: datasetRows,
   };
 }

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -1,4 +1,3 @@
-import loadable from "@loadable/component";
 import Head from "next/head";
 import React, { useMemo } from "react";
 import { Column, useFilters, useSortBy, useTable } from "react-table";
@@ -40,22 +39,9 @@ const COLLECTION_NAME = "name";
  */
 const COLUMN_ID_RECENCY = "recency";
 
-/**
- * Gene sets CSV upload functionality, available if gene sets feature flag is enabled
- */
-const AsyncUploadCSV = loadable(
-  () =>
-    /*webpackChunkName: 'src/components/UploadCSV' */ import(
-      "src/components/UploadCSV"
-    )
-);
-
 export default function Collections(): JSX.Element {
   // Pop toast if user has been redirected from a tombstoned collection.
   useExplainTombstoned();
-
-  // Determine if gene sets functionality is available to user.
-  const isGeneSetsOn = useFeatureFlag(FEATURES.GENE_SETS);
 
   // Filterable collection datasets joined from datasets index and collections index responses.
   const { isError, isLoading, rows: collectionRows } = useFetchCollectionRows();
@@ -199,10 +185,6 @@ export default function Collections(): JSX.Element {
             <Filter {...filterInstance} />
           </SideBar>
           <View>
-            {
-              // (thuang): TEMP. Remove when we do https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/corpora-data-portal/917
-              isGeneSetsOn && <AsyncUploadCSV />
-            }
             {!rows || rows.length === 0 ? (
               <GridHero>
                 <h3>No Results</h3>


### PR DESCRIPTION
### Reviewers
**Functional:** 
@tihuan 

---

## Changes
- Updated state management of filter-related queries.
- Freebie: removed gene set-related functionality from collections page as per [Slack](https://clevercanary.slack.com/archives/C02CF7MQPGV/p1642706774046900?thread_ts=1642655185.046100&cid=C02CF7MQPGV) ([here](https://github.com/chanzuckerberg/single-cell-data-portal/pull/1870/files#diff-cacbfc6dcdd6f563592e6b8dbe34c27d187e17be08ab7211320aaf4dd76cbe82L43), [here](https://github.com/chanzuckerberg/single-cell-data-portal/pull/1870/files#diff-cacbfc6dcdd6f563592e6b8dbe34c27d187e17be08ab7211320aaf4dd76cbe82L57) and [here](https://github.com/chanzuckerberg/single-cell-data-portal/pull/1870/files#diff-cacbfc6dcdd6f563592e6b8dbe34c27d187e17be08ab7211320aaf4dd76cbe82L202)).

## Definition of Done
* "No results" is only displayed if collections and datasets are loaded and there are no results matching the selected filter.

## QA steps
### Collections
1. View `/collections` with a throttled network (e.g. "Fast 3G").
=> Collections should load without briefly displaying "No Results" hero.

### Datasets
1. View `/datasets` with a throttled network (e.g. "Fast 3G").
=> Datasets should load without briefly displaying "No Results" hero.
