### PR TITLE
fix: ensure toast about rds incompatibility is presented

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -11,7 +11,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v3.4.0
+      - uses: amannn/action-semantic-pull-request@v3.4.1
         with:
           validateSingleCommit: true
         env:

--- a/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/index.tsx
@@ -160,8 +160,6 @@ const DatasetRow: FC<Props> = ({
 
   const isOverMaxCellCount = checkIsOverMaxCellCount(cell_count);
 
-  const isRDSSkipped = datasetStatus.rds_status === CONVERSION_STATUS.SKIPPED;
-
   return (
     <tr>
       <td>
@@ -225,8 +223,6 @@ const DatasetRow: FC<Props> = ({
             dataAssets={dataset?.dataset_assets}
             Button={DownloadButton}
             isDisabled={dataset.tombstone}
-            // isRDSSkipped is drilled 3 components down to `frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx`
-            isRDSSkipped={isRDSSkipped}
           />
           {hasCXGFile(dataset) && (
             <Tooltip

--- a/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DownloadDataset/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DownloadDataset/index.tsx
@@ -11,7 +11,6 @@ interface Props {
   Button?: React.ElementType;
   datasetId: string;
   isDisabled?: boolean;
-  isRDSSkipped: boolean;
   name: string;
 }
 
@@ -24,7 +23,6 @@ interface Props {
 const DownloadDataset: FC<Props> = ({
   Button = StyledButton,
   datasetId,
-  isRDSSkipped,
   isDisabled = false,
   name,
 }) => {
@@ -78,7 +76,6 @@ const DownloadDataset: FC<Props> = ({
             name={name}
             dataAssets={datasetAssets}
             onClose={toggleOpen}
-            isRDSSkipped={isRDSSkipped}
           />
         ) : null}
       </Modal>

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
@@ -16,7 +16,6 @@ interface Props {
   isDisabled: boolean;
   selectedFormat: DATASET_ASSET_FORMAT | "";
   availableFormats: DATASET_ASSET_FORMAT[];
-  isRDSSkipped: boolean;
 }
 
 const DataFormat: FC<Props> = ({
@@ -24,7 +23,6 @@ const DataFormat: FC<Props> = ({
   isDisabled = false,
   selectedFormat,
   availableFormats,
-  isRDSSkipped,
 }) => {
   const handleChange = (event: React.FormEvent<HTMLElement>) => {
     const value = (event.target as HTMLInputElement)
@@ -80,7 +78,9 @@ const DataFormat: FC<Props> = ({
         selectedValue={selectedFormat}
       >
         {renderH5adRadio()}
-        {isRDSSkipped ? renderDisabledRdsRadio() : renderRdsRadio()}
+        {availableFormats.includes(DATASET_ASSET_FORMAT.RDS)
+          ? renderRdsRadio()
+          : renderDisabledRdsRadio()}
       </RadioGroup>
     </Section>
   );

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
@@ -15,10 +15,9 @@ interface Props {
   onClose: () => void;
   name: string;
   dataAssets: Dataset["dataset_assets"];
-  isRDSSkipped: boolean;
 }
 
-const Content: FC<Props> = ({ onClose, name, dataAssets, isRDSSkipped }) => {
+const Content: FC<Props> = ({ onClose, name, dataAssets }) => {
   const [selectedFormat, setSelectedFormat] = useState<
     DATASET_ASSET_FORMAT | ""
   >("");
@@ -114,7 +113,6 @@ const Content: FC<Props> = ({ onClose, name, dataAssets, isRDSSkipped }) => {
             isDisabled={isLoading}
             selectedFormat={selectedFormat}
             availableFormats={availableFormats}
-            isRDSSkipped={isRDSSkipped}
           />
           <Details
             isLoading={isLoading}

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/index.tsx
@@ -12,12 +12,10 @@ interface Props {
   dataAssets: Dataset["dataset_assets"];
   isDisabled?: boolean;
   Button?: React.ElementType;
-  isRDSSkipped: boolean;
 }
 
 const DownloadDataset: FC<Props> = ({
   name,
-  isRDSSkipped,
   dataAssets = EMPTY_ARRAY,
   isDisabled = false,
   Button = StyledButton,
@@ -48,12 +46,7 @@ const DownloadDataset: FC<Props> = ({
       </Tooltip>
 
       <Modal title="Download Dataset" isOpen={isOpen} onClose={toggleOpen}>
-        <Content
-          name={name}
-          dataAssets={dataAssets}
-          onClose={toggleOpen}
-          isRDSSkipped={isRDSSkipped}
-        />
+        <Content name={name} dataAssets={dataAssets} onClose={toggleOpen} />
       </Modal>
     </>
   );

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
@@ -159,8 +159,6 @@ const DatasetRow: FC<Props> = ({
 
   const isOverMaxCellCount = checkIsOverMaxCellCount(cell_count);
 
-  const isRDSSkipped = datasetStatus.rds_status === CONVERSION_STATUS.SKIPPED;
-
   return (
     <StyledRow>
       <DetailsCell>
@@ -228,8 +226,6 @@ const DatasetRow: FC<Props> = ({
               dataAssets={dataset?.dataset_assets}
               Button={DownloadButton}
               isDisabled={dataset.tombstone}
-              // isRDSSkipped is drilled 3 components down to `frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx`
-              isRDSSkipped={isRDSSkipped}
             />
           </ActionButton>
 

--- a/frontend/src/components/Datasets/components/Grid/components/DatasetActionsCell/index.tsx
+++ b/frontend/src/components/Datasets/components/Grid/components/DatasetActionsCell/index.tsx
@@ -10,7 +10,6 @@ import DatasetExploreSvg from "src/components/Datasets/components/Grid/component
 interface Props {
   datasetId: string;
   isOverMaxCellCount: boolean;
-  isRDSSkipped: boolean;
   name: string;
   tombstone: boolean;
   explorerUrl: string;
@@ -20,7 +19,6 @@ export default function DatasetsActionsCell({
   datasetId,
   explorerUrl,
   isOverMaxCellCount = false, // TODO(cc) either set isOverMaxCellCount here to false when undefined or in parent...
-  isRDSSkipped,
   name,
   tombstone,
 }: Props): JSX.Element {
@@ -38,7 +36,6 @@ export default function DatasetsActionsCell({
         Button={DownloadButton}
         datasetId={datasetId}
         isDisabled={tombstone || !explorerUrl}
-        isRDSSkipped={isRDSSkipped}
         name={name}
       />
       <Tooltip

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -130,7 +130,6 @@ export default function Datasets(): JSX.Element {
           <DatasetsActionsCell
             datasetId={values.id}
             isOverMaxCellCount={values.isOverMaxCellCount}
-            isRDSSkipped={false} // We can ignore RDS skipped check for public datasets (as this is curator-specific).
             name={values.name}
             tombstone={false} // Only public datasets are displayed in the datasets index.
             explorerUrl={values.explorer_url}


### PR DESCRIPTION
This commit simplifies the previous logic for determining whether or not
to display a message to the user telling them that rds is unavailable
specifically when it is due to the conversation status being set to
SKIPPED. This change makes the code more blunt -- now the message is
displayed whenever rds is unavailable, regardless of whether the
conversion status is SKIPPED. This helps address a bug where the status
is not updated to SKIPPED after dataset processor (?) crash.

### Reviewers
**Functional:** 
@seve 
**Readability:** 

---

## Changes
- add
- remove all instances of isRDSSkipped flag and simply go by presence/absence of rds asset
- modify

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
