### PR TITLE
fix: Datasets tab requires horizontal scrolling (#1771)

### DIFF
--- a/frontend/src/components/Collection/components/CollectionDatasetsGrid/style.ts
+++ b/frontend/src/components/Collection/components/CollectionDatasetsGrid/style.ts
@@ -2,7 +2,10 @@ import DatasetsGrid from "src/components/Collection/components/CollectionDataset
 import styled from "styled-components";
 
 export const CollectionDatasetsGrid = styled(DatasetsGrid)`
-  grid-template-columns:
-    minmax(520px, 6.9fr) minmax(200px, 2.5fr) minmax(160px, 2fr)
-    repeat(2, minmax(104px, 1.3fr)) minmax(80px, 1fr) minmax(64px, auto); /* collection column min value at 520px to allow for more dropdown action button */
+  grid-template-columns: 13.2fr 5fr 4fr repeat(2, 3fr) 2fr auto;
+
+  th,
+  td {
+    word-break: break-word; /* word break on columns; maintains grid fr allocation on small viewports */
+  }
 `;

--- a/frontend/src/components/Collections/components/Grid/components/CollectionsGrid/style.ts
+++ b/frontend/src/components/Collections/components/Grid/components/CollectionsGrid/style.ts
@@ -2,8 +2,12 @@ import Grid from "src/components/common/Grid";
 import styled from "styled-components";
 
 export const CollectionsGrid = styled(Grid)`
-  grid-template-columns: minmax(552px, 4.6fr) repeat(2, minmax(200px, 1.5fr)) minmax(
-      120px,
-      1fr
-    ); /* review grid template when publications column added */
+  grid-template-columns:
+    minmax(0, 8fr)
+    minmax(0, 5.4fr) repeat(2, minmax(0, 5fr)) minmax(0, 3fr);
+
+  th:first-of-type,
+  td:first-of-type {
+    grid-column: 1 / 3; /* review grid column allocation for collection name when publications column added */
+  }
 `;

--- a/frontend/src/components/Datasets/components/Grid/components/DatasetsGrid/style.ts
+++ b/frontend/src/components/Datasets/components/Grid/components/DatasetsGrid/style.ts
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 export const DatasetsGrid = styled(Grid)`
   grid-template-columns:
-    minmax(312px, 3.9fr) minmax(200px, 2.5fr) minmax(160px, 2fr)
-    repeat(2, minmax(104px, 1.3fr)) minmax(80px, 1fr) 64px;
+    minmax(0, 8fr) minmax(0, 4.2fr) minmax(0, 4fr)
+    repeat(2, minmax(0, 3fr))
+    minmax(0, 2fr) 56px;
 `;

--- a/frontend/src/components/common/Grid/components/ActionButton/style.ts
+++ b/frontend/src/components/common/Grid/components/ActionButton/style.ts
@@ -4,9 +4,9 @@ import styled from "styled-components";
 
 export const ActionButton = styled(Button)`
   &.${Classes.BUTTON}.${Classes.MINIMAL} {
-    height: 32px;
-    padding: 8px;
-    width: 32px;
+    height: 24px;
+    padding: 4px;
+    width: 24px;
 
     svg {
       fill: ${PRIMARY_BLUE};

--- a/frontend/src/components/common/Grid/components/ActionsCell/style.ts
+++ b/frontend/src/components/common/Grid/components/ActionsCell/style.ts
@@ -2,7 +2,8 @@ import styled from "styled-components";
 
 export const Actions = styled.div`
   display: grid;
-  grid-auto-columns: 32px; /* specifies an action button slot of 32px */
+  gap: 0 8px;
+  grid-auto-columns: 24px; /* specifies an action button slot of 24px */
   grid-auto-flow: column;
-  margin-top: -8px; /* visually top aligns action button icon with td padding and maintains desired action button clickable area */
+  margin-top: -4px; /* visually top aligns action button icon with td padding and maintains desired action button clickable area */
 `;

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -185,7 +185,7 @@ const Collection: FC = () => {
       <Head>
         <title>cellxgene | {collection.name}</title>
       </Head>
-      <ViewGrid>
+      <ViewGrid isFilterEnabled={isFilterEnabled}>
         {collection.has_revision && visibility === VISIBILITY_TYPE.PRIVATE && (
           <StyledCallout intent={Intent.PRIMARY} icon={null}>
             <span data-test-id="revision-status">

--- a/frontend/src/views/Collection/style.ts
+++ b/frontend/src/views/Collection/style.ts
@@ -14,7 +14,6 @@ export const Description = styled.div`
   line-height: 18px;
   letter-spacing: -0.1px;
   text-align: left;
-  width: 90ch;
 `;
 
 export const LinkContainer = styled.div`

--- a/frontend/src/views/globalStyle.ts
+++ b/frontend/src/views/globalStyle.ts
@@ -2,12 +2,20 @@ import { layout } from "src/components/common/layout";
 import { contentWrapper } from "src/components/Layout/style";
 import styled from "styled-components";
 
-export const ViewGrid = styled.div`
+interface Props {
+  isFilterEnabled?: boolean;
+}
+
+export const ViewGrid = styled.div<Props>`
   ${layout}
   ${contentWrapper}
   display: grid;
   grid-template-columns: repeat(8, 1fr);
   margin-top: 10vh;
+  min-width: ${(props) =>
+    props.isFilterEnabled
+      ? "unset"
+      : undefined}; /* overrides layout min-width specification to facilitate shrink to fit responsiveness */
 `;
 
 export const View = styled.div`


### PR DESCRIPTION
### Reviewers
**Functional:**
@tihuan

---

## Changes
- Modified collections, datasets and collection datasets grids to match mocks ([here](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=2667%3A29344), [here](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=2667%3A29372) and [here](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=2805%3A29708)) in order to prevent horizontal scroll.
