### PR TITLE
feat: Delete rows and columns infrastructure

### DIFF
--- a/frontend/src/views/WheresMyGene/common/store/actions.ts
+++ b/frontend/src/views/WheresMyGene/common/store/actions.ts
@@ -1,0 +1,94 @@
+/**
+ * Create a corresponding action creator function for each action type defined
+ * in `./reducer.ts`.
+ */
+
+import { REDUCERS, State } from "./reducer";
+
+export function deleteSelectedGenesAndSelectedCellTypeIds({
+  genesToDelete,
+  cellTypeIdsToDelete,
+}: {
+  genesToDelete: string[];
+  cellTypeIdsToDelete: string[];
+}): GetActionTypeOfReducer<
+  typeof REDUCERS["deleteSelectedGenesAndSelectedCellTypeIds"]
+> {
+  return {
+    payload: {
+      cellTypeIdsToDelete,
+      genesToDelete,
+    },
+    type: "deleteSelectedGenesAndSelectedCellTypeIds",
+  };
+}
+
+export function toggleGeneToDelete(
+  geneToDelete: string
+): GetActionTypeOfReducer<typeof REDUCERS["toggleGeneToDelete"]> {
+  return {
+    payload: geneToDelete,
+    type: "toggleGeneToDelete",
+  };
+}
+
+export function toggleCellTypeIdToDelete(
+  cellTypeIdToDelete: string
+): GetActionTypeOfReducer<typeof REDUCERS["toggleCellTypeIdToDelete"]> {
+  return {
+    payload: cellTypeIdToDelete,
+    type: "toggleCellTypeIdToDelete",
+  };
+}
+
+export function selectOrganism(
+  organism: State["selectedOrganism"]
+): GetActionTypeOfReducer<typeof REDUCERS["selectOrganism"]> {
+  return {
+    payload: organism,
+    type: "selectOrganism",
+  };
+}
+
+export function selectGenes(
+  genes: State["selectedGenes"]
+): GetActionTypeOfReducer<typeof REDUCERS["selectGenes"]> {
+  return {
+    payload: genes,
+    type: "selectGenes",
+  };
+}
+
+export function selectCellTypeIds(
+  cellTypeIndices: State["selectedCellTypeIds"]
+): GetActionTypeOfReducer<typeof REDUCERS["selectCellTypeIds"]> {
+  return {
+    payload: cellTypeIndices,
+    type: "selectCellTypeIds",
+  };
+}
+
+export function selectTissues(
+  tissues: State["selectedTissues"]
+): GetActionTypeOfReducer<typeof REDUCERS["selectTissues"]> {
+  return {
+    payload: tissues,
+    type: "selectTissues",
+  };
+}
+
+export function resetGenesToDeleteAndCellTypeIdsToDelete(): GetActionTypeOfReducer<
+  typeof REDUCERS["resetGenesToDeleteAndCellTypeIdsToDelete"]
+> {
+  return {
+    payload: null,
+    type: "resetGenesToDeleteAndCellTypeIdsToDelete",
+  };
+}
+
+type GetActionTypeOfReducer<T> = T extends (
+  state: never,
+  action: infer Action
+) => unknown
+  ? Action
+  : never;

--- a/frontend/src/views/WheresMyGene/common/store/index.ts
+++ b/frontend/src/views/WheresMyGene/common/store/index.ts
@@ -1,0 +1,10 @@
+import { createContext, Dispatch } from "react";
+import { INITIAL_STATE, PayloadAction, State } from "./reducer";
+
+export { reducer } from "./reducer";
+export type { State };
+export { INITIAL_STATE };
+export const DispatchContext = createContext<Dispatch<
+  PayloadAction<unknown>
+> | null>(null);
+export const StateContext = createContext<State>(INITIAL_STATE);

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -1,0 +1,178 @@
+export interface PayloadAction<Payload> {
+  type: keyof typeof REDUCERS;
+  payload: Payload;
+}
+
+export interface State {
+  cellTypeIdsToDelete: string[];
+  genesToDelete: string[];
+  selectedGenes: string[];
+  selectedCellTypeIds: string[];
+  selectedOrganism: string;
+  selectedTissues: string[];
+}
+
+export const INITIAL_STATE: State = {
+  cellTypeIdsToDelete: [],
+  genesToDelete: [],
+  selectedCellTypeIds: [],
+  selectedGenes: [],
+  selectedOrganism: "",
+  selectedTissues: [],
+};
+
+export const REDUCERS = {
+  deleteSelectedGenesAndSelectedCellTypeIds,
+  resetGenesToDeleteAndCellTypeIdsToDelete,
+  selectCellTypeIds,
+  selectGenes,
+  selectOrganism,
+  selectTissues,
+  toggleCellTypeIdToDelete,
+  toggleGeneToDelete,
+};
+
+export function reducer(state: State, action: PayloadAction<unknown>): State {
+  const { type } = action;
+
+  const handler = REDUCERS[type];
+
+  if (!handler) {
+    throw new Error(`Unknown action type: ${type}`);
+  }
+
+  /**
+   * (thuang): Figuring out the typing here is more work than its rewards
+   * Ideally we'll use Redux Toolkit's `createSlice` here, but I think that's
+   * too heavy for now
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return handler(state, action as any);
+}
+
+/**
+ * Individual action type reducers below. Please add their corresponding action
+ * creators in `./actions.ts`
+ */
+
+function deleteSelectedGenesAndSelectedCellTypeIds(
+  state: State,
+  action: PayloadAction<{
+    genesToDelete: string[];
+    cellTypeIdsToDelete: string[];
+  }>
+): State {
+  const { genesToDelete, cellTypeIdsToDelete } = action.payload;
+
+  if (!genesToDelete.length && !cellTypeIdsToDelete.length) {
+    return state;
+  }
+
+  const { selectedGenes, selectedCellTypeIds } = state;
+
+  const newSelectedGenes = deleteByIds<State["selectedGenes"][number]>(
+    selectedGenes,
+    genesToDelete
+  );
+
+  const newSelectedCellTypeIds = deleteByIds<
+    State["selectedCellTypeIds"][number]
+  >(selectedCellTypeIds, cellTypeIdsToDelete);
+
+  return {
+    ...state,
+    selectedCellTypeIds: newSelectedCellTypeIds,
+    selectedGenes: newSelectedGenes,
+  };
+}
+
+function selectOrganism(state: State, action: PayloadAction<string>): State {
+  return {
+    ...state,
+    selectedOrganism: action.payload,
+  };
+}
+
+function selectGenes(
+  state: State,
+  action: PayloadAction<State["selectedGenes"]>
+): State {
+  return {
+    ...state,
+    cellTypeIdsToDelete: [],
+    genesToDelete: [],
+    selectedGenes: action.payload,
+  };
+}
+
+function selectCellTypeIds(
+  state: State,
+  action: PayloadAction<State["selectedCellTypeIds"]>
+): State {
+  return {
+    ...state,
+    selectedCellTypeIds: action.payload,
+  };
+}
+
+function selectTissues(
+  state: State,
+  action: PayloadAction<State["selectedTissues"]>
+): State {
+  return {
+    ...state,
+    selectedTissues: action.payload,
+  };
+}
+
+function toggleGeneToDelete(
+  state: State,
+  action: PayloadAction<string>
+): State {
+  if (state.genesToDelete.includes(action.payload)) {
+    return {
+      ...state,
+      genesToDelete: deleteByIds<string>(state.genesToDelete, [action.payload]),
+    };
+  }
+
+  return {
+    ...state,
+    genesToDelete: [...state.genesToDelete, action.payload],
+  };
+}
+
+function toggleCellTypeIdToDelete(
+  state: State,
+  action: PayloadAction<string>
+): State {
+  if (state.cellTypeIdsToDelete.includes(action.payload)) {
+    return {
+      ...state,
+      cellTypeIdsToDelete: deleteByIds<string>(state.cellTypeIdsToDelete, [
+        action.payload,
+      ]),
+    };
+  }
+
+  return {
+    ...state,
+    cellTypeIdsToDelete: [...state.cellTypeIdsToDelete, action.payload],
+  };
+}
+
+function deleteByIds<Item>(collection: Item[], collectionToDelete: Item[]) {
+  return collection.filter((item) => !collectionToDelete.includes(item));
+}
+
+function resetGenesToDeleteAndCellTypeIdsToDelete(
+  state: State,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _: PayloadAction<null>
+): State {
+  return {
+    ...state,
+    cellTypeIdsToDelete: [],
+    genesToDelete: [],
+  };
+}

--- a/frontend/src/views/WheresMyGene/components/GeneFetcher/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneFetcher/index.tsx
@@ -5,7 +5,6 @@ import { apiTemplateToUrl } from "src/common/utils/apiTemplateToUrl";
 import { API_URL } from "src/configs/configs";
 import {
   CellTypeGeneExpressionSummaryData,
-  Gene,
   GeneExpressionSummary,
   RawCellTypeGeneExpressionSummaryData,
 } from "../../common/types";
@@ -16,7 +15,6 @@ interface Props {
   onError: (id: string) => void;
   minDelayMS?: number;
   maxDelayMS?: number;
-  fetchedGenes: Gene[];
 }
 
 const renderedGenes: string[] = [];

--- a/frontend/src/views/WheresMyGene/components/HeatMap/hooks/useDeleteGenesAndCellTypes.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/hooks/useDeleteGenesAndCellTypes.ts
@@ -1,0 +1,53 @@
+import { useCallback, useContext } from "react";
+import {
+  DispatchContext,
+  StateContext,
+} from "src/views/WheresMyGene/common/store";
+import {
+  resetGenesToDeleteAndCellTypeIdsToDelete,
+  toggleCellTypeIdToDelete,
+  toggleGeneToDelete,
+} from "src/views/WheresMyGene/common/store/actions";
+
+export function useDeleteGenesAndCellTypes(): {
+  cellTypeIdsToDelete: string[];
+  genesToDelete: string[];
+  handleCellTypeClick: (cellTypeId: string) => void;
+  handleGeneClick: (gene: string) => void;
+  reset: () => void;
+} {
+  const dispatch = useContext(DispatchContext);
+  const { genesToDelete, cellTypeIdsToDelete } = useContext(StateContext);
+
+  const handleGeneClick = useCallback(
+    (gene: string) => {
+      if (!dispatch) return;
+
+      dispatch(toggleGeneToDelete(gene));
+    },
+    [dispatch]
+  );
+
+  const handleCellTypeClick = useCallback(
+    (cellTypeId: string) => {
+      if (!dispatch) return;
+
+      dispatch(toggleCellTypeIdToDelete(cellTypeId));
+    },
+    [dispatch]
+  );
+
+  const reset = useCallback(() => {
+    if (!dispatch) return;
+
+    dispatch(resetGenesToDeleteAndCellTypeIdsToDelete());
+  }, [dispatch]);
+
+  return {
+    cellTypeIdsToDelete,
+    genesToDelete,
+    handleCellTypeClick,
+    handleGeneClick,
+    reset,
+  };
+}

--- a/frontend/src/views/WheresMyGene/index.tsx
+++ b/frontend/src/views/WheresMyGene/index.tsx
@@ -2,7 +2,7 @@ import { Intent } from "@blueprintjs/core";
 import cloneDeep from "lodash/cloneDeep";
 import debounce from "lodash/debounce";
 import Head from "next/head";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { API } from "src/common/API";
 import { EMPTY_ARRAY } from "src/common/constants/utils";
 import { DEFAULT_FETCH_OPTIONS } from "src/common/queries/common";
@@ -11,6 +11,13 @@ import { Position } from "src/components/common/SideBar/style";
 import { API_URL } from "src/configs/configs";
 import Toast from "../Collection/components/Toast";
 import { View } from "../globalStyle";
+import {
+  DispatchContext,
+  INITIAL_STATE,
+  reducer,
+  StateContext,
+} from "./common/store";
+import { selectGenes } from "./common/store/actions";
 import {
   CellTypeGeneExpressionSummaryData,
   CellTypeSummary,
@@ -25,10 +32,9 @@ import { Wrapper } from "./style";
 const DEBOUNCE_MS = 2 * 1000;
 
 const WheresMyGene = (): JSX.Element => {
-  /**
-   * This is the genes that are currently selected.
-   */
-  const [genes, setGenes] = useState<Gene[]>(EMPTY_ARRAY);
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+
+  const { selectedGenes } = state;
 
   /**
    * This holds ALL the geneData we have loaded from the API, including previously
@@ -36,20 +42,24 @@ const WheresMyGene = (): JSX.Element => {
    * We use `selectedGeneData` to subset the data to only the genes that are
    * currently selected.
    */
-  const [geneData, setGeneData] =
+  const [geneExpressionSummaries, setGeneExpressionSummaries] =
     useState<GeneExpressionSummary[]>(EMPTY_ARRAY);
+
   const [cellTypes, setCellTypes] = useState<CellTypeSummary[]>(EMPTY_ARRAY);
 
   /**
    * This is the formatted data that we use to render the heatmap.
    */
-  const [data, setData] = useState<CellTypeSummary[]>(EMPTY_ARRAY);
+  const [cellTypeSummaries, setCellTypeSummaries] =
+    useState<CellTypeSummary[]>(EMPTY_ARRAY);
 
   const selectedGeneData = useMemo(() => {
-    return geneData.filter((geneData) =>
-      genes.some((gene) => gene.name === geneData.name)
+    return geneExpressionSummaries.filter((geneExpressionSummary) =>
+      selectedGenes.some(
+        (selectedGene) => selectedGene === geneExpressionSummary.name
+      )
     );
-  }, [genes, geneData]);
+  }, [selectedGenes, geneExpressionSummaries]);
 
   useEffect(() => {
     fetchCellTypes();
@@ -71,6 +81,7 @@ const WheresMyGene = (): JSX.Element => {
       const cellTypes = await response.json();
 
       // (thuang): Table y-axis defaults to descending order
+      // .reverse() mutates the original array
       setCellTypes(cellTypes.reverse());
     }
   }, []);
@@ -78,7 +89,7 @@ const WheresMyGene = (): JSX.Element => {
   const debouncedIntegrateCellTypesAndGenes = useMemo(() => {
     return debounce(
       (cellTypes, geneData) => {
-        setData(integrateCelTypesAndGenes(cellTypes, geneData));
+        setCellTypeSummaries(integrateCelTypesAndGenes(cellTypes, geneData));
       },
       DEBOUNCE_MS,
       { leading: false }
@@ -87,62 +98,76 @@ const WheresMyGene = (): JSX.Element => {
 
   /**
    * Performance optimization:
-   * We only format and `setData()` after the watch list has stopped changing for
+   * We only format and `setCellTypeSummaries()` after the watch list has stopped changing for
    * `DEBOUNCE_MS`
    */
   useEffect(() => {
     debouncedIntegrateCellTypesAndGenes(cellTypes, selectedGeneData);
   }, [selectedGeneData, cellTypes, debouncedIntegrateCellTypesAndGenes]);
 
+  const handleGenesOnchange = useCallback(
+    (genes: Gene[]) => {
+      dispatch(selectGenes(genes.map((gene) => gene.name)));
+    },
+    [dispatch]
+  );
+
   return (
-    <>
-      <Head>
-        <title>cellxgene | Where&apos;s My Gene</title>
-      </Head>
+    <DispatchContext.Provider value={dispatch}>
+      <StateContext.Provider value={state}>
+        <Head>
+          <title>cellxgene | Where&apos;s My Gene</title>
+        </Head>
 
-      <SideBar label="Filters" isOpen>
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Doloribus
-          autem deserunt assumenda repudiandae repellat quis sunt quae, aut vero
-          rem itaque labore praesentium iure exercitationem minus iste
-          laudantium sed aliquid.
-        </span>
-      </SideBar>
-      <SideBar label="Filters" isOpen position={Position.RIGHT}>
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Doloribus
-          autem deserunt assumenda repudiandae repellat quis sunt quae, aut vero
-          rem itaque labore praesentium iure exercitationem minus iste
-          laudantium sed aliquid.
-        </span>
-      </SideBar>
+        <SideBar label="Filters" isOpen>
+          <span>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Doloribus
+            autem deserunt assumenda repudiandae repellat quis sunt quae, aut
+            vero rem itaque labore praesentium iure exercitationem minus iste
+            laudantium sed aliquid.
+          </span>
+        </SideBar>
 
-      <View hideOverflow>
-        <Wrapper>
-          <GeneSearchBar onGenesChange={setGenes} />
+        <SideBar label="Filters" isOpen position={Position.RIGHT}>
+          <span>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Doloribus
+            autem deserunt assumenda repudiandae repellat quis sunt quae, aut
+            vero rem itaque labore praesentium iure exercitationem minus iste
+            laudantium sed aliquid.
+          </span>
+        </SideBar>
 
-          <HeatMap cellTypes={cellTypes} data={data} genes={genes} />
+        <View hideOverflow>
+          <Wrapper>
+            <GeneSearchBar onGenesChange={handleGenesOnchange} />
 
-          {genes.map((gene) => {
-            const { name } = gene;
+            <HeatMap
+              cellTypes={cellTypes}
+              data={cellTypeSummaries}
+              genes={selectedGenes}
+            />
 
-            return (
-              <GeneFetcher
-                fetchedGenes={genes}
-                name={name}
-                key={name}
-                onSuccess={handleGeneFetchSuccess}
-                onError={handleGeneFetchError}
-              />
-            );
-          })}
-        </Wrapper>
-      </View>
-    </>
+            {selectedGenes.map((selectedGene) => {
+              return (
+                <GeneFetcher
+                  name={selectedGene}
+                  key={selectedGene}
+                  onSuccess={handleGeneFetchSuccess}
+                  onError={handleGeneFetchError}
+                />
+              );
+            })}
+          </Wrapper>
+        </View>
+      </StateContext.Provider>
+    </DispatchContext.Provider>
   );
 
   function handleGeneFetchSuccess(geneData: GeneExpressionSummary) {
-    setGeneData((latestGeneData) => [...latestGeneData, geneData]);
+    setGeneExpressionSummaries((latestGeneData) => [
+      ...latestGeneData,
+      geneData,
+    ]);
   }
 
   function handleGeneFetchError(name: Gene["name"]) {


### PR DESCRIPTION
### Reviewers

**Functional:** 
@seve 

**Readability:** 
@MDunitz 

---

## Changes
- add
1. `src/views/WheresMyGene/common/store` for `useReducer` to centralize heat map state, since many values change together in various events
2. The reducer/actions pattern follows closely to how [Redux Toolkit](https://redux-toolkit.js.org/usage/usage-with-typescript#createslice) structures the code to reduce boilerplate. I didn't dynamically generate actions like RTK does because the TS overhead involved to type things properly would take a lot more time for me to figure out 😆 And I don't think the app is global/heavy enough to justify adding RTK, so hopefully the current approach is a good balance
3. Add `useDeleteGenesAndCellTypes()` hook to encapsulate business logic, which internally uses the reducer and dispatch relevant actions as needed
4. Add `ehcarts` click events for row and column labels. Also update its style to highlight labels when selected
- remove
- modify
1. Move `selectedGenes` to use the store state

## Definition of Done (from ticket)

## QA steps (optional)

1. Load some genes
2. You can now select/deselect rows and columns! NOTE: I looked into highlighting rows and columns on selection as shown in [Figma](https://www.figma.com/file/htICFl7zihfs1z9eIYVwzw/Gene-Search?node-id=2442%3A430111), but couldn't find a quick way to do it, so decided to just highlight the labels for now
3. I haven't added delete key press detection yet 😆 
4. If you delete a gene, it will deselect the labels

![demo](https://user-images.githubusercontent.com/6309723/152224891-4864f149-2ee8-49f3-bfb7-17e0720fe4cf.gif)


## Known Issues
