### PR TITLE
fix: change Dropbox content length header

### DIFF
--- a/backend/corpora/common/utils/dl_sources/url.py
+++ b/backend/corpora/common/utils/dl_sources/url.py
@@ -73,7 +73,7 @@ class DropBoxURL(URL):
         resp.raise_for_status()
 
         return {
-            "size": int(self._get_key(resp.headers, "content-length")),
+            "size": int(self._get_key(resp.headers, "x-dropbox-content-length")),
             "name": self._get_key(resp.headers, "content-disposition").split(";")[1].split("=", 1)[1][1:-1],
         }
 


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve @Bento007 

**Readability:** 

This is a hotfix to production.

---

## Changes
- Changes the Dropbox content length header. This is currently broken in all environments and causes the dataset upload to fail. Note that there is no documentation around these headers, so this might change any time. I can't think of a better solution though. We could make the size check optional but as @maniarathi pointed out, that would still break one of our features (block datasets that are too big) and it will do so silently.
