### PR TITLE
feat(layout): Update optional layout logic

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -5,8 +5,6 @@ import { FC } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { checkFeatureFlags } from "src/common/featureFlags";
-import { FEATURES } from "src/common/featureFlags/features";
-import { useFeatureFlag } from "src/common/hooks/useFeatureFlag";
 import DefaultLayout from "src/components/Layout/components/defaultLayout";
 import configs from "src/configs/configs";
 import "src/global.scss";
@@ -26,8 +24,7 @@ type AppPropsWithLayout = AppProps & {
 };
 
 function App({ Component, pageProps }: AppPropsWithLayout): JSX.Element {
-  const isFilterEnabled = useFeatureFlag(FEATURES.FILTER);
-  const Layout = (isFilterEnabled && Component.Layout) || DefaultLayout;
+  const Layout = Component.Layout || DefaultLayout;
   return (
     <>
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,8 +1,20 @@
+import { FEATURES } from "src/common/featureFlags/features";
+import { useFeatureFlag } from "src/common/hooks/useFeatureFlag";
+import DefaultLayout from "src/components/Layout/components/defaultLayout";
 import SidebarLayout from "src/components/Layout/components/sidebarLayout";
 import Homepage from "src/views/Homepage";
 
 const Page = (): JSX.Element => <Homepage />;
 
-Page.Layout = SidebarLayout;
+Page.Layout = function _Layout({
+  children,
+}: {
+  children: JSX.Element;
+}): JSX.Element {
+  const isFilterEnabled = useFeatureFlag(FEATURES.FILTER);
+  const Layout = isFilterEnabled ? SidebarLayout : DefaultLayout;
+
+  return <Layout>{children}</Layout>;
+};
 
 export default Page;


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve 

**Readability:** 
@frano-m 
---

## Changes
Since Where's My Gene page also needs a custom layout that doesn't depend on the feature flag, this PR moves the homepage's layout logic to homepage's view file!

PTAL thank you 🙏 

## Definition of Done (from ticket)

## QA steps (optional)
1. Homepage layout with feature flag on off should work as expected
2. WMG page layout should be 3 panels regardless of feature flag status

![demo](https://user-images.githubusercontent.com/6309723/152423318-e79ce86e-ecf8-4dd4-885a-7294951c0cd0.gif)

## Known Issues
