### PR TITLE
fix: pin scipy to version 1.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pytest
 requests>=2.22.0
 s3fs==0.4.2
 scanpy
+scipy==1.7.3
 tenacity
 tiledb==0.10.1
 click==7.1.2


### PR DESCRIPTION
### Reviewers
**Functional:** 
@atolopko-czi @metakuni 

**Readability:** 

---

## Changes
- Pins `scipy` to version 1.7.3. The newer version (1.8.0) isn't compatible with the Seurat conversion script and will cause it to crash.
