### PR TITLE
feat: use Crossref API key

### DIFF
--- a/backend/corpora/common/providers/crossref_provider.py
+++ b/backend/corpora/common/providers/crossref_provider.py
@@ -46,7 +46,10 @@ class CrossrefProvider(object):
 
         # TODO: if we're using the commercial API, the token should also be parametrized
         try:
-            res = requests.get(f"{self.base_crossref_uri}/{doi}", headers={"Crossref-Plus-API-Token": f"Bearer {self.crossref_api_key}"})
+            res = requests.get(
+                f"{self.base_crossref_uri}/{doi}",
+                headers={"Crossref-Plus-API-Token": f"Bearer {self.crossref_api_key}"},
+            )
             res.raise_for_status()
         except Exception as e:
             raise CrossrefFetchException("Cannot fetch metadata from Crossref") from e

--- a/backend/corpora/common/providers/crossref_provider.py
+++ b/backend/corpora/common/providers/crossref_provider.py
@@ -22,10 +22,11 @@ class CrossrefProvider(object):
     """
 
     def __init__(self) -> None:
+        self.base_crossref_uri = "https://api.crossref.org/works"
         try:
-            self.base_crossref_uri = CorporaConfig().crossref_api_uri
+            self.crossref_api_key = CorporaConfig().crossref_api_key
         except RuntimeError:
-            self.base_crossref_uri = None
+            self.crossref_api_key = None
         super().__init__()
 
     @staticmethod
@@ -39,13 +40,13 @@ class CrossrefProvider(object):
         If the Crossref API URI isn't in the configuration, we will just return an empty object.
         This is to avoid calling Crossref in non-production environments.
         """
-        if self.base_crossref_uri is None:
-            logging.info("No Crossref API URI found, skipping metadata fetching.")
+        if self.crossref_api_key is None:
+            logging.info("No Crossref API key found, skipping metadata fetching.")
             return None
 
         # TODO: if we're using the commercial API, the token should also be parametrized
         try:
-            res = requests.get(f"{self.base_crossref_uri}/{doi}")
+            res = requests.get(f"{self.base_crossref_uri}/{doi}", headers={"Crossref-Plus-API-Token": f"Bearer {self.crossref_api_key}"})
             res.raise_for_status()
         except Exception as e:
             raise CrossrefFetchException("Cannot fetch metadata from Crossref") from e

--- a/tests/unit/backend/corpora/common/providers/test_crossref_provider.py
+++ b/tests/unit/backend/corpora/common/providers/test_crossref_provider.py
@@ -21,9 +21,9 @@ class TestCrossrefProvider(unittest.TestCase):
 
     @patch("backend.corpora.common.providers.crossref_provider.requests.get")
     @patch("backend.corpora.common.providers.crossref_provider.CorporaConfig")
-    def test__provider_calls_crossref_if_api_url_defined(self, mock_config, mock_get):
+    def test__provider_calls_crossref_if_api_key_defined(self, mock_config, mock_get):
 
-        # Defining a mocked CorporaConfig will allow the provider to consider the `crossref_api_uri`
+        # Defining a mocked CorporaConfig will allow the provider to consider the `crossref_api_key`
         # not None, so it will go ahead and do the mocked call.
 
         response = Response()


### PR DESCRIPTION
### Reviewers
**Functional:** 
@metakuni

**Readability:** 
@MDunitz 

---

## Changes
- Use the Crossref API key to call their API.
- If a key isn't found in the secret, just skip the call. This is useful for pre-staging environments if we want to avoid Crossref calls.
- Move the URL into the code. There is arguably no need to configure it since it's an immutable URI which is provided by Crossref.
