### PR TITLE
feat: updated collections and datasets sort by recency.

### DIFF
--- a/frontend/src/components/common/Filter/common/entities.ts
+++ b/frontend/src/components/common/Filter/common/entities.ts
@@ -141,6 +141,7 @@ export interface CollectionRow extends Categories, PublisherMetadataCategories {
   name: string;
   published_at: number;
   publisher_metadata?: PublisherMetadata; // Collection publication metadata
+  recency: number; // Used by sort
   revised_at?: number;
 }
 
@@ -171,6 +172,7 @@ export interface DatasetRow extends Categories, PublisherMetadataCategories {
   isOverMaxCellCount: boolean;
   name: string;
   published_at: number;
+  recency: number; // Used by sort
   revised_at?: number;
 }
 

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -41,6 +41,11 @@ const COLLECTION_NAME = "name";
 const COLUMN_ID_RECENCY = "recency";
 
 /**
+ * Recency object key.
+ */
+const RECENCY = "recency";
+
+/**
  * Gene sets CSV upload functionality, available if gene sets feature flag is enabled
  */
 const AsyncUploadCSV = loadable(
@@ -107,9 +112,7 @@ export default function Collections(): JSX.Element {
       },
       // Hidden, required for sorting
       {
-        // Sort by revised_at if specified otherwise published_at.
-        accessor: (collectionRow: CollectionRow): number =>
-          collectionRow.revised_at ?? collectionRow.published_at,
+        accessor: RECENCY,
         id: COLUMN_ID_RECENCY,
       },
       // Hidden, required for accessing collection ID via row.values, for building link to collection detail page.

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -51,6 +51,11 @@ const DATASET_NAME = "name";
 const EXPLORER_URL = "explorer_url";
 
 /**
+ * Recency object key.
+ */
+const RECENCY = "recency";
+
+/**
  * Key identifying recency sort by column.
  */
 const COLUMN_ID_RECENCY = "recency";
@@ -140,8 +145,7 @@ export default function Datasets(): JSX.Element {
       },
       // Hidden, required for sorting by recency.
       {
-        accessor: (datasetRow: DatasetRow): number =>
-          datasetRow.revised_at ?? datasetRow.published_at,
+        accessor: RECENCY,
         id: COLUMN_ID_RECENCY,
       },
       // Hidden, required for accessing dataset ID via row.values, for download functionality.

--- a/frontend/tests/common/queries/filter.test.ts
+++ b/frontend/tests/common/queries/filter.test.ts
@@ -5,6 +5,8 @@
 // App dependencies
 import {
   calculateMonthsSincePublication,
+  calculateRecency,
+  CollectionResponse,
   createPublicationDateValues,
 } from "src/common/queries/filter";
 import { PUBLICATION_DATE_VALUES } from "src/components/common/Filter/common/entities";
@@ -86,6 +88,50 @@ describe("filter", () => {
       // Expecting 36.
       expect(dateBins.length).toEqual(1);
       validateDateValue(dateBins, PUBLICATION_DATE_VALUES.slice(5));
+    });
+  });
+  describe("Calculate Recency", () => {
+    it("calculates recency for collection with publisher metadata", () => {
+      const day = 11;
+      const month = 0; // JS month
+      const year = 2022;
+      const collection = {
+        publisher_metadata: {
+          published_day: day,
+          published_month: month + 1, // Publisher metadata month
+          published_year: year,
+        },
+      } as CollectionResponse;
+      const recency = calculateRecency(
+        collection,
+        collection.publisher_metadata
+      );
+      const expected = new Date(year, month, day).getTime() / 1000; // Seconds since Unix epoch.
+      expect(recency).toEqual(expected);
+    });
+    it("calculates recency for collection with revised at", () => {
+      const revisedAt = 1644527777.095609; // JS month
+      const collection = {
+        // No publisher metadata
+        revised_at: revisedAt,
+      } as CollectionResponse;
+      const recency = calculateRecency(
+        collection,
+        collection.publisher_metadata
+      );
+      expect(recency).toEqual(revisedAt);
+    });
+    it("calculates recency for collection with published at", () => {
+      const publishedAt = 1644526776.095609;
+      const collection = {
+        // No publisher metadata or revised_at
+        published_at: publishedAt,
+      } as CollectionResponse;
+      const recency = calculateRecency(
+        collection,
+        collection.publisher_metadata
+      );
+      expect(recency).toEqual(publishedAt);
     });
   });
 });


### PR DESCRIPTION
### Reviewers
**Functional:** 
@tihuan!

---

## Changes
- Updated recency sort order of collections and datasets to use (collection) publisher metadata, revised_at, published_at.
