### PR TITLE
feat: Add publication column to collections index (#1912)

### DIFF
--- a/frontend/src/components/Collections/components/Grid/components/CollectionsGrid/style.ts
+++ b/frontend/src/components/Collections/components/Grid/components/CollectionsGrid/style.ts
@@ -5,9 +5,4 @@ export const CollectionsGrid = styled(Grid)`
   grid-template-columns:
     minmax(0, 8fr)
     minmax(0, 6fr) repeat(2, minmax(0, 5fr)) minmax(0, 3fr);
-
-  th:first-of-type,
-  td:first-of-type {
-    grid-column: 1 / 3; /* review grid column allocation for collection name when publications column added */
-  }
 `;

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -36,6 +36,11 @@ const COLLECTION_ID = "id";
 const COLLECTION_NAME = "name";
 
 /**
+ * Collection summary citation object key.
+ */
+const COLLECTION_SUMMARY_CITATION = "summaryCitation";
+
+/**
  * Key identifying recency sort by column.
  */
 const COLUMN_ID_RECENCY = "recency";
@@ -82,6 +87,13 @@ export default function Collections(): JSX.Element {
         },
         Header: "Collection",
         accessor: COLLECTION_NAME,
+      },
+      {
+        Cell: ({ row }: RowPropsValue<CollectionRow>) => {
+          return <div>{row.values.summaryCitation || "No publication"}</div>;
+        },
+        Header: "Publication",
+        accessor: COLLECTION_SUMMARY_CITATION,
       },
       {
         Cell: ({ value }: CellPropsValue<string[]>) => (


### PR DESCRIPTION
### Reviewers
**Functional:** 
@tihuan 

---

## Changes
- Added the publication column to the collections index ([mock](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=1509%3A19110), [redlines](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=2667%3A29344)).
- Added the summary citation displayed for collections with corresponding publication metadata.
- Shows "No publication" for collections with no corresponding publication metadata.