### PR TITLE
feat(wmg): Incremental debounce

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@loadable/component": "^5.15.0",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
-        "@material-ui/lab": "*",
+        "@material-ui/lab": "latest",
         "@types/d3-scale-chromatic": "^3.0.0",
         "babel-plugin-styled-components": "^1.13.3",
         "clipboard-copy": "^4.0.1",

--- a/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
@@ -306,7 +306,7 @@ export interface ChartFormat {
 
 export function dataToChartFormat(
   cellTypeSummaries: CellTypeSummary[],
-  genes: GeneExpressionSummary[]
+  genes: (GeneExpressionSummary | undefined)[]
 ): ChartFormat[] {
   let min = Infinity;
   let max = -Infinity;
@@ -342,7 +342,7 @@ export function dataToChartFormat(
 
       const scaledMeanExpression = (meanExpression - min) / oldRange;
 
-      const geneIndex = genes.findIndex((gene) => gene.name === geneName);
+      const geneIndex = genes.findIndex((gene) => gene?.name === geneName);
 
       const cellTypeIndex = cellTypeSummaries.findIndex(
         (cellTypeSummary) => cellTypeSummary.id === dataPoint.id
@@ -372,7 +372,7 @@ const HEAT_MAP_BASE_CELL_PX = 20;
  * of the number of genes selected.
  */
 export function getHeatmapWidth(
-  genes: GeneExpressionSummary[] | State["selectedGenes"]
+  genes: (GeneExpressionSummary | undefined)[] | State["selectedGenes"]
 ): number {
   return HEAT_MAP_BASE_WIDTH_PX + HEAT_MAP_BASE_CELL_PX * genes.length;
 }
@@ -426,6 +426,8 @@ export function checkIsTissue(cellTypeMetadata: CellTypeMetadata): boolean {
 /**
  * Value format: `${name}`
  */
-export function getGeneNames(genes: { name: string }[]): string[] {
-  return genes.map(({ name }) => name);
+export function getGeneNames(
+  genes: ({ name: string } | undefined)[]
+): string[] {
+  return genes.map((gene) => gene?.name || "");
 }


### PR DESCRIPTION
Instead of hard coding a set debounce time, we apply a sliding scale depending on how many genes are selected. So the long debounce time is only applied on large gene selection. This way for small amount of genes, we get snappy interaction like the users expect!

![demo](https://user-images.githubusercontent.com/6309723/155474199-4b2df658-0d36-4dd0-a33b-49e3d1a8e2ea.gif)


## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
