### PR TITLE
chore: add mean_genes_per_cell field to dataset/index

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -847,6 +847,8 @@ paths:
                       type: integer
                     cell_type:
                       $ref: "#/components/schemas/ontology_element_array"
+                    mean_genes_per_cell:
+                      type: number
         "400":
           $ref: "#/components/responses/400"
 

--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -183,6 +183,7 @@ class Dataset(Entity):
             DbDataset.ethnicity,
             DbDataset.development_stage,
             DbDataset.is_primary_data,
+            DbDataset.mean_genes_per_cell,
             DbDataset.schema_version,  # Required for schema manipulation
             DbDataset.explorer_url,
             DbDataset.published_at,

--- a/tests/unit/backend/corpora/api_server/test_v1_dataset.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_dataset.py
@@ -120,6 +120,7 @@ class TestDataset(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
             self.session,
             id="test_dataset_id_for_index",
             cell_count=42,
+            mean_genes_per_cell=0.05,
             published_at=datetime.now(),
             revised_at=datetime.now(),
         )
@@ -151,6 +152,7 @@ class TestDataset(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         self.assertEqual(actual_dataset["cell_count"], dataset.cell_count)
         self.assertEqual(actual_dataset["cell_type"], dataset.cell_type)
         self.assertEqual(actual_dataset["is_primary_data"], dataset.is_primary_data.name)
+        self.assertEqual(actual_dataset["mean_genes_per_cell"], dataset.mean_genes_per_cell)
         self.assertEqual(actual_dataset["explorer_url"], dataset.explorer_url)
         self.assertEqual(actual_dataset["published_at"], dataset.published_at.timestamp())
         self.assertEqual(actual_dataset["revised_at"], dataset.revised_at.timestamp())


### PR DESCRIPTION
### Reviewers
**Functional:** 
@MillenniumFalconMechanic 

**Readability:** 

---

## Changes
- Adds `mean_genes_per_cell` to the `dataset/index` endpoint
