### PR TITLE
feat: added filter by cell and gene count. #1820, #1823

### DIFF
--- a/frontend/src/common/hooks/useCategoryFilter.ts
+++ b/frontend/src/common/hooks/useCategoryFilter.ts
@@ -628,7 +628,7 @@ function isCategorySetCategoryKeyValue(
 function isSelectCategoryValue(
   categoryValue: RangeCategory | KeyedSelectCategoryValue
 ): categoryValue is KeyedSelectCategoryValue {
-  return (categoryValue as KeyedSelectCategoryValue).get !== undefined;
+  return categoryValue instanceof Map;
 }
 
 /**

--- a/frontend/src/common/hooks/useCategoryFilter.ts
+++ b/frontend/src/common/hooks/useCategoryFilter.ts
@@ -617,7 +617,7 @@ function isCategoryValueKey(
 function isCategorySetCategoryKeyValue(
   categorySetValue: CategorySetValue
 ): categorySetValue is Set<CategoryValueKey> {
-  return (categorySetValue as Set<CategoryValueKey>).has !== undefined;
+  return categorySetValue instanceof Set;
 }
 
 /**

--- a/frontend/src/common/hooks/useCategoryFilter.ts
+++ b/frontend/src/common/hooks/useCategoryFilter.ts
@@ -748,7 +748,7 @@ function summarizeSelectCategory<T extends Categories>(
       categoryValues = [categoryValues];
     }
 
-    // Init category value it doesn't already exist. Default selected state to false (selected state is updated
+    // Init category value if it doesn't already exist. Default selected state to false (selected state is updated
     // from the filter state at a later point).
     categoryValues.forEach((categoryValueKey: CategoryValueKey) => {
       let categoryValue = accum.get(categoryValueKey);

--- a/frontend/src/common/queries/filter.ts
+++ b/frontend/src/common/queries/filter.ts
@@ -704,8 +704,9 @@ function sanitizeDataset(dataset: DatasetResponse): DatasetResponse {
     (accum: DatasetResponse, categoryKey: CATEGORY_KEY) => {
       // Check for fields that don't require sanitizing.
       if (
-        categoryKey === CATEGORY_KEY.PUBLICATION_DATE_VALUES ||
-        categoryKey === CATEGORY_KEY.PUBLICATION_AUTHORS
+        categoryKey === CATEGORY_KEY.CELL_COUNT ||
+        categoryKey === CATEGORY_KEY.PUBLICATION_AUTHORS ||
+        categoryKey === CATEGORY_KEY.PUBLICATION_DATE_VALUES
       ) {
         return accum;
       }

--- a/frontend/src/common/queries/filter.ts
+++ b/frontend/src/common/queries/filter.ts
@@ -88,6 +88,7 @@ export interface DatasetResponse {
   explorer_url: string;
   id: string;
   is_primary_data: IS_PRIMARY_DATA;
+  mean_genes_per_cell: number | null;
   name: string;
   organism: Ontology[];
   published_at: number;
@@ -705,6 +706,7 @@ function sanitizeDataset(dataset: DatasetResponse): DatasetResponse {
       // Check for fields that don't require sanitizing.
       if (
         categoryKey === CATEGORY_KEY.CELL_COUNT ||
+        categoryKey === CATEGORY_KEY.MEAN_GENES_PER_CELL ||
         categoryKey === CATEGORY_KEY.PUBLICATION_AUTHORS ||
         categoryKey === CATEGORY_KEY.PUBLICATION_DATE_VALUES
       ) {

--- a/frontend/src/components/common/Filter/common/entities.ts
+++ b/frontend/src/components/common/Filter/common/entities.ts
@@ -253,7 +253,7 @@ export type Range = [number, number] | []; // TODO(cc) revisit []
  */
 export interface RangeCategoryView {
   key: CATEGORY_KEY;
-  label: string;
+  label: CATEGORY_LABEL;
   max: number;
   min: number;
   selectedMax?: number;

--- a/frontend/src/components/common/Filter/common/entities.ts
+++ b/frontend/src/components/common/Filter/common/entities.ts
@@ -34,6 +34,7 @@ export enum CATEGORY_KEY {
   "CELL_TYPE" = "cell_type",
   "DISEASE" = "disease",
   "IS_PRIMARY_DATA" = "is_primary_data",
+  "MEAN_GENES_PER_CELL" = "mean_genes_per_cell",
   "ORGANISM" = "organism",
   "PUBLICATION_AUTHORS" = "publicationAuthors",
   "PUBLICATION_DATE_VALUES" = "publicationDateValues",
@@ -64,6 +65,11 @@ const CATEGORY_CONFIGS: CategoryConfig[] = [
     categoryKey: CATEGORY_KEY.DISEASE,
     categoryType: CATEGORY_FILTER_TYPE.INCLUDES_SOME,
     multiselect: true,
+  },
+  {
+    categoryKey: CATEGORY_KEY.MEAN_GENES_PER_CELL,
+    categoryType: CATEGORY_FILTER_TYPE.BETWEEN,
+    multiselect: false,
   },
   {
     categoryKey: CATEGORY_KEY.IS_PRIMARY_DATA,
@@ -164,6 +170,7 @@ export interface DatasetRow extends Categories, PublisherMetadataCategories {
   explorer_url: string;
   id: string;
   isOverMaxCellCount: boolean;
+  mean_genes_per_cell: number | null;
   name: string;
   published_at: number;
   recency: number; // Used by sort
@@ -206,6 +213,7 @@ export enum IS_PRIMARY_DATA_LABEL {
 export type OntologyCategoryKey = keyof Omit<
   Record<CATEGORY_KEY, string>,
   | CATEGORY_KEY.CELL_COUNT
+  | CATEGORY_KEY.MEAN_GENES_PER_CELL
   | CATEGORY_KEY.IS_PRIMARY_DATA
   | CATEGORY_KEY.PUBLICATION_DATE_VALUES
   | CATEGORY_KEY.PUBLICATION_AUTHORS
@@ -214,12 +222,13 @@ export type OntologyCategoryKey = keyof Omit<
 /**
  * Display value of category labels.
  */
-export enum CATEGORY_LABEL { // TODO(cc) combine with config
+export enum CATEGORY_LABEL {
   assay = "Assay",
   cell_count = "Cell Count",
   cell_type = "Cell Type",
   disease = "Disease",
   is_primary_data = "Data Source",
+  mean_genes_per_cell = "Gene Count",
   publicationAuthors = "Authors",
   publicationDateValues = "Publication Date",
   organism = "Organism",
@@ -244,9 +253,9 @@ export type OnUpdateSearchValueFn = (
 ) => void;
 
 /**
- * Min and max values selected in range category.
+ * Min and max values selected in range category. Empty array if no range is specified (e.g. on clear of range).
  */
-export type Range = [number, number] | []; // TODO(cc) revisit []
+export type Range = [number, number] | [];
 
 /**
  * View model of range metadata key.

--- a/frontend/src/components/common/Filter/common/entities.ts
+++ b/frontend/src/components/common/Filter/common/entities.ts
@@ -246,7 +246,7 @@ export type OnUpdateSearchValueFn = (
 /**
  * Min and max values selected in range category.
  */
-export type Range = [number, number];
+export type Range = [number, number] | []; // TODO(cc) revisit []
 
 /**
  * View model of range metadata key.

--- a/frontend/src/components/common/Filter/common/utils.ts
+++ b/frontend/src/components/common/Filter/common/utils.ts
@@ -25,27 +25,23 @@ export function ontologyCellAccessorFn(
 
 /**
  * Returns formatted number with corresponding magnitude.
- * Based off https://stackoverflow.com/a/9462382.
- * @param num
- * @returns string (a displayable number with corresponding magnitude).
+ * @param num - Number to format.
+ * @returns String containing number with corresponding magnitude.
  */
 export function formatNumberToMagnitude(num: number): string {
-  const si = [
-    { symbol: "", value: 1 },
-    { symbol: "k", value: 1e3 },
-    { symbol: "M", value: 1e6 },
-    { symbol: "G", value: 1e9 },
-    { symbol: "T", value: 1e12 },
-    { symbol: "PB", value: 1e15 },
-    { symbol: "E", value: 1e18 },
-  ];
-  const rx = /\.0+$|(\.[0-9]*[1-9])0+$/;
-  let i;
-  for (i = si.length - 1; i > 0; i--) {
-    if (num >= si[i].value) {
-      break;
-    }
-  }
-  const symbol = si[i].symbol;
-  return (num / si[i].value).toFixed(1).replace(rx, "$1") + symbol;
+  // TODO(cc) demo code only - must be productionalized.
+  const magnitude = num < 100000 ? 1000 : 1000000;
+  const precision = num < 1000000 ? 1 : 2;
+  const symbol = magnitude === 1000 ? "k" : "M";
+  return `${roundToPrecision(precision, num) / magnitude}${symbol}`;
+}
+
+/**
+ * Round the given number to the given significant digits.
+ * @param precision - Number of significant digits.
+ * @param num - Number to round to significant digits.
+ * @returns Rounded number to the given significant digits.
+ */
+function roundToPrecision(precision: number, num: number): number {
+  return parseFloat(num.toPrecision(precision));
 }

--- a/frontend/src/components/common/Filter/common/utils.ts
+++ b/frontend/src/components/common/Filter/common/utils.ts
@@ -18,7 +18,7 @@ const FIXED_TO = 1;
 /**
  * Value to divide numbers by when scaling by million.
  */
-const SCALE_MILLION = 1000000;
+const SCALE_MILLION = 1_000_000;
 
 /**
  * Value to divide numbers by when scaling by thousand.

--- a/frontend/src/components/common/Filter/common/utils.ts
+++ b/frontend/src/components/common/Filter/common/utils.ts
@@ -54,9 +54,9 @@ export function ontologyCellAccessorFn(
  * @returns String containing number, possibly rounded, with corresponding scale symbol.
  */
 export function formatNumberToScale(num: number): string {
-  // Return numbers less than 100 as is.
-  if (num < 100) {
-    return `${num}`;
+  // Return numbers less than 1000 rounded.
+  if (num < 1000) {
+    return `${Math.round(num)}`;
   }
 
   // Handle numbers smaller than 10,000: format to thousands. For example, 1400 becomes 1.4k.

--- a/frontend/src/components/common/Filter/common/utils.ts
+++ b/frontend/src/components/common/Filter/common/utils.ts
@@ -11,7 +11,7 @@ import {
 type OntologyCellAccessorFn = (categories: Categories) => string[];
 
 /**
- * Number of digits to format digits to.
+ * Number of digits to format decmial points to.
  */
 const FIXED_TO = 1;
 
@@ -26,12 +26,12 @@ const SCALE_MILLION = 1000000;
 const SCALE_THOUSAND = 1000;
 
 /**
- * Magnitude symbol for million.
+ * Scale symbol for million.
  */
 export const SYMBOL_MILLION = "M";
 
 /**
- * Magnitude symbol for million.
+ * Scale symbol for million.
  */
 export const SYMBOL_THOUSAND = "k";
 
@@ -49,9 +49,9 @@ export function ontologyCellAccessorFn(
 }
 
 /**
- * Formatted number to the correct scale and possibly rounded.
+ * Format number to the correct scale and possibly round.
  * @param num - Number to format.
- * @returns String containing number, possibly rounded, with corresponding scale symbol.
+ * @returns String representation of given number, possibly rounded, with corresponding scale symbol.
  */
 export function formatNumberToScale(num: number): string {
   // Return numbers less than 1000 rounded.
@@ -71,7 +71,7 @@ export function formatNumberToScale(num: number): string {
     return `${rounded}${SYMBOL_THOUSAND}`;
   }
 
-  // Handle numbers larger than 100,000: format to millions. For example, 1,450,000 becomes 1.5M.
+  // Handle numbers larger than 1,000,000: format to millions. For example, 1,450,000 becomes 1.5M.
   const formatted = scaleAndFix(num, SCALE_MILLION, FIXED_TO);
   return `${formatted}${SYMBOL_MILLION}`;
 }

--- a/frontend/src/components/common/Filter/common/utils.ts
+++ b/frontend/src/components/common/Filter/common/utils.ts
@@ -65,8 +65,8 @@ export function formatNumberToScale(num: number): string {
     return `${formatted}${SYMBOL_THOUSAND}`;
   }
 
-  // Handle numbers smaller than 100,000: format to thousands and round. For example, 14,500 becomes 15k.
-  if (num < 100000) {
+  // Handle numbers smaller than 1,000,000: format to thousands and round. For example, 14,500 becomes 15k.
+  if (num < 1000000) {
     const rounded = Math.round(scaleAndFix(num, SCALE_THOUSAND, FIXED_TO));
     return `${rounded}${SYMBOL_THOUSAND}`;
   }

--- a/frontend/src/components/common/Filter/common/utils.ts
+++ b/frontend/src/components/common/Filter/common/utils.ts
@@ -55,18 +55,18 @@ export function ontologyCellAccessorFn(
  */
 export function formatNumberToScale(num: number): string {
   // Return numbers less than 1000 rounded.
-  if (num < 1000) {
+  if (num < SCALE_THOUSAND) {
     return `${Math.round(num)}`;
   }
 
   // Handle numbers smaller than 10,000: format to thousands. For example, 1400 becomes 1.4k.
-  if (num < 10000) {
+  if (num < 10 * SCALE_THOUSAND) {
     const formatted = scaleAndFix(num, SCALE_THOUSAND, FIXED_TO);
     return `${formatted}${SYMBOL_THOUSAND}`;
   }
 
   // Handle numbers smaller than 1,000,000: format to thousands and round. For example, 14,500 becomes 15k.
-  if (num < 1000000) {
+  if (num < SCALE_MILLION) {
     const rounded = Math.round(scaleAndFix(num, SCALE_THOUSAND, FIXED_TO));
     return `${rounded}${SYMBOL_THOUSAND}`;
   }

--- a/frontend/src/components/common/Filter/common/utils.ts
+++ b/frontend/src/components/common/Filter/common/utils.ts
@@ -22,3 +22,30 @@ export function ontologyCellAccessorFn(
   return (categories: Categories) =>
     categories[categoryKey].map((o: Ontology) => o.label);
 }
+
+/**
+ * Returns formatted number with corresponding magnitude.
+ * Based off https://stackoverflow.com/a/9462382.
+ * @param num
+ * @returns string (a displayable number with corresponding magnitude).
+ */
+export function formatNumberToMagnitude(num: number): string {
+  const si = [
+    { symbol: "", value: 1 },
+    { symbol: "k", value: 1e3 },
+    { symbol: "M", value: 1e6 },
+    { symbol: "G", value: 1e9 },
+    { symbol: "T", value: 1e12 },
+    { symbol: "PB", value: 1e15 },
+    { symbol: "E", value: 1e18 },
+  ];
+  const rx = /\.0+$|(\.[0-9]*[1-9])0+$/;
+  let i;
+  for (i = si.length - 1; i > 0; i--) {
+    if (num >= si[i].value) {
+      break;
+    }
+  }
+  const symbol = si[i].symbol;
+  return (num / si[i].value).toFixed(1).replace(rx, "$1") + symbol;
+}

--- a/frontend/src/components/common/Filter/components/FilterMenu/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterMenu/index.tsx
@@ -2,12 +2,12 @@ import { InputGroup, Menu, MenuItem } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { Fragment, useEffect, useRef, useState } from "react";
 import {
-  CategoryValueView,
   CATEGORY_KEY,
   FilterCategoryValuesFn,
   FilterCategoryValuesWithCountFn,
   OnFilterFn,
   OnUpdateSearchValueFn,
+  SelectCategoryValueView,
 } from "src/components/common/Filter/common/entities";
 import {
   InputGroupWrapper,
@@ -26,7 +26,7 @@ interface Props {
   isSearchable: boolean;
   onFilter: OnFilterFn;
   onUpdateSearchValue: OnUpdateSearchValueFn;
-  values: CategoryValueView[];
+  values: SelectCategoryValueView[];
 }
 
 const ADDITIONAL_MENU_WIDTH = 8;

--- a/frontend/src/components/common/Filter/components/FilterRange/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterRange/index.tsx
@@ -9,7 +9,7 @@ import { formatNumberToMagnitude } from "src/components/common/Filter/common/uti
 import { useSliderStyles } from "src/components/common/Filter/components/FilterRange/style";
 
 type SliderEl = HTMLSpanElement; /* TODO(cc) review */
-type SliderRange = number | number[];
+type SliderRange = number | number[]; // TODO(cc) combine with range?
 
 interface Props {
   categoryView: RangeCategoryView;
@@ -39,6 +39,7 @@ export default function FilterRange({
     selectedMax || max,
   ]);
   const marks = buildMarks([min, max]);
+  const step = Math.floor((max - min) / 100); // TODO(cc) Only makes sense if diff is > 100?
 
   const onChangeSliderRange = (
     // eslint-disable-next-line @typescript-eslint/ban-types
@@ -66,6 +67,7 @@ export default function FilterRange({
       onChange={onChangeSliderRange}
       onChangeCommitted={onCommittedSliderRange}
       ref={sliderRef} // TODO(cc) for wrapper component
+      step={step}
       value={range}
       valueLabelFormat={formatNumberToMagnitude}
       valueLabelDisplay="on"

--- a/frontend/src/components/common/Filter/components/FilterRange/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterRange/index.tsx
@@ -5,11 +5,20 @@ import {
   Range,
   RangeCategoryView,
 } from "src/components/common/Filter/common/entities";
-import { formatNumberToMagnitude } from "src/components/common/Filter/common/utils";
+import { formatNumberToScale } from "src/components/common/Filter/common/utils";
 import { useSliderStyles } from "src/components/common/Filter/components/FilterRange/style";
 
 type SliderEl = HTMLSpanElement; /* TODO(cc) review */
-type SliderRange = number | number[]; // TODO(cc) combine with range?
+
+/**
+ * Value returned on change events from MUI Slider.
+ */
+type SliderRange = number | number[];
+
+/**
+ * Slider step size.
+ */
+const STEP_SIZE = 100;
 
 interface Props {
   categoryView: RangeCategoryView;
@@ -23,7 +32,7 @@ interface Props {
  */
 function buildMarks(values: number[]): Mark[] {
   return values.map((value) => {
-    return { label: formatNumberToMagnitude(value), value: value };
+    return { label: formatNumberToScale(value), value: value };
   });
 }
 
@@ -39,19 +48,19 @@ export default function FilterRange({
     selectedMax || max,
   ]);
   const marks = buildMarks([min, max]);
-  const step = Math.floor((max - min) / 100); // TODO(cc) Only makes sense if diff is > 100?
+  const step = Math.floor((max - min) / STEP_SIZE);
 
   const onChangeSliderRange = (
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    _changeEvent: ChangeEvent<{}>, // TODO(cc)
+    // eslint-disable-next-line @typescript-eslint/ban-types -- {} as per Mui spec.
+    _changeEvent: ChangeEvent<{}>,
     newRange: SliderRange
   ): void => {
     setRange(newRange);
   };
 
   const onCommittedSliderRange = (
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    _changeEvent: ChangeEvent<{}>, // TODO(cc)
+    // eslint-disable-next-line @typescript-eslint/ban-types -- {} as per Mui spec.
+    _changeEvent: ChangeEvent<{}>,
     committedRange: SliderRange
   ): void => {
     onFilter(key, committedRange as Range);
@@ -69,7 +78,7 @@ export default function FilterRange({
       ref={sliderRef} // TODO(cc) for wrapper component
       step={step}
       value={range}
-      valueLabelFormat={formatNumberToMagnitude}
+      valueLabelFormat={formatNumberToScale}
       valueLabelDisplay="on"
     />
   );

--- a/frontend/src/components/common/Filter/components/FilterRange/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterRange/index.tsx
@@ -1,5 +1,5 @@
 import { Mark, Slider } from "@material-ui/core";
-import React, { ChangeEvent, useRef, useState } from "react";
+import React, { ChangeEvent, useState } from "react";
 import {
   OnFilterFn,
   Range,
@@ -7,8 +7,6 @@ import {
 } from "src/components/common/Filter/common/entities";
 import { formatNumberToScale } from "src/components/common/Filter/common/utils";
 import { useSliderStyles } from "src/components/common/Filter/components/FilterRange/style";
-
-type SliderEl = HTMLSpanElement; /* TODO(cc) review */
 
 /**
  * Value returned on change events from MUI Slider.
@@ -42,7 +40,6 @@ export default function FilterRange({
 }: Props): JSX.Element {
   const { key, max, min, selectedMax, selectedMin } = categoryView;
   const classes = useSliderStyles();
-  const sliderRef = useRef<SliderEl>(null);
   const [range, setRange] = useState<SliderRange>([
     selectedMin || min,
     selectedMax || max,
@@ -75,7 +72,6 @@ export default function FilterRange({
       min={min}
       onChange={onChangeSliderRange}
       onChangeCommitted={onCommittedSliderRange}
-      ref={sliderRef} // TODO(cc) for wrapper component
       step={step}
       value={range}
       valueLabelFormat={formatNumberToScale}

--- a/frontend/src/components/common/Filter/components/FilterRange/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterRange/index.tsx
@@ -14,7 +14,7 @@ import { useSliderStyles } from "src/components/common/Filter/components/FilterR
 type SliderRange = number | number[];
 
 /**
- * Slider step size.
+ * Slider step size - default to 100.
  */
 const STEP_SIZE = 100;
 

--- a/frontend/src/components/common/Filter/components/FilterRange/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterRange/index.tsx
@@ -1,0 +1,74 @@
+import { Mark, Slider } from "@material-ui/core";
+import React, { ChangeEvent, useRef, useState } from "react";
+import {
+  OnFilterFn,
+  Range,
+  RangeCategoryView,
+} from "src/components/common/Filter/common/entities";
+import { formatNumberToMagnitude } from "src/components/common/Filter/common/utils";
+import { useSliderStyles } from "src/components/common/Filter/components/FilterRange/style";
+
+type SliderEl = HTMLSpanElement; /* TODO(cc) review */
+type SliderRange = number | number[];
+
+interface Props {
+  categoryView: RangeCategoryView;
+  onFilter: OnFilterFn;
+}
+
+/**
+ * Returns marks that indicate predetermined values to which the user can move the slider.
+ * @param values
+ * @returns Array of slider marks.
+ */
+function buildMarks(values: number[]): Mark[] {
+  return values.map((value) => {
+    return { label: formatNumberToMagnitude(value), value: value };
+  });
+}
+
+export default function FilterRange({
+  categoryView,
+  onFilter,
+}: Props): JSX.Element {
+  const { key, max, min, selectedMax, selectedMin } = categoryView;
+  const classes = useSliderStyles();
+  const sliderRef = useRef<SliderEl>(null);
+  const [range, setRange] = useState<SliderRange>([
+    selectedMin || min,
+    selectedMax || max,
+  ]);
+  const marks = buildMarks([min, max]);
+
+  const onChangeSliderRange = (
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    _changeEvent: ChangeEvent<{}>, // TODO(cc)
+    newRange: SliderRange
+  ): void => {
+    setRange(newRange);
+  };
+
+  const onCommittedSliderRange = (
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    _changeEvent: ChangeEvent<{}>, // TODO(cc)
+    committedRange: SliderRange
+  ): void => {
+    onFilter(key, committedRange as Range);
+  };
+
+  return (
+    <Slider
+      className={classes.root}
+      color="primary"
+      marks={marks}
+      max={max}
+      min={min}
+      onChange={onChangeSliderRange}
+      onChangeCommitted={onCommittedSliderRange}
+      ref={sliderRef} // TODO(cc) for wrapper component
+      value={range}
+      valueLabelFormat={formatNumberToMagnitude}
+      valueLabelDisplay="on"
+    />
+  );
+}

--- a/frontend/src/components/common/Filter/components/FilterRange/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterRange/style.ts
@@ -13,8 +13,8 @@ export const useSliderStyles = makeStyles({
     display: "block",
     height: 4,
     margin: 0,
-    marginLeft: 13, // TODO(cc) temporary
-    marginRight: 13, // TODO(cc) temporary
+    marginLeft: 24, // TODO(cc) temporary
+    marginRight: 24, // TODO(cc) temporary
     paddingBottom: 30, // TODO(cc) temporary; use 24
     paddingTop: 34, // TODO(cc) temporary; use 28
     width: 220, // TODO(cc) temporary
@@ -26,7 +26,7 @@ export const useSliderStyles = makeStyles({
       fontSize: 12,
       letterSpacing: "normal",
       lineHeight: "15px",
-      top: 41,
+      top: 47, // TODO(cc) temporary; use 41
     },
     "& .MuiSlider-rail": {
       borderRadius: 2,

--- a/frontend/src/components/common/Filter/components/FilterRange/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterRange/style.ts
@@ -6,7 +6,7 @@ import {
   PT_TEXT_COLOR,
 } from "src/components/common/theme";
 
-/* eslint sort-keys: 0 */ /* TODO(cc) */
+/* eslint-disable sort-keys -- ignore object key order for style objects */
 export const useSliderStyles = makeStyles({
   root: {
     color: PRIMARY_BLUE,
@@ -71,3 +71,4 @@ export const useSliderStyles = makeStyles({
     },
   },
 });
+/* eslint-enable sort-keys -- ignore object key order for style objects */

--- a/frontend/src/components/common/Filter/components/FilterRange/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterRange/style.ts
@@ -13,11 +13,11 @@ export const useSliderStyles = makeStyles({
     display: "block",
     height: 4,
     margin: 0,
-    marginLeft: 24, // TODO(cc) temporary
-    marginRight: 24, // TODO(cc) temporary
-    paddingBottom: 30, // TODO(cc) temporary; use 24
-    paddingTop: 34, // TODO(cc) temporary; use 28
-    width: 220, // TODO(cc) temporary
+    marginLeft: 24,
+    marginRight: 24,
+    paddingBottom: 30,
+    paddingTop: 34,
+    width: 220,
     "& .MuiSlider-mark": {
       display: "none",
     },
@@ -26,7 +26,7 @@ export const useSliderStyles = makeStyles({
       fontSize: 12,
       letterSpacing: "normal",
       lineHeight: "15px",
-      top: 47, // TODO(cc) temporary; use 41
+      top: 47,
     },
     "& .MuiSlider-rail": {
       borderRadius: 2,

--- a/frontend/src/components/common/Filter/components/FilterRange/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterRange/style.ts
@@ -1,0 +1,73 @@
+import { makeStyles } from "@material-ui/core";
+import {
+  GRAY,
+  LIGHT_GRAY,
+  PRIMARY_BLUE,
+  PT_TEXT_COLOR,
+} from "src/components/common/theme";
+
+/* eslint sort-keys: 0 */ /* TODO(cc) */
+export const useSliderStyles = makeStyles({
+  root: {
+    color: PRIMARY_BLUE,
+    display: "block",
+    height: 4,
+    margin: 0,
+    marginLeft: 13, // TODO(cc) temporary
+    marginRight: 13, // TODO(cc) temporary
+    paddingBottom: 30, // TODO(cc) temporary; use 24
+    paddingTop: 34, // TODO(cc) temporary; use 28
+    width: 220, // TODO(cc) temporary
+    "& .MuiSlider-mark": {
+      display: "none",
+    },
+    "& .MuiSlider-markLabel": {
+      color: GRAY.A,
+      fontSize: 12,
+      letterSpacing: "normal",
+      lineHeight: "15px",
+      top: 41,
+    },
+    "& .MuiSlider-rail": {
+      borderRadius: 2,
+      color: LIGHT_GRAY.C,
+      height: 4,
+      opacity: 1,
+    },
+    "& .MuiSlider-thumb": {
+      height: 14,
+      marginLeft: -7,
+      width: 14,
+      "&:hover": {
+        boxShadow: "none",
+      },
+    },
+    "& .MuiSlider-track": {
+      borderRadius: 2,
+      height: 4,
+    },
+    "& .MuiSlider-valueLabel": {
+      fontSize: 12,
+      fontWeight: 600,
+      left: "50%",
+      letterSpacing: "normal",
+      lineHeight: "15px",
+      top: -13,
+      transform: "scale(1) translateX(-50%) translateY(-10px) !important",
+
+      "& > span": {
+        background: LIGHT_GRAY.E,
+        borderRadius: 4,
+        height: "unset",
+        padding: "2px 4px",
+        width: "unset",
+      },
+
+      "& *": {
+        color: PT_TEXT_COLOR,
+        transform:
+          "none" /* removes transform rotate from all children of valueLabel */,
+      },
+    },
+  },
+});

--- a/frontend/src/components/common/Filter/components/FilterTags/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterTags/index.tsx
@@ -1,32 +1,28 @@
 import { Tag } from "@blueprintjs/core";
-import {
-  CATEGORY_KEY,
-  OnFilterFn,
-  SelectCategoryValueView,
-} from "src/components/common/Filter/common/entities";
+import React from "react";
 import { SelectedTags } from "./style";
 
+type OnRemoveFn = () => void;
+
+export interface CategoryTag {
+  label: string;
+  onRemove: OnRemoveFn;
+}
+
 interface Props {
-  categoryKey: CATEGORY_KEY;
-  onFilter: OnFilterFn;
-  selectedValues: SelectCategoryValueView[];
+  rangeCategoryTag?: CategoryTag;
+  selectCategoryTags?: CategoryTag[];
 }
 
 export default function FilterTags({
-  categoryKey,
-  onFilter,
-  selectedValues,
+  rangeCategoryTag,
+  selectCategoryTags,
 }: Props): JSX.Element | null {
-  return selectedValues.length ? (
+  const tags = rangeCategoryTag ? [rangeCategoryTag] : selectCategoryTags;
+  return tags && tags.length ? (
     <SelectedTags>
-      {selectedValues.map(({ key, label }) => (
-        <Tag
-          key={key}
-          large
-          minimal
-          multiline
-          onRemove={() => onFilter(categoryKey, key)}
-        >
+      {tags.map(({ label, onRemove }) => (
+        <Tag key={label} large minimal multiline onRemove={onRemove}>
           {label}
         </Tag>
       ))}

--- a/frontend/src/components/common/Filter/components/FilterTags/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterTags/index.tsx
@@ -10,15 +10,10 @@ export interface CategoryTag {
 }
 
 interface Props {
-  rangeCategoryTag?: CategoryTag;
-  selectCategoryTags?: CategoryTag[];
+  tags?: CategoryTag[];
 }
 
-export default function FilterTags({
-  rangeCategoryTag,
-  selectCategoryTags,
-}: Props): JSX.Element | null {
-  const tags = rangeCategoryTag ? [rangeCategoryTag] : selectCategoryTags;
+export default function FilterTags({ tags }: Props): JSX.Element | null {
   return tags && tags.length ? (
     <SelectedTags>
       {tags.map(({ label, onRemove }) => (

--- a/frontend/src/components/common/Filter/components/FilterTags/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterTags/index.tsx
@@ -5,7 +5,7 @@ import { SelectedTags } from "./style";
 type OnRemoveFn = () => void;
 
 export interface CategoryTag {
-  label: string;
+  label: string | [string, string]; // Single value ("label") or range tuple ("label[0] &ndash; label[1]")
   onRemove: OnRemoveFn;
 }
 
@@ -17,10 +17,31 @@ export default function FilterTags({ tags }: Props): JSX.Element | null {
   return tags && tags.length ? (
     <SelectedTags>
       {tags.map(({ label, onRemove }) => (
-        <Tag key={label} large minimal multiline onRemove={onRemove}>
-          {label}
+        <Tag
+          key={isLabelRange(label) ? label.join("") : label}
+          large
+          minimal
+          multiline
+          onRemove={onRemove}
+        >
+          {isLabelRange(label) ? (
+            <>
+              {label[0]} &ndash; {label[1]}
+            </>
+          ) : (
+            label
+          )}
         </Tag>
       ))}
     </SelectedTags>
   ) : null;
+}
+
+/**
+ * Returns true if the given label is multi value.
+ * @param label - Label to check if it is a single string or a string array.
+ * @returns True if label is multi value.
+ */
+function isLabelRange(label: string | string[]): label is [string, string] {
+  return Array.isArray(label);
 }

--- a/frontend/src/components/common/Filter/components/FilterTags/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterTags/index.tsx
@@ -1,15 +1,15 @@
 import { Tag } from "@blueprintjs/core";
 import {
-  CategoryValueView,
   CATEGORY_KEY,
   OnFilterFn,
+  SelectCategoryValueView,
 } from "src/components/common/Filter/common/entities";
 import { SelectedTags } from "./style";
 
 interface Props {
   categoryKey: CATEGORY_KEY;
   onFilter: OnFilterFn;
-  selectedValues: CategoryValueView[];
+  selectedValues: SelectCategoryValueView[];
 }
 
 export default function FilterTags({

--- a/frontend/src/components/common/Filter/index.tsx
+++ b/frontend/src/components/common/Filter/index.tsx
@@ -86,7 +86,7 @@ function buildRangeCategoryTag(
     // singleton array.
     return [
       {
-        label: createTagLabel(selectedMin, selectedMax),
+        label: createRangeTagLabel(selectedMin, selectedMax),
         onRemove: () => onFilter(categoryKey, []),
       },
     ];
@@ -122,10 +122,10 @@ function buildSelectCategoryTags(
  * @param max
  * @returns string portraying the selected range of the slider.
  */
-function createTagLabel(min: number, max: number): string {
+function createRangeTagLabel(min: number, max: number): [string, string] {
   const minLabel = formatNumberToScale(min);
   const maxLabel = formatNumberToScale(max);
-  return `${minLabel} - ${maxLabel}`;
+  return [minLabel, maxLabel];
 }
 
 /**

--- a/frontend/src/components/common/Filter/index.tsx
+++ b/frontend/src/components/common/Filter/index.tsx
@@ -45,6 +45,7 @@ export default function Filter({ categories, onFilter }: Props): JSX.Element {
               <span>
                 {selectedMin} - {selectedMax}
               </span>
+              <span onClick={() => onFilter(categoryView.key, [])}>x</span>
             </div>
           );
         }

--- a/frontend/src/components/common/Filter/index.tsx
+++ b/frontend/src/components/common/Filter/index.tsx
@@ -1,8 +1,11 @@
 import { ChangeEvent } from "react";
+import { isCategoryTypeBetween } from "src/common/hooks/useCategoryFilter";
 import {
-  CategoryValueView,
   CategoryView,
   OnFilterFn,
+  RangeCategoryView,
+  SelectCategoryValueView,
+  SelectCategoryView,
   SetSearchValueFn,
 } from "src/components/common/Filter/common/entities";
 import { MAX_DISPLAYABLE_MENU_ITEMS } from "src/components/common/Filter/components/FilterMenu/style";
@@ -19,7 +22,33 @@ interface Props {
 export default function Filter({ categories, onFilter }: Props): JSX.Element {
   return (
     <>
-      {categories.map(({ label, key, values }) => {
+      {categories.map((categoryView: CategoryView) => {
+        if (isCategoryTypeBetween(categoryView.key)) {
+          // Send [] to clear filter.
+          const { max, min, selectedMax, selectedMin } =
+            categoryView as RangeCategoryView;
+          return (
+            <div key={categoryView.key}>
+              <div>
+                <span onClick={() => onFilter(categoryView.key, [5000, max])}>
+                  {min}
+                </span>
+                {" - "}
+                <span
+                  onClick={() =>
+                    onFilter(categoryView.key, [min, max - 300000])
+                  }
+                >
+                  {max}
+                </span>
+              </div>
+              <span>
+                {selectedMin} - {selectedMax}
+              </span>
+            </div>
+          );
+        }
+        const { label, key, values } = categoryView as SelectCategoryView;
         const isDisabled = isCategoryNA(values);
         return (
           <BasicFilter
@@ -59,9 +88,9 @@ export default function Filter({ categories, onFilter }: Props): JSX.Element {
  * @returns array of category values filtered by the given search value
  */
 function filterCategoryValues(
-  values: CategoryValueView[],
+  values: SelectCategoryValueView[],
   searchValue: string
-): CategoryValueView[] {
+): SelectCategoryValueView[] {
   return values.filter(({ key }) => key.toLowerCase().includes(searchValue));
 }
 
@@ -71,8 +100,8 @@ function filterCategoryValues(
  * @returns category values with a count
  */
 function filterCategoryValuesWithCount(
-  values: CategoryValueView[]
-): CategoryValueView[] {
+  values: SelectCategoryValueView[]
+): SelectCategoryValueView[] {
   return values.filter(({ count }) => count > 0);
 }
 
@@ -82,8 +111,8 @@ function filterCategoryValuesWithCount(
  * @returns selected category values
  */
 function filterSelectedValues(
-  values: CategoryValueView[]
-): CategoryValueView[] {
+  values: SelectCategoryValueView[]
+): SelectCategoryValueView[] {
   return values.filter((value) => value.selected);
 }
 
@@ -92,7 +121,7 @@ function filterSelectedValues(
  * @param values
  * @returns true when all category values have a count of 0
  */
-function isCategoryNA(values: CategoryValueView[]) {
+function isCategoryNA(values: SelectCategoryValueView[]) {
   return values.every((value) => value.count === 0);
 }
 

--- a/frontend/src/components/common/Filter/index.tsx
+++ b/frontend/src/components/common/Filter/index.tsx
@@ -36,7 +36,7 @@ export default function Filter({ categories, onFilter }: Props): JSX.Element {
                   categoryKey={key}
                   filterCategoryValues={filterCategoryValues}
                   filterCategoryValuesWithCount={filterCategoryValuesWithCount}
-                  isMultiselect={true} // Can possibly be single select with future filter types
+                  isMultiselect // Can possibly be single select with future filter types
                   isSearchable={values.length > MAX_DISPLAYABLE_MENU_ITEMS}
                   onFilter={onFilter}
                   onUpdateSearchValue={onUpdateSearchValue}

--- a/frontend/src/components/common/Filter/index.tsx
+++ b/frontend/src/components/common/Filter/index.tsx
@@ -24,6 +24,7 @@ interface Props {
   onFilter: OnFilterFn;
 }
 
+// TODO(cc) add type guard to prevent "as XXX"
 export default function Filter({ categories, onFilter }: Props): JSX.Element {
   return (
     <>

--- a/frontend/src/components/common/Grid/components/ActionButton/index.tsx
+++ b/frontend/src/components/common/Grid/components/ActionButton/index.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from "react";
 import { ActionButton as StyledActionButton } from "src/components/common/Grid/components/ActionButton/style";
 
 interface Props {
-  iconSvg: ReactElement; // TODO(cc) check type
+  iconSvg: ReactElement;
   isAnchorButton?: boolean;
 }
 

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -5,7 +5,10 @@ import { Column, useFilters, useSortBy, useTable } from "react-table";
 import { PLURALIZED_METADATA_LABEL } from "src/common/constants/metadata";
 import { ROUTES } from "src/common/constants/routes";
 import { FEATURES } from "src/common/featureFlags/features";
-import { useCategoryFilter } from "src/common/hooks/useCategoryFilter";
+import {
+  CategoryKey,
+  useCategoryFilter,
+} from "src/common/hooks/useCategoryFilter";
 import { useFeatureFlag } from "src/common/hooks/useFeatureFlag";
 import { useFetchCollectionRows } from "src/common/queries/filter";
 import { useExplainTombstoned } from "src/components/Collections/common/utils";
@@ -201,6 +204,20 @@ export default function Collections(): JSX.Element {
     useSortBy
   );
 
+  // Determine the set of categories to display for the datasets view.
+  const categories = useMemo<Set<CATEGORY_KEY>>(() => {
+    return Object.values(CATEGORY_KEY)
+      .filter(
+        (categoryKey: CategoryKey) =>
+          categoryKey !== CATEGORY_KEY.CELL_COUNT &&
+          categoryKey !== CATEGORY_KEY.MEAN_GENES_PER_CELL
+      )
+      .reduce((accum, categoryKey: CategoryKey) => {
+        accum.add(categoryKey);
+        return accum;
+      }, new Set<CATEGORY_KEY>());
+  }, []);
+
   // Filter init.
   const {
     preFilteredRows,
@@ -208,7 +225,12 @@ export default function Collections(): JSX.Element {
     setFilter,
     state: { filters },
   } = tableInstance;
-  const filterInstance = useCategoryFilter(preFilteredRows, filters, setFilter);
+  const filterInstance = useCategoryFilter(
+    preFilteredRows,
+    categories,
+    filters,
+    setFilter
+  );
 
   // Hide datasets behind feature flag - start
   const isFilterEnabled = useFeatureFlag(FEATURES.FILTER);

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -176,13 +176,13 @@ export default function Datasets(): JSX.Element {
       },
       // Hidden, required for filter.
       {
-        accessor: CATEGORY_KEY.MEAN_GENES_PER_CELL,
-        filter: "between",
+        accessor: CATEGORY_KEY.IS_PRIMARY_DATA,
+        filter: "includesSome",
       },
       // Hidden, required for filter.
       {
-        accessor: CATEGORY_KEY.IS_PRIMARY_DATA,
-        filter: "includesSome",
+        accessor: CATEGORY_KEY.MEAN_GENES_PER_CELL,
+        filter: "between",
       },
       // Hidden, required for filter.
       {
@@ -218,8 +218,8 @@ export default function Datasets(): JSX.Element {
           COLLECTION_NAME,
           COLUMN_ID_RECENCY,
           CATEGORY_KEY.CELL_TYPE,
-          CATEGORY_KEY.MEAN_GENES_PER_CELL,
           CATEGORY_KEY.IS_PRIMARY_DATA,
+          CATEGORY_KEY.MEAN_GENES_PER_CELL,
           CATEGORY_KEY.PUBLICATION_AUTHORS,
           CATEGORY_KEY.PUBLICATION_DATE_VALUES,
           CATEGORY_KEY.SEX,

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -129,6 +129,7 @@ export default function Datasets(): JSX.Element {
         ),
         Header: <RightAlignCell>Cells</RightAlignCell>,
         accessor: "cell_count",
+        filter: "between",
       },
       {
         Cell: ({ row: { values } }: RowPropsValue<DatasetRow>) => (
@@ -235,6 +236,7 @@ export default function Datasets(): JSX.Element {
     state: { filters },
   } = tableInstance;
 
+  // TODO(cc) specify set of categories for datasets. same with collections.
   const filterInstance = useCategoryFilter(preFilteredRows, filters, setFilter);
 
   // Hide datasets behind feature flag - start

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/index.tsx
@@ -328,8 +328,8 @@ export default function GeneSearchBar({ onGenesChange }: Props): JSX.Element {
           }
           renderOption={(option) => option.name}
           onPaste={handlePaste}
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- TODO(cc) revisit
-          // @ts-ignore -- TODO(cc) revisit
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- TODO revisit lint errors
+          // @ts-ignore -- TODO revisit lint errors
           InputBaseProps={{
             onChange: (
               event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/index.tsx
@@ -328,6 +328,8 @@ export default function GeneSearchBar({ onGenesChange }: Props): JSX.Element {
           }
           renderOption={(option) => option.name}
           onPaste={handlePaste}
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- TODO(cc) revisit
+          // @ts-ignore -- TODO(cc) revisit
           InputBaseProps={{
             onChange: (
               event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>

--- a/frontend/tests/features/filter/utils.test.ts
+++ b/frontend/tests/features/filter/utils.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Test suite for filter-related utils.
+ */
+
+import {
+  formatNumberToScale,
+  SYMBOL_MILLION,
+  SYMBOL_THOUSAND,
+} from "src/components/common/Filter/common/utils";
+
+describe("filter", () => {
+  describe("Format Number to Magnitude", () => {
+    const testConfigs = [
+      {
+        formatted: "4",
+        value: 4,
+      },
+      {
+        formatted: "6",
+        value: 6,
+      },
+      {
+        formatted: "40",
+        value: 40,
+      },
+      {
+        formatted: "60",
+        value: 60,
+      },
+      {
+        formatted: `0.1${SYMBOL_THOUSAND}`,
+        value: 140,
+      },
+      {
+        formatted: `0.2${SYMBOL_THOUSAND}`,
+        value: 150,
+      },
+      {
+        formatted: `0.2${SYMBOL_THOUSAND}`,
+        value: 160,
+      },
+      {
+        formatted: `0.2${SYMBOL_THOUSAND}`,
+        value: 190,
+      },
+      {
+        formatted: `0.2${SYMBOL_THOUSAND}`,
+        value: 240,
+      },
+      {
+        formatted: `0.3${SYMBOL_THOUSAND}`,
+        value: 250,
+      },
+      {
+        formatted: `0.3${SYMBOL_THOUSAND}`,
+        value: 260,
+      },
+      {
+        formatted: `0.9${SYMBOL_THOUSAND}`,
+        value: 899,
+      },
+      {
+        formatted: `0.9${SYMBOL_THOUSAND}`,
+        value: 940,
+      },
+      {
+        formatted: `1${SYMBOL_THOUSAND}`,
+        value: 950,
+      },
+      {
+        formatted: `1${SYMBOL_THOUSAND}`,
+        value: 960,
+      },
+      {
+        formatted: `1${SYMBOL_THOUSAND}`,
+        value: 999,
+      },
+      {
+        formatted: `1.4${SYMBOL_THOUSAND}`,
+        value: 1400,
+      },
+      {
+        formatted: `1.5${SYMBOL_THOUSAND}`,
+        value: 1500,
+      },
+      {
+        formatted: `1.6${SYMBOL_THOUSAND}`,
+        value: 1600,
+      },
+      {
+        formatted: `2${SYMBOL_THOUSAND}`,
+        value: 1995,
+      },
+      {
+        formatted: `14${SYMBOL_THOUSAND}`,
+        value: 14000,
+      },
+      {
+        formatted: `15${SYMBOL_THOUSAND}`,
+        value: 14500,
+      },
+      {
+        formatted: `82${SYMBOL_THOUSAND}`,
+        value: 81572,
+      },
+      {
+        formatted: `0.1${SYMBOL_MILLION}`,
+        value: 140000,
+      },
+      {
+        formatted: `0.2${SYMBOL_MILLION}`,
+        value: 160000,
+      },
+      {
+        formatted: `0.2${SYMBOL_MILLION}`,
+        value: 190000,
+      },
+      {
+        formatted: `0.2${SYMBOL_MILLION}`,
+        value: 240000,
+      },
+      {
+        formatted: `0.3${SYMBOL_MILLION}`,
+        value: 250000,
+      },
+      {
+        formatted: `0.3${SYMBOL_MILLION}`,
+        value: 260000,
+      },
+      {
+        formatted: `1.4${SYMBOL_MILLION}`,
+        value: 1400000,
+      },
+      {
+        formatted: `1.6${SYMBOL_MILLION}`,
+        value: 1600000,
+      },
+      {
+        formatted: `1.9${SYMBOL_MILLION}`,
+        value: 1940000,
+      },
+      {
+        formatted: `2${SYMBOL_MILLION}`,
+        value: 1950000,
+      },
+    ];
+    testConfigs.forEach(
+      ({ value, formatted }: { value: number; formatted: string }) => {
+        it(`formats ${value} to ${formatted}`, () => {
+          const actual = formatNumberToScale(value);
+          expect(actual).toEqual(formatted);
+        });
+      }
+    );
+  });
+});

--- a/frontend/tests/features/filter/utils.test.ts
+++ b/frontend/tests/features/filter/utils.test.ts
@@ -72,28 +72,20 @@ describe("filter", () => {
         value: 81572,
       },
       {
-        formatted: `0.1${SYMBOL_MILLION}`,
+        formatted: `140${SYMBOL_THOUSAND}`,
         value: 140000,
       },
       {
-        formatted: `0.2${SYMBOL_MILLION}`,
+        formatted: `160${SYMBOL_THOUSAND}`,
         value: 160000,
       },
       {
-        formatted: `0.2${SYMBOL_MILLION}`,
+        formatted: `190${SYMBOL_THOUSAND}`,
         value: 190000,
       },
       {
-        formatted: `0.2${SYMBOL_MILLION}`,
+        formatted: `240${SYMBOL_THOUSAND}`,
         value: 240000,
-      },
-      {
-        formatted: `0.3${SYMBOL_MILLION}`,
-        value: 250000,
-      },
-      {
-        formatted: `0.3${SYMBOL_MILLION}`,
-        value: 260000,
       },
       {
         formatted: `1.4${SYMBOL_MILLION}`,

--- a/frontend/tests/features/filter/utils.test.ts
+++ b/frontend/tests/features/filter/utils.test.ts
@@ -28,51 +28,19 @@ describe("filter", () => {
         value: 60,
       },
       {
-        formatted: `0.1${SYMBOL_THOUSAND}`,
+        formatted: "140",
         value: 140,
       },
       {
-        formatted: `0.2${SYMBOL_THOUSAND}`,
+        formatted: "150",
         value: 150,
       },
       {
-        formatted: `0.2${SYMBOL_THOUSAND}`,
+        formatted: "160",
         value: 160,
       },
       {
-        formatted: `0.2${SYMBOL_THOUSAND}`,
-        value: 190,
-      },
-      {
-        formatted: `0.2${SYMBOL_THOUSAND}`,
-        value: 240,
-      },
-      {
-        formatted: `0.3${SYMBOL_THOUSAND}`,
-        value: 250,
-      },
-      {
-        formatted: `0.3${SYMBOL_THOUSAND}`,
-        value: 260,
-      },
-      {
-        formatted: `0.9${SYMBOL_THOUSAND}`,
-        value: 899,
-      },
-      {
-        formatted: `0.9${SYMBOL_THOUSAND}`,
-        value: 940,
-      },
-      {
-        formatted: `1${SYMBOL_THOUSAND}`,
-        value: 950,
-      },
-      {
-        formatted: `1${SYMBOL_THOUSAND}`,
-        value: 960,
-      },
-      {
-        formatted: `1${SYMBOL_THOUSAND}`,
+        formatted: "999",
         value: 999,
       },
       {


### PR DESCRIPTION
### Reviewers
**Functional:** 
@tihuan 

---

## Changes
- Added filter by cell count ([mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=1468%3A9713)).
- Added filter by gene count ([mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=1468%3A9713)).

## Definition of Done (from ticket)
#### Cell Count
* Cell count filter displayed in datasets filter sidebar.
* Slider UI matches [mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=1468%3A9713).
* Selected state matches [mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=2681%3A31105).
* Selecting min and max cell count values filters corresponding datasets result set.

#### Gene Count
* Gene count filter displayed in datasets filter sidebar.
* Slider UI matches [mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=1468%3A9713).
* Selecting min and max gene count values filters corresponding datasets result set.

