### PR TITLE
feat: wmg query endpoint impl with filter dim datasets metadata

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -40,11 +40,11 @@ db/rollback:
 
 db/new_migration:
 	# Usage: make db/new_migration MESSAGE="purpose_of_migration"
-	PYTHONPATH=.. alembic -c=./config/database.ini revision --message $(MESSAGE)
+	PYTHONPATH=.. alembic -c=./config/database.ini revision --message "$(MESSAGE)"
 
 db/new_migration_auto:
-	# Usage: make db/new_migration MESSAGE="purpose_of_migration"
-	PYTHONPATH=.. alembic -c=./config/database.ini revision --autogenerate --message $(MESSAGE)
+	# Usage: make db/new_migration_auto MESSAGE="purpose_of_migration"
+	PYTHONPATH=.. alembic -c=./config/database.ini revision --autogenerate --message "$(MESSAGE)"
 
 db/connect:
 	# Assuming you've created a tunnel to the DB. Check the docs for information on how to do that

--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -1005,15 +1005,11 @@ paths:
                         $ref: "#/components/schemas/wmg_ontology_term_id_list"
                       ethnicity_ontology_term_ids:
                         $ref: "#/components/schemas/wmg_ontology_term_id_list"
-                response_option:
-                  type: string
-                  enum:
-                    - include_filter_dims_include_dataset_links
-                    - include_filter_dims_exclude_dataset_links
-                    - exclude_filter_dims
+                include_filter_dims:
+                  type: boolean
+                  default: false
               required:
                 - filter
-                - response_option
       responses:
         "200":
           description: OK

--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -1,14 +1,11 @@
-from urllib.parse import urlparse
-
 import csv
 import logging
 import os
 import typing
+from collections import OrderedDict
 from datetime import datetime
 from pathlib import PurePosixPath
-from collections import OrderedDict
-
-from ..utils.ontology_mapping import ontology_mapping
+from urllib.parse import urlparse
 
 from .dataset_asset import DatasetAsset
 from .entity import Entity
@@ -26,6 +23,7 @@ from ..corpora_orm import (
     ConversionStatus,
 )
 from ..utils.db_helpers import clone
+from ..utils.ontology_mapping import ontology_mapping
 from ..utils.s3_buckets import buckets
 
 logger = logging.getLogger(__name__)

--- a/backend/database/README.md
+++ b/backend/database/README.md
@@ -2,94 +2,104 @@
 
 - General information about Alembic migrations can be found [here](https://alembic.sqlalchemy.org/en/latest/index.html).
 - For database [make recipes](../Makefile)
+- See [Environment variables](../../README.md#environment-variables) for 
+usage explanation of `DEPLOYMENT_STAGE`, `AWS_PROFILE` and `CORPORA_LOCAL_DEV`
+- `$REPO_ROOT` - root directory where the `single-cell-data-portal` project is cloned (e.g. `~/PyCharmProjects/single-cell-data-portal`)
 
 ## How to perform a database migration
 
-1. From the top level directory (`corpora-data-portal`), `cd backend`.
+1. `cd $REPO_ROOT/backend`
 1. Run `make db/new_migration MESSAGE="purpose_of_migration"` where `purpose_of_migration` is a short phrase describing why the database migration is occurring.
-1. Head over to the file that was just created. The path will be something like `backend/database/versions/xxxxxxxxxxxx_purpose_of_migration.py`. Edit the `upgrade()` and `downgrade()` functions such that `upgrade()` contains the commands to perform the migration you would like and `downgrade()` contains the commands to undo it.
-1. Rename the file by prepending the migration count to the filename (`xxx_purpose_of_migration` -> `03_xxx_purpose_of_migration`)
-1. Update the `Revision ID` and the `revision` (used by alembic) to include the migration count
+   This generates a file in `$REPO_ROOT/backend/database/versions/xxxxxxxxxxxx_purpose_of_migration.py`
+1. In the generated file, edit the `upgrade()` and `downgrade()` functions such that `upgrade()` contains the Alembic DDL commands to perform the migration you would like and `downgrade()` contains the commands to undo it.
+1. Rename the generated file by prepending the migration count to the filename (`xxx_purpose_of_migration.py` -> `03_xxx_purpose_of_migration.py`)
+1. In the generated file, update the `Revision ID` and the `revision` (used by Alembic) to include the migration count.
 For example `Revision ID: a8cd0dc08805` becomes `Revision ID: 18_a8cd0dc08805` and `revision = "a8cd0dc08805"` becomes `revision = "18_a8cd0dc08805"` 
 1. [Test your migration](#test-a-migration)
-1. Check that [corpora.orm](../corpora/common/corpora_orm.py) matches up with your changes.
-1. Once you've completed the changes, create a PR to get the functions reviewed. 
+1. Check that [corpora_orm.py](../corpora/common/corpora_orm.py) matches up with your changes.
+1. Once you've completed the changes, create a PR to get the functions reviewed.
 1. Once the PR is merged, you can run the migration.
 1. [Connect to Remote RDS](#connect-to-remote-rds)
 1. In a new terminal, complete the migration by running:
 ```shell
-cd corpora-data-portal/backend
-export CORPORA_LOCAL_DEV=1
-export DEPLOYMENT_STAGE=test
-make db/migrate
+cd $REPO_ROOT/backend
+CORPORA_LOCAL_DEV=1 DEPLOYMENT_STAGE=test make db/migrate
 ```
 
 ## How to autogenerate migration script
 
-1. From the top level directory (`corpora-data-portal`), `cd backend`.
-1. Make changes to [corpora_orm.py](../corpora/common/corpora_orm.py)
-1. [Connect to Remote RDS](#connect-to-remote-rds)
-1. Run Auto-migration:
+1. Make changes to the ORM class(es) in [corpora_orm.py](../corpora/common/corpora_orm.py)
+2. [Connect to Remote RDS](#connect-to-remote-rds). Note, generally, you should be connecting to prod
+   (`AWS_PROFILE=single-cell-prod DEPLOYMENT_STAGE=prod`) since we want to generate 
+a migration from the database schema currently deployed in prod.
+3. Autogenerate the migration using the steps below. `AWS_PROFILE` and `DEPLOYMENT_STAGE` should be the same values
+used in the previous [Connect to Remote RDS](#connect-to-remote-rds) step. For details about Alembic's migration autogeneration, 
+see [What does Autogenerate Detect (and what does it not detect?)](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect)
 ```shell
-cd corpora-data-portal/backend
-export CORPORA_LOCAL_DEV=1
-export DEPLOYMENT_STAGE=test
-make db/new_migration_auto MESSAGE="purpose_of_migration"
+cd $REPO_ROOT/backend
+AWS_PROFILE=single-cell-{dev,prod} DEPLOYMENT_STAGE={dev,staging,prod} CORPORA_LOCAL_DEV=1 make db/new_migration_auto MESSAGE="purpose_of_migration"
 ```
-See [What does Autogenerate Detect (and what does it not detect?)](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect).
-5. Follow [How to perform a database migration](#how-to-perform-a-database-migration) starting from **step 3**.
+4. Follow [How to perform a database migration](#how-to-perform-a-database-migration) starting from **step 3** 
+(i.e. editing the `upgrade()` and `downgrade()` functions).
 
 ### Test a Migration
 The following steps will test that a migration script works on a local database using data downloaded from a deployed database. 
 
 1. [Connect to Remote RDS](#connect-to-remote-rds)
-2. Open a new terminal and download the remote database schema:
+2. Open a new terminal and using the same values for `AWS_PROFILE` and `DEPLOYMENT_STAGE`, download the remote database schema:
 ```shell
-cd corpora-data-portal/backend
-export DEPLOYMENT_STAGE=test
-make db/download
+cd $REPO_ROOT/backend
+AWS_PROFILE=single-cell-{dev,prod} DEPLOYMENT_STAGE={dev,staging,prod} make db/download
 ```
-This wll download the database into a file ending in *.sqlc*.
+This will download the database into the `$REPO_ROOT/backend/database` directory in a file named `corpora_${DEPLOYMENT_STAGE}-<YYYYmmddHHMM>.sqlc`.
+
 3. Close the tunnel to the remote database
-4. Start the local database environment: 
+4. Start the local database environment:
 ```shell
-cd corpora-data-portal
+cd $REPO_ROOT
 make local-start
-export DEPLOYMENT_STAGE=test
 ```
-5. Import the remote database schema into your local database:  
+5. Import the remote database schema into your local database:
 ```shell
-cd backend/
-make db/import FROM=${}
+cd $REPO_ROOT/backend
+DEPLOYMENT_STAGE=test make db/import FROM=corpora_{dev,staging,prod}-<YYYYmmddHHMM>  # exclude the .sqlc extension
 ```
-where from is the name of the *.sqlc* file downloaded. For example 
-```shell script
-make db/import FROM=corpora_dev-202102221309
+where the `FROM` parameter is the base name of the `.sqlc` file downloaded from the `make db/download` step above. For example 
+```shell
+make db/import FROM=corpora_prod-202102221309
 ```
-- Note: The file is stored under backend/database/file_name but the make command will look in import/file_name this is due to the way [the local paths are mapped to the docker container](https://github.com/chanzuckerberg/corpora-data-portal/blob/ffca067b9e4aea237fa2bd7c7a9cbc5813ebd449/docker-compose.yml#L13)
+- Note: The file is stored locally under `$REPO_ROOT/backend/database/corpora_${DEPLOYMENT_STAGE}-<YYYYmmddHHMM>.sqlc` 
+but the `make db/import` command retrieves it from `/import/$(FROM).sqlc` due to the way [the local paths are mapped to the Docker container](https://github.com/chanzuckerberg/corpora-data-portal/blob/ffca067b9e4aea237fa2bd7c7a9cbc5813ebd449/docker-compose.yml#L13)
 
 You may need to run this a few times, until there are no significant errors.
  - Note: `pg_restore: error: could not execute query: ERROR:  role "rdsadmin" does not exist` is not a significant error
 6. Run the migration test:
 ```shell
-make db/test_migration
+AWS_PROFILE=single-cell-{dev,prod} DEPLOYMENT_STAGE=test make db/test_migration
 ``` 
+This test will:
+1. Dump the current schema (before)
+1. Apply the migration (upgrade)
+1. Rollback the migration (downgrade)
+1. Dump the schema (after)
+1. Compare the before vs after schemas. These should be identical if the database migration's `upgrade()` and `downgrade()` functions were implemented correctly.
+
 If there are no differences then the test passed. If the test didn't pass, make adjustments to your migration script and restart from step 5. Repeat until there are no errors.
 
 ## Connect to Remote RDS
 Enable local connection to the private RDS instance:
 
 - Note: Since the default PostgreSQL port is `5432`, the above command will conflict with a local PostgreSQL instance.
-To stop it run `make local-stop` from `./corpora-data-portal`
+To stop it run `make local-stop` from the `$REPO_ROOT` directory.
 
 
 ```shell
-cd ./corpora-data-poral/backend
-export DEPLOYMENT_STAGE=test
-make db/tunnel
+cd $REPO_ROOT/backend
+AWS_PROFILE=single-cell-{dev,prod} DEPLOYMENT_STAGE={dev,staging,prod} make db/tunnel
 ```
 
 This command opens an SSH tunnel from `localhost:5432` to the RDS connection endpoint via the *bastion* server.
-The local port `5432` is fixed and encoded in the DB connection string stored in the AWS Secret at
-`corpora/backend/<DEPLOYMENT_STAGE>/database_local`.
+The local port `5432` is fixed and encoded in the DB connection string stored in 
+[AWS Secrets Manager](https://us-west-2.console.aws.amazon.com/secretsmanager/home?region=us-west-2#!/listSecrets/)
+in the secret named `corpora/backend/${DEPLOYMENT_STAGE}/database_local`.
 

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -1,11 +1,11 @@
 import logging
 from collections import defaultdict
-from typing import Dict, List, Union
+from typing import Dict, List
 from uuid import uuid4
 
 import connexion
 import tiledb
-from flask import jsonify, request
+from flask import jsonify
 from pandas import DataFrame
 
 from backend.corpora.common.corpora_orm import DbDataset
@@ -19,6 +19,7 @@ from backend.wmg.data.query import (
     WmgQueryCriteria,
     build_dot_plot_matrix,
 )
+
 # TODO: Replace with real snapshot uuid
 from backend.wmg.data.schema import cube_non_indexed_dims
 
@@ -92,10 +93,9 @@ def fetch_datasets(dataset_ids: List[str]) -> List[Dict]:
     # We return a DTO because the db entity can't access its attributes after the db session ends,
     # and we want to keep session management out of the calling method
     def result(dataset: DbDataset):
-        return dict(id=dataset.id,
-                    name=dataset.name,
-                    collection=dict(id=dataset.collection.id,
-                                    name=dataset.collection.name))
+        return dict(
+            id=dataset.id, name=dataset.name, collection=dict(id=dataset.collection.id, name=dataset.collection.name)
+        )
 
     with db_session_manager() as session:
         return [result(Dataset.get(session, dataset_id).db_object) for dataset_id in dataset_ids]
@@ -105,10 +105,10 @@ def build_datasets(dataset_ids: List[str]) -> List[Dict]:
     datasets = fetch_datasets(dataset_ids)
     return [
         dict(
-                id=dataset['id'],
-                label=dataset['name'],
-                collection_id=dataset['collection']['id'],
-                collection_label=dataset['collection']['name'],
+            id=dataset["id"],
+            label=dataset["name"],
+            collection_id=dataset["collection"]["id"],
+            collection_label=dataset["collection"]["name"],
         )
         for dataset in datasets
     ]

--- a/backend/wmg/data/ontology_labels.py
+++ b/backend/wmg/data/ontology_labels.py
@@ -70,6 +70,6 @@ def __open_ontology_resource(file) -> IO:
     # return gzip.open(path)
 
     # Python 3.8 hack. Likely a cleaner way to do this, but it works, and best to just use above after upgrading to 3.9
-    with resources.path('cellxgene_schema', 'cli.py') as cellxgene_schema_abs_dir:
-        ontology_file = os.path.join(os.path.dirname(cellxgene_schema_abs_dir), 'ontology_files', file)
+    with resources.path("cellxgene_schema", "cli.py") as cellxgene_schema_abs_dir:
+        ontology_file = os.path.join(os.path.dirname(cellxgene_schema_abs_dir), "ontology_files", file)
         return gzip.open(ontology_file)

--- a/backend/wmg/data/query.py
+++ b/backend/wmg/data/query.py
@@ -32,6 +32,7 @@ class WmgQuery:
         super().__init__()
         self._cube = cube
 
+    # TODO: refactor for readability
     def execute(self, criteria: WmgQueryCriteria) -> DataFrame:
         # As TileDB API does not yet support logical OR'ing of attribute values in query conditions, the best we can do
         # for a single TileDB query is to have TileDB perform the filtering for only the attributes that have

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
         - HAPPY_TAG
     restart: "no"
     ports:
-      - "9000:8080"
+      - "9001:8080"
     volumes:
       - ./backend/corpora/upload_success:/var/task
       - ./backend/corpora/common:/var/task/backend/corpora/common
@@ -188,7 +188,8 @@ services:
       - localstack
       - database
     ports:
-      - "5000:5000"
+      # port 5000 is 'unofficially' used by Apple's Control Center! 🤬
+      - "5001:5000"
     environment:
       - PYTHONUNBUFFERED=1
       - CORPORA_LOCAL_DEV=true

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/style.ts
@@ -1,3 +1,5 @@
+import { css } from "@emotion/css";
+import { TooltipTable } from "czifui";
 import styled from "styled-components";
 
 export const ChartContainer = styled.div`
@@ -20,3 +22,11 @@ function getWidthAndHeight({
     height: ${height}px;
   `;
 }
+
+export const StyledTooltipTable = styled(TooltipTable)``;
+
+export const tooltipCss = css`
+  margin: 0;
+  margin-top: 20px;
+  max-width: 400px !important;
+`;

--- a/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
@@ -1,5 +1,5 @@
 import { Intent, Spinner } from "@blueprintjs/core";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { State } from "../../common/store";
 import {
   CellTypeSummary,
@@ -29,10 +29,6 @@ export default memo(function HeatMap({
 }: Props): JSX.Element {
   // Loading state per tissue
   const [isLoading, setIsLoading] = useState(setInitialIsLoading(cellTypes));
-
-  useEffect(() => {
-    setIsLoading((isLoading) => ({ ...isLoading, lung: true }));
-  }, [genes, cellTypes]);
 
   const yAxisWrapperHeight = useMemo(() => {
     const yAxisChartHeight = Object.values(cellTypes).reduce(

--- a/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
@@ -35,17 +35,6 @@ const COMMON_SERIES: ScatterSeriesOption = {
   type: "scatter",
 };
 
-const COMMON_AXIS_POINTER: EChartsOption["axisPointer"] = {
-  link: [
-    {
-      xAxisIndex: "all",
-    },
-  ],
-  show: true,
-  triggerOn: "click",
-  triggerTooltip: false,
-};
-
 interface CreateChartOptionsProps {
   cellTypeMetadata: string[];
   chartData: ChartFormat[];
@@ -59,7 +48,16 @@ export function createChartOptions({
 }: CreateChartOptionsProps): EChartsOption {
   return {
     ...COMMON_OPTIONS,
-    axisPointer: { ...COMMON_AXIS_POINTER, label: { show: false } },
+    axisPointer: {
+      label: { show: false },
+      link: [
+        {
+          xAxisIndex: "all",
+        },
+      ],
+      show: true,
+      triggerOn: "mousemove",
+    },
     dataset: {
       source: chartData as DatasetComponentOption["source"],
     },
@@ -87,36 +85,6 @@ export function createChartOptions({
         },
       },
     ],
-    tooltip: {
-      formatter(props) {
-        const { name: cellTypeMetadata, data } = props as unknown as {
-          name: string;
-          data: ChartFormat;
-        };
-
-        if (!data) return "";
-
-        const { geneIndex, percentage, meanExpression, scaledMeanExpression } =
-          data;
-
-        const { name } = deserializeCellTypeMetadata(
-          cellTypeMetadata as CellTypeMetadata
-        );
-
-        return `
-          cell type: ${name}
-          <br />
-          gene: ${geneNames[geneIndex]}
-          <br />
-          percentage: ${percentage}
-          <br />
-          mean expression: ${meanExpression}
-          <br />
-          scaledMeanExpression: ${scaledMeanExpression}
-        `;
-      },
-      position: "top",
-    },
     xAxis: [
       {
         axisLabel: { fontSize: 0, rotate: 90 },
@@ -164,7 +132,6 @@ export function createXAxisOptions({
 }: CreateXAxisOptionsProps): EChartsOption {
   return {
     ...COMMON_OPTIONS,
-    axisPointer: { ...COMMON_AXIS_POINTER },
     grid: {
       bottom: "0",
       left: "300px",
@@ -232,7 +199,6 @@ export function createYAxisOptions({
 }: CreateYAxisOptionsProps): EChartsOption {
   return {
     ...COMMON_OPTIONS,
-    axisPointer: { ...COMMON_AXIS_POINTER },
     grid: {
       bottom: Y_AXIS_BOTTOM_PADDING,
       left: "300px",

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/common/style.ts
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/common/style.ts
@@ -1,0 +1,27 @@
+import styled from "@emotion/styled";
+import { fontBodyXxs, fontHeaderXxs, getColors } from "czifui";
+
+export const LowHigh = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const Header = styled.h5`
+  ${fontHeaderXxs}
+
+  margin-bottom: 10px;
+`;
+
+export const Content = styled.div`
+  ${fontBodyXxs}
+
+  width: 100px;
+
+  ${(props) => {
+    const colors = getColors(props);
+
+    return `
+      color: ${colors?.gray[500]};
+    `;
+  }}
+`;

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/ExpressedInCells/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/ExpressedInCells/index.tsx
@@ -1,0 +1,24 @@
+import { Content, Header, LowHigh } from "../../common/style";
+import { Dot, Dots, Wrapper } from "./style";
+
+const SIZES = [2, 4, 8, 12, 16];
+
+export default function ExpressedInCells(): JSX.Element {
+  return (
+    <Wrapper>
+      <Header>Expressed in Cells (%)</Header>
+
+      <Content>
+        <Dots>
+          {SIZES.map((size) => (
+            <Dot size={size} key={size} />
+          ))}
+        </Dots>
+        <LowHigh>
+          <span>0</span>
+          <span>100</span>
+        </LowHigh>
+      </Content>
+    </Wrapper>
+  );
+}

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/ExpressedInCells/style.ts
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/ExpressedInCells/style.ts
@@ -1,0 +1,32 @@
+import styled from "@emotion/styled";
+import { CommonThemeProps, getColors } from "czifui";
+
+interface DotProps extends CommonThemeProps {
+  size: number;
+}
+
+export const Wrapper = styled.div`
+  margin-bottom: 24px;
+`;
+
+export const Dot = styled.span`
+  border-radius: 50%;
+
+  ${(props: DotProps) => {
+    const colors = getColors(props);
+    const { size } = props;
+
+    return `
+      background-color: ${colors?.gray[300]};
+      width: ${size}px;
+      height: ${size}px;
+    `;
+  }}
+`;
+
+export const Dots = styled.div`
+  display: flex;
+  margin-bottom: 10px;
+  justify-content: space-between;
+  align-items: center;
+`;

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/Methodology/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/Methodology/index.tsx
@@ -1,0 +1,18 @@
+import { Header } from "../../common/style";
+import { Content, Wrapper } from "./style";
+
+export default function Methodology(): JSX.Element {
+  return (
+    <Wrapper>
+      <Header>Methodology</Header>
+      <Content>
+        After filtering cells with low coverage (less than 500 genes expressed),
+        gene counts are normalized independently for each cell by converting
+        counts to quantiles and obtaining the corresponding values from the
+        standard normal distribution. Then normalized cell vectors are
+        concatenated along the gene axis. The algorithm is summarized in detail
+        in our documentation.
+      </Content>
+    </Wrapper>
+  );
+}

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/Methodology/style.ts
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/Methodology/style.ts
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+import { Content as CommonContent } from "../../common/style";
+
+export const Wrapper = styled.div`
+  margin-bottom: 40px;
+`;
+
+export const Content = styled(CommonContent)`
+  width: unset;
+`;

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/RelativeGeneExpression/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/RelativeGeneExpression/index.tsx
@@ -1,0 +1,23 @@
+import { Content, Header, LowHigh } from "../../common/style";
+import { Dot, Dots, Wrapper } from "./style";
+
+const COLORS = ["#FFFFC1", "#FDD66D", "#F95929", "#CD0019", "#6C001D"];
+
+export default function RelativeGeneExpression(): JSX.Element {
+  return (
+    <Wrapper>
+      <Header>Relative Gene Expression</Header>
+      <Content>
+        <Dots>
+          {COLORS.map((color) => (
+            <Dot color={color} key={color} />
+          ))}
+        </Dots>
+        <LowHigh>
+          <span>Low</span>
+          <span>High</span>
+        </LowHigh>
+      </Content>
+    </Wrapper>
+  );
+}

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/RelativeGeneExpression/style.ts
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/RelativeGeneExpression/style.ts
@@ -1,0 +1,23 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  margin-bottom: 16px;
+`;
+
+export const Dot = styled.span`
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+
+  ${({ color }: { color: string }) => {
+    return `
+      background-color: ${color};
+    `;
+  }}
+`;
+
+export const Dots = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+`;

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/SourceData/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/SourceData/index.tsx
@@ -1,0 +1,157 @@
+import { List, ListItem } from "czifui";
+import { useMemo } from "react";
+import { Content, Header, ListSubheader, Wrapper } from "./style";
+
+const MOCK_COLLECTION_URL = "https://czi.org";
+
+const DATA_SETS = [
+  {
+    collection_label:
+      "LungMAP — The genomic, epigenomic and biophysical cues controlling the emergence of the gas exchange niche in the lung",
+    collection_url: MOCK_COLLECTION_URL,
+    id: "Developmental single-cell atlas of the murine lung",
+    label: "Developmental single-cell atlas of the murine lung",
+  },
+  {
+    collection_label:
+      "COVID-19 immune features revealed by a large-scale single-cell transcriptome atlas",
+    collection_url: MOCK_COLLECTION_URL,
+    id: "Large-scale single-cell analysis reveals critical immune characteristics of COVID-19 patients",
+    label:
+      "Large-scale single-cell analysis reveals critical immune characteristics of COVID-19 patients",
+  },
+  {
+    collection_label:
+      "COVID-19 immune features revealed by a large-scale single-cell transcriptome atlas",
+    collection_url: MOCK_COLLECTION_URL,
+    id: "Medium-scale single-cell analysis reveals critical immune characteristics of COVID-19 patients",
+    label:
+      "Medium-scale single-cell analysis reveals critical immune characteristics of COVID-19 patients",
+  },
+  {
+    collection_label:
+      "A molecular cell atlas of the human lung from single cell RNA sequencing",
+    collection_url: MOCK_COLLECTION_URL,
+    id: "Krasnow Lab Human Lung Cell Atlas, 10X",
+    label: "Krasnow Lab Human Lung Cell Atlas, 10X",
+  },
+  {
+    collection_label: "Tabula Muris Senis",
+    collection_url: MOCK_COLLECTION_URL,
+    id: "All - A single-cell transcriptomic atlas characterizes ageing tissues in the mouse - 10x",
+    label:
+      "All - A single-cell transcriptomic atlas characterizes ageing tissues in the mouse - 10x",
+  },
+  {
+    collection_label: "Tabula Sapiens",
+    collection_url: MOCK_COLLECTION_URL,
+    id: "Tabula Sapiens - All Cells",
+    label: "Tabula Sapiens - All Cells",
+  },
+  {
+    collection_label:
+      "LungMAP — Human data from a broad age healthy donor group",
+    collection_url: MOCK_COLLECTION_URL,
+    id: "Single-cell multiomic profiling of human lungs across age groups",
+    label: "Single-cell multiomic profiling of human lungs across age groups",
+  },
+  {
+    collection_label:
+      // eslint-disable-next-line sonarjs/no-duplicate-string
+      "Single-cell transcriptomics of human T cells reveals tissue and activation signatures in health and disease",
+    collection_url: MOCK_COLLECTION_URL,
+    id: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam tempus leo id quam commodo lacinia.",
+    label:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam tempus leo id quam commodo lacinia.",
+  },
+  {
+    collection_label:
+      "Single-cell transcriptomics of human T cells reveals tissue and activation signatures in health and disease",
+    collection_url: MOCK_COLLECTION_URL,
+    id: "Lorem ipsum doladipiscing elit. Etiam tempus leo id quam commodo lacinia.",
+    label:
+      "Lorem ipsum doladipiscing elit. Etiam tempus leo id quam commodo lacinia.",
+  },
+  {
+    collection_label:
+      "Single-cell transcriptomics of human T cells reveals tissue and activation signatures in health and disease",
+    collection_url: MOCK_COLLECTION_URL,
+    id: "Lo id quam commodo lacinia.",
+    label: "Lo id quam commodo lacinia.",
+  },
+];
+
+interface Dataset {
+  id: string;
+  label: string;
+  collection_label: string;
+  collection_url: string;
+}
+
+interface Collection {
+  name: string;
+  url: string;
+  datasets: { id: string; label: string }[];
+}
+
+interface Collections {
+  [name: string]: Collection;
+}
+
+export default function SourceData(): JSX.Element {
+  const collections: Collections = useMemo(() => {
+    return getCollections(DATA_SETS);
+  }, []);
+
+  return (
+    <Wrapper>
+      <Header>Source Data</Header>
+      <Content>
+        <List ordered>
+          {Object.values(collections).map(({ name, url, datasets }) => {
+            return (
+              <ListItem ordered key={name} fontSize="xxxs">
+                <List
+                  key={name}
+                  subheader={
+                    <a href={url} target="_blank" rel="noopener">
+                      <ListSubheader>{name}</ListSubheader>
+                    </a>
+                  }
+                >
+                  {datasets.map(({ id, label }) => {
+                    return (
+                      <ListItem fontSize="xxxs" key={id}>
+                        {label}
+                      </ListItem>
+                    );
+                  })}
+                </List>
+              </ListItem>
+            );
+          })}
+        </List>
+      </Content>
+    </Wrapper>
+  );
+}
+
+function getCollections(datasets: Dataset[]): Collections {
+  const collections: Collections = {};
+
+  for (const dataset of datasets) {
+    const { collection_label, collection_url, id, label } = dataset;
+
+    if (!collections[collection_label]) {
+      collections[collection_label] = {
+        datasets: [],
+        name: collection_label,
+        url: collection_url,
+      };
+    }
+
+    collections[collection_label].datasets.push({ id, label });
+  }
+
+  return collections;
+}

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/SourceData/style.ts
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/SourceData/style.ts
@@ -1,0 +1,33 @@
+import styled from "@emotion/styled";
+import { fontBodyXxxs, getColors } from "czifui";
+import {
+  Content as CommonContent,
+  Header as CommonHeader,
+} from "../../common/style";
+
+export const Wrapper = styled.div`
+  overflow-y: scroll;
+`;
+
+export const Header = styled(CommonHeader)`
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(16, 22, 26, 0.15);
+`;
+
+export const Content = styled(CommonContent)`
+  width: unset;
+`;
+
+export const ListSubheader = styled.li`
+  ${fontBodyXxxs}
+
+  margin-bottom: 4px !important;
+
+  ${(props) => {
+    const colors = getColors(props);
+
+    return `
+      color: ${colors?.gray[600]};
+    `;
+  }}
+`;

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/index.tsx
@@ -1,0 +1,16 @@
+import { memo } from "react";
+import ExpressedInCells from "./components/ExpressedInCells";
+import Methodology from "./components/Methodology";
+import RelativeGeneExpression from "./components/RelativeGeneExpression";
+import SourceData from "./components/SourceData";
+
+export default memo(function InfoPanel(): JSX.Element {
+  return (
+    <>
+      <RelativeGeneExpression />
+      <ExpressedInCells />
+      <Methodology />
+      <SourceData />
+    </>
+  );
+});

--- a/frontend/src/views/WheresMyGene/index.tsx
+++ b/frontend/src/views/WheresMyGene/index.tsx
@@ -34,7 +34,10 @@ import GeneFetcher from "./components/GeneFetcher";
 import GeneSearchBar from "./components/GeneSearchBar";
 import GetStarted from "./components/GetStarted";
 import HeatMap from "./components/HeatMap";
+import InfoPanel from "./components/InfoPanel";
 import { Top, Wrapper } from "./style";
+
+const INFO_PANEL_WIDTH_PX = 320;
 
 const WheresMyGene = (): JSX.Element => {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
@@ -181,13 +184,13 @@ const WheresMyGene = (): JSX.Element => {
           <Filters filters={filters} onFiltersChange={handleFiltersChange} />
         </SideBar>
 
-        <SideBar label="Info" isOpen position={Position.RIGHT}>
-          <span>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Doloribus
-            autem deserunt assumenda repudiandae repellat quis sunt quae, aut
-            vero rem itaque labore praesentium iure exercitationem minus iste
-            laudantium sed aliquid.
-          </span>
+        <SideBar
+          width={INFO_PANEL_WIDTH_PX}
+          label="Info"
+          isOpen
+          position={Position.RIGHT}
+        >
+          <InfoPanel />
         </SideBar>
 
         <View hideOverflow>

--- a/scripts/populate_db.py
+++ b/scripts/populate_db.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import sys
 
 import click
 from sqlalchemy import create_engine

--- a/scripts/setup_dev_data.sh
+++ b/scripts/setup_dev_data.sh
@@ -82,16 +82,6 @@ dd if=/dev/zero of=fake-h5ad-file.h5ad bs=1024 count=1024 &>/dev/null
 ${local_aws} s3 cp fake-h5ad-file.h5ad s3://corpora-data-dev/
 rm fake-h5ad-file.h5ad
 
-# Make a WMG cube
-echo "Writing WMG cube to s3"
-tmp_cube_dir=`mktemp -d`
-# TODO: Also generate & store:
-#  * s3://wmg-<env>/latest_snapshot_uuid
-#  * cell type orderings
-#  * total cell counts cube
-python3 -m tests.unit.backend.wmg.fixtures.cube ${tmp_cube_dir}
-${local_aws} s3 sync --delete --quiet ${tmp_cube_dir} s3://wmg-dev/dummy-snapshot/cube/
-
 echo "Populating test db"
 export CORPORA_LOCAL_DEV=true
 export BOTO_ENDPOINT_URL=${LOCALSTACK_URL}
@@ -101,3 +91,13 @@ echo
 echo "Dev env is up and running!"
 echo "  Frontend: ${FRONTEND_URL}"
 echo "  Backend: ${BACKEND_URL}"
+
+# Make a WMG cube
+echo "Writing WMG cube to s3"
+tmp_cube_dir=`mktemp -d`
+# TODO: Also generate & store:
+#  * s3://wmg-<env>/latest_snapshot_uuid
+#  * cell type orderings
+#  * total cell counts cube
+python3 -m tests.unit.backend.wmg.fixtures.cube ${tmp_cube_dir}
+${local_aws} s3 sync --delete --quiet ${tmp_cube_dir} s3://wmg-dev/dummy-snapshot/cube/

--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -1,6 +1,5 @@
 import json
 import unittest
-from unittest import mock
 from unittest.mock import patch
 
 from backend.corpora.api_server.app import app
@@ -59,7 +58,7 @@ class WmgApiV1Tests(unittest.TestCase):
                 "snapshot_id": v1.DUMMY_SNAPSHOT_UUID,
                 "expression_summary": {},
                 "term_id_labels": {"cell_types": [], "genes": []},
-                "filter_dims": {}
+                "filter_dims": {},
             }
 
             self.assertEqual(expected_response, json.loads(response.data))
@@ -199,22 +198,31 @@ class WmgApiV1Tests(unittest.TestCase):
                     tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
                 ),
                 # matters for this test
-                include_filter_dims=True
+                include_filter_dims=True,
             )
 
             response = self.app.post("/wmg/v1/query", json=request)
 
             expected = {
                 "datasets": [
-                    {"id": "dataset_id_0", "label": "dataset_id_0_name",
-                     "collection_label": "dataset_id_0_coll_name",
-                     "collection_id": "dataset_id_0_coll_id"},
-                    {"id": "dataset_id_1", "label": "dataset_id_1_name",
-                     "collection_label": "dataset_id_1_coll_name",
-                     "collection_id": "dataset_id_1_coll_id"},
-                    {"id": "dataset_id_2", "label": "dataset_id_2_name",
-                     "collection_label": "dataset_id_2_coll_name",
-                     "collection_id": "dataset_id_2_coll_id"},
+                    {
+                        "id": "dataset_id_0",
+                        "label": "dataset_id_0_name",
+                        "collection_label": "dataset_id_0_coll_name",
+                        "collection_id": "dataset_id_0_coll_id",
+                    },
+                    {
+                        "id": "dataset_id_1",
+                        "label": "dataset_id_1_name",
+                        "collection_label": "dataset_id_1_coll_name",
+                        "collection_id": "dataset_id_1_coll_id",
+                    },
+                    {
+                        "id": "dataset_id_2",
+                        "label": "dataset_id_2_name",
+                        "collection_label": "dataset_id_2_coll_name",
+                        "collection_id": "dataset_id_2_coll_id",
+                    },
                 ],
                 "development_stage_terms": [
                     {"development_stage_ontology_term_id_0": "development_stage_ontology_term_id_0_label"},
@@ -237,7 +245,7 @@ class WmgApiV1Tests(unittest.TestCase):
                     {"sex_ontology_term_id_2": "sex_ontology_term_id_2_label"},
                 ],
             }
-            self.assertEqual(expected, json.loads(response.data)['filter_dims'])
+            self.assertEqual(expected, json.loads(response.data)["filter_dims"])
 
     @patch("backend.wmg.api.v1.fetch_datasets")
     @patch("backend.wmg.data.query.gene_term_label")
@@ -271,16 +279,19 @@ class WmgApiV1Tests(unittest.TestCase):
                     development_stage_ontology_term_ids=["development_stage_ontology_term_id_1"],
                     ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_0"],
                 ),
-                include_filter_dims=True
+                include_filter_dims=True,
             )
 
             response = self.app.post("/wmg/v1/query", json=request)
 
             expected_filter_dims = {
                 "datasets": [
-                    {"id": "dataset_id_0", "label": "dataset_id_0_name",
-                     "collection_label": "dataset_id_0_coll_name",
-                     "collection_id": "dataset_id_0_coll_id"},
+                    {
+                        "id": "dataset_id_0",
+                        "label": "dataset_id_0_name",
+                        "collection_label": "dataset_id_0_coll_name",
+                        "collection_id": "dataset_id_0_coll_id",
+                    },
                 ],
                 "disease_terms": [
                     {"disease_ontology_term_id_1": "disease_ontology_term_id_1_label"},
@@ -303,8 +314,11 @@ class WmgApiV1Tests(unittest.TestCase):
 # we only care that we're building the response correctly from the cube; WMG API integration tests verify
 # with real datasets
 def mock_datasets(dataset_ids):
-    return [dict(id=dataset_id,
-                 name=f"{dataset_id}_name",
-                 collection=dict(id=f"{dataset_id}_coll_id",
-                                 name=f"{dataset_id}_coll_name"))
-            for dataset_id in dataset_ids]
+    return [
+        dict(
+            id=dataset_id,
+            name=f"{dataset_id}_name",
+            collection=dict(id=f"{dataset_id}_coll_id", name=f"{dataset_id}_coll_name"),
+        )
+        for dataset_id in dataset_ids
+    ]

--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -208,13 +208,13 @@ class WmgApiV1Tests(unittest.TestCase):
                 "datasets": [
                     {"id": "dataset_id_0", "label": "dataset_id_0_name",
                      "collection_label": "dataset_id_0_coll_name",
-                     "collection_url": "http://localhost/dp/v1/collections/dataset_id_0_coll_id"},
+                     "collection_id": "dataset_id_0_coll_id"},
                     {"id": "dataset_id_1", "label": "dataset_id_1_name",
                      "collection_label": "dataset_id_1_coll_name",
-                     "collection_url": "http://localhost/dp/v1/collections/dataset_id_1_coll_id"},
+                     "collection_id": "dataset_id_1_coll_id"},
                     {"id": "dataset_id_2", "label": "dataset_id_2_name",
                      "collection_label": "dataset_id_2_coll_name",
-                     "collection_url": "http://localhost/dp/v1/collections/dataset_id_2_coll_id"},
+                     "collection_id": "dataset_id_2_coll_id"},
                 ],
                 "development_stage_terms": [
                     {"development_stage_ontology_term_id_0": "development_stage_ontology_term_id_0_label"},
@@ -280,7 +280,7 @@ class WmgApiV1Tests(unittest.TestCase):
                 "datasets": [
                     {"id": "dataset_id_0", "label": "dataset_id_0_name",
                      "collection_label": "dataset_id_0_coll_name",
-                     "collection_url": "http://localhost/dp/v1/collections/dataset_id_0_coll_id"},
+                     "collection_id": "dataset_id_0_coll_id"},
                 ],
                 "disease_terms": [
                     {"disease_ontology_term_id_1": "disease_ontology_term_id_1_label"},
@@ -303,14 +303,8 @@ class WmgApiV1Tests(unittest.TestCase):
 # we only care that we're building the response correctly from the cube; WMG API integration tests verify
 # with real datasets
 def mock_datasets(dataset_ids):
-    def mock_dataset(dataset_id):
-        dataset = mock.Mock()
-        dataset.id = dataset_id
-        dataset.name = f"{dataset_id}_name"
-        collection = mock.Mock()
-        collection.id = f"{dataset_id}_coll_id"
-        collection.name = f"{dataset_id}_coll_name"
-        dataset.collection = collection
-        return dataset
-
-    return [mock_dataset(dataset_id) for dataset_id in dataset_ids]
+    return [dict(id=dataset_id,
+                 name=f"{dataset_id}_name",
+                 collection=dict(id=f"{dataset_id}_coll_id",
+                                 name=f"{dataset_id}_coll_name"))
+            for dataset_id in dataset_ids]

--- a/tests/unit/backend/wmg/fixtures/cube.py
+++ b/tests/unit/backend/wmg/fixtures/cube.py
@@ -105,6 +105,7 @@ def semi_real_dimension_values_generator(dimension_name: str, dim_size: int) -> 
     raise AssertionError(f"unknown dimension name {dimension_name}")
 
 
+# TODO: refactor for readability
 def create_cube(
     cube_dir,
     dim_size=3,

--- a/tests/unit/backend/wmg/fixtures/cube.py
+++ b/tests/unit/backend/wmg/fixtures/cube.py
@@ -50,14 +50,14 @@ def create_dataset(dataset_id_ordinal: int) -> str:
             id=coll_id,
             visibility=CollectionVisibility.PUBLIC.name,
             name=f"dataset_id_{dataset_id_ordinal}_coll_name",
-            owner="owner"
+            owner="owner",
         )
         session.add(collection)
         dataset = DbDataset(
-                id=f"dataset_id_{dataset_id_ordinal}",
-                name=f"dataset_name_{dataset_id_ordinal}",
-                collection_id=coll_id,
-                collection_visibility=CollectionVisibility.PUBLIC,
+            id=f"dataset_id_{dataset_id_ordinal}",
+            name=f"dataset_name_{dataset_id_ordinal}",
+            collection_id=coll_id,
+            collection_visibility=CollectionVisibility.PUBLIC,
         )
         session.add(dataset)
         return dataset.id


### PR DESCRIPTION
Part 4 of 4 of [story](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1959).

Branched off of https://github.com/chanzuckerberg/single-cell-data-portal/pull/2045

### Reviewers
**Functional:** 
@MDunitz 

**Readability:** 
@tihuan 

---

## Changes
* wmg query endpoint response now includes dataset metadata in the `filter_dimensions` section
* API spec changes (relative to prev pr):
    * `response_option` (enum) -> `include_filter_dims` (bool_)
    * `query` endpoint response: `filter_dimensions.datasets.collection_url` -> `collection_id`

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
