### PR TITLE
feat(wmg): Update Heatmap design

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/style.ts
@@ -1,3 +1,5 @@
+import { css } from "@emotion/css";
+import { TooltipTable } from "czifui";
 import styled from "styled-components";
 
 export const ChartContainer = styled.div`
@@ -20,3 +22,11 @@ function getWidthAndHeight({
     height: ${height}px;
   `;
 }
+
+export const StyledTooltipTable = styled(TooltipTable)``;
+
+export const tooltipCss = css`
+  margin: 0;
+  margin-top: 20px;
+  max-width: 400px !important;
+`;

--- a/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
@@ -1,5 +1,5 @@
 import { Intent, Spinner } from "@blueprintjs/core";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { State } from "../../common/store";
 import {
   CellTypeSummary,
@@ -29,10 +29,6 @@ export default memo(function HeatMap({
 }: Props): JSX.Element {
   // Loading state per tissue
   const [isLoading, setIsLoading] = useState(setInitialIsLoading(cellTypes));
-
-  useEffect(() => {
-    setIsLoading((isLoading) => ({ ...isLoading, lung: true }));
-  }, [genes, cellTypes]);
 
   const yAxisWrapperHeight = useMemo(() => {
     const yAxisChartHeight = Object.values(cellTypes).reduce(

--- a/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
@@ -35,17 +35,6 @@ const COMMON_SERIES: ScatterSeriesOption = {
   type: "scatter",
 };
 
-const COMMON_AXIS_POINTER: EChartsOption["axisPointer"] = {
-  link: [
-    {
-      xAxisIndex: "all",
-    },
-  ],
-  show: true,
-  triggerOn: "click",
-  triggerTooltip: false,
-};
-
 interface CreateChartOptionsProps {
   cellTypeMetadata: string[];
   chartData: ChartFormat[];
@@ -59,7 +48,16 @@ export function createChartOptions({
 }: CreateChartOptionsProps): EChartsOption {
   return {
     ...COMMON_OPTIONS,
-    axisPointer: { ...COMMON_AXIS_POINTER, label: { show: false } },
+    axisPointer: {
+      label: { show: false },
+      link: [
+        {
+          xAxisIndex: "all",
+        },
+      ],
+      show: true,
+      triggerOn: "mousemove",
+    },
     dataset: {
       source: chartData as DatasetComponentOption["source"],
     },
@@ -87,36 +85,6 @@ export function createChartOptions({
         },
       },
     ],
-    tooltip: {
-      formatter(props) {
-        const { name: cellTypeMetadata, data } = props as unknown as {
-          name: string;
-          data: ChartFormat;
-        };
-
-        if (!data) return "";
-
-        const { geneIndex, percentage, meanExpression, scaledMeanExpression } =
-          data;
-
-        const { name } = deserializeCellTypeMetadata(
-          cellTypeMetadata as CellTypeMetadata
-        );
-
-        return `
-          cell type: ${name}
-          <br />
-          gene: ${geneNames[geneIndex]}
-          <br />
-          percentage: ${percentage}
-          <br />
-          mean expression: ${meanExpression}
-          <br />
-          scaledMeanExpression: ${scaledMeanExpression}
-        `;
-      },
-      position: "top",
-    },
     xAxis: [
       {
         axisLabel: { fontSize: 0, rotate: 90 },
@@ -164,7 +132,6 @@ export function createXAxisOptions({
 }: CreateXAxisOptionsProps): EChartsOption {
   return {
     ...COMMON_OPTIONS,
-    axisPointer: { ...COMMON_AXIS_POINTER },
     grid: {
       bottom: "0",
       left: "300px",
@@ -232,7 +199,6 @@ export function createYAxisOptions({
 }: CreateYAxisOptionsProps): EChartsOption {
   return {
     ...COMMON_OPTIONS,
-    axisPointer: { ...COMMON_AXIS_POINTER },
     grid: {
       bottom: Y_AXIS_BOTTOM_PADDING,
       left: "300px",


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
1. Tooltip is now triggered by table cell, not actual dot
2. Highlight gene and cell rows on hover rather than click
3. Update tooltip to match Figma design
4. Update heatmap to match design

## Definition of Done (from ticket)
https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1852

https://app.zenhub.com/workspace/o/chanzuckerberg/single-cell-data-portal/issues/1856

## QA steps (optional)

<img width="924" alt="Screen Shot 2022-03-04 at 3 28 25 PM" src="https://user-images.githubusercontent.com/6309723/156856116-0a830c88-024c-4984-8827-32846af2532c.png">

![demo](https://user-images.githubusercontent.com/6309723/156856129-d15d2728-ae37-4960-af3b-7375818a291b.gif)


## Known Issues
1. Tooltip data is not complete. Will fill that out after connecting to API next week!
2. Not truncating gene names yet. Will leave it for the [polish ticket](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1968) 