### PR TITLE
feat: wmg query api requires gene terms

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -986,6 +986,7 @@ paths:
                 filter:
                   type: object
                   required:
+                    - gene_ontology_term_ids
                     - organism_ontology_term_id
                     - tissue_ontology_term_ids
                   properties:
@@ -994,7 +995,6 @@ paths:
                       organism_ontology_term_id:
                         type: string
                       tissue_ontology_term_ids:
-                        minItems: 1
                         $ref: "#/components/schemas/wmg_ontology_term_id_list"
                       dataset_ids:
                         type: array

--- a/backend/wmg/data/query.py
+++ b/backend/wmg/data/query.py
@@ -7,12 +7,11 @@ from tiledb import Array
 
 from backend.wmg.data.ontology_labels import gene_term_label, ontology_term_label
 
-ALL_DIM_VALUES = slice(None)
 EMPTY_DIM_VALUES = ""
 
 
 class WmgQueryCriteria(BaseModel):
-    gene_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+    gene_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=1)
     organism_ontology_term_id: str  # required!
     tissue_ontology_term_ids: List[str] = Field(unique_items=True, min_items=1)  # required!
     dataset_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
@@ -52,9 +51,11 @@ class WmgQuery:
         attr_cond = tiledb.QueryCondition(query_cond_expr) if query_cond_expr else None
 
         tiledb_dims_query = (
-            criteria.gene_ontology_term_ids or EMPTY_DIM_VALUES,  # at least one gene required for a non-empty result
-            criteria.tissue_ontology_term_ids or ALL_DIM_VALUES,
-            criteria.organism_ontology_term_id or ALL_DIM_VALUES,
+            # use of EMPTY_DIM_VALUES ensures an empty result if any of the primary dimensions are unspecified (
+            # avoids introducing another code path for forming an empty result return value)
+            criteria.gene_ontology_term_ids or EMPTY_DIM_VALUES,
+            criteria.tissue_ontology_term_ids or EMPTY_DIM_VALUES,
+            criteria.organism_ontology_term_id or EMPTY_DIM_VALUES,
         )
         query_result_df = self._cube.query(attr_cond=attr_cond).df[tiledb_dims_query]
 

--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -90,8 +90,9 @@ class WmgApiV1Tests(unittest.TestCase):
     @patch("backend.wmg.data.query.gene_term_label")
     @patch("backend.wmg.data.query.ontology_term_label")
     @patch("backend.wmg.api.v1.find_cube_latest_snapshot")
-    def test__query_minimal_valid_request__returns_200_and_empty_expr_summary(self, find_cube_latest_snapshot,
-                                                                              ontology_term_label, gene_term_label):
+    def test__query_minimal_valid_request__returns_200_and_empty_expr_summary(
+        self, find_cube_latest_snapshot, ontology_term_label, gene_term_label
+    ):
         dim_size = 1
         with create_temp_cube(dim_size=dim_size, attr_vals_fn=all_ones_attr_values) as all_ones_cube:
             # setup up API endpoints to use a cube containing all stat values of 1, for a deterministic expected query
@@ -105,11 +106,13 @@ class WmgApiV1Tests(unittest.TestCase):
             gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
 
             request = dict(
-                    filter=dict(
-                            gene_ontology_term_ids=["gene_ontology_term_id_0", ],
-                            organism_ontology_term_id="organism_ontology_term_id_0",
-                            tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
-                    ),
+                filter=dict(
+                    gene_ontology_term_ids=[
+                        "gene_ontology_term_id_0",
+                    ],
+                    organism_ontology_term_id="organism_ontology_term_id_0",
+                    tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+                ),
             )
 
             response = self.app.post("/wmg/v1/query", json=request)
@@ -119,25 +122,17 @@ class WmgApiV1Tests(unittest.TestCase):
             expected_response = {
                 "snapshot_id": v1.DUMMY_SNAPSHOT_UUID,
                 "expression_summary": {
-                    'gene_ontology_term_id_0':
-                        {
-                            'tissue_ontology_term_id_0': [
-                                {
-                                    'id': 'cell_type_ontology_term_id_0',
-                                    'me': 1.0,
-                                    'n': 1,
-                                    'pc': 0.0,
-                                    'tpc': 0.0
-                                }
-                            ]
-                        },
-                },
-                "term_id_labels":
-                    {
-                        'cell_types': [{'cell_type_ontology_term_id_0': 'cell_type_ontology_term_id_0_label'}],
-                        'genes': [{'gene_ontology_term_id_0': 'gene_ontology_term_id_0_label'}]
+                    "gene_ontology_term_id_0": {
+                        "tissue_ontology_term_id_0": [
+                            {"id": "cell_type_ontology_term_id_0", "me": 1.0, "n": 1, "pc": 0.0, "tpc": 0.0}
+                        ]
                     },
-                    "filter_dims": {},
+                },
+                "term_id_labels": {
+                    "cell_types": [{"cell_type_ontology_term_id_0": "cell_type_ontology_term_id_0_label"}],
+                    "genes": [{"gene_ontology_term_id_0": "gene_ontology_term_id_0_label"}],
+                },
+                "filter_dims": {},
             }
             self.assertEqual(expected_response, json.loads(response.data))
 


### PR DESCRIPTION
Sub-PR of #2071, as part of this [story](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/2051). This separate PR is intended to ease CR, since these changes are somewhat out-of-scope for the story.

### Reviewers
**Functional:** 
@MDunitz 

**Readability:** 
@tihuan 

---

## Changes
* wmg `query` api now requires gene terms; this was originally an optional filter param, but the api design changed


## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
