### PR TITLE
fix: updated DOI form field value on edit.

### DIFF
--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -137,26 +137,37 @@ const Content: FC<Props> = (props) => {
   if (isTombstonedCollection(data)) data = null;
   const { name, description, contact_email, contact_name } = data || {};
 
-  const [links, setLinks] = useState<Link[]>(
-    data?.links.map((link, index) => {
-      const {
-        link_name: linkName,
-        link_type: linkType,
-        link_url: linkUrl,
-      } = link;
+  const [links, setLinks] = useState<Link[]>([]);
+  // TODO useEffect can be reverted back to useState once isFilterEnabled is removed (#1718). See 7210a51d18b2747ea79b47fcad28579bb5b514b6.
+  useEffect(() => {
+    if (isTombstonedCollection(data)) {
+      return;
+    }
+    setLinks(
+      data?.links.map((link, index) => {
+        const {
+          link_name: linkName,
+          link_type: linkType,
+          link_url: linkUrl,
+        } = link;
 
-      // DOI links are specified as path only, all other links are specified as full URLs.
-      const url = isLinkTypeDOI(linkType) ? getDOIPath(linkUrl) : linkUrl;
-
-      return {
-        id: Date.now() + index,
-        isValid: true,
-        linkName,
-        linkType,
-        url,
-      };
-    }) || []
-  );
+        // DOI links are specified as path only, all other links are specified as full URLs.
+        let url;
+        if (isLinkTypeDOI(linkType)) {
+          url = isFilterEnabled ? getDOIPath(linkUrl) : linkUrl;
+        } else {
+          url = linkUrl;
+        }
+        return {
+          id: Date.now() + index,
+          isValid: true,
+          linkName,
+          linkType,
+          url,
+        };
+      }) || []
+    );
+  }, [data, isFilterEnabled]);
 
   useEffect(() => {
     const areLinksValid = links.every((link) => link.isValid);


### PR DESCRIPTION
### Reviewers
**Functional:** 
@tihuan 

---

## Changes
- Updated create of link view model to only convert DOI URLs to path if filter state is enabled.

## QA steps
#### Steps to Reproduce
1. Remove filter feature flag.
2. Edit collection that has a DOI specified.

#### What Happened
DOI form field displays a DOI path (e.g. `/123/123`).

#### What I Expected
DOI form field displays the full DOI URL (e.g. `https://doi.org/123/123`).