### PR TITLE
fix: Add tests for collection access control

### DIFF
--- a/tests/functional/backend/corpora/common.py
+++ b/tests/functional/backend/corpora/common.py
@@ -27,10 +27,13 @@ class BaseFunctionalTestCase(unittest.TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.deployment_stage = os.environ["DEPLOYMENT_STAGE"]
+        cls.config = CorporaAuthConfig()
+        token = cls.get_auth_token(cls.config.test_account_username, cls.config.test_account_password)
+        cls.curator_cookie = cls.make_cookie(token)
 
     def setUp(self):
         super().setUp()
-        self.get_auth_token()
+        config = CorporaAuthConfig()
         self.api = API_URL.get(self.deployment_stage)
         self.test_collection_id = "005d611a-14d5-4fbf-846e-571a1f874f70"
         self.test_file_id = "7c93775542b056e048aa474535b8e5c2"
@@ -38,30 +41,37 @@ class BaseFunctionalTestCase(unittest.TestCase):
         self.bad_file_id = "DNE"
 
     @classmethod
-    def get_auth_token(cls):
-        config = CorporaAuthConfig()
-
+    def get_auth_token(cls, username: str, password: str, additional_claims: list = None):
+        standard_claims = "openid profile email offline"
+        if additional_claims:
+            additional_claims.append(standard_claims)
+            claims = " ".join(additional_claims)
+        else:
+            claims = standard_claims
         response = requests.post(
             "https://czi-cellxgene-dev.us.auth0.com/oauth/token",
             headers={"content-type": "application/x-www-form-urlencoded"},
             data=dict(
                 grant_type="password",
-                username=config.test_account_username,
-                password=config.test_account_password,
+                username=username,
+                password=password,
                 audience=AUDIENCE.get(cls.deployment_stage),
-                scope="openid profile email offline",
-                client_id=config.client_id,
-                client_secret=config.client_secret,
+                scope=claims,
+                client_id=cls.config.client_id,
+                client_secret=cls.config.client_secret,
             ),
         )
-
         access_token = response.json()["access_token"]
         id_token = response.json()["id_token"]
         token = {"access_token": access_token, "id_token": id_token}
-        cls.cookie = base64.b64encode(json.dumps(dict(token)).encode("utf-8")).decode()
+        return token
+
+    @staticmethod
+    def make_cookie(token: dict) -> str:
+        return base64.b64encode(json.dumps(dict(token)).encode("utf-8")).decode()
 
     def upload_and_wait(self, collection_uuid, dropbox_url, existing_dataset_id=None):
-        headers = {"Cookie": f"cxguser={self.cookie}", "Content-Type": "application/json"}
+        headers = {"Cookie": f"cxguser={self.curator_cookie}", "Content-Type": "application/json"}
         body = {"url": dropbox_url}
 
         if existing_dataset_id is None:

--- a/tests/functional/backend/corpora/common.py
+++ b/tests/functional/backend/corpora/common.py
@@ -33,7 +33,6 @@ class BaseFunctionalTestCase(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        config = CorporaAuthConfig()
         self.api = API_URL.get(self.deployment_stage)
         self.test_collection_id = "005d611a-14d5-4fbf-846e-571a1f874f70"
         self.test_file_id = "7c93775542b056e048aa474535b8e5c2"

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -20,7 +20,7 @@ class TestApi(BaseFunctionalTestCase):
         self.assertIsNotNone(res.json()["Data Portal"])
 
     def test_auth(self):
-        headers = {"Cookie": f"cxguser={self.cookie}", "Content-Type": "application/json"}
+        headers = {"Cookie": f"cxguser={self.curator_cookie}", "Content-Type": "application/json"}
         res = requests.get(f"{self.api}/dp/v1/userinfo", headers=headers)
         res.raise_for_status()
         self.assertEqual(res.status_code, requests.codes.ok)
@@ -55,7 +55,7 @@ class TestApi(BaseFunctionalTestCase):
             "name": "my2collection",
         }
 
-        headers = {"Cookie": f"cxguser={self.cookie}", "Content-Type": "application/json"}
+        headers = {"Cookie": f"cxguser={self.curator_cookie}", "Content-Type": "application/json"}
         res = requests.post(f"{self.api}/dp/v1/collections", data=json.dumps(data), headers=headers)
         res.raise_for_status()
         data = json.loads(res.content)
@@ -132,7 +132,7 @@ class TestApi(BaseFunctionalTestCase):
             "name": "my2collection",
         }
 
-        headers = {"Cookie": f"cxguser={self.cookie}", "Content-Type": "application/json"}
+        headers = {"Cookie": f"cxguser={self.curator_cookie}", "Content-Type": "application/json"}
         res = requests.post(f"{self.api}/dp/v1/collections", data=json.dumps(data), headers=headers)
         res.raise_for_status()
         data = json.loads(res.content)
@@ -172,7 +172,7 @@ class TestApi(BaseFunctionalTestCase):
             "name": "my2collection",
         }
 
-        headers = {"Cookie": f"cxguser={self.cookie}", "Content-Type": "application/json"}
+        headers = {"Cookie": f"cxguser={self.curator_cookie}", "Content-Type": "application/json"}
         res = requests.post(f"{self.api}/dp/v1/collections", data=json.dumps(body), headers=headers)
         res.raise_for_status()
         data = json.loads(res.content)

--- a/tests/functional/backend/corpora/test_api_key.py
+++ b/tests/functional/backend/corpora/test_api_key.py
@@ -10,7 +10,7 @@ class TestApiKey(BaseFunctionalTestCase):
         super().setUpClass()
 
     def test_api_key_crud(self):
-        headers = {"Cookie": f"cxguser={self.cookie}", "Content-Type": "application/json"}
+        headers = {"Cookie": f"cxguser={self.curator_cookie}", "Content-Type": "application/json"}
 
         def _cleanup():
             requests.delete(f"{self.api}/dp/v1/auth/key", headers=headers)

--- a/tests/functional/backend/corpora/test_collection_access.py
+++ b/tests/functional/backend/corpora/test_collection_access.py
@@ -1,0 +1,78 @@
+import unittest
+
+import requests
+from jose import jwt
+
+from tests.functional.backend.corpora.common import BaseFunctionalTestCase
+
+
+class TestCollectionAccess(BaseFunctionalTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.supercurator_token = cls.get_auth_token(
+            "supercurator@example.com",
+            cls.config.test_auth0_user_account_password,
+            additional_claims=["write:collections"],
+        )
+        cls.supercurator_cookie = cls.make_cookie(cls.supercurator_token)
+        cls.nocollection_token = cls.get_auth_token(
+            "nocollection@example.com",
+            cls.config.test_auth0_user_account_password,
+            additional_claims=["write:collections"],
+        )
+        cls.nocollection_cookie = cls.make_cookie(cls.nocollection_token)
+        cls.curator_token = cls.get_auth_token(
+            "nocollection@example.com",
+            cls.config.test_auth0_user_account_password,
+            additional_claims=["write:collections"],
+        )
+        cls.curator_cookie = cls.make_cookie(cls.curator_token)
+
+    def test_collection_access(self):
+        """Test that only a super curator has access to all of the collections"""
+        # get collections for nocollection user
+        headers = {"Cookie": f"cxguser={self.nocollection_cookie}", "Content-Type": "application/json"}
+        res = requests.get(f"{self.api}/dp/v1/collections", headers=headers)
+        self.assertEqual(res.status_code, requests.codes.ok)
+        # length should be 0
+        collections = res.json()["collections"]
+        private_collections = [c for c in collections if c["visibility"] == "PRIVATE"]
+        self.assertEqual(len(private_collections), 0)
+
+        # get collection for supercurator user
+        headers = {"Cookie": f"cxguser={self.supercurator_cookie}", "Content-Type": "application/json"}
+        res = requests.get(f"{self.api}/dp/v1/collections", headers=headers)
+        self.assertEqual(res.status_code, requests.codes.ok)
+        # len should be a lot
+        superuser_collections = [c for c in res.json()["collections"] if c["visibility"] == "PRIVATE"]
+
+        # get collection for curator user
+        headers = {"Cookie": f"cxguser={self.curator_cookie}", "Content-Type": "application/json"}
+        res = requests.get(f"{self.api}/dp/v1/collections", headers=headers)
+        self.assertEqual(res.status_code, requests.codes.ok)
+
+        # len should be less than super curator
+        curator_collections = [c for c in res.json()["collections"] if c["visibility"] == "PRIVATE"]
+
+        self.assertLess(len(curator_collections), len(superuser_collections))
+
+    def test_claims(self):
+        access_token = self.supercurator_token["access_token"]
+        token = jwt.get_unverified_claims(access_token)
+        claims = token["scope"]
+        self.assertIn("write:collections", claims)
+
+        access_token = self.curator_token["access_token"]
+        token = jwt.get_unverified_claims(access_token)
+        claims = token["scope"]
+        self.assertNotIn("write:collections", claims)
+
+        access_token = self.nocollection_token["access_token"]
+        token = jwt.get_unverified_claims(access_token)
+        claims = token["scope"]
+        self.assertNotIn("write:collections", claims)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -42,7 +42,7 @@ class TestRevisions(BaseFunctionalTestCase):
     @unittest.skipIf(os.environ["DEPLOYMENT_STAGE"] == "prod", "Do not make test collections public in prod")
     def test_revision_flow(self):
 
-        headers = {"Cookie": f"cxguser={self.cookie}", "Content-Type": "application/json"}
+        headers = {"Cookie": f"cxguser={self.curator_cookie}", "Content-Type": "application/json"}
 
         collection_uuid = self.create_collection(headers)
 


### PR DESCRIPTION

### Reviewers
**Functional:** @danieljhegeman 

**Readability:** @tihuan 

---

## Changes
- change r/self.cookie/self.curator_cookie.
- add auth0 user supercurator@example.com who has super curator permission.
- added auth0 user nocollection@example.com who is a curator with no collections.
- Add test to verify only a super curator can use the `write:collections` claim
- Add test to verify users can view only their private collections unless they are a super curator.
- moved access token generation to the class method for functional tests. This prevents creating excessive auth0 tokens.

## QA steps (optional)
Run functional tests again the dev deployment to test
