### PR TITLE
chore: Remove parenthesis from OpenAPI spec for error code 413.

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -1560,7 +1560,7 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/problem"
-    "413":
+    413:
       description: Exceed File Size Limit
       content:
         application/problem+json:


### PR DESCRIPTION
### Reviewers

**Functional:** @Bento007

**Readability:** N/A

---

### Changes

#### Modifications

- Remove parenthesis from error code in OpenAPI spec.