### PR TITLE
feat: added filter by ethnicity. #1833. #1860.

### DIFF
--- a/frontend/src/common/hooks/useCategoryFilter.ts
+++ b/frontend/src/common/hooks/useCategoryFilter.ts
@@ -10,6 +10,7 @@ import {
   CATEGORY_FILTER_TYPE,
   CATEGORY_KEY,
   CATEGORY_LABEL,
+  ETHNICITY_UNSPECIFIED_LABEL,
   IS_PRIMARY_DATA_LABEL,
   OnFilterFn,
   PUBLICATION_DATE_LABELS,
@@ -357,6 +358,15 @@ function buildCategoryValueLabel(
     ];
   }
 
+  if (
+    categoryKey === CATEGORY_KEY.ETHNICITY &&
+    !isEthnicitySpecified(categoryValueKey)
+  ) {
+    return ETHNICITY_UNSPECIFIED_LABEL[
+      categoryValueKey as keyof typeof ETHNICITY_UNSPECIFIED_LABEL
+    ];
+  }
+
   // Return all other category values as is.
   return categoryValueKey;
 }
@@ -581,6 +591,20 @@ export function isCategoryTypeBetween(categoryKey: CategoryKey): boolean {
     CATEGORY_CONFIGS_BY_CATEGORY_KEY[categoryKey].categoryType ===
     CATEGORY_FILTER_TYPE.BETWEEN
   );
+}
+
+/**
+ * Determine if the given ethnicity is considered unspecified (that is, na or unknown).
+ * @param categoryValueKey - Ethnicity value to check if it's specified.
+ * @returns True if ethnicity is either na or unknown.
+ */
+
+function isEthnicitySpecified(categoryValueKey: CategoryValueKey) {
+  const label =
+    ETHNICITY_UNSPECIFIED_LABEL[
+      categoryValueKey as keyof typeof ETHNICITY_UNSPECIFIED_LABEL
+    ];
+  return !label;
 }
 
 /**

--- a/frontend/src/common/queries/filter.ts
+++ b/frontend/src/common/queries/filter.ts
@@ -85,6 +85,7 @@ export interface DatasetResponse {
   cell_type: Ontology[];
   collection_id: string;
   disease: Ontology[];
+  ethnicity: Ontology[];
   explorer_url: string;
   id: string;
   is_primary_data: IS_PRIMARY_DATA;
@@ -242,6 +243,7 @@ function aggregateCollectionDatasetRows(
         assay: [...accum.assay, ...collectionDatasetRow.assay],
         cell_type: [...accum.cell_type, ...collectionDatasetRow.cell_type],
         disease: [...accum.disease, ...collectionDatasetRow.disease],
+        ethnicity: [...accum.ethnicity, ...collectionDatasetRow.ethnicity],
         is_primary_data: [
           ...accum.is_primary_data,
           ...collectionDatasetRow.is_primary_data,
@@ -255,6 +257,7 @@ function aggregateCollectionDatasetRows(
       assay: [],
       cell_type: [],
       disease: [],
+      ethnicity: [],
       is_primary_data: [],
       organism: [],
       sex: [],
@@ -267,6 +270,7 @@ function aggregateCollectionDatasetRows(
     assay: uniqueOntologies(aggregatedCategoryValues.assay),
     cell_type: uniqueOntologies(aggregatedCategoryValues.cell_type),
     disease: uniqueOntologies(aggregatedCategoryValues.disease),
+    ethnicity: uniqueOntologies(aggregatedCategoryValues.ethnicity),
     is_primary_data: [...new Set(aggregatedCategoryValues.is_primary_data)],
     organism: uniqueOntologies(aggregatedCategoryValues.organism),
     sex: uniqueOntologies(aggregatedCategoryValues.sex),

--- a/frontend/src/components/common/Filter/common/entities.ts
+++ b/frontend/src/components/common/Filter/common/entities.ts
@@ -33,6 +33,7 @@ export enum CATEGORY_KEY {
   "CELL_COUNT" = "cell_count",
   "CELL_TYPE" = "cell_type",
   "DISEASE" = "disease",
+  "ETHNICITY" = "ethnicity",
   "IS_PRIMARY_DATA" = "is_primary_data",
   "MEAN_GENES_PER_CELL" = "mean_genes_per_cell",
   "ORGANISM" = "organism",
@@ -63,6 +64,11 @@ const CATEGORY_CONFIGS: CategoryConfig[] = [
   },
   {
     categoryKey: CATEGORY_KEY.DISEASE,
+    categoryType: CATEGORY_FILTER_TYPE.INCLUDES_SOME,
+    multiselect: true,
+  },
+  {
+    categoryKey: CATEGORY_KEY.ETHNICITY,
     categoryType: CATEGORY_FILTER_TYPE.INCLUDES_SOME,
     multiselect: true,
   },
@@ -130,6 +136,7 @@ export interface Categories {
   assay: Ontology[];
   cell_type: Ontology[];
   disease: Ontology[];
+  ethnicity: Ontology[];
   is_primary_data: IS_PRIMARY_DATA[];
   organism: Ontology[];
   sex: Ontology[];
@@ -175,6 +182,14 @@ export interface DatasetRow extends Categories, PublisherMetadataCategories {
   published_at: number;
   recency: number; // Used by sort
   revised_at?: number;
+}
+
+/**
+ * Display values of unspecified ethnicity labels.
+ */
+export enum ETHNICITY_UNSPECIFIED_LABEL {
+  "na" = "N/A",
+  "unknown" = "Unknown",
 }
 
 /**
@@ -227,6 +242,7 @@ export enum CATEGORY_LABEL {
   cell_count = "Cell Count",
   cell_type = "Cell Type",
   disease = "Disease",
+  ethnicity = "Ethnicity",
   is_primary_data = "Data Source",
   mean_genes_per_cell = "Gene Count",
   publicationAuthors = "Authors",

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -148,6 +148,12 @@ export default function Collections(): JSX.Element {
       },
       // Hidden, required for filter.
       {
+        accessor: ontologyCellAccessorFn(CATEGORY_KEY.ETHNICITY),
+        filter: "includesSome",
+        id: CATEGORY_KEY.ETHNICITY,
+      },
+      // Hidden, required for filter.
+      {
         accessor: (collectionRow: CollectionRow) =>
           collectionRow.is_primary_data,
         filter: "includesSome",
@@ -187,6 +193,7 @@ export default function Collections(): JSX.Element {
           COLUMN_ID_RECENCY,
           CATEGORY_KEY.ASSAY,
           CATEGORY_KEY.CELL_TYPE,
+          CATEGORY_KEY.ETHNICITY,
           CATEGORY_KEY.IS_PRIMARY_DATA,
           CATEGORY_KEY.PUBLICATION_AUTHORS,
           CATEGORY_KEY.PUBLICATION_DATE_VALUES,

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -176,6 +176,12 @@ export default function Datasets(): JSX.Element {
       },
       // Hidden, required for filter.
       {
+        accessor: ontologyCellAccessorFn(CATEGORY_KEY.ETHNICITY),
+        filter: "includesSome",
+        id: CATEGORY_KEY.ETHNICITY,
+      },
+      // Hidden, required for filter.
+      {
         accessor: CATEGORY_KEY.IS_PRIMARY_DATA,
         filter: "includesSome",
       },
@@ -218,6 +224,7 @@ export default function Datasets(): JSX.Element {
           COLLECTION_NAME,
           COLUMN_ID_RECENCY,
           CATEGORY_KEY.CELL_TYPE,
+          CATEGORY_KEY.ETHNICITY,
           CATEGORY_KEY.IS_PRIMARY_DATA,
           CATEGORY_KEY.MEAN_GENES_PER_CELL,
           CATEGORY_KEY.PUBLICATION_AUTHORS,


### PR DESCRIPTION
### Reviewers
**Functional:** 
@tihuan 

---

## Changes
- Added filter datasets by ethnicity (#1833).
- Added filter collections by ethnicity (#1860).
- This is PR 1 of 2 and covers just the addition of the ethnicity filter. A second PR will be created at a later point to cover the disabled/tooltip functionality (see [mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=1670%3A50787)).

## Known Issues
~~- I am seeing a couple of linting errors that I have suppressed in the previous [filter by development stage PR](https://github.com/chanzuckerberg/single-cell-data-portal/pull/2166). I have left the linting errors in this PR and am expecting the development stage PR to resolve these errors. Please let me know if you would prefer a different approach!~~ Linting issues resolved with `npm ci`.