### PR TITLE
fix: correct jwt attr spelling "ait" => "iat"

### DIFF
--- a/backend/corpora/common/utils/api_key.py
+++ b/backend/corpora/common/utils/api_key.py
@@ -10,7 +10,7 @@ def generate(user_id: str, secret: str, days_to_live: int = 1) -> str:
     iat = time.time()
     exp = iat + (seconds_in_day * days_to_live)
     sub = user_id
-    return jws.sign({"exp": exp, "ait": iat, "sub": sub}, secret, algorithm=ALGORITHMS.HS256)
+    return jws.sign({"exp": exp, "iat": iat, "sub": sub}, secret, algorithm=ALGORITHMS.HS256)
 
 
 def verify(token: str, secret: str):


### PR DESCRIPTION
The attribute for the Issued At claim on the Curator API Key jwt was
misspelled and would not be recognized as a result.

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---

## Changes
- fix the attribute typo for "iat"

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
