### PR TITLE
fix: set refetch to false for collection detail. #2204

### DIFF
--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -196,7 +196,17 @@ export function useCollection({
   return useQuery<Collection | TombstonedCollection | null>(
     [USE_COLLECTION, id, visibility, collections],
     () => queryFn(id, visibility),
-    { enabled: !!collections, refetchOnWindowFocus: false } // Refetch can cause loss of unsaved links during edit.
+    {
+      enabled: !!collections,
+      // TODO review use of refetch flag below on remove of filter flag (#1718). This is set to false as a fix for #2204
+      //  where unsaved links on the collection edit form are cleared if the user clicks away and back again. The root
+      //  cause of the defect is the useEffect that was added in /components/CreateCollectionModal/components/Content/index.tsx
+      //  to handle filter flag-related functionality is re-run after the refetch causing unsaved links to be removed.
+      //  The useEffect can be reverted to useState on remove of the filter flag and will therefore remove the side
+      //  effect of the links being cleared as reported in #2204. Options going forward are to remove the refetch
+      //  option below and allow it to default to true, or to review setting the refetch option to false for all queries.
+      refetchOnWindowFocus: false,
+    }
   );
 }
 

--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -196,7 +196,7 @@ export function useCollection({
   return useQuery<Collection | TombstonedCollection | null>(
     [USE_COLLECTION, id, visibility, collections],
     () => queryFn(id, visibility),
-    { enabled: !!collections }
+    { enabled: !!collections, refetchOnWindowFocus: false } // Refetch can cause loss of unsaved links during edit.
   );
 }
 

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -138,8 +138,10 @@ const Content: FC<Props> = (props) => {
   const { name, description, contact_email, contact_name } = data || {};
 
   const [links, setLinks] = useState<Link[]>([]);
-  // TODO useEffect can be reverted back to useState once isFilterEnabled is removed (#1718). See 7210a51d18b2747ea79b47fcad28579bb5b514b6.
   useEffect(() => {
+    // TODO on remove of filter flag (1718):
+    // 1. useEffect can be reverted back to useState once isFilterEnabled is removed. See 7210a51d18b2747ea79b47fcad28579bb5b514b6.
+    // 2. Review usage of refetchOnWindowFocus in useCollection. See full comments in /common/queries/collections.ts.
     if (isTombstonedCollection(data)) {
       return;
     }


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve 

---

## Changes
- Added `refetchOnWindowFocus: false` for collection detail-related React Query fetches. The general approach for handling of stale data on the FE is currently being reviewed (see [Determine approach for updating search results when backend data changes](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1809) and [Add Cloudfront caching+invalidation for datasets/index and collections/index endpoints](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1899).

