### PR TITLE
refactor: updated recency to use endpoint published_at. #2050

### DIFF
--- a/frontend/src/common/entities.ts
+++ b/frontend/src/common/entities.ts
@@ -248,6 +248,7 @@ export interface GeneSet {
 export interface PublisherMetadata {
   authors: (Author | Consortium)[];
   journal: string;
+  published_at: number;
   published_day: number;
   published_month: number;
   published_year: number;

--- a/frontend/src/common/queries/filter.ts
+++ b/frontend/src/common/queries/filter.ts
@@ -480,15 +480,9 @@ export function calculateRecency(
   response: CollectionResponse | DatasetResponse,
   publisherMetadata?: PublisherMetadata
 ): number {
-  // Pull date values from publication metadata if specified.
+  // Pull date value from publication metadata if specified.
   if (publisherMetadata) {
-    const {
-      published_day: day,
-      published_month: month,
-      published_year: year,
-    } = publisherMetadata;
-    const recency = new Date(year, month - 1, day); // Publication months are 1-indexed, JS months are 0-indexed.
-    return recency.getTime() / 1000; // Convert JS date millis to Unix timestamp seconds.
+    return publisherMetadata.published_at;
   }
 
   // Collection (or dataset's collection) has no publication metadata, use revised at or published at, in priority order.


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve

---

## Changes
- Modified collections and datasets to use `publisher_metadata.published_at` as their primary field for recency ([Update frontend to use publisher_metadata timestamp for recency](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/2050)).