### PR TITLE
fix: add `id` to ignored fields

### DIFF
--- a/frontend/src/common/utils/checkForRevisionChange.ts
+++ b/frontend/src/common/utils/checkForRevisionChange.ts
@@ -105,30 +105,18 @@ export default function checkForRevisionChange(
       !IGNORED_COLLECTION_FIELDS.includes(collectionKey) &&
       publishedCollection[collectionKey] !== revision[collectionKey]
     ) {
-      console.log("found diff for");
-      console.log(collectionKey);
-      console.log(publishedCollection[collectionKey]);
-      console.log(revision[collectionKey]);
       return true;
     }
   }
-  if (publishedCollection.links.length !== revision.links.length) {
-    console.log("link length diff");
-    console.log(publishedCollection.links.length);
-    console.log(revision.links.length);
-    return true;
-  }
+  if (publishedCollection.links.length !== revision.links.length) return true;
   //Check links for differences
-  if (checkListForChanges(revision.links, publishedCollection.links)) {
-    console.log("changes in link lists");
+  if (checkListForChanges(revision.links, publishedCollection.links))
     return true;
-  }
+
   if (
     checkDatasetsForChanges(revision.datasets, publishedCollection.datasets)
   ) {
-    console.log("datasets changed");
     return true;
   }
-  console.log("no changes!");
   return false;
 }

--- a/frontend/src/common/utils/checkForRevisionChange.ts
+++ b/frontend/src/common/utils/checkForRevisionChange.ts
@@ -4,6 +4,7 @@ import xorWith from "lodash/xorWith";
 import { Collection, Dataset } from "../entities";
 
 const IGNORED_COLLECTION_FIELDS = [
+  "id",
   "visibility",
   "created_at",
   "updated_at",
@@ -20,6 +21,7 @@ const IGNORED_DATASET_FIELDS = [
   "collection_visibility",
   "original_uuid",
   "id",
+  "collection_id",
   "processing_status",
   "dataset_assets",
   "dataset_deployments",

--- a/frontend/src/common/utils/checkForRevisionChange.ts
+++ b/frontend/src/common/utils/checkForRevisionChange.ts
@@ -103,18 +103,30 @@ export default function checkForRevisionChange(
       !IGNORED_COLLECTION_FIELDS.includes(collectionKey) &&
       publishedCollection[collectionKey] !== revision[collectionKey]
     ) {
+      console.log("found diff for");
+      console.log(collectionKey);
+      console.log(publishedCollection[collectionKey]);
+      console.log(revision[collectionKey]);
       return true;
     }
   }
-  if (publishedCollection.links.length !== revision.links.length) return true;
-  //Check links for differences
-  if (checkListForChanges(revision.links, publishedCollection.links))
+  if (publishedCollection.links.length !== revision.links.length) {
+    console.log("link length diff");
+    console.log(publishedCollection.links.length);
+    console.log(revision.links.length);
     return true;
-
+  }
+  //Check links for differences
+  if (checkListForChanges(revision.links, publishedCollection.links)) {
+    console.log("changes in link lists");
+    return true;
+  }
   if (
     checkDatasetsForChanges(revision.datasets, publishedCollection.datasets)
   ) {
+    console.log("datasets changed");
     return true;
   }
+  console.log("no changes!");
   return false;
 }


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve 
**Readability:** 

---

## Changes
- add `id` (collections) and `collection_id` (datasets) to the ignored fields so that they don't erroneously cause the Collection to be marked as changed when it isn't (during revision).

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
