### PR TITLE
fix(wmg): Update heatmap dot size

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
@@ -82,11 +82,7 @@ export function createChartOptions({
         symbolSize: function (props: { percentage: number }) {
           const { percentage } = props;
 
-          const maxRadius = MAX_FIRST_PART_LENGTH_PX / 2;
-
-          const r = Math.sqrt(percentage * maxRadius ** 2);
-
-          return Math.round(2 * r);
+          return convertPercentageToDiameter(percentage);
         },
       },
     ],
@@ -124,6 +120,20 @@ export function createChartOptions({
       },
     ],
   };
+}
+
+export function convertPercentageToDiameter(percentage: number): number {
+  const maxRadius = MAX_FIRST_PART_LENGTH_PX / 2;
+
+  const RADIUS_OFFSET = 0.2;
+
+  const baseRadius = RADIUS_OFFSET * (MAX_FIRST_PART_LENGTH_PX - RADIUS_OFFSET);
+
+  const radius = Math.sqrt(
+    percentage * (maxRadius - RADIUS_OFFSET) ** 2 + baseRadius
+  );
+
+  return Math.round(2 * radius);
 }
 
 const SELECTED_STYLE = {

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/ExpressedInCells/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/ExpressedInCells/index.tsx
@@ -1,7 +1,8 @@
+import { convertPercentageToDiameter } from "../../../HeatMap/utils";
 import { Content, Header, LowHigh } from "../../common/style";
 import { Dot, Dots, Wrapper } from "./style";
 
-const SIZES = [2, 4, 8, 12, 16];
+const PERCENTAGES = [0, 0.25, 0.5, 0.75, 1];
 
 export default function ExpressedInCells(): JSX.Element {
   return (
@@ -10,8 +11,11 @@ export default function ExpressedInCells(): JSX.Element {
 
       <Content>
         <Dots>
-          {SIZES.map((size) => (
-            <Dot size={size} key={size} />
+          {PERCENTAGES.map((percentage) => (
+            <Dot
+              size={convertPercentageToDiameter(percentage)}
+              key={percentage}
+            />
           ))}
         </Dots>
         <LowHigh>


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve 

**Readability:** 

---

## Changes
Update dot size to use Pablo's formula

The percentages used in the legend are: `0.0, 0.25, 0.50, 0.75, 1.0`
<img width="255" alt="Screen Shot 2022-04-04 at 4 10 12 PM" src="https://user-images.githubusercontent.com/6309723/161647271-401dede9-8ed7-4d44-aa2c-0d451fb5f0f2.png">


## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
