### PR TITLE
feat: support tiledb config overrides for WMG

### DIFF
--- a/backend/wmg/config.py
+++ b/backend/wmg/config.py
@@ -22,7 +22,5 @@ class WmgConfig(SecretConfig):
 
     def get_defaults_template(self):
         deployment_stage = os.getenv("DEPLOYMENT_STAGE", "test")
-        defaults_template = {"bucket": f"wmg-{deployment_stage}",
-                             "data_path_prefix": "",
-                             "tiledb_config_overrides": {}}
+        defaults_template = {"bucket": f"wmg-{deployment_stage}", "data_path_prefix": "", "tiledb_config_overrides": {}}
         return defaults_template

--- a/backend/wmg/config.py
+++ b/backend/wmg/config.py
@@ -7,7 +7,22 @@ class WmgConfig(SecretConfig):
     def __init__(self, *args, **kwargs):
         super().__init__("backend", secret_name="wmg_config", **kwargs)
 
+    # TODO: promote this impl to parent class, if new behavior works universally
+    def __getattr__(self, name):
+        # Environment variables intentionally override config file.
+        if not self.config_is_loaded():
+            self.load()
+        if (value := self.value_from_env(name)) is not None:
+            return value
+        if (value := self.value_from_config(name)) is not None:
+            return value
+        if (value := self.value_from_defaults(name)) is not None:
+            return value
+        self.raise_error(name)
+
     def get_defaults_template(self):
         deployment_stage = os.getenv("DEPLOYMENT_STAGE", "test")
-        defaults_template = {"bucket": f"wmg-{deployment_stage}", "data_path_prefix": "", "tiledb_mem_gb": "1"}
+        defaults_template = {"bucket": f"wmg-{deployment_stage}",
+                             "data_path_prefix": "",
+                             "tiledb_config_overrides": {}}
         return defaults_template

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -78,7 +78,7 @@ def _load_snapshot(new_snapshot_identifier) -> WmgSnapshot:
 
 
 def _open_cube(cube_uri) -> Array:
-    return tiledb.open(cube_uri, ctx=create_ctx(WmgConfig().tiledb_config_overrides))
+    return tiledb.open(cube_uri, ctx=create_ctx(json.loads(WmgConfig().tiledb_config_overrides)))
 
 
 def _load_cell_type_order(snapshot_identifier: str) -> DataFrame:

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -89,9 +89,7 @@ def _read_s3obj(relative_path: str) -> str:
     s3 = buckets.portal_resource
     wmg_config = WmgConfig()
     wmg_config.load()
-    prefixed_relative_path = os.path.join(
-        wmg_config.data_path_prefix, relative_path or ""
-    )
+    prefixed_relative_path = os.path.join(wmg_config.data_path_prefix, relative_path or "")
     s3obj = s3.Object(WmgConfig().bucket, prefixed_relative_path)
     return s3obj.get()["Body"].read().decode("utf-8").strip()
 

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from dataclasses import dataclass
@@ -77,7 +78,7 @@ def _load_snapshot(new_snapshot_identifier) -> WmgSnapshot:
 
 
 def _open_cube(cube_uri) -> Array:
-    return tiledb.open(cube_uri, ctx=create_ctx(tiledb_mem_gb=float(WmgConfig().tiledb_mem_gb)))
+    return tiledb.open(cube_uri, ctx=create_ctx(WmgConfig().tiledb_config_overrides))
 
 
 def _load_cell_type_order(snapshot_identifier: str) -> DataFrame:
@@ -89,7 +90,7 @@ def _read_s3obj(relative_path: str) -> str:
     wmg_config = WmgConfig()
     wmg_config.load()
     prefixed_relative_path = os.path.join(
-        wmg_config.data_path_prefix if "data_path_prefix" in wmg_config.config else "", relative_path or ""
+        wmg_config.data_path_prefix, relative_path or ""
     )
     s3obj = s3.Object(WmgConfig().bucket, prefixed_relative_path)
     return s3obj.get()["Body"].read().decode("utf-8").strip()

--- a/backend/wmg/data/tiledb.py
+++ b/backend/wmg/data/tiledb.py
@@ -6,9 +6,9 @@ import tiledb
 from backend.corpora.common.utils.math_utils import MB, GB
 
 
-def create_ctx(tiledb_mem_gb: float = 0.5, config_overrides: dict = {}) -> tiledb.Ctx:
+def create_ctx(config_overrides: dict = {}) -> tiledb.Ctx:
     cfg = {
-        "py.init_buffer_bytes": int(float(tiledb_mem_gb) * GB),
+        "py.init_buffer_bytes": int(0.5 * GB),
         "sm.tile_cache_size": 100 * MB if os.getenv("DEPLOYMENT_STAGE", "test") == "test" else virtual_memory_size(0.5),
         "sm.consolidation.buffer_size": consolidation_buffer_size(0.1),
         "sm.query.sparse_unordered_with_dups.non_overlapping_ranges": "true",


### PR DESCRIPTION
### Reviewers
**Functional:** 
@ebezzi 

**Readability:** 
@MDunitz 

---

## Changes
- WmgConfig() accepts a `tiledb_config_overrides` JSON object
- WmgSnapshot uses all tiledb config overrides for TileDB init
- removed support for `tiledb_mem` config param, replaced by lower-level `py.init_buffer_bytes` setting in config overrides.


## Definition of Done (from ticket)

## QA steps (optional)
rdev verified

## Known Issues
