### PR TITLE
fix: database setup for rdev

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -5,7 +5,7 @@ db/migrate:
 .PHONY: db/remote_migration_init
 db/remote_migration_init:
 	# Run utility installation before invoking these commands.
-	pip install awscli
+	pip install awscli -r ../requirements.txt
 	apt-get update && apt-get install -y postgresql-client jq
 
 .PHONY: db/init_remote_dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ scanpy
 scipy==1.7.3
 tenacity
 tiledb==0.13.2  # Portal's tiledb version should always be the same or older than Explorer's
-click==8.0.1
 -r ./backend/corpora/api_server/requirements.txt
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
 parameterized


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

---
currently `db/init_remote_dev` and `db/delete_remote_dev` are failing because we aren't installing the requirements needed to run `scripts.populate_db`. This is causing 500 errors on the backend because the database is not created. It's also causing issues when tearing down an rdev because the database is not deleted.

## Changes
- removed extra click
- install requirements for scripts.populate_db

## Definition of Done (from ticket)
- `happy` correctly sets up and tears down the databases used by rdev environments