### PR TITLE
fix(wmg): Update dropdown height

### DIFF
--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
@@ -23,8 +23,8 @@ import { noop } from "src/common/constants/utils";
 import { Label } from "../../style";
 import { ButtonWrapper, StyledIconButton, StyledMenuItem } from "./style";
 
+const MAX_ITEMS_TO_SHOW = 9.5;
 const LISTBOX_ITEM_HEIGHT_PX = 48;
-const LISTBOX_HEIGHT_PX = 152;
 
 const ListBoxContext = createContext({});
 
@@ -48,11 +48,16 @@ const ListboxComponent = React.forwardRef<HTMLDivElement>(
     const itemData = React.Children.toArray(children);
     const itemCount = itemData.length;
 
+    const height = Math.min(
+      LISTBOX_ITEM_HEIGHT_PX * itemCount,
+      LISTBOX_ITEM_HEIGHT_PX * MAX_ITEMS_TO_SHOW
+    );
+
     return (
       <div ref={ref}>
         <ListBoxContext.Provider value={other}>
           <FixedSizeList
-            height={LISTBOX_HEIGHT_PX}
+            height={height}
             itemCount={itemCount}
             outerElementType={OuterElementType}
             itemSize={LISTBOX_ITEM_HEIGHT_PX}


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve 
**Readability:** 

---

## Changes
Update dropdown height based on the number of options available with a max of 9.5 options tall

<img width="466" alt="Screen Shot 2022-04-08 at 3 08 09 PM" src="https://user-images.githubusercontent.com/6309723/162540419-0aa8c395-7e08-43ff-871b-dd9ff7828df4.png">

![demo](https://user-images.githubusercontent.com/6309723/162540470-90ffaf10-3494-4721-9b61-f68a3d738cb1.gif)


## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
