### PR TITLE
chore: bump flake8 pre-commit version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
         stages: [commit]
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         stages: [commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
         stages: [commit]
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 4.0.1 # Must be kept in sync with flake8 version in requirements.txt
     hooks:
       - id: flake8
         stages: [commit]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.11.17
 click==8.0.1
 coverage>=2.0.15
 flake8-black==0.3.2
-flake8==4.0.1
+flake8==4.0.1  # Must be kept in sync with flake8 version in .pre-commit-config.yaml
 furl
 h5py<3.0.0
 jsonschema


### PR DESCRIPTION
### Reviewers
**Functional:** 
@Bento007 @tihuan 
**Readability:** 

---

## Changes
need to update flake8 pre-commit version in order to not have disparities in linting demands from pre-commit hook vs GHA hook

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
