### PR TITLE
fix: check if expression summary is already an empty object

### DIFF
--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -269,6 +269,7 @@ export function useCellTypesByTissueName(): {
     if (
       isLoading ||
       !data ||
+      Object.keys(data).length === 0 ||
       isLoadingPrimaryFilterDimensions ||
       !primaryFilterDimensions ||
       isLoadingTermIdLabels ||


### PR DESCRIPTION
### Reviewers
**Functional:** @tihuan 

---

This doesn't include an error message if any condition causes this conditional to return true. We could split this conditional in to the expected, often, trues (loading), and the error states. Returning a broad warning for the others. Cut this PR now immediately  so we can unblock.



