### PR TITLE
fix(wmg): 2272 tooltip placement FE polish

### DIFF
--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
@@ -16,7 +16,7 @@ import {
   MenuSelect,
 } from "czifui";
 import { pull, uniq } from "lodash";
-import React, { createContext, useRef, useState } from "react";
+import React, { createContext, ReactChild, useRef, useState } from "react";
 import { FixedSizeList, ListChildComponentProps } from "react-window";
 import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
@@ -42,8 +42,12 @@ function rowRender(props: ListChildComponentProps) {
   return <div style={style}>{data[index]}</div>;
 }
 
-const ListboxComponent = React.forwardRef<HTMLDivElement>(
-  function ListboxComponent(props, ref) {
+interface ListboxProps {
+  children: ReactChild;
+}
+
+const ListboxComponent = React.forwardRef<HTMLDivElement, ListboxProps>(
+  function ListboxComponent(props: ListboxProps, ref) {
     const { children, ...other } = props;
 
     const itemData = React.Children.toArray(children);

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
@@ -280,10 +280,10 @@ export default memo(function Chart({
   return (
     <Wrapper height={heatmapHeight} width={heatmapWidth}>
       <Tooltip
-        placement="right-start"
         classes={tooltipClasses}
         title={tooltipContent || <>No data</>}
         leaveDelay={0}
+        placement="right-end"
         PopperProps={{
           anchorEl: {
             clientHeight: 0,

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
@@ -38,7 +38,7 @@ import {
 
 interface Props {
   cellTypes: CellType[];
-  selectedGeneData: (GeneExpressionSummary | undefined)[];
+  selectedGeneData?: (GeneExpressionSummary | undefined)[];
   setIsLoading: Dispatch<
     SetStateAction<{
       [tissue: Tissue]: boolean;
@@ -58,7 +58,7 @@ const TOOLTIP_THROTTLE_MS = 100;
 
 export default memo(function Chart({
   cellTypes,
-  selectedGeneData,
+  selectedGeneData = EMPTY_ARRAY,
   setIsLoading,
   tissue,
   scaledMeanExpressionMax,
@@ -136,7 +136,10 @@ export default memo(function Chart({
 
   const debouncedIntegrateCellTypesAndGenes = useMemo(() => {
     return debounce(
-      (cellTypes: CellType[], geneData: Props["selectedGeneData"]) => {
+      (
+        cellTypes: CellType[],
+        geneData: Props["selectedGeneData"] = EMPTY_ARRAY
+      ) => {
         setCellTypeSummaries(
           integrateCelTypesAndGenes({
             cellTypes,
@@ -168,7 +171,7 @@ export default memo(function Chart({
     return debounce(
       (
         cellTypeSummaries: CellTypeSummary[],
-        selectedGeneData: Props["selectedGeneData"]
+        selectedGeneData: Props["selectedGeneData"] = EMPTY_ARRAY
       ) => {
         const result = {
           cellTypeMetadata: getAllSerializedCellTypeMetadata(
@@ -316,7 +319,7 @@ export default memo(function Chart({
  */
 function integrateCelTypesAndGenes({
   cellTypes,
-  geneExpressionSummaries,
+  geneExpressionSummaries = EMPTY_ARRAY,
 }: {
   cellTypes: CellType[];
   geneExpressionSummaries: Props["selectedGeneData"];

--- a/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
@@ -5,6 +5,7 @@ import {
   EChartsOption,
   ScatterSeriesOption,
 } from "echarts";
+import { EMPTY_ARRAY } from "src/common/constants/utils";
 import { LIGHT_GRAY } from "src/components/common/theme";
 import { State } from "../../common/store";
 import {
@@ -367,7 +368,9 @@ const HEAT_MAP_BASE_CELL_PX = 20;
  * of the number of genes selected.
  */
 export function getHeatmapWidth(
-  genes: (GeneExpressionSummary | undefined)[] | State["selectedGenes"]
+  genes:
+    | (GeneExpressionSummary | undefined)[]
+    | State["selectedGenes"] = EMPTY_ARRAY
 ): number {
   return HEAT_MAP_BASE_WIDTH_PX + HEAT_MAP_BASE_CELL_PX * genes.length;
 }
@@ -375,7 +378,7 @@ export function getHeatmapWidth(
 /**
  * Approximating the heatmap height by the number of cells.
  */
-export function getHeatmapHeight(cellTypes: CellType[] = []): number {
+export function getHeatmapHeight(cellTypes: CellType[] = EMPTY_ARRAY): number {
   return HEAT_MAP_BASE_HEIGHT_PX + HEAT_MAP_BASE_CELL_PX * cellTypes.length;
 }
 

--- a/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
@@ -5,6 +5,7 @@ import {
   EChartsOption,
   ScatterSeriesOption,
 } from "echarts";
+import { LIGHT_GRAY } from "src/components/common/theme";
 import { State } from "../../common/store";
 import {
   CellType,
@@ -146,7 +147,7 @@ export function convertPercentageToDiameter(percentage: number): number {
 }
 
 const SELECTED_STYLE = {
-  backgroundColor: "#F8F8F8",
+  backgroundColor: LIGHT_GRAY.D,
   fontWeight: "bold" as never,
   padding: 4,
 };
@@ -344,13 +345,13 @@ export function dataToChartFormat({
 
       return {
         cellTypeIndex,
+        expressedCellCount,
         geneIndex,
         id,
         meanExpression,
         percentage,
         scaledMeanExpression,
         tissuePercentage,
-        expressedCellCount,
       } as ChartFormat;
     });
   }


### PR DESCRIPTION
### Reviewers
**Functional:** 
@pablo-gar @hthomas-czi 
**Readability:** 

---

## Changes

1. Selected state background color to `LIGHT_GRAY.D` (⚠️ : This seems to be the only place not using `theme.ts` for color. If there are other things, please help point them out for me 🙏 Thank you!):

    <img width="595" alt="Screen Shot 2022-04-11 at 7 27 02 PM" src="https://user-images.githubusercontent.com/6309723/162867079-2bf578ce-c194-496c-b8da-642cb6f5e86f.png">


1. Tooltip placement:
    <img width="1034" alt="Screen Shot 2022-04-11 at 7 08 39 PM" src="https://user-images.githubusercontent.com/6309723/162865084-9cc91f75-78a0-433e-85ad-61d1efccded0.png">

    <img width="1013" alt="Screen Shot 2022-04-11 at 7 09 05 PM" src="https://user-images.githubusercontent.com/6309723/162865091-4d447db9-6d49-4edb-a483-543a71bde939.png">

    ![demo](https://user-images.githubusercontent.com/6309723/162865171-dd017dae-294d-47fa-a01d-dbce25482a16.gif)

1. Don't clear text:

    ![demo](https://user-images.githubusercontent.com/6309723/162877119-78638556-1a17-411e-b235-ed4b1b3f537a.gif)

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
