### PR TITLE
refactor: use InputBaseProps

### DIFF
--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
@@ -2,7 +2,6 @@ import { Theme } from "@emotion/react";
 import { makeStyles, Popper } from "@material-ui/core";
 import {
   AutocompleteCloseReason,
-  AutocompleteInputChangeReason,
   AutocompleteRenderOptionState,
 } from "@material-ui/lab";
 import {
@@ -192,17 +191,6 @@ export default function QuickSelect<
 
   const ref = useRef(null);
 
-  const handleInputChange = (
-    _: React.ChangeEvent<Record<string, never>>,
-    value: string,
-    reason: AutocompleteInputChangeReason
-  ) => {
-    if (!reason || reason === "reset" || !value) {
-      return;
-    }
-    setInput(value);
-  };
-
   return (
     <>
       <ButtonWrapper>
@@ -243,11 +231,14 @@ export default function QuickSelect<
           renderOption={renderOption}
           onPaste={handlePaste}
           InputBaseProps={{
+            onChange: (
+              event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+            ) => {
+              setInput(event.target.value);
+            },
             placeholder,
           }}
           inputValue={input}
-          // @ts-expect-error -- We ignore the first attribute and its a pain to type
-          onInputChange={handleInputChange}
         />
       </Popper>
     </>


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
Revert back to use `InputBaseProps` to add `onChange`, since `onInputChange` is not typed correctly and no longer needed, since we now expose `InputBaseProps`!

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
