### PR TITLE
fix(local): Update port to 5005

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -21,7 +21,7 @@ locals {
   deletion_cmd                 = ["make", "-C", "/corpora-data-portal/backend", "db/delete_remote_dev"]
   frontend_cmd                 = []
   # TODO: Assess whether this is safe for Portal API as well. Trying 1 worker in rdev portal backend containers, to minimize use of memory by TileDB (allocates multi-GB per process)
-  backend_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "1", "--bind", "0.0.0.0:5000", "backend.corpora.api_server.app:app", "--max-requests", "10000", "--timeout", "180", "--keep-alive", "5", "--log-level", "info"]
+  backend_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "1", "--bind", "0.0.0.0:5005", "backend.corpora.api_server.app:app", "--max-requests", "10000", "--timeout", "180", "--keep-alive", "5", "--log-level", "info"]
   data_load_path               = "s3://${local.secret["s3_buckets"]["env"]["name"]}/database/dev_data.sql"
 
   vpc_id                       = local.secret["vpc_id"]
@@ -116,7 +116,7 @@ module backend_service {
   subnets           = local.subnets
   security_groups   = local.security_groups
   task_role_arn     = local.ecs_role_arn
-  service_port      = 5000
+  service_port      = 5005
   memory            = var.backend_memory
   cmd               = local.backend_cmd
   deployment_stage  = local.deployment_stage

--- a/DEV_ENV.md
+++ b/DEV_ENV.md
@@ -5,7 +5,7 @@
 1. [install docker](https://docs.docker.com/get-docker/). If brew is installed run `brew install docker`. If you have a Mac, [install Docker Desktop](https://www.docker.com/products/docker-desktop) and open it so it's running on your machine. Note: If you have a Mac M1 (arm64 CPU), follow instructions in [`docker-compose.yml`](docker-compose.yml) under `oidc` service, for manually building the oidc-server-mock images for the M1 architecture.
 1. [install chamber](https://github.com/segmentio/chamber). If brew is installed run `brew install chamber`. (This is needed for running functional tests.)
 1. From the root of this repository, run `make local-init` to build and run the dev environment. The first build takes awhile, but subsequent runs will use cached artifacts.
-1. Visit [http://backend.corporanet.local:5000](http://backend.corporanet.local:5000) to view the backend, and [http://frontend.corporanet.local:3000](http://frontend:3000) for the frontend.
+1. Visit [http://backend.corporanet.local:5005](http://backend.corporanet.local:5005) to view the backend, and [http://frontend.corporanet.local:3000](http://frontend:3000) for the frontend.
 1. `make local-dbconsole` starts a connection with the local postgresql db.
 1. **Open the source code and start editing!**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ADD backend/corpora/api_server/requirements.txt /corpora-data-portal/requirement
 RUN grep -v requirements.txt requirements.txt > reqs.txt \
     && cat requirements-api.txt >> reqs.txt \
     && python3 -m pip install -r reqs.txt
-EXPOSE 5000
+EXPOSE 5005
 
 # Install utilities to /corpora-data-portal so we can run db migrations.
 ADD tests /corpora-data-portal/tests
@@ -35,4 +35,4 @@ ENV COMMIT_SHA=${HAPPY_COMMIT}
 ENV COMMIT_BRANCH=${HAPPY_BRANCH}
 
 # Note: Using just 1 worker for dev/test env. Multiple workers are used in deployment envs, as defined in Terraform code.
-CMD gunicorn --worker-class gevent --workers 1 --bind 0.0.0.0:5000 backend.corpora.api_server.app:app --max-requests 10000 --timeout 180 --keep-alive 5 --log-level info
+CMD gunicorn --worker-class gevent --workers 1 --bind 0.0.0.0:5005 backend.corpora.api_server.app:app --max-requests 10000 --timeout 180 --keep-alive 5 --log-level info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,8 +218,7 @@ services:
       - localstack
       - database
     ports:
-      # port 5000 is 'unofficially' used by Apple's Control Center! 🤬
-      - "5000:5000"
+      - "5005:5005"
     environment:
       - PYTHONUNBUFFERED=1
       - CORPORA_LOCAL_DEV=true

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -112,7 +112,7 @@ This starts an FE server that hits a **local** API server
 1. Requirements:
 
    1. You are able to spin up a local BE server
-   1. Your `src/configs/configs.js` points to local BE server. E.g., `http://backend.corporanet.local:5000`
+   1. Your `src/configs/configs.js` points to local BE server. E.g., `http://backend.corporanet.local:5005`
 
 1. For Gatsby Prod Build: `npm run smoke-test-with-local-backend`
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,7 +109,7 @@
     "build-and-start-local-backend": "DEPLOYMENT_STAGE=test AWS_PROFILE=single-cell-dev npm run _build-and-start-local-backend",
     "smoke-test": "start-server-and-test start :3000 e2e",
     "smoke-test-prod-build": "start-server-and-test build-and-start-prod :9000 e2e-localProd",
-    "smoke-test-with-local-backend": "start-server-and-test build-and-start-local-backend :5000 build-and-start-prod :9000 e2e-localProd"
+    "smoke-test-with-local-backend": "start-server-and-test build-and-start-local-backend :5005 build-and-start-prod :9000 e2e-localProd"
   },
   "repository": {
     "type": "git",

--- a/frontend/src/configs/local-docker.js
+++ b/frontend/src/configs/local-docker.js
@@ -3,7 +3,7 @@ const { PLAUSIBLE_DATA_DOMAIN_STAGING } = require("./common");
 // Temporarily route API calls to the backend app to http://backend
 // instead of http://localhost
 const configs = {
-  API_URL: "http://backend:5000",
+  API_URL: "http://backend:5005",
   PLAUSIBLE_DATA_DOMAIN: PLAUSIBLE_DATA_DOMAIN_STAGING,
 };
 

--- a/frontend/src/configs/local.js
+++ b/frontend/src/configs/local.js
@@ -4,7 +4,7 @@ const { PLAUSIBLE_DATA_DOMAIN_STAGING } = require("./common");
 // to a new file named `configs.js` in this directory.
 
 const configs = {
-  API_URL: "http://backend.corporanet.local:5000",
+  API_URL: "http://backend.corporanet.local:5005",
   PLAUSIBLE_DATA_DOMAIN: PLAUSIBLE_DATA_DOMAIN_STAGING,
 };
 

--- a/oauth/clients-config.json
+++ b/oauth/clients-config.json
@@ -8,8 +8,8 @@
             "authorization_code"
         ],
         "RedirectUris": [
-            "https://backend.corporanet.local:5000/dp/v1/oauth2/callback",
-            "http://backend.corporanet.local:5000/dp/v1/oauth2/callback"
+            "https://backend.corporanet.local:5005/dp/v1/oauth2/callback",
+            "http://backend.corporanet.local:5005/dp/v1/oauth2/callback"
         ],
         "AllowedScopes": [
            "openid", "profile", "email", "offline_access", "write:collections"

--- a/scripts/login.py
+++ b/scripts/login.py
@@ -8,7 +8,7 @@ def get_cxguser_cookie():
     # suppress https warnings.
     requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
-    OIDC_LOGIN_URL = "http://backend.corporanet.local:5000/dp/v1/login"
+    OIDC_LOGIN_URL = "http://backend.corporanet.local:5005/dp/v1/login"
     USERS_CONFIGURATION_PATH = "oauth/users.json"
     CLIENTS_CONFIGURATION_PATH = "oauth/clients-config.json"
 
@@ -24,7 +24,7 @@ def get_cxguser_cookie():
     client_data = data[0]
     client_id = client_data["ClientId"]
 
-    # Calling http://backend.corporanet.local:5000/dp/v1/login
+    # Calling http://backend.corporanet.local:5005/dp/v1/login
     session = requests.session()
     response = session.get(OIDC_LOGIN_URL, verify=False, allow_redirects=False)
     location = response.headers["Location"]

--- a/scripts/setup_dev_data.sh
+++ b/scripts/setup_dev_data.sh
@@ -5,7 +5,7 @@ export AWS_ACCESS_KEY_ID=nonce
 export AWS_SECRET_ACCESS_KEY=nonce
 
 export FRONTEND_URL=http://frontend.corporanet.local:3000
-export BACKEND_URL=http://backend.corporanet.local:5000
+export BACKEND_URL=http://backend.corporanet.local:5005
 
 # NOTE: This script is intended to run INSIDE the dockerized dev environment!
 # If you need to run it directly on your laptop for some reason, change

--- a/tests/functional/backend/corpora/common.py
+++ b/tests/functional/backend/corpora/common.py
@@ -11,7 +11,7 @@ API_URL = {
     "prod": "https://api.cellxgene.cziscience.com",
     "staging": "https://api.cellxgene.staging.single-cell.czi.technology",
     "dev": "https://api.cellxgene.dev.single-cell.czi.technology",
-    "test": "http://localhost:5000",
+    "test": "http://localhost:5005",
 }
 
 AUDIENCE = {

--- a/tests/unit/backend/corpora/common/test_auth0_manager.py
+++ b/tests/unit/backend/corpora/common/test_auth0_manager.py
@@ -7,7 +7,7 @@ from tests.unit.backend.corpora.api_server.base_api_test import BaseAuthAPITest
 
 class TestSession(BaseAuthAPITest):
     def test_session_refresh(self):
-        auth0_management_session.domain = "http://localhost:5000"
+        auth0_management_session.domain = "http://localhost:5005"
         auth0_management_session.get_auth0_management_token = MagicMock(return_value="Bearer good")
         auth0_management_session.headers["Authorization"] = "Bearer bad"
         response = auth0_management_session.session.get(self.auth_config.api_base_url + "/test-refresh")


### PR DESCRIPTION
### Reviewers
**Functional:** @metakuni 


---

## Changes
- modify the port used by dataportal backend from 5000 to 5005

## Definition of Done (from ticket)
- able to make a local deployment
- able to make an rdev

## QA steps (optional)
- `make local-rebuild` and verify you can access the backend and the frontend can access the backend.
