### PR TITLE
fix: black version bump to be compatible with click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0 # Must be kept in sync with black version in requirements.txt
+    rev: 22.3.0 # Must be kept in sync with black version in requirements.txt
     hooks:
       - id: black
         stages: [commit]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic
 anndata==0.7.6
-black==22.1.0  # Must be kept in sync with black version in .pre-commit-config.yaml
+black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
 botocore>=1.14.17
 boto3>=1.11.17
 click==8.0.1


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve @tihuan 
**Readability:** 

---

## Changes
- Recent update of click version causes problems for older black version. Updated.

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
