### PR TITLE
fix: remove memoization, remove visibility from query invalidations

### DIFF
--- a/frontend/src/common/queries/datasets.ts
+++ b/frontend/src/common/queries/datasets.ts
@@ -6,11 +6,7 @@ import {
 } from "react-query";
 import { API_URL } from "src/configs/configs";
 import { API } from "../API";
-import {
-  DatasetAsset,
-  DatasetUploadStatus,
-  VISIBILITY_TYPE,
-} from "../entities";
+import { DatasetAsset, DatasetUploadStatus } from "../entities";
 import { apiTemplateToUrl } from "../utils/apiTemplateToUrl";
 import { USE_COLLECTION } from "./collections";
 import { DEFAULT_FETCH_OPTIONS, DELETE_FETCH_OPTIONS } from "./common";
@@ -67,11 +63,7 @@ export function useDeleteDataset(collection_uuid = "") {
 
   return useMutation(deleteDataset, {
     onSuccess: (uploadStatus: DatasetUploadStatus) => {
-      queryClient.invalidateQueries([
-        USE_COLLECTION,
-        collection_uuid,
-        VISIBILITY_TYPE.PRIVATE,
-      ]);
+      queryClient.invalidateQueries([USE_COLLECTION, collection_uuid]);
 
       queryClient.cancelQueries([USE_DATASET_STATUS, uploadStatus.dataset_id]);
 

--- a/frontend/src/views/Collection/components/DatasetTab/index.tsx
+++ b/frontend/src/views/Collection/components/DatasetTab/index.tsx
@@ -1,6 +1,5 @@
 import { Button, Intent, UL } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
-import memoize from "lodash/memoize";
 import { FC, useState } from "react";
 import { useQueryClient } from "react-query";
 import { Collection, Dataset } from "src/common/entities";
@@ -50,12 +49,9 @@ const DatasetTab: FC<Props> = ({
   const isDatasetPresent =
     datasets?.length > 0 || Object.keys(uploadedFiles).length > 0;
 
-  const invalidateCollectionQuery = memoize(
-    () => {
-      queryClient.invalidateQueries([USE_COLLECTION, collectionId, visibility]);
-    },
-    () => collectionId + visibility
-  );
+  const invalidateCollectionQuery = () => {
+    queryClient.invalidateQueries([USE_COLLECTION, collectionId]);
+  };
 
   const addNewFile = (mutationFunction = uploadLink, originalId?: string) => {
     return (newFile: UploadingFile) => {


### PR DESCRIPTION
The usage of memoization for this particular function call appears to be
incorrect. Also, 'visibility' should have been removed from the key
array for the query invalidation call as part of the original primary
key migration.

### Reviewers
**Functional:** 
@seve @tihuan 
**Readability:** 

---

## Changes
- remove visibility from query invalidations, an instance of memoization
