### PR TITLE
test(wmg): Fix smoke test sex filter tags

### DIFF
--- a/frontend/src/components/common/SideBar/index.tsx
+++ b/frontend/src/components/common/SideBar/index.tsx
@@ -26,6 +26,7 @@ export interface Props {
   position?: typeof Position[keyof typeof Position];
   SideBarWrapperComponent?: typeof SideBarWrapper;
   SideBarPositionerComponent?: typeof SideBarPositioner;
+  testId?: string;
 }
 
 export default function SideBar({
@@ -37,6 +38,7 @@ export default function SideBar({
   position = Position.LEFT,
   SideBarWrapperComponent = SideBarWrapper,
   SideBarPositionerComponent = SideBarPositioner,
+  testId,
 }: Props): JSX.Element {
   const [isExpanded, setIsExpanded] = useState(isOpen);
   const sideBarWidth = isExpanded ? width : COLLAPSED_WIDTH_PX;
@@ -59,7 +61,11 @@ export default function SideBar({
   };
 
   return (
-    <SideBarWrapperComponent sideBarWidth={sideBarWidth} position={position}>
+    <SideBarWrapperComponent
+      sideBarWidth={sideBarWidth}
+      position={position}
+      data-test-id={testId}
+    >
       <SideBarPositionerComponent isExpanded={isExpanded}>
         <SideBarToggleButtonWrapper>
           <Button

--- a/frontend/src/views/WheresMyGene/components/Main/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Main/index.tsx
@@ -228,6 +228,7 @@ export default function WheresMyGene(): JSX.Element {
         isOpen
         SideBarWrapperComponent={SideBarWrapper}
         SideBarPositionerComponent={SideBarPositioner}
+        testId="filters-panel"
       >
         <Filters />
       </SideBar>

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -102,7 +102,7 @@ describeIfDevStagingProd("Where's My Gene", () => {
     await expect(selectedSexesAfter.length).toBe(1);
 
     async function getFiltersPanel() {
-      return page.$("*css=div >> text=Filters");
+      return page.$(getTestID("filters-panel"));
     }
 
     async function getSexSelector() {


### PR DESCRIPTION
Seems like `return page.$("*css=div >> text=Filters");` is picking up the `Beta` tag on the new nav button, so I'm changing the selector to narrow it down to the left panel only!

<img width="1150" alt="Screen Shot 2022-05-02 at 6 02 30 PM" src="https://user-images.githubusercontent.com/6309723/166390615-d20d56fe-960c-417d-bf88-cba65d67eaab.png">


## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
