### PR TITLE
chore: use stack_name in submission lambda IAMs

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -236,7 +236,7 @@ module dataset_submissions_lambda {
 }
 
 resource "aws_iam_role" "dataset_submissions_lambda_service_role" {
-  name               = "corpora-dataset-submissions-service-role-${var.deployment_stage}"
+  name               = "corpora-dataset-submissions-service-role-${local.custom_stack_name}"
   path               = "/service-role/"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
@@ -316,7 +316,7 @@ data "aws_iam_policy_document" "lambda_step_function_execution_policy" {
 }
 
 resource "aws_iam_policy" "lambda_step_function_execution_policy" {
-  name = "lambda-step-function-execution-policy-${var.deployment_stage}"
+  name = "lambda-step-function-execution-policy-${local.custom_stack_name}"
   policy = data.aws_iam_policy_document.lambda_step_function_execution_policy.json
 }
 

--- a/scripts/cxg_admin.py
+++ b/scripts/cxg_admin.py
@@ -783,7 +783,7 @@ def cxg_remaster(ctx):
         import boto3
 
         client = boto3.client("stepfunctions")
-        import time
+        from time import time, sleep
 
         for record in session.query(DbDataset):
             if not record.tombstone:
@@ -796,6 +796,12 @@ def cxg_remaster(ctx):
                     bucket = p.hostname
                     dataset_id = p.path.strip("/").strip(".cxg")
 
+                    if dataset_id == "2e5273bd-aa36-4478-8f6f-62fa0abcea43":
+                        continue
+
+                    if bucket != "hosted-cellxgene-dev":
+                        continue
+
                     print(bucket, dataset_id)
 
                     input = {"dataset_uuid": dataset_id}
@@ -805,13 +811,13 @@ def cxg_remaster(ctx):
                     happy_stack_name = get_happy_stack_name(deployment)
 
                     response = client.start_execution(
-                        stateMachineArn=f"arn:aws:states:us-west-2:{aws_account_id}:stateMachine:dp-{happy_stack_name}-sfn",
+                        stateMachineArn=f"arn:aws:states:us-west-2:{aws_account_id}:stateMachine:dp-{happy_stack_name}-cxg-remaster-sfn",
                         name=f"{dataset_id}-{int(time())}",
                         input=json.dumps(input),
                     )
 
                     print(response["executionArn"])
-                    time.sleep(1)
+                    sleep(1)
 
 
 def get_database_uri() -> str:


### PR DESCRIPTION
### Reviewers
**Functional:** 
@metakuni 

**Readability:** 

---

## Changes
- Uses `stack_name` in place of `deployment_stage` in IAMs, to avoid rdev duplication.
