### PR TITLE
feat: Truncate long collection descriptions and display a 'read more' link (#1938)

### DIFF
--- a/frontend/src/common/hooks/useResizeObserver.ts
+++ b/frontend/src/common/hooks/useResizeObserver.ts
@@ -28,13 +28,11 @@ export function useResizeObserver(
 
   // Observed element is resized or repositioned - set state elementRect with the element's new dimensions or position.
   const onResize = useCallback((entries: ResizeObserverEntry[]) => {
-    for (const entry of entries) {
-      if (entry) {
-        const scrollHeight = entry.target.scrollHeight;
-        const contentRect = entry.contentRect.toJSON();
-        setElementRect({ ...contentRect, scrollHeight });
-        break;
-      }
+    if (entries && entries.length > 0) {
+      const entry = entries[0]; // grab the first entry; observing a single element
+      const scrollHeight = entry.target.scrollHeight;
+      const contentRect = entry.contentRect.toJSON();
+      setElementRect({ ...contentRect, scrollHeight });
     }
   }, []);
 

--- a/frontend/src/common/hooks/useResizeObserver.ts
+++ b/frontend/src/common/hooks/useResizeObserver.ts
@@ -1,0 +1,56 @@
+// Core dependencies
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+export type ElementRect = {
+  bottom: number;
+  height: number;
+  left: number;
+  right: number;
+  scrollHeight: number;
+  top: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
+/**
+ * Element resizing and repositioning observer.
+ * @param ref - element to be observed for changes to its size or position.
+ * @returns Element size and position properties for the given element.
+ */
+export function useResizeObserver(
+  ref: RefObject<HTMLElement>
+): ElementRect | undefined {
+  const [elementRect, setElementRect] = useState<ElementRect>();
+  const observerRef = useRef<ResizeObserver>();
+  const observer = observerRef && observerRef.current;
+  const observedEl = ref && ref.current;
+
+  // Observed element is resized or repositioned - set state elementRect with the element's new dimensions or position.
+  const onResize = useCallback((entries: ResizeObserverEntry[]) => {
+    for (const entry of entries) {
+      if (entry) {
+        const scrollHeight = entry.target.scrollHeight;
+        const contentRect = entry.contentRect.toJSON();
+        setElementRect({ ...contentRect, scrollHeight });
+        break;
+      }
+    }
+  }, []);
+
+  // Creates a new ResizeObserver object which can be used to report changes to an element's dimensions or position.
+  useEffect(() => {
+    observerRef.current = new ResizeObserver(onResize);
+  }, [onResize]);
+
+  // Element is "observed" and reports any changes to the element's dimensions or position.
+  useEffect(() => {
+    if (!observer || !observedEl) return;
+    observer.observe(observedEl);
+    return () => {
+      observer.unobserve(observedEl);
+    };
+  }, [observedEl, observer]);
+
+  return elementRect;
+}

--- a/frontend/src/components/Collection/components/CollectionDescription/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDescription/index.tsx
@@ -1,0 +1,132 @@
+import { Intent } from "@blueprintjs/core";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  CollectionDescription as Description,
+  DescriptionText,
+  DESCRIPTION_LINE_HEIGHT_PX,
+  MAX_LINE_COUNT,
+} from "src/components/Collection/components/CollectionDescription/style";
+import { StyledPrimaryAnchorButton } from "src/components/common/Button/common/style";
+
+enum EllipsisMode {
+  "NONE" = "NONE",
+  "OFF" = "OFF",
+  "ON" = "ON",
+}
+
+interface Props {
+  description: string;
+}
+
+export default function CollectionDescription({
+  description,
+}: Props): JSX.Element {
+  const descriptionRef = useRef<HTMLParagraphElement>(null);
+  const [ellipsisMode, setEllipsisMode] = useState<EllipsisMode>(
+    EllipsisMode.NONE
+  );
+  const isEllipsis = ellipsisMode === EllipsisMode.ON;
+
+  /**
+   * Updates the state of ellipsis mode by toggling between "ON" and "OFF" values.
+   */
+  const onToggleMode = (): void => {
+    setEllipsisMode((currentMode) => {
+      if (currentMode === EllipsisMode.ON) {
+        return EllipsisMode.OFF;
+      }
+      return EllipsisMode.ON;
+    });
+  };
+
+  /**
+   * Updates ellipsis mode state.
+   */
+  const onUpdateMode = useCallback((): void => {
+    if (descriptionRef.current) {
+      const el = descriptionRef.current;
+      setEllipsisMode((currentMode) => getEllipsisMode(el, currentMode));
+    }
+  }, []);
+
+  useEffect(() => {
+    onUpdateMode(); /* Initialize ellipsis mode. */
+    window.addEventListener("resize", onUpdateMode);
+    return () => {
+      document.removeEventListener("resize", onUpdateMode);
+    };
+  }, [onUpdateMode]);
+
+  return (
+    <Description data-test-id="collection-description">
+      <DescriptionText isEllipsis={isEllipsis} ref={descriptionRef}>
+        {description}
+      </DescriptionText>
+      {isModeActivated(ellipsisMode) && (
+        <StyledPrimaryAnchorButton
+          intent={Intent.PRIMARY}
+          minimal
+          onClick={onToggleMode}
+          text={getModeText(ellipsisMode)}
+        />
+      )}
+    </Description>
+  );
+}
+
+/**
+ * Returns one of the following ellipsis mode for the description paragraph:
+ * - "ON" - paragraph is ellipsis view with the option to toggle view, or
+ * - "OFF" - paragraph is in full view with the option to toggle view, or
+ * - "NONE" - paragraph is in full view with no option to toggle view as it does not require ellipsis.
+ * @param el - description paragraph element.
+ * @param currentMode - current ellipsis mode.
+ * @returns EllipsisMode
+ */
+function getEllipsisMode(
+  el: HTMLParagraphElement,
+  currentMode: EllipsisMode
+): EllipsisMode {
+  /* Grab the measurement of element height, including hidden content due to overflow. */
+  const elScrollHeight = el.scrollHeight;
+  /* Calculate the number of lines rendered. */
+  const elLineCount = elScrollHeight / DESCRIPTION_LINE_HEIGHT_PX;
+
+  if (elLineCount <= MAX_LINE_COUNT) {
+    /* Element does not have hidden content and line count is within allowable limit. */
+    /* Mode is "NONE" - ellipsis mode not required. */
+    return EllipsisMode.NONE;
+  }
+
+  if (currentMode === EllipsisMode.NONE) {
+    /* Line count exceeds allowable limit, and ellipsis mode is "NONE". */
+    /* Change mode to "ON" - ellipsis mode required. */
+    return EllipsisMode.ON;
+  }
+
+  return currentMode;
+}
+
+/**
+ * Returns applicable button text for display corresponding with current mode.
+ * When the current mode is "ON" the return value will be "Read More", otherwise the return value is "Read Less".
+ * @param currentMode - current ellipsis mode.
+ * @returns string for display as button text.
+ */
+function getModeText(currentMode: EllipsisMode): string {
+  if (currentMode === EllipsisMode.ON) {
+    return "Read More";
+  }
+
+  return "Read Less";
+}
+
+/**
+ * Ellipsis mode is "activated" when description text is long enough to be truncated.
+ * i.e. the current mode will not equal "NONE".
+ * @param currentMode - current ellipsis mode.
+ * @returns true when mode is not "NONE".
+ */
+function isModeActivated(currentMode: EllipsisMode): boolean {
+  return currentMode !== EllipsisMode.NONE;
+}

--- a/frontend/src/components/Collection/components/CollectionDescription/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDescription/index.tsx
@@ -1,5 +1,6 @@
 import { Intent } from "@blueprintjs/core";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { useResizeObserver } from "src/common/hooks/useResizeObserver";
 import {
   CollectionDescription as Description,
   DescriptionText,
@@ -26,6 +27,8 @@ export default function CollectionDescription({
     EllipsisMode.NONE
   );
   const isEllipsis = ellipsisMode === EllipsisMode.ON;
+  const descriptionRect = useResizeObserver(descriptionRef);
+  const { scrollHeight: descriptionScrollHeight } = descriptionRect || {};
 
   /**
    * Updates the state of ellipsis mode by toggling between "ON" and "OFF" values.
@@ -40,22 +43,13 @@ export default function CollectionDescription({
   };
 
   /**
-   * Updates ellipsis mode state.
+   * Ellipsis mode state updates with changes to the description paragraph scroll height.
    */
-  const onUpdateMode = useCallback((): void => {
-    if (descriptionRef.current) {
-      const el = descriptionRef.current;
-      setEllipsisMode((currentMode) => getEllipsisMode(el, currentMode));
-    }
-  }, []);
-
   useEffect(() => {
-    onUpdateMode(); /* Initialize ellipsis mode. */
-    window.addEventListener("resize", onUpdateMode);
-    return () => {
-      document.removeEventListener("resize", onUpdateMode);
-    };
-  }, [onUpdateMode]);
+    setEllipsisMode((currentMode) =>
+      getEllipsisMode(descriptionScrollHeight, currentMode)
+    );
+  }, [descriptionScrollHeight]);
 
   return (
     <Description data-test-id="collection-description">
@@ -79,29 +73,29 @@ export default function CollectionDescription({
  * - "ON" - paragraph is ellipsis view with the option to toggle view, or
  * - "OFF" - paragraph is in full view with the option to toggle view, or
  * - "NONE" - paragraph is in full view with no option to toggle view as it does not require ellipsis.
- * @param el - description paragraph element.
- * @param currentMode - current ellipsis mode.
- * @returns EllipsisMode
+ * @param elScrollHeight - description paragraph scroll height.
+ * @param currentMode - current ellipsis mode for the description paragraph.
+ * @returns Ellipsis mode for the description paragraph.
  */
 function getEllipsisMode(
-  el: HTMLParagraphElement,
+  elScrollHeight: number | undefined,
   currentMode: EllipsisMode
 ): EllipsisMode {
-  /* Grab the measurement of element height, including hidden content due to overflow. */
-  const elScrollHeight = el.scrollHeight;
-  /* Calculate the number of lines for the content fully rendered. */
-  const elLineCount = elScrollHeight / DESCRIPTION_LINE_HEIGHT_PX;
+  if (elScrollHeight) {
+    /* Calculate the number of lines for the content fully rendered. */
+    const elLineCount = elScrollHeight / DESCRIPTION_LINE_HEIGHT_PX;
 
-  if (elLineCount <= MAX_LINE_COUNT) {
-    /* Element does not have hidden content and line count is within allowable limit. */
-    /* Mode is "NONE" - ellipsis mode not required. */
-    return EllipsisMode.NONE;
-  }
+    if (elLineCount <= MAX_LINE_COUNT) {
+      /* Element does not have hidden content and line count is within allowable limit. */
+      /* Mode is "NONE" - ellipsis mode not required. */
+      return EllipsisMode.NONE;
+    }
 
-  if (currentMode === EllipsisMode.NONE) {
-    /* Line count exceeds allowable limit, and ellipsis mode is "NONE". */
-    /* Change mode to "ON" - ellipsis mode required. */
-    return EllipsisMode.ON;
+    if (currentMode === EllipsisMode.NONE) {
+      /* Line count exceeds allowable limit, and ellipsis mode is "NONE". */
+      /* Change mode to "ON" - ellipsis mode required. */
+      return EllipsisMode.ON;
+    }
   }
 
   return currentMode;
@@ -117,7 +111,6 @@ function getModeText(currentMode: EllipsisMode): string {
   if (currentMode === EllipsisMode.ON) {
     return "Show More";
   }
-
   return "Show Less";
 }
 

--- a/frontend/src/components/Collection/components/CollectionDescription/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDescription/index.tsx
@@ -81,21 +81,23 @@ function getEllipsisMode(
   elScrollHeight: number | undefined,
   currentMode: EllipsisMode
 ): EllipsisMode {
-  if (elScrollHeight) {
-    /* Calculate the number of lines for the content fully rendered. */
-    const elLineCount = elScrollHeight / DESCRIPTION_LINE_HEIGHT_PX;
+  if (!elScrollHeight) {
+    return currentMode;
+  }
 
-    if (elLineCount <= MAX_LINE_COUNT) {
-      /* Element does not have hidden content and line count is within allowable limit. */
-      /* Mode is "NONE" - ellipsis mode not required. */
-      return EllipsisMode.NONE;
-    }
+  /* Calculate the number of lines for the content fully rendered. */
+  const elLineCount = elScrollHeight / DESCRIPTION_LINE_HEIGHT_PX;
 
-    if (currentMode === EllipsisMode.NONE) {
-      /* Line count exceeds allowable limit, and ellipsis mode is "NONE". */
-      /* Change mode to "ON" - ellipsis mode required. */
-      return EllipsisMode.ON;
-    }
+  if (elLineCount <= MAX_LINE_COUNT) {
+    /* Element does not have hidden content and line count is within allowable limit. */
+    /* Mode is "NONE" - ellipsis mode not required. */
+    return EllipsisMode.NONE;
+  }
+
+  if (currentMode === EllipsisMode.NONE) {
+    /* Line count exceeds allowable limit, and ellipsis mode is "NONE". */
+    /* Change mode to "ON" - ellipsis mode required. */
+    return EllipsisMode.ON;
   }
 
   return currentMode;

--- a/frontend/src/components/Collection/components/CollectionDescription/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDescription/index.tsx
@@ -89,7 +89,7 @@ function getEllipsisMode(
 ): EllipsisMode {
   /* Grab the measurement of element height, including hidden content due to overflow. */
   const elScrollHeight = el.scrollHeight;
-  /* Calculate the number of lines rendered. */
+  /* Calculate the number of lines for the content fully rendered. */
   const elLineCount = elScrollHeight / DESCRIPTION_LINE_HEIGHT_PX;
 
   if (elLineCount <= MAX_LINE_COUNT) {
@@ -109,16 +109,16 @@ function getEllipsisMode(
 
 /**
  * Returns applicable button text for display corresponding with current mode.
- * When the current mode is "ON" the return value will be "Read More", otherwise the return value is "Read Less".
+ * When the current mode is "ON" the return value will be "Show More", otherwise the return value is "Show Less".
  * @param currentMode - current ellipsis mode.
  * @returns string for display as button text.
  */
 function getModeText(currentMode: EllipsisMode): string {
   if (currentMode === EllipsisMode.ON) {
-    return "Read More";
+    return "Show More";
   }
 
-  return "Read Less";
+  return "Show Less";
 }
 
 /**

--- a/frontend/src/components/Collection/components/CollectionDescription/style.ts
+++ b/frontend/src/components/Collection/components/CollectionDescription/style.ts
@@ -1,0 +1,31 @@
+import { PT_TEXT_COLOR } from "src/components/common/theme";
+import styled, { css } from "styled-components";
+
+export const DESCRIPTION_LINE_HEIGHT_PX = 18;
+export const MAX_LINE_COUNT = 6;
+
+interface Props {
+  isEllipsis: boolean;
+}
+
+export const CollectionDescription = styled.div`
+  grid-area: description;
+`;
+
+export const DescriptionText = styled.p<Props>`
+  color: ${PT_TEXT_COLOR};
+  letter-spacing: -0.1px;
+  line-height: ${DESCRIPTION_LINE_HEIGHT_PX}px;
+  margin-bottom: 8px;
+  ${(props) => {
+    return (
+      props.isEllipsis &&
+      css`
+        -webkit-box-orient: vertical;
+        display: -webkit-box;
+        -webkit-line-clamp: ${MAX_LINE_COUNT};
+        overflow: hidden;
+      `
+    );
+  }};
+`;

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -16,6 +16,7 @@ import {
 } from "src/common/queries/collections";
 import { removeParams } from "src/common/utils/removeParams";
 import { isTombstonedCollection } from "src/common/utils/typeGuards";
+import CollectionDescription from "src/components/Collection/components/CollectionDescription";
 import CollectionMetadata from "src/components/Collection/components/CollectionMetadata";
 import CollectionMigrationCallout from "src/components/Collection/components/CollectionMigrationCallout";
 import CollectionRevisionStatusCallout from "src/components/Collection/components/CollectionRevisionStatusCallout";
@@ -24,12 +25,7 @@ import DatasetTab from "src/views/Collection/components/DatasetTab";
 import ActionButtons from "./components/ActionButtons";
 import DeleteCollectionButton from "./components/ActionButtons/components/DeleteButton";
 import Toast from "./components/Toast";
-import {
-  CollectionDescription,
-  CollectionDetail,
-  CollectionHero,
-  ViewCollection,
-} from "./style";
+import { CollectionDetail, CollectionHero, ViewCollection } from "./style";
 import {
   buildCollectionMetadataLinks,
   getIsPublishable,
@@ -207,9 +203,7 @@ const Collection: FC = () => {
         </CollectionHero>
         {/* Collection description and metadata */}
         <CollectionDetail>
-          <CollectionDescription data-test-id="collection-description">
-            {collection.description}
-          </CollectionDescription>
+          <CollectionDescription description={collection.description} />
           {collectionMetadataLinks.length > 0 && (
             <CollectionMetadata
               collectionMetadataLinks={collectionMetadataLinks}

--- a/frontend/src/views/Collection/style.ts
+++ b/frontend/src/views/Collection/style.ts
@@ -26,10 +26,3 @@ export const CollectionDetail = styled.div`
   grid-template-columns: 8fr 1fr 8fr; /* grid columns for collection description and metadata (with 1fr allocated to column separation) */
   margin: 16px 0 44px;
 `;
-
-export const CollectionDescription = styled.div`
-  color: ${PT_TEXT_COLOR};
-  grid-area: description;
-  letter-spacing: -0.1px;
-  line-height: 18px;
-`;


### PR DESCRIPTION
### Reviewers
**Functional:** 

@tihuan 

---

## Changes
- added to long collection descriptions a button to toggle between [Show More](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=2988%3A31078) and [Show Less](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=3584%3A31174) views.