### PR TITLE
fix: revert backend port mapping

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -21,7 +21,7 @@ locals {
   deletion_cmd                 = ["make", "-C", "/corpora-data-portal/backend", "db/delete_remote_dev"]
   frontend_cmd                 = []
   # TODO: Assess whether this is safe for Portal API as well. Trying 1 worker in rdev portal backend containers, to minimize use of memory by TileDB (allocates multi-GB per process)
-  backend_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "1", "--bind", "0.0.0.0:5000", "backend.corpora.api_server.app:app", "--max-requests", "10000", "--timeout", "180", "--keep-alive", "5", "--log-level", "info"]
+  backend_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "1", "--bind", "0.0.0.0:5050", "backend.corpora.api_server.app:app", "--max-requests", "10000", "--timeout", "180", "--keep-alive", "5", "--log-level", "info"]
   data_load_path               = "s3://${local.secret["s3_buckets"]["env"]["name"]}/database/dev_data.sql"
 
   vpc_id                          = local.secret["vpc_id"]
@@ -118,7 +118,7 @@ module backend_service {
   subnets           = local.subnets
   security_groups   = local.security_groups
   task_role_arn     = local.ecs_role_arn
-  service_port      = 5000
+  service_port      = 5050
   memory            = var.backend_memory
   cmd               = local.backend_cmd
   deployment_stage  = local.deployment_stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ADD backend/corpora/api_server/requirements.txt /corpora-data-portal/requirement
 RUN grep -v requirements.txt requirements.txt > reqs.txt \
     && cat requirements-api.txt >> reqs.txt \
     && python3 -m pip install -r reqs.txt
-EXPOSE 5000
+EXPOSE 5050
 
 # Install utilities to /corpora-data-portal so we can run db migrations.
 ADD tests /corpora-data-portal/tests
@@ -35,4 +35,4 @@ ENV COMMIT_SHA=${HAPPY_COMMIT}
 ENV COMMIT_BRANCH=${HAPPY_BRANCH}
 
 # Note: Using just 1 worker for dev/test env. Multiple workers are used in deployment envs, as defined in Terraform code.
-CMD gunicorn --worker-class gevent --workers 1 --bind 0.0.0.0:5000 backend.corpora.api_server.app:app --max-requests 10000 --timeout 180 --keep-alive 5 --log-level info
+CMD gunicorn --worker-class gevent --workers 1 --bind 0.0.0.0:5050 backend.corpora.api_server.app:app --max-requests 10000 --timeout 180 --keep-alive 5 --log-level info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,7 +252,7 @@ services:
       - localstack
       - database
     ports:
-      - "5000:5000"
+      - "5050:5050"
     environment:
       - PYTHONUNBUFFERED=1
       - CORPORA_LOCAL_DEV=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
       - database:/var/lib/postgresql/data
       - ./backend/database:/import
     networks:
-       corporanet:
-          aliases:
-            - database.corporanet.local
+      corporanet:
+        aliases:
+          - database.corporanet.local
   localstack:
     image: localstack/localstack@sha256:7c6635493185d25165979995fb073fd789c72b6d8b17ef3a70b798d55576732f
     ports:
@@ -30,9 +30,9 @@ services:
     volumes:
       - localstack:/tmp/localstack
     networks:
-       corporanet:
-          aliases:
-            - localstack.corporanet.local
+      corporanet:
+        aliases:
+          - localstack.corporanet.local
   frontend:
     image: "${DOCKER_REPO}corpora-frontend"
     platform: linux/amd64
@@ -62,9 +62,9 @@ services:
       - ./frontend:/corpora-frontend
       - /corpora-frontend/node_modules/
     networks:
-       corporanet:
-          aliases:
-            - frontend.corporanet.local
+      corporanet:
+        aliases:
+          - frontend.corporanet.local
   upload_failures:
     image: "${DOCKER_REPO}corpora-upload-failures"
     platform: linux/amd64
@@ -98,9 +98,9 @@ services:
       - ARTIFACT_BUCKET=artifact-bucket
       - CELLXGENE_BUCKET=cellxgene-bucket
     networks:
-       corporanet:
-          aliases:
-            - uploadfailures.corporanet.local
+      corporanet:
+        aliases:
+          - uploadfailures.corporanet.local
   upload_success:
     image: "${DOCKER_REPO}corpora-upload-success"
     platform: linux/amd64
@@ -133,9 +133,9 @@ services:
       - ARTIFACT_BUCKET=artifact-bucket
       - CELLXGENE_BUCKET=cellxgene-bucket
     networks:
-       corporanet:
-          aliases:
-            - uploadsuccess.corporanet.local
+      corporanet:
+        aliases:
+          - uploadsuccess.corporanet.local
   dataset_submissions:
     image: "${DOCKER_REPO}dataset-submissions"
     platform: linux/amd64
@@ -167,9 +167,9 @@ services:
       - ARTIFACT_BUCKET=artifact-bucket
       - CELLXGENE_BUCKET=cellxgene-bucket
     networks:
-       corporanet:
-          aliases:
-            - dataset_submissions.corporanet.local
+      corporanet:
+        aliases:
+          - dataset_submissions.corporanet.local
   processing:
     image: "${DOCKER_REPO}corpora-upload"
     platform: linux/amd64
@@ -202,9 +202,9 @@ services:
       - ARTIFACT_BUCKET=artifact-bucket
       - CELLXGENE_BUCKET=cellxgene-bucket
     networks:
-       corporanet:
-          aliases:
-            - processing.corporanet.local
+      corporanet:
+        aliases:
+          - processing.corporanet.local
   wmg_processing:
     image: "${DOCKER_REPO}wmg-processing"
     platform: linux/amd64
@@ -232,9 +232,9 @@ services:
       - ARTIFACT_BUCKET=artifact-bucket
       - CELLXGENE_BUCKET=cellxgene-bucket
     networks:
-       corporanet:
-          aliases:
-            - processing.corporanet.local
+      corporanet:
+        aliases:
+          - processing.corporanet.local
   backend:
     image: "${DOCKER_REPO}corpora-backend"
     platform: linux/amd64
@@ -252,7 +252,7 @@ services:
       - localstack
       - database
     ports:
-      - "5050:5000"
+      - "5000:5000"
     environment:
       - PYTHONUNBUFFERED=1
       - CORPORA_LOCAL_DEV=true
@@ -271,9 +271,9 @@ services:
       # SecretsManager population relies on oauth json
       - ./oauth/users.json:/oauth/users.json
     networks:
-       corporanet:
-          aliases:
-            - backend.corporanet.local
+      corporanet:
+        aliases:
+          - backend.corporanet.local
   oidc:
     image: soluto/oidc-server-mock:0.3.0
     # For Mac M1, you may need to build this image from source.
@@ -304,9 +304,9 @@ services:
       - ./oauth/pkcs12:/tmp/pkcs12:ro
       - ./oauth:/tmp/config:ro
     networks:
-       corporanet:
-          aliases:
-            - oidc.corporanet.local
+      corporanet:
+        aliases:
+          - oidc.corporanet.local
 networks:
   corporanet:
 volumes:


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- modify backend port in docker-compose, will have to revisit how to move dp backend off of 5000 later

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
