### PR TITLE
revert: "fix: up s3 credential duration from 1 hr to 12 hrs (#2482)"

### DIFF
--- a/backend/corpora/lambdas/api/v1/curation/collection/dataset.py
+++ b/backend/corpora/lambdas/api/v1/curation/collection/dataset.py
@@ -28,7 +28,7 @@ def create_policy(data_bucket: str, collection_id: str) -> str:
     return json.dumps(policy)
 
 
-duration = 43200  # 12 hrs -- max time limit for AssumeRole call from within the AWS environment
+duration = 3600
 
 
 @dbconnect


### PR DESCRIPTION
This reverts commit ffe1ef8768ab4cb666bd92e41e780ed203ee9e23.

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---

## Changes
- Trying to exceed 1 hr causes failure; no way to get around it due to container's assumed role (role chaining issue).

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
