### PR TITLE
fix(wmg): Refresh when snapshot changes

### DIFF
--- a/frontend/src/views/WheresMyGene/common/store/actions.ts
+++ b/frontend/src/views/WheresMyGene/common/store/actions.ts
@@ -109,6 +109,15 @@ export function selectFilters(
   };
 }
 
+export function setSnapshotId(
+  snapshotId: State["snapshotId"]
+): GetActionTypeOfReducer<typeof REDUCERS["setSnapshotId"]> {
+  return {
+    payload: snapshotId,
+    type: "setSnapshotId",
+  };
+}
+
 type GetActionTypeOfReducer<T> = T extends (
   state: never,
   action: infer Action

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -27,6 +27,11 @@ export interface State {
     ethnicities?: string[];
     sexes?: string[];
   };
+  /**
+   * (thuang): BE API response always returns a snapshot ID. When the ID changes,
+   * FE needs refresh the queries
+   */
+  snapshotId: string | null;
 }
 
 // (thuang): If you have derived states based on the state, use `useMemo`
@@ -39,6 +44,7 @@ export const INITIAL_STATE: State = {
   selectedGenes: [],
   selectedOrganismId: null,
   selectedTissues: [],
+  snapshotId: null,
 };
 
 export const REDUCERS = {
@@ -50,6 +56,7 @@ export const REDUCERS = {
   selectGenes,
   selectOrganism,
   selectTissues,
+  setSnapshotId,
   tissueCellTypesFetched,
   toggleCellTypeIdToDelete,
   toggleGeneToDelete,
@@ -117,6 +124,10 @@ function selectOrganism(
   state: State,
   action: PayloadAction<string | null>
 ): State {
+  if (state.selectedOrganismId === action.payload) {
+    return state;
+  }
+
   return {
     ...state,
     selectedGenes: [],
@@ -308,5 +319,17 @@ function selectFilters(
   return {
     ...state,
     selectedFilters: newSelectedFilters,
+  };
+}
+
+function setSnapshotId(
+  state: State,
+  action: PayloadAction<State["snapshotId"]>
+): State {
+  const { payload } = action;
+
+  return {
+    ...state,
+    snapshotId: payload,
   };
 }

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/Organism/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/Organism/index.tsx
@@ -42,8 +42,9 @@ export default function Organism({ isLoading }: Props): JSX.Element {
     );
   }, [organisms]);
 
+  // (thuang): Default to "Homo sapiens" on first load
   useEffect(() => {
-    if (!organisms || !dispatch) return;
+    if (!organisms || !dispatch || selectedOrganismId) return;
 
     const organism = organisms.find(
       (organism: IOrganism) => organism.name === "Homo sapiens"
@@ -52,7 +53,7 @@ export default function Organism({ isLoading }: Props): JSX.Element {
     if (!organism) return;
 
     dispatch(selectOrganism(organism.id));
-  }, [organisms, dispatch]);
+  }, [organisms, dispatch, selectedOrganismId]);
 
   const organismsById = useMemo(() => {
     const result: { [id: string]: IOrganism } = {};


### PR DESCRIPTION
## Changes
1. This PR automatically refetches both `/primary_filter_dimensions` and `/query` when `snapshotId` changes!

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
