### PR TITLE
fix: exclude datasets with multiple organisms

### DIFF
--- a/backend/wmg/data/extract.py
+++ b/backend/wmg/data/extract.py
@@ -29,16 +29,16 @@ def get_dataset_s3_uris():
         dataset_ids = []
         published_dataset_non_null_assays = (
             session.query(Dataset.table.id, Dataset.table.assay, Dataset.table.organism)
-                .join(Dataset.table.collection)
-                .filter(
+            .join(Dataset.table.collection)
+            .filter(
                 Dataset.table.assay != "null",
                 Dataset.table.published == "TRUE",
                 Dataset.table.is_primary_data == "PRIMARY",
                 Collection.table.visibility == "PUBLIC",
                 Dataset.table.tombstone == "FALSE",
-                Dataset.table.organism != "null"
+                Dataset.table.organism != "null",
             )
-                .all()
+            .all()
         )
 
         for dataset_id, assays, organisms in published_dataset_non_null_assays:

--- a/backend/wmg/data/extract.py
+++ b/backend/wmg/data/extract.py
@@ -4,7 +4,6 @@ from backend.corpora.common.corpora_orm import DatasetArtifactFileType
 from backend.corpora.common.entities import Collection, Dataset, DatasetAsset
 from backend.corpora.common.utils.db_session import db_session_manager
 
-
 included_assay_ontologies = {
     "EFO:0010550": "sci-RNA-seq",
     "EFO:0009901": "10x 3' v1",
@@ -29,20 +28,23 @@ def get_dataset_s3_uris():
 
         dataset_ids = []
         published_dataset_non_null_assays = (
-            session.query(Dataset.table.id, Dataset.table.assay)
-            .join(Dataset.table.collection)
-            .filter(
+            session.query(Dataset.table.id, Dataset.table.assay, Dataset.table.organism)
+                .join(Dataset.table.collection)
+                .filter(
                 Dataset.table.assay != "null",
                 Dataset.table.published == "TRUE",
                 Dataset.table.is_primary_data == "PRIMARY",
                 Collection.table.visibility == "PUBLIC",
                 Dataset.table.tombstone == "FALSE",
+                Dataset.table.organism != "null"
             )
-            .all()
+                .all()
         )
-        for dataset_id, assays in published_dataset_non_null_assays:
+
+        for dataset_id, assays, organisms in published_dataset_non_null_assays:
             if any(assay["ontology_term_id"] in included_assay_ontologies for assay in assays):
-                dataset_ids.append(dataset_id)
+                if len(organisms) < 2:
+                    dataset_ids.append(dataset_id)
 
         s3_uris = DatasetAsset.s3_uris_for_datasets(session, dataset_ids, DatasetArtifactFileType.H5AD)
     return s3_uris

--- a/tests/unit/backend/wmg/data/test_extract.py
+++ b/tests/unit/backend/wmg/data/test_extract.py
@@ -152,7 +152,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             self.dataset__private_collection,
             self.dataset__wrong_assay,
             self.dataset__multiple_organisms,
-            self.dataset__null_organism
+            self.dataset__null_organism,
         ]
         for dataset in not_expected_datasets:
             dataset_assets = dataset.get_assets()

--- a/tests/unit/backend/wmg/data/test_extract.py
+++ b/tests/unit/backend/wmg/data/test_extract.py
@@ -104,7 +104,17 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
             assay=[{"ontology_term_id": assay_ontologies[1], "label": "test_assay"}],
         )
-
+        self.dataset__null_organism = self.generate_dataset_with_s3_resources(
+            self.session,
+            artifacts=True,
+            explorer_s3_object=False,
+            collection_id=pub_collection.id,
+            published=True,
+            is_primary_data="PRIMARY",
+            tombstone=False,
+            organism=None,
+            assay=[{"ontology_term_id": assay_ontologies[1], "label": "test_assay"}],
+        )
         private_collection = self.generate_collection(self.session, visibility="PRIVATE")
         self.dataset__private_collection = self.generate_dataset_with_s3_resources(
             self.session,
@@ -142,6 +152,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             self.dataset__private_collection,
             self.dataset__wrong_assay,
             self.dataset__multiple_organisms,
+            self.dataset__null_organism
         ]
         for dataset in not_expected_datasets:
             dataset_assets = dataset.get_assets()

--- a/tests/unit/backend/wmg/data/test_extract.py
+++ b/tests/unit/backend/wmg/data/test_extract.py
@@ -25,6 +25,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             published=True,
             is_primary_data="PRIMARY",
             tombstone=False,
+            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
             assay=[{"ontology_term_id": assay_ontologies[0], "label": "test_assay"}],
         )
         self.dataset_1 = self.generate_dataset_with_s3_resources(
@@ -35,6 +36,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             published=True,
             is_primary_data="PRIMARY",
             tombstone=False,
+            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
             # Only one assay needs to be included in the list of allowed assays
             assay=[
                 {"ontology_term_id": assay_ontologies[1], "label": "test_assay"},
@@ -43,6 +45,18 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
         )
 
         # DONT INCLUDE
+        self.dataset__multiple_organisms = self.generate_dataset_with_s3_resources(
+            self.session,
+            artifacts=True,
+            explorer_s3_object=False,
+            collection_id=pub_collection.id,
+            published=True,
+            is_primary_data="PRIMARY",
+            tombstone=False,
+            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"},
+                      {"label": "Mus musculus", "ontology_term_id": "NCBITaxon:10090"}],
+            assay=[{"ontology_term_id": assay_ontologies[0], "label": "test_assay"}],
+        )
         self.dataset__wrong_assay = self.generate_dataset_with_s3_resources(
             self.session,
             artifacts=True,
@@ -51,6 +65,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             published=True,
             is_primary_data="PRIMARY",
             tombstone=False,
+            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
             assay=[{"ontology_term_id": "any_other_obo_id", "label": "test_assay"}],
         )
         self.dataset__not_primary = self.generate_dataset_with_s3_resources(
@@ -61,6 +76,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             published=True,
             is_primary_data="SECONDARY",
             tombstone=True,
+            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
             assay=[{"ontology_term_id": assay_ontologies[1], "label": "test_assay"}],
         )
 
@@ -72,6 +88,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             published=False,
             is_primary_data="PRIMARY",
             tombstone=False,
+            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
             assay=[{"ontology_term_id": assay_ontologies[1], "label": "test_assay"}],
         )
         self.dataset__tombstoned = self.generate_dataset_with_s3_resources(
@@ -82,6 +99,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             published=True,
             is_primary_data="PRIMARY",
             tombstone=True,
+            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
             assay=[{"ontology_term_id": assay_ontologies[1], "label": "test_assay"}],
         )
 
@@ -94,6 +112,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             published=True,
             is_primary_data="PRIMARY",
             tombstone=False,
+            organism=[{"label": "Mus musculus", "ontology_term_id": "NCBITaxon:10090"}],
             assay=[{"ontology_term_id": assay_ontologies[0], "label": "test_assay"}],
         )
 
@@ -109,6 +128,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             - contain primary data
             - not tombstoned
             - correct assay type
+            - only contain one organism
         """
         expected_s3_uris = []
         not_expected_s3_uris = []
@@ -132,6 +152,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
 
         s3_uris = set(extract.get_dataset_s3_uris().values())
         self.assertEquals(set(expected_s3_uris), s3_uris)
+        self.assertEquals(1, 0)  # is this test even running?
 
         @unittest.skip
         def test_datasets_copied_to_correct_location(self):

--- a/tests/unit/backend/wmg/data/test_extract.py
+++ b/tests/unit/backend/wmg/data/test_extract.py
@@ -53,8 +53,10 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             published=True,
             is_primary_data="PRIMARY",
             tombstone=False,
-            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"},
-                      {"label": "Mus musculus", "ontology_term_id": "NCBITaxon:10090"}],
+            organism=[
+                {"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"},
+                {"label": "Mus musculus", "ontology_term_id": "NCBITaxon:10090"},
+            ],
             assay=[{"ontology_term_id": assay_ontologies[0], "label": "test_assay"}],
         )
         self.dataset__wrong_assay = self.generate_dataset_with_s3_resources(

--- a/tests/unit/backend/wmg/data/test_extract.py
+++ b/tests/unit/backend/wmg/data/test_extract.py
@@ -141,6 +141,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             self.dataset__not_published,
             self.dataset__private_collection,
             self.dataset__wrong_assay,
+            self.dataset__multiple_organisms,
         ]
         for dataset in not_expected_datasets:
             dataset_assets = dataset.get_assets()
@@ -154,7 +155,6 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
 
         s3_uris = set(extract.get_dataset_s3_uris().values())
         self.assertEquals(set(expected_s3_uris), s3_uris)
-        self.assertEquals(1, 0)  # is this test even running?
 
         @unittest.skip
         def test_datasets_copied_to_correct_location(self):


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

---

## Changes

- modify dataset selection function to exclude datasets with multiple organisms

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
