### PR TITLE
fix(wmg): 2500 and 2521 scExpr rendering bugs

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/hooks/useUpdateXAxisChart.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/hooks/useUpdateXAxisChart.ts
@@ -19,7 +19,7 @@ export function useUpdateXAxisChart({
   const throttledUpdateXAxisChart = useMemo(() => {
     return throttle(
       ({ geneNames = [], genesToDelete, xAxisChart }: Props) => {
-        if (!geneNames.length || !xAxisChart) {
+        if (!xAxisChart) {
           return;
         }
 

--- a/frontend/src/views/WheresMyGene/components/HeatMap/hooks/useUpdateYAxisChart.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/hooks/useUpdateYAxisChart.ts
@@ -20,7 +20,7 @@ export function useUpdateYAxisChart({
   const throttledUpdateYAxisChart = useMemo(() => {
     return throttle(
       ({ cellTypeIdsToDelete, cellTypeMetadata = [], yAxisChart }: Props) => {
-        if (!cellTypeMetadata.length || !yAxisChart) {
+        if (!yAxisChart) {
           return;
         }
 


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
1. Seems like #2500 is caused by accidental guard clauses 🤦 
    <img width="380" alt="Screen Shot 2022-05-11 at 5 33 05 PM" src="https://user-images.githubusercontent.com/6309723/167968930-b73848a2-5ff0-42cf-8eaf-80784aff982d.png">

1. #2521 is fixed using @frano-m 's brand new `useResizeObserver` hook 🤩 👏 Thanks so much for making it reusable 🔥 !!

![demo](https://user-images.githubusercontent.com/6309723/167969066-4042ac19-9f2a-4461-92e8-7dde7eac90e9.gif)

## Definition of Done (from ticket)
1. https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/2500

1. https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/2521

## QA steps (optional)

## Known Issues
