### PR TITLE
feat: Add depths to cell types for dot plot

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -178,7 +178,7 @@ def build_ordered_cell_types_by_tissue(
     return structured_result
 
 
-def build_ordered_cell_types_by_tissue_update_depths(x):
+def build_ordered_cell_types_by_tissue_update_depths(x: DataFrame):
     """
     Updates the depths of the cell ontology tree based on cell types that have to be removed
     because they have 0 counts

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -160,7 +160,7 @@ def build_ordered_cell_types_by_tissue(
     )
 
     # Updates depths based on the rows that need to be removed
-    joined = build_ordered_cell_types_by_tissue_fix_depths(joined)
+    joined = build_ordered_cell_types_by_tissue_update_depths(joined)
 
     # Remove cell types without counts
     joined = joined[joined["n_total_cells"].notnull()]
@@ -178,9 +178,9 @@ def build_ordered_cell_types_by_tissue(
     return structured_result
 
 
-def build_ordered_cell_types_by_tissue_fix_depths(x):
+def build_ordered_cell_types_by_tissue_update_depths(x):
     """
-    Updated the depths of the cell ontology tree based on cell types that have to be removed
+    Updates the depths of the cell ontology tree based on cell types that have to be removed
     because they have 0 counts
     """
 

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -155,23 +155,24 @@ def build_ordered_cell_types_by_tissue(
         ["tissue_ontology_term_id", "cell_type_ontology_term_id"], as_index=False
     ).first()[["tissue_ontology_term_id", "cell_type_ontology_term_id", "n_total_cells"]]
 
-    joined = cell_type_orderings.merge(distinct_tissues_cell_types,
-                                       on=["tissue_ontology_term_id", "cell_type_ontology_term_id"],
-                                       how="left")
+    joined = cell_type_orderings.merge(
+        distinct_tissues_cell_types, on=["tissue_ontology_term_id", "cell_type_ontology_term_id"], how="left"
+    )
 
     # Fix depths based on the rows that need to be removed
     joined = build_ordered_cell_types_by_tissue_fix_depths(joined)
 
     # Remove cell types without counts
-    joined = joined[joined['n_total_cells'].notnull()]
+    joined = joined[joined["n_total_cells"].notnull()]
 
     structured_result: Dict[str, List[Dict[str, str]]] = defaultdict(list)
     for row in joined.itertuples(index=False):
         structured_result[row.tissue_ontology_term_id].append(
-            {"cell_type_ontology_term_id": row.cell_type_ontology_term_id,
-             "cell_type": ontology_term_label(row.cell_type_ontology_term_id),
-             "depth": row.depth
-             }
+            {
+                "cell_type_ontology_term_id": row.cell_type_ontology_term_id,
+                "cell_type": ontology_term_label(row.cell_type_ontology_term_id),
+                "depth": row.depth,
+            }
         )
 
     return structured_result
@@ -186,7 +187,7 @@ def build_ordered_cell_types_by_tissue_fix_depths(x):
     depth_col = x.columns.get_loc("depth")
     n_cells = x.columns.get_loc("n_total_cells")
 
-    x['depth'] = x['depth'].astype('int')
+    x["depth"] = x["depth"].astype("int")
 
     for i in range(len(x)):
         if isnan(x.iloc[i, n_cells]):

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -155,11 +155,9 @@ def build_ordered_cell_types_by_tissue(
         ["tissue_ontology_term_id", "cell_type_ontology_term_id"], as_index=False
     ).first()[["tissue_ontology_term_id", "cell_type_ontology_term_id", "n_cells"]]
 
-    joined = cell_type_orderings.merge(
-        distinct_tissues_cell_types,
-        on=["tissue_ontology_term_id", "cell_type_ontology_term_id"],
-        how="left"
-    )
+    joined = cell_type_orderings.merge(distinct_tissues_cell_types,
+                                       on=["tissue_ontology_term_id", "cell_type_ontology_term_id"],
+                                       how="left")
 
     # Fix depths based on the rows that need to be removed
     joined = build_ordered_cell_types_by_tissue_fix_depths(joined)
@@ -200,4 +198,3 @@ def build_ordered_cell_types_by_tissue_fix_depths(x):
                     break
 
     return x
-

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -163,7 +163,10 @@ def build_ordered_cell_types_by_tissue(
 
     for row in sorted.itertuples(index=False):
         structured_result[row.tissue_ontology_term_id].append(
-            {row.cell_type_ontology_term_id: ontology_term_label(row.cell_type_ontology_term_id)}
+            {"cell_type_ontology_term_id": row.cell_type_ontology_term_id,
+             "cell_type": ontology_term_label(row.cell_type_ontology_term_id),
+             "depth": row.depth
+             }
         )
 
     return structured_result

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -180,17 +180,17 @@ def build_ordered_cell_types_by_tissue(
 
 def build_ordered_cell_types_by_tissue_fix_depths(x):
     """
-    Fixes the depths of the cell ontology tree based on cell types that have to be removed
+    Updated the depths of the cell ontology tree based on cell types that have to be removed
     because they have 0 counts
     """
 
     depth_col = x.columns.get_loc("depth")
-    n_cells = x.columns.get_loc("n_total_cells")
+    n_cells_col = x.columns.get_loc("n_total_cells")
 
     x["depth"] = x["depth"].astype("int")
 
     for i in range(len(x)):
-        if isnan(x.iloc[i, n_cells]):
+        if isnan(x.iloc[i, n_cells_col]):
             original_depth = x.iloc[i, depth_col]
             for j in range(i + 1, len(x)):
                 if original_depth < x.iloc[j, depth_col]:

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -159,7 +159,7 @@ def build_ordered_cell_types_by_tissue(
         distinct_tissues_cell_types, on=["tissue_ontology_term_id", "cell_type_ontology_term_id"], how="left"
     )
 
-    # Fix depths based on the rows that need to be removed
+    # Updates depths based on the rows that need to be removed
     joined = build_ordered_cell_types_by_tissue_fix_depths(joined)
 
     # Remove cell types without counts

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -153,7 +153,7 @@ def build_ordered_cell_types_by_tissue(
 ) -> Dict[str, List[Dict[str, str]]]:
     distinct_tissues_cell_types: DataFrame = cell_counts.groupby(
         ["tissue_ontology_term_id", "cell_type_ontology_term_id"], as_index=False
-    ).first()[["tissue_ontology_term_id", "cell_type_ontology_term_id", "n_cells"]]
+    ).first()[["tissue_ontology_term_id", "cell_type_ontology_term_id", "n_total_cells"]]
 
     joined = cell_type_orderings.merge(distinct_tissues_cell_types,
                                        on=["tissue_ontology_term_id", "cell_type_ontology_term_id"],
@@ -163,7 +163,7 @@ def build_ordered_cell_types_by_tissue(
     joined = build_ordered_cell_types_by_tissue_fix_depths(joined)
 
     # Remove cell types without counts
-    joined = joined[joined['n_cells'].notnull()]
+    joined = joined[joined['n_total_cells'].notnull()]
 
     structured_result: Dict[str, List[Dict[str, str]]] = defaultdict(list)
     for row in joined.itertuples(index=False):
@@ -184,7 +184,7 @@ def build_ordered_cell_types_by_tissue_fix_depths(x):
     """
 
     depth_col = x.columns.get_loc("depth")
-    n_cells = x.columns.get_loc("n_cells")
+    n_cells = x.columns.get_loc("n_total_cells")
 
     x['depth'] = x['depth'].astype('int')
 

--- a/backend/wmg/data/transform.py
+++ b/backend/wmg/data/transform.py
@@ -2,7 +2,7 @@ import tiledb
 import pandas as pd
 
 from backend.wmg.data.ontology_labels import ontology_term_label, gene_term_label
-from typing import Dict, List, Iterable
+from typing import Dict, List, Iterable, Set
 import json
 
 from backend.wmg.data.snapshot import (

--- a/backend/wmg/data/transform.py
+++ b/backend/wmg/data/transform.py
@@ -70,7 +70,7 @@ def generate_cell_ordering(snapshot_path: str, cell_type_by_tissue: Dict) -> Non
             if node in cells:
 
                 cells.remove(node)
-                yield {"id": onto[node].name, "depth": depth}
+                yield {"id": node, "depth": depth}
 
                 if node != "CL:0000003":
                     depth += 1

--- a/backend/wmg/data/transform.py
+++ b/backend/wmg/data/transform.py
@@ -65,18 +65,25 @@ def generate_cell_ordering(snapshot_path: str, cell_type_by_tissue: Dict) -> Non
 
         ancestor_ids = [a.id for a in ancestors]
 
-        def recurse(node):
+        def recurse(node: Set[str], depth=0):
+
             if node in cells:
-                yield (node)
+
+                cells.remove(node)
+                yield {"id": onto[node].name, "depth": depth}
+
+                if node != "CL:0000003":
+                    depth += 1
+
             children = [
                 (c, positions[c.id]) for c in onto[node].subclasses(with_self=False, distance=1) if c.id in ancestor_ids
             ]
             sorted_children = sorted(children, key=lambda x: x[1][0])
             for child in sorted_children:
-                yield from recurse(child[0].id)
+                yield from recurse(child[0].id, depth=depth)
 
-        ordered_list = list(dict.fromkeys(recurse(root)))
-        return ordered_list
+        ordered_list = recurse(root)
+        return list(ordered_list)
 
     mapping = {}
     for tissue, cell_df in cell_type_by_tissue.items():
@@ -87,9 +94,9 @@ def generate_cell_ordering(snapshot_path: str, cell_type_by_tissue: Dict) -> Non
     data = []
     for tissue, cells in mapping.items():
         for i, cell in enumerate(cells):
-            data.append((tissue, cell, i))
+            data.append((tissue, cell["id"], cell["depth"], i))
 
-    df = pd.DataFrame(data, columns=["tissue_ontology_term_id", "cell_type_ontology_term_id", "order"])
+    df = pd.DataFrame(data, columns=["tissue_ontology_term_id", "cell_type_ontology_term_id", "depth", "order"])
     df.to_json(f"{snapshot_path}/{CELL_TYPE_ORDERINGS_FILENAME}")
 
 

--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -367,25 +367,25 @@ class WmgApiV1Tests(unittest.TestCase):
             expected = {
                 "tissue_ontology_term_id_0": [
                     {
-                        "cell_type": "cell_type_ontology_term_id_1_label",
-                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
+                        "cell_type": "cell_type_ontology_term_id_0_label",
+                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
                         "depth": 0,
                     },
                     {
-                        "cell_type": "cell_type_ontology_term_id_0_label",
-                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
+                        "cell_type": "cell_type_ontology_term_id_1_label",
+                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
                         "depth": 1,
                     },
                 ],
                 "tissue_ontology_term_id_1": [
                     {
-                        "cell_type": "cell_type_ontology_term_id_1_label",
-                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
+                        "cell_type": "cell_type_ontology_term_id_0_label",
+                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
                         "depth": 0,
                     },
                     {
-                        "cell_type": "cell_type_ontology_term_id_0_label",
-                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
+                        "cell_type": "cell_type_ontology_term_id_1_label",
+                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
                         "depth": 1,
                     },
                 ],

--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -286,14 +286,38 @@ class WmgApiV1Tests(unittest.TestCase):
                 "term_id_labels": {
                     "cell_types": {
                         "tissue_ontology_term_id_1": [
-                            {"cell_type_ontology_term_id_0": "cell_type_ontology_term_id_0_label"},
-                            {"cell_type_ontology_term_id_1": "cell_type_ontology_term_id_1_label"},
-                            {"cell_type_ontology_term_id_2": "cell_type_ontology_term_id_2_label"},
+                            {
+                                "cell_type": "cell_type_ontology_term_id_0_label",
+                                "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
+                                "depth": 0,
+                            },
+                            {
+                                "cell_type": "cell_type_ontology_term_id_1_label",
+                                "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
+                                "depth": 0,
+                            },
+                            {
+                                "cell_type": "cell_type_ontology_term_id_2_label",
+                                "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
+                                "depth": 0,
+                            },
                         ],
                         "tissue_ontology_term_id_2": [
-                            {"cell_type_ontology_term_id_0": "cell_type_ontology_term_id_0_label"},
-                            {"cell_type_ontology_term_id_1": "cell_type_ontology_term_id_1_label"},
-                            {"cell_type_ontology_term_id_2": "cell_type_ontology_term_id_2_label"},
+                            {
+                                "cell_type": "cell_type_ontology_term_id_0_label",
+                                "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
+                                "depth": 0,
+                            },
+                            {
+                                "cell_type": "cell_type_ontology_term_id_1_label",
+                                "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
+                                "depth": 0,
+                            },
+                            {
+                                "cell_type": "cell_type_ontology_term_id_2_label",
+                                "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
+                                "depth": 0,
+                            },
                         ],
                     },
                     "genes": [
@@ -342,13 +366,29 @@ class WmgApiV1Tests(unittest.TestCase):
 
             expected = {
                 "tissue_ontology_term_id_0": [
-                    {"cell_type_ontology_term_id_1": "cell_type_ontology_term_id_1_label"},
-                    {"cell_type_ontology_term_id_0": "cell_type_ontology_term_id_0_label"},
+                    {
+                        "cell_type": "cell_type_ontology_term_id_1_label",
+                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
+                        "depth": 0,
+                    },
+                    {
+                        "cell_type": "cell_type_ontology_term_id_0_label",
+                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
+                        "depth": 0,
+                    },
                 ],
                 "tissue_ontology_term_id_1": [
-                    {"cell_type_ontology_term_id_1": "cell_type_ontology_term_id_1_label"},
-                    {"cell_type_ontology_term_id_0": "cell_type_ontology_term_id_0_label"},
-                ],
+                    {
+                        "cell_type": "cell_type_ontology_term_id_1_label",
+                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
+                        "depth": 0,
+                    },
+                    {
+                        "cell_type": "cell_type_ontology_term_id_0_label",
+                        "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
+                        "depth": 0,
+                    },
+                ]
             }
             self.assertEqual(expected, json.loads(response.data)["term_id_labels"]["cell_types"])
 

--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -294,12 +294,12 @@ class WmgApiV1Tests(unittest.TestCase):
                             {
                                 "cell_type": "cell_type_ontology_term_id_1_label",
                                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
-                                "depth": 0,
+                                "depth": 1,
                             },
                             {
                                 "cell_type": "cell_type_ontology_term_id_2_label",
                                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
-                                "depth": 0,
+                                "depth": 2,
                             },
                         ],
                         "tissue_ontology_term_id_2": [
@@ -311,12 +311,12 @@ class WmgApiV1Tests(unittest.TestCase):
                             {
                                 "cell_type": "cell_type_ontology_term_id_1_label",
                                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
-                                "depth": 0,
+                                "depth": 1,
                             },
                             {
                                 "cell_type": "cell_type_ontology_term_id_2_label",
                                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
-                                "depth": 0,
+                                "depth": 2,
                             },
                         ],
                     },
@@ -374,7 +374,7 @@ class WmgApiV1Tests(unittest.TestCase):
                     {
                         "cell_type": "cell_type_ontology_term_id_0_label",
                         "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
-                        "depth": 0,
+                        "depth": 1,
                     },
                 ],
                 "tissue_ontology_term_id_1": [
@@ -386,9 +386,9 @@ class WmgApiV1Tests(unittest.TestCase):
                     {
                         "cell_type": "cell_type_ontology_term_id_0_label",
                         "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
-                        "depth": 0,
+                        "depth": 1,
                     },
-                ]
+                ],
             }
             self.assertEqual(expected, json.loads(response.data)["term_id_labels"]["cell_types"])
 

--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -125,7 +125,11 @@ class WmgApiV1Tests(unittest.TestCase):
                 "term_id_labels": {
                     "cell_types": {
                         "tissue_ontology_term_id_0": [
-                            {"cell_type_ontology_term_id_0": "cell_type_ontology_term_id_0_label"}
+                            {
+                                "cell_type": "cell_type_ontology_term_id_0_label",
+                                "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
+                                "depth": 0,
+                            }
                         ]
                     },
                     "genes": [{"gene_ontology_term_id_0": "gene_ontology_term_id_0_label"}],

--- a/tests/unit/backend/wmg/fixtures/test_snapshot.py
+++ b/tests/unit/backend/wmg/fixtures/test_snapshot.py
@@ -162,12 +162,11 @@ def build_cell_orderings(cell_counts_cube_dir_, cell_ordering_generator_fn) -> D
             ordering = cell_ordering_generator_fn(cell_type_ontology_term_ids)
             cell_type_orderings.append(
                 pd.DataFrame(
-                    data={
-                        "tissue_ontology_term_id": [tissue_ontology_term_id] * len(cell_type_ontology_term_ids),
-                        "cell_type_ontology_term_id": cell_type_ontology_term_ids,
-                        "depth": list(islice(cycle([0, 1, 2]), len(cell_type_ontology_term_ids))),
-                        "order": ordering
-                    }
+                    data={"tissue_ontology_term_id": [tissue_ontology_term_id] * len(cell_type_ontology_term_ids),
+                          "cell_type_ontology_term_id": cell_type_ontology_term_ids,
+                          "depth": list(islice(cycle([0, 1, 2]), len(cell_type_ontology_term_ids))),
+                          "order": ordering
+                          }
                 )
             )
     return pd.concat(cell_type_orderings)

--- a/tests/unit/backend/wmg/fixtures/test_snapshot.py
+++ b/tests/unit/backend/wmg/fixtures/test_snapshot.py
@@ -165,8 +165,8 @@ def build_cell_orderings(cell_counts_cube_dir_, cell_ordering_generator_fn) -> D
                     data={
                         "tissue_ontology_term_id": [tissue_ontology_term_id] * len(cell_type_ontology_term_ids),
                         "cell_type_ontology_term_id": cell_type_ontology_term_ids,
-                        "depth": list(islice(cycle([0,1,2]), len(cell_type_ontology_term_ids))),
-                        "order": ordering,
+                        "depth": list(islice(cycle([0, 1, 2]), len(cell_type_ontology_term_ids))),
+                        "order": ordering
                     }
                 )
             )

--- a/tests/unit/backend/wmg/fixtures/test_snapshot.py
+++ b/tests/unit/backend/wmg/fixtures/test_snapshot.py
@@ -162,11 +162,12 @@ def build_cell_orderings(cell_counts_cube_dir_, cell_ordering_generator_fn) -> D
             ordering = cell_ordering_generator_fn(cell_type_ontology_term_ids)
             cell_type_orderings.append(
                 pd.DataFrame(
-                    data={"tissue_ontology_term_id": [tissue_ontology_term_id] * len(cell_type_ontology_term_ids),
-                          "cell_type_ontology_term_id": cell_type_ontology_term_ids,
-                          "depth": list(islice(cycle([0, 1, 2]), len(cell_type_ontology_term_ids))),
-                          "order": ordering
-                          }
+                    data={
+                        "tissue_ontology_term_id": [tissue_ontology_term_id] * len(cell_type_ontology_term_ids),
+                        "cell_type_ontology_term_id": cell_type_ontology_term_ids,
+                        "depth": list(islice(cycle([0, 1, 2]), len(cell_type_ontology_term_ids))),
+                        "order": ordering,
+                    }
                 )
             )
     return pd.concat(cell_type_orderings)

--- a/tests/unit/backend/wmg/fixtures/test_snapshot.py
+++ b/tests/unit/backend/wmg/fixtures/test_snapshot.py
@@ -3,7 +3,7 @@ import os
 import sys
 import tempfile
 from collections import namedtuple
-from itertools import filterfalse
+from itertools import filterfalse, cycle, islice
 from typing import List, Callable, Tuple, Dict, NamedTuple
 
 import numpy as np
@@ -165,6 +165,7 @@ def build_cell_orderings(cell_counts_cube_dir_, cell_ordering_generator_fn) -> D
                     data={
                         "tissue_ontology_term_id": [tissue_ontology_term_id] * len(cell_type_ontology_term_ids),
                         "cell_type_ontology_term_id": cell_type_ontology_term_ids,
+                        "depth": list(islice(cycle([0,1,2]), len(cell_type_ontology_term_ids))),
                         "order": ordering,
                     }
                 )


### PR DESCRIPTION
- #2501

## Changes
- modify backend to create a tree structure for cell type ordering of scExpression
- update `generate_cell_ordering` from `transform.py` to write a pandas dataframe into a json file with the following columns `"tissue_ontology_term_id", "cell_type_ontology_term_id", "depth", "order"]`. The column `depth` encodes the level in the tree where a cell type is
- update `build_ordered_cell_types_by_tissue` of `v1.py` to work with the file mentioned above, the api request now returns a json file of the following structure `{tissue_id : [{id = "", name = "", depth = 10}, ... ], ...} `
