### PR TITLE
feat(curation api): Add PUT /v1/collections/{collection_uuid}/datasets/upload-link Endpoint 

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -334,6 +334,7 @@ paths:
         request body; if an existing Dataset has this tag, the existing Dataset SHALL be replaced, otherwise a new
         Dataset will be added. MAY include the **id** of an existing Dataset, in which case the existing Dataset
         SHALL be replaced.
+      operationId: backend.corpora.lambdas.api.v1.collection_uuid.upload.relink
       tags:
         - collection
       security:

--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -97,6 +97,15 @@ class Dataset(Entity):
         return dataset
 
     @classmethod
+    def get_dataset_from_curator_tag(cls, session: Session, collection_id, curator_tag) -> "Dataset":
+        dataset = (
+            session.query(cls.table)
+            .filter(cls.table.collection_id == collection_id, cls.table.curator_tag == curator_tag)
+            .one_or_none()
+        )
+        return cls(dataset) if dataset else None
+
+    @classmethod
     def get_by_explorer_url(cls, session: Session, explorer_url):
         """
         Return the most recently created dataset with the given explorer_url or None

--- a/backend/corpora/common/upload.py
+++ b/backend/corpora/common/upload.py
@@ -16,6 +16,7 @@ from .utils.exceptions import (
     NonExistentCollectionException,
     InvalidProcessingStateException,
     NonExistentDatasetException,
+    DuplicateTagExistsException,
 )
 from .utils.math_utils import GB
 
@@ -89,6 +90,8 @@ def upload(
                 dataset.reprocess()
 
     else:
+        if curator_tag and Dataset.get_dataset_from_curator_tag(db_session, collection_uuid, curator_tag):
+            raise DuplicateTagExistsException()
         # Add new dataset
         dataset = Dataset.create(db_session, collection=collection, curator_tag=curator_tag)
 

--- a/backend/corpora/common/utils/exceptions.py
+++ b/backend/corpora/common/utils/exceptions.py
@@ -21,3 +21,7 @@ class InvalidProcessingStateException(CorporaException):
 
 class NonExistentDatasetException(CorporaException):
     pass
+
+
+class DuplicateTagExistsException(CorporaException):
+    pass

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_upload_link.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_upload_link.py
@@ -1,0 +1,107 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from backend.corpora.common.corpora_orm import CollectionVisibility, ProcessingStatus
+from tests.unit.backend.corpora.api_server.base_api_test import BaseAuthAPITest
+
+
+class TestPutLink(BaseAuthAPITest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.good_link = "https://www.dropbox.com/s/ow84zm4h0wkl409/test.h5ad?dl=0"
+        cls.dummy_link = "https://www.dropbox.com/s/12345678901234/test.h5ad?dl=0"
+
+    def _test_new(self, collection_params: dict = None, headers: dict = None, body: dict = None):
+        headers = headers if headers else {}
+        collection_params = collection_params if collection_params else {}
+        body = body if body else ""
+        headers["Content-Type"] = "application/json"
+        collection = self.generate_collection(self.session, **collection_params)
+        response = self.app.put(
+            f"/curation/v1/collections/{collection.id}/datasets/upload-link", data=json.dumps(body), headers=headers
+        )
+        return response
+
+    def test__from_link__no_auth(self):
+        response = self._test_new()
+        self.assertEqual(401, response.status_code)
+
+    def test__from_link__Not_Public(self):
+        response = self._test_new(
+            dict(visibility=CollectionVisibility.PUBLIC.name),
+            self.get_auth_headers(),
+            body={"curator_tag": "test", "link": self.dummy_link},
+        )
+        self.assertEqual(403, response.status_code)
+
+    def test__from_link__Not_Owner(self):
+        response = self._test_new(
+            dict(owner="someone else"), self.get_auth_headers(), body={"curator_tag": "test", "link": self.dummy_link}
+        )
+        self.assertEqual(403, response.status_code)
+
+    @patch("backend.corpora.common.upload.start_upload_sfn")
+    def test__new_from_link__OK(self, start_upload_sfn):
+        response = self._test_new({}, self.get_auth_headers(), body={"curator_tag": "test", "link": self.good_link})
+        self.assertEqual(202, response.status_code)
+
+    @patch("backend.corpora.common.upload.start_upload_sfn")
+    def test__new_from_link__Super_Curator(self, start_upload_sfn):
+        headers = {"Authorization": "Bearer " + self.make_super_curator_token(), "Content-Type": "application/json"}
+        response = self._test_new({}, headers, body={"curator_tag": "test", "link": self.good_link})
+        self.assertEqual(202, response.status_code)
+
+    @patch("backend.corpora.common.upload.start_upload_sfn")
+    def test__duplicate_tags__forbidden(self, start_upload_sfn):
+        curator_tag = "test.h5ad"
+        headers = self.get_auth_headers()
+        headers["Content-Type"] = "application/json"
+        collection = self.generate_collection(self.session)
+        dataset = self.generate_dataset(self.session, collection_id=collection.id, curator_tag=curator_tag)
+        body = {"id": dataset.id, "link": self.good_link, "curator_tag": curator_tag}
+        response = self.app.put(
+            f"/curation/v1/collections/{collection.id}/datasets/upload-link", data=json.dumps(body), headers=headers
+        )
+        self.assertEqual(405, response.status_code)
+
+    def _test_existing(self, headers: dict = None, use_curator_tag=False):
+        curator_tag = "test.h5ad"
+        headers = headers if headers else {}
+        headers["Content-Type"] = "application/json"
+        collection = self.generate_collection(self.session)
+        processing_status = dict(processing_status=ProcessingStatus.SUCCESS)
+        dataset = self.generate_dataset(
+            self.session, collection_id=collection.id, curator_tag=curator_tag, processing_status=processing_status
+        )
+        body = {"id": dataset.id, "link": self.good_link}
+        if use_curator_tag:
+            body["curator_tag"] = curator_tag
+        response = self.app.put(
+            f"/curation/v1/collections/{collection.id}/datasets/upload-link", data=json.dumps(body), headers=headers
+        )
+        return response
+
+    @patch("backend.corpora.common.upload.start_upload_sfn")
+    def test__existing_from_link__OK(self, start_upload_sfn):
+        with self.subTest("dataset_id"):
+            response = self._test_existing(self.get_auth_headers())
+            self.assertEqual(202, response.status_code)
+        with self.subTest("curator_tag"):
+            response = self._test_existing(self.get_auth_headers(), use_curator_tag=True)
+            self.assertEqual(202, response.status_code)
+
+    @patch("backend.corpora.common.upload.start_upload_sfn")
+    def test__existing_from_link__Super_Curator(self, start_upload_sfn):
+        headers = {"Authorization": "Bearer " + self.make_super_curator_token(), "Content-Type": "application/json"}
+        with self.subTest("dataset_id"):
+            response = self._test_existing(headers, use_curator_tag=True)
+            self.assertEqual(202, response.status_code)
+        with self.subTest("curator_tag"):
+            response = self._test_existing(headers, use_curator_tag=True)
+            self.assertEqual(202, response.status_code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/backend/corpora/api_server/test_v1_collection_upload_link.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_collection_upload_link.py
@@ -52,7 +52,7 @@ class TestCollectionPostUploadLink(BaseAuthAPITest):
         self.assertEqual(403, response.status_code)
 
     def test__bad_link__400(self):
-        path = "/dp/v1/collections/test_collection_id/upload-links"
+        path = "/dp/v1/collections/test_collection_id_revision/upload-links"
 
         with self.subTest("Unsupported Provider"):
             headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
@@ -74,7 +74,7 @@ class TestCollectionPostUploadLink(BaseAuthAPITest):
         "backend.corpora.common.utils.dl_sources.url.DropBoxURL.file_info", return_value={"size": 1, "name": "file.txt"}
     )
     def test__unsupported_format__400(self, mock_func):
-        path = "/dp/v1/collections/test_collection_id/upload-links"
+        path = "/dp/v1/collections/test_collection_id_revision/upload-links"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
         body = {"url": self.dummy_link}
 
@@ -87,7 +87,7 @@ class TestCollectionPostUploadLink(BaseAuthAPITest):
         return_value={"size": 31 * GB, "name": "file.txt"},
     )
     def test__oversized__413(self, mock_func):
-        path = "/dp/v1/collections/test_collection_id/upload-links"
+        path = "/dp/v1/collections/test_collection_id_revision/upload-links"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
         body = {"url": self.dummy_link}
 


### PR DESCRIPTION
- #TICKET_NUMBER

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- add new tests for curation api
- update existing test
- add function to get dataset from curation tag and collection uuid.
- check for duplicate curation tags before creating a new dataset.
- move check for collection permission to upload_from_link to simplify unit testing.
- update relink to support a link passed in as either url or link.
- 
## QA steps (optional)

## Notes for Reviewer
