### PR TITLE
style: use proper terminology for s3 upload key prefix

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -425,7 +425,7 @@ paths:
                         type: string
                       SessionToken:
                         type: string
-                  UploadPath:
+                  UploadKeyPrefix:
                     type: string
                   Bucket:
                     type: string

--- a/backend/corpora/lambdas/api/v1/curation/collection/dataset.py
+++ b/backend/corpora/lambdas/api/v1/curation/collection/dataset.py
@@ -24,7 +24,7 @@ def post_s3_credentials(collection_uuid: str, token_info: dict):
         db_session, collection_uuid, visibility=CollectionVisibility.PRIVATE.name, owner=owner_or_allowed(token_info)
     )
     user_id = token_info["sub"]
-    upload_path = f"{user_id}/{collection_uuid}"
+    upload_key_prefix = f"{user_id}/{collection_uuid}"
     parameters = dict(
         RoleArn=config.curator_role_arn,
         RoleSessionName=user_id.replace("|", "-"),
@@ -33,6 +33,6 @@ def post_s3_credentials(collection_uuid: str, token_info: dict):
     )
     logger.info(json.dumps(parameters))
     response = sts_client.assume_role_with_web_identity(**parameters)
-    response["UploadPath"] = f"{upload_path}/"
+    response["UploadKeyPrefix"] = f"{upload_key_prefix}/"
     response["Bucket"] = config.submission_bucket
     return make_response(jsonify(response), 200)

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_collections.py
@@ -31,9 +31,9 @@ class TestAuthToken(BaseAuthAPITest):
             self.assertEqual(200, response.status_code)
             self.assertEqual(response.json["Bucket"], "cellxgene-dataset-submissions-test")
             if additional_scope:
-                self.assertEqual(response.json["UploadPath"], f"super|curator/{collection.id}/")
+                self.assertEqual(response.json["UploadKeyPrefix"], f"super|curator/{collection.id}/")
             else:
-                self.assertEqual(response.json["UploadPath"], f"{user_name}/{collection.id}/")
+                self.assertEqual(response.json["UploadKeyPrefix"], f"{user_name}/{collection.id}/")
 
         with self.subTest("collection owner"):
             _test(


### PR DESCRIPTION
We were referring to what is techically a 'key prefix' as a 'path'.
Changing because it is surfaced to users as an attribute in the response
body.

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- modify var name

## QA steps (optional)

## Notes for Reviewer
