### PR TITLE
feat: add google slide support in docs

### DIFF
--- a/frontend/doc-site/dev/writing-documentation.mdx
+++ b/frontend/doc-site/dev/writing-documentation.mdx
@@ -45,6 +45,16 @@ We can also override the default markdown renderer to render our own components 
 
 - next/Image
 
+  - ```typescript
+    <Image src={"/doc-site/poly.jpg"} width={250} height={250} />
+    ```
+
+- EmbeddedGoogleSlides
+
+  - ```typescript
+    <EmbeddedGoogleSlides src="https://docs.google.com/presentation/d/e/2PACX-1vQzA99mYecRu0Y5v--QsUCAuoTJFxo7VIhApCB-E669-00KCKww8AumBZcX0pwV41qHIuLRTsL7AckB/embed?start=false&loop=true&delayms=3000" />
+    ```
+
 #### Images
 
 You can add images to the documentation by adding files to the public directory(`corpora-data-portal/frontend/public/doc-site`) and then display it in MDX using the `<Image/>` component from Next.js (`![](/doc-site/image.png)`).
@@ -53,6 +63,12 @@ You can add images to the documentation by adding files to the public directory(
   <Image src={"/doc-site/poly.jpg"} width={250} height={250} />
   Example image
 </div>
+
+#### Embedded Google Slides
+
+You can embed a google slide iframe using the `<EmbeddedGoogleSlides/>` component. Just extract the source url from the published iframe on google slides and pass it in the `src` prop.
+
+<EmbeddedGoogleSlides src="https://docs.google.com/presentation/d/e/2PACX-1vQzA99mYecRu0Y5v--QsUCAuoTJFxo7VIhApCB-E669-00KCKww8AumBZcX0pwV41qHIuLRTsL7AckB/embed?start=false&loop=true&delayms=3000" />
 
 ### Deleting a page
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -42,9 +42,13 @@ const defaultSecureHeaders = {
 
 // unsafe-eval is required for next-mdx-remote
 const docSiteScriptSrc = [...SCRIPT_SRC, "'unsafe-eval'"];
+// Required for google slides iframe
+const docSiteFrameSrc = ["https://docs.google.com"];
 const docSiteSecureHeaders = cloneDeep(defaultSecureHeaders);
 docSiteSecureHeaders.contentSecurityPolicy.directives.scriptSrc =
   docSiteScriptSrc;
+docSiteSecureHeaders.contentSecurityPolicy.directives.frameSrc =
+  docSiteFrameSrc;
 
 module.exports = {
   eslint: { dirs: ["doc-site", "pages", "components", "lib"] },

--- a/frontend/src/components/EmbeddedGoogleSlides/index.tsx
+++ b/frontend/src/components/EmbeddedGoogleSlides/index.tsx
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+import { ReactElement } from "react";
+
+const ResponsiveContainer = styled.div`
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  padding-top: 56.25%;
+`;
+
+const ResponsiveIFrame = styled.iframe`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+const EmbeddedGoogleSlides = ({ src }: { src: string }): ReactElement => {
+  return (
+    <ResponsiveContainer>
+      <ResponsiveIFrame
+        sandbox="allow-scripts"
+        src={src}
+        frameBorder="0"
+        allowFullScreen={true}
+      ></ResponsiveIFrame>
+    </ResponsiveContainer>
+  );
+};
+
+export default EmbeddedGoogleSlides;

--- a/frontend/src/pages/docs/[...slug].tsx
+++ b/frontend/src/pages/docs/[...slug].tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 import NextLink from "next/link";
 import pathTool from "path";
 import { memo } from "react";
+import EmbeddedGoogleSlides from "src/components/EmbeddedGoogleSlides";
 import styled from "styled-components";
 
 const DOC_SITE_FOLDER_NAME = "doc-site";
@@ -147,7 +148,10 @@ const DocContent = styled.div`
   margin: 16px;
 `;
 
-const components = { Image };
+const components = {
+  EmbeddedGoogleSlides,
+  Image,
+};
 const DocPage = ({ mdxSource, filePath }: Props) => {
   return (
     <StyledDocsLayout>


### PR DESCRIPTION
- #2585 

### Reviewers
**Functional:** @tihuan 

**Readability:** 

---


## Changes
- add
  - docs.google frame source
  - slides iframe component
  - example in docs  


## QA steps (optional)

## Notes for Reviewer
* responsiveness is a bit funky since the rest of the doc site isn't styled yet