### PR TITLE
fix: keep links on final update call during revision

### DIFF
--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -258,7 +258,6 @@ class Collection(Entity):
                 commit=False,
                 **revision,
             )
-            self.session.expire(public_collection)
             for link in self.links:
                 CollectionLink(link).update(collection_id=self.revision_of, commit=False)
             is_existing_collection = True

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -254,10 +254,11 @@ class Collection(Entity):
                 remove_relationships=True,
             )
             revision["data_submission_policy_version"] = data_submission_policy_version
-            public_collection.update(
+            public_collection.update(  # This function call deletes old links (keep_links param defaults to False)
                 commit=False,
                 **revision,
             )
+            self.session.expire(public_collection)
             for link in self.links:
                 CollectionLink(link).update(collection_id=self.revision_of, commit=False)
             is_existing_collection = True
@@ -290,7 +291,7 @@ class Collection(Entity):
 
         if is_existing_collection:
             if has_dataset_changes:
-                public_collection.update(commit=False, remove_attr="revised_at", revised_at=now)
+                public_collection.update(commit=False, remove_attr="revised_at", revised_at=now, keep_links=True)
             self.delete()
             self.db_object = public_collection.db_object
 

--- a/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
+++ b/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
@@ -164,7 +164,9 @@ class TestPublish(BaseAuthAPITest):
         self.verify_publish_collection_with_links(collection, revision.id)
 
     def test__publish_collection_revision_with_links_and_dataset_changes__OK(self):
-        collection = Collection.get_collection(self.session, collection_uuid="test_collection_with_link")
+        collection = Collection.get_collection(
+            self.session, collection_uuid="test_collection_with_link_and_dataset_changes"
+        )
         self.generate_dataset(self.session, collection_id=collection.id, published_at=self.mock_published_at)
         revision = collection.create_revision()
         self.generate_dataset(self.session, collection_id=revision.id)  # Collection will have Dataset changes

--- a/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
+++ b/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
@@ -163,6 +163,16 @@ class TestPublish(BaseAuthAPITest):
 
         self.verify_publish_collection_with_links(collection, revision.id)
 
+    def test__publish_collection_revision_with_links_and_dataset_changes__OK(self):
+        collection = Collection.get_collection(self.session, collection_uuid="test_collection_with_link")
+        self.generate_dataset(self.session, collection_id=collection.id, published_at=self.mock_published_at)
+        revision = collection.create_revision()
+        self.generate_dataset(self.session, collection_id=revision.id)  # Collection will have Dataset changes
+
+        collection.update(published_at=self.mock_published_at, keep_links=True)
+
+        self.verify_publish_collection_with_links(collection, revision.id)
+
     @patch("backend.corpora.common.utils.cloudfront.create_invalidation_for_index_paths")
     def test_publish_collection_does_cloudfront_invalidation(self, mock_cloudfront):
         """Publish a new collection with a single dataset."""

--- a/tests/unit/backend/fixtures/test_db.py
+++ b/tests/unit/backend/fixtures/test_db.py
@@ -130,6 +130,17 @@ class TestDatabase:
             contact_email="somebody@chanzuckerberg.com",
         )
         self.session.add(collection)
+        collection = DbCollection(
+            id="test_collection_with_link_and_dataset_changes",
+            visibility=CollectionVisibility.PUBLIC.name,
+            owner="test_user_id",
+            name="test_collection_name",
+            description="test_description",
+            data_submission_policy_version="0",
+            contact_name="Some Body",
+            contact_email="somebody@chanzuckerberg.com",
+        )
+        self.session.add(collection)
         self.session.commit()
 
     def _create_test_geneset(self):
@@ -173,8 +184,17 @@ class TestDatabase:
             )
             self.session.add(
                 DbCollectionLink(
-                    id=f"test_publish_revision_with_links__{link_type.value}_link",
+                    id=f"test_publish_revision_with_link__{link_type.value}_link",
                     collection_id="test_collection_with_link",
+                    link_name=f"test_{link_type.value}_link_name",
+                    link_url=f"http://test_link_{link_type.value}_url.place",
+                    link_type=link_type.name,
+                )
+            )
+            self.session.add(
+                DbCollectionLink(
+                    id=f"test_publish_revision_with_link_and_dataset_changes__{link_type.value}_link",
+                    collection_id="test_collection_with_link_and_dataset_changes",
                     link_name=f"test_{link_type.value}_link_name",
                     link_url=f"http://test_link_{link_type.value}_url.place",
                     link_type=link_type.name,


### PR DESCRIPTION
This commit fixes a bug present that deletes links for revisions of
collections in most scenarios when publishing

- #TICKET_NUMBER

### Reviewers
**Functional:** 
@atolopko-czi @Bento007 @brianraymor 
**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
