### PR TITLE
fix: streamline publish function to prevent loss of links

### DIFF
--- a/backend/corpora/common/corpora_orm.py
+++ b/backend/corpora/common/corpora_orm.py
@@ -117,6 +117,9 @@ class TransformingBase(object):
 
     id = Column(String, primary_key=True, default=generate_uuid)
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__}(id={self.id})>"
+
 
 class AuditMixin(object):
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -262,6 +262,8 @@ class Collection(Entity):
                     revised_dataset.publish_new(now)
                     has_dataset_changes = True
             self.session.flush()
+            # calling expire because the above code updates and deletes rows related to this object. If we don't expire
+            # the object, SqlAlchmey will try to modify rows that don't exists and thrown an error.
             self.session.expire(self.db_object)
             revision = self.to_dict(
                 remove_attr=(

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -279,7 +279,9 @@ class Collection(Entity):
             )
             revision["data_submission_policy_version"] = data_submission_policy_version
             revision["revised_at"] = now if has_dataset_changes else self.revised_at
-            public_collection.update(**revision, commit=False)  # This function call deletes old links (keep_links param defaults to False)
+            public_collection.update(
+                **revision, commit=False
+            )  # This function call deletes old links (keep_links param defaults to False)
             for link in self.links:
                 link.collection_id = self.revision_of
             self.delete()

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -284,6 +284,7 @@ class Collection(Entity):
             )  # This function call deletes old links (keep_links param defaults to False)
             for link in self.links:
                 link.collection_id = self.revision_of
+            self.session.flush()
             self.delete()
             self.db_object = public_collection.db_object
         else:

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -254,10 +254,11 @@ class Collection(Entity):
                 remove_relationships=True,
             )
             revision["data_submission_policy_version"] = data_submission_policy_version
-            public_collection.update(
+            public_collection.update(  # This function call deletes old links (keep_links param defaults to False)
                 commit=False,
                 **revision,
             )
+            self.session.expire(public_collection)
             for link in self.links:
                 CollectionLink(link).update(collection_id=self.revision_of, commit=False)
             is_existing_collection = True
@@ -290,7 +291,7 @@ class Collection(Entity):
 
         if is_existing_collection:
             if has_dataset_changes:
-                public_collection.update(commit=False, remove_attr="revised_at", revised_at=now)
+                public_collection.update(commit=False, remove_attr="revised_at", revised_at=now, keep_links=True)
             self.delete()
             self.db_object = public_collection.db_object
 

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session
 from . import Dataset
 from .entity import Entity
 from .geneset import Geneset
-from .collection_link import CollectionLink
 from ..corpora_orm import (
     CollectionLinkType,
     DbCollection,
@@ -245,24 +244,44 @@ class Collection(Entity):
         # Timestamp for published_at and revised_at
         now = datetime.utcnow()
         # Create a public collection with the same uuid and same fields
-        is_existing_collection = False
         if self.revision_of:
             # This is a revision of a published Collection
             public_collection = Collection.get_collection(self.session, collection_uuid=self.revision_of)
+            has_dataset_changes = False
+            for dataset in self.datasets:
+                revised_dataset = Dataset(dataset)
+                original = (
+                    Dataset.get(self.session, revised_dataset.original_id) if revised_dataset.original_id else None
+                )
+                if original and public_collection.check_has_dataset(original):
+                    dataset_is_changed = original.publish_revision(revised_dataset, now)
+                    if dataset_is_changed:
+                        has_dataset_changes = True
+                else:
+                    # The dataset is new
+                    revised_dataset.publish_new(now)
+                    has_dataset_changes = True
+            self.session.flush()
+            self.session.expire(self.db_object)
             revision = self.to_dict(
-                remove_attr=("updated_at", "created_at", "visibility", "id", "revision_of", "published_at"),
+                remove_attr=(
+                    "updated_at",
+                    "created_at",
+                    "visibility",
+                    "id",
+                    "revision_of",
+                    "published_at",
+                    "revised_at",
+                ),
                 remove_relationships=True,
             )
             revision["data_submission_policy_version"] = data_submission_policy_version
-            public_collection.update(  # This function call deletes old links (keep_links param defaults to False)
-                commit=False,
-                **revision,
-            )
-            self.session.expire(public_collection)
+            revision["revised_at"] = now if has_dataset_changes else self.revised_at
+            public_collection.update(**revision, commit=False)
             for link in self.links:
-                CollectionLink(link).update(collection_id=self.revision_of, commit=False)
-            is_existing_collection = True
-
+                link.collection_id = self.revision_of
+            self.delete()
+            self.db_object = public_collection.db_object
         else:
             # This is the first publishing of this Collection
             self.update(
@@ -272,28 +291,8 @@ class Collection(Entity):
                 data_submission_policy_version=data_submission_policy_version,
                 keep_links=True,
             )
-
-        has_dataset_changes = False
-        for dataset in self.datasets:
-            revised_dataset = Dataset(dataset)
-            original = Dataset.get(self.session, revised_dataset.original_id) if revised_dataset.original_id else None
-            if original and public_collection.check_has_dataset(original):
-                dataset_is_changed = original.publish_revision(revised_dataset, now)
-                if dataset_is_changed:
-                    has_dataset_changes = True
-            else:
-                # The dataset is new
-                revised_dataset.publish_new(now)
-                has_dataset_changes = True
-
-        self.session.flush()
-        self.session.expire_all()
-
-        if is_existing_collection:
-            if has_dataset_changes:
-                public_collection.update(commit=False, remove_attr="revised_at", revised_at=now, keep_links=True)
-            self.delete()
-            self.db_object = public_collection.db_object
+            for dataset in self.datasets:
+                Dataset(dataset).publish_new(now)
 
         self.session.commit()
 

--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -317,7 +317,6 @@ class Dataset(Entity):
                     "published",
                     "revised_at",
                     "explorer_url",
-                    "published_at",
                 ],
                 remove_relationships=True,
             )

--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -317,12 +317,13 @@ class Dataset(Entity):
                     "published",
                     "revised_at",
                     "explorer_url",
+                    "published_at",
                 ],
                 remove_relationships=True,
             )
 
             if revision.tombstone is not False:
-                self.update(commit=False, **updates, remove_attr="published_at")
+                self.update(commit=False, **updates)
             else:
                 # There was an update to a dataset, so update revised_at
                 self.update(commit=False, **updates, revised_at=now)

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -80,3 +80,6 @@ class Entity:
                 setattr(self.db_object, key, value)
         if commit:
             self.session.commit()
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}(id={self.id})>"

--- a/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
+++ b/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
@@ -164,7 +164,9 @@ class TestPublish(BaseAuthAPITest):
         self.verify_publish_collection_with_links(collection, revision.id)
 
     def test__publish_collection_revision_with_links_and_dataset_changes__OK(self):
-        collection = Collection.get_collection(self.session, collection_uuid="test_collection_with_link")
+        collection = Collection.get_collection(
+            self.session, collection_uuid="test_collection_with_link_and_dataset_changes"
+        )
         self.generate_dataset(self.session, collection_id=collection.id, published_at=self.mock_published_at)
         revision = collection.create_revision()
         self.generate_dataset(self.session, collection_id=revision.id)  # Collection will have Dataset changes

--- a/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
+++ b/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
@@ -155,9 +155,11 @@ class TestPublish(BaseAuthAPITest):
         self.verify_publish_collection_with_links(collection)
 
     def test__publish_collection_revision_with_links__OK(self):
-        revision = Collection.get_collection(self.session, revision_of="test_collection_id")
-        collection = Collection.get_collection(self.session, collection_uuid="test_collection_id")
-        collection.update(published_at=self.mock_published_at)
+        collection = Collection.get_collection(self.session, collection_uuid="test_collection_with_link")
+        self.generate_dataset(self.session, collection_id=collection.id, published_at=self.mock_published_at)
+        revision = collection.create_revision()
+
+        collection.update(published_at=self.mock_published_at, keep_links=True)
 
         self.verify_publish_collection_with_links(collection, revision.id)
 

--- a/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
+++ b/tests/unit/backend/corpora/api_server/collection_uuid/test_publish.py
@@ -163,6 +163,16 @@ class TestPublish(BaseAuthAPITest):
 
         self.verify_publish_collection_with_links(collection, revision.id)
 
+    def test__publish_collection_revision_with_links_and_dataset_changes__OK(self):
+        collection = Collection.get_collection(self.session, collection_uuid="test_collection_with_link")
+        self.generate_dataset(self.session, collection_id=collection.id, published_at=self.mock_published_at)
+        revision = collection.create_revision()
+        self.generate_dataset(self.session, collection_id=revision.id)  # Collection will have Dataset changes
+
+        collection.update(published_at=self.mock_published_at, keep_links=True)
+
+        self.verify_publish_collection_with_links(collection, revision.id)
+
     @patch("backend.corpora.common.utils.cloudfront.create_invalidation_for_index_paths")
     def test_publish_collection_does_cloudfront_invalidation(self, mock_cloudfront):
         """Publish a new collection with a single dataset."""

--- a/tests/unit/backend/corpora/api_server/test_revisions.py
+++ b/tests/unit/backend/corpora/api_server/test_revisions.py
@@ -365,6 +365,22 @@ class TestPublishRevision(BaseRevisionTest):
         self.base_path = "/dp/v1/collections"
         self.mock_timestamp = datetime(2000, 12, 25, 0, 0)
 
+    def update_revision_details(self):
+        expected_body = {
+            "name": "collection name",
+            "description": "This is a test collection",
+            "contact_name": "person human",
+            "contact_email": "person@human.com",
+            "links": [
+                {"link_name": "DOI Link", "link_url": "http://doi.org/10.1016", "link_type": "DOI"},
+                {"link_name": "DOI Link 2", "link_url": "http://doi.org/10.1017", "link_type": "OTHER"},
+                *self.public_links,
+            ],
+            "data_submission_policy_version": "1.0",
+        }
+        self.rev_collection.update(**expected_body)
+        return expected_body
+
     def publish_collection(self, collection: Collection) -> dict:
         """
         Verify publish a collection under revision.
@@ -562,19 +578,7 @@ class TestPublishRevision(BaseRevisionTest):
 
     def test__publish_revision_with_collection_info_updated__201(self):
         """Publish a revision with collection detail changes."""
-        expected_body = {
-            "name": "collection name",
-            "description": "This is a test collection",
-            "contact_name": "person human",
-            "contact_email": "person@human.com",
-            "links": [
-                {"link_name": "DOI Link", "link_url": "http://doi.org/10.1016", "link_type": "DOI"},
-                {"link_name": "DOI Link 2", "link_url": "http://doi.org/10.1017", "link_type": "DOI"},
-                *self.public_links,
-            ],
-            "data_submission_policy_version": "1.0",
-        }
-        self.rev_collection.update(**expected_body)
+        expected_body = self.update_revision_details()
         pub_s3_objects, _ = self.get_s3_objects_from_collections()
 
         # Published revision with collection details updated
@@ -594,37 +598,14 @@ class TestPublishRevision(BaseRevisionTest):
             self.assertIsNone(dataset.get("revised_at"))
 
     def test__publish_revision_with_collection_info_updated_and_refreshed_datasets__201(self):
-        """Publish a revision with collection detail changes."""
-        expected_body = {
-            "name": "collection name",
-            "description": "This is a test collection",
-            "contact_name": "person human",
-            "contact_email": "person@human.com",
-            "links": [
-                {"link_name": "DOI Link", "link_url": "http://doi.org/10.1016", "link_type": "DOI"},
-                {"link_name": "DOI Link 2", "link_url": "http://doi.org/10.1017", "link_type": "OTHER"},
-                *self.public_links,
-            ],
-            "data_submission_policy_version": "1.0",
-        }
+        """Publish a revision with collection detail changes and refreshed datasets."""
+        expected_body = self.update_revision_details()
         self.refresh_datasets()
-
-        # add new dataset
-        new_dataset_id = self.generate_dataset_with_s3_resources(self.session, collection_id=self.rev_collection.id).id
-        dataset_ids = {ds.id for ds in self.pub_collection.datasets}
-        dataset_ids.add(new_dataset_id)
-
-        # Modify collectoin details
-        self.rev_collection.update(**expected_body)
-
-        # get revision datasets
         _, rev_s3_objects = self.get_s3_objects_from_collections()
-
         # Published revision with collection details updated, new dataset, and refreshed datasets
         response_json = self.publish_collection(self.rev_collection)
+        self.verify_datasets(response_json, {ds.id for ds in self.pub_collection.datasets})
         self.assertPublishedCollectionOK(expected_body, rev_s3_objects)
-
-        self.verify_datasets(response_json, dataset_ids)
 
         # Check published_at and revised_at
         # Collection: Only revised_at should be updated
@@ -635,6 +616,66 @@ class TestPublishRevision(BaseRevisionTest):
         for dataset in response_json["datasets"]:
             self.assertIsNone(dataset.get("published_at"))
             self.assertEqual(self.mock_timestamp, datetime.utcfromtimestamp(dataset["revised_at"]))
+
+    def test__publish_revision_with_collection_info_updated_and_new_datasets__201(self):
+        """Publish a revision with collection detail changes and new datasets."""
+        expected_body = self.update_revision_details()
+
+        # add new dataset
+        new_dataset_id = self.generate_dataset_with_s3_resources(self.session, collection_id=self.rev_collection.id).id
+        dataset_ids = {ds.id for ds in self.pub_collection.datasets}
+        dataset_ids.add(new_dataset_id)
+
+        # get revision datasets
+        _, rev_s3_objects = self.get_s3_objects_from_collections()
+
+        # Published revision with collection details updated, new dataset, and refreshed datasets
+        response_json = self.publish_collection(self.rev_collection)
+        self.assertPublishedCollectionOK(expected_body, rev_s3_objects)
+
+        # Check published_at and revised_at
+        # Collection: Only revised_at should be updated
+        self.assertIsNone(response_json.get("published_at"))
+        self.assertEqual(self.mock_timestamp, datetime.utcfromtimestamp(response_json["revised_at"]))
+
+        # Datasets: Only the newly added dataset should have published_at updated
+        for dataset in response_json["datasets"]:
+            if dataset["id"] == new_dataset_id:
+                self.assertEqual(self.mock_timestamp, datetime.utcfromtimestamp(dataset["published_at"]))
+            else:
+                self.assertIsNone(dataset.get("published_at"))
+            self.assertIsNone(dataset.get("revised_at"))
+
+    def test__publish_revision_with_collection_info_updated_new_and_refreshed_datasets__201(self):
+        """Publish a revision with collection detail changes, new datasets, and refreshed datasets."""
+        expected_body = self.update_revision_details()
+        self.refresh_datasets()
+
+        # add new dataset
+        new_dataset_id = self.generate_dataset_with_s3_resources(self.session, collection_id=self.rev_collection.id).id
+        dataset_ids = {ds.id for ds in self.pub_collection.datasets}
+        dataset_ids.add(new_dataset_id)
+
+        # get revision datasets
+        _, rev_s3_objects = self.get_s3_objects_from_collections()
+
+        # Published revision with collection details updated, new dataset, and refreshed datasets
+        response_json = self.publish_collection(self.rev_collection)
+        self.assertPublishedCollectionOK(expected_body, rev_s3_objects)
+
+        # Check published_at and revised_at
+        # Collection: Only revised_at should be updated
+        self.assertIsNone(response_json.get("published_at"))
+        self.assertEqual(self.mock_timestamp, datetime.utcfromtimestamp(response_json["revised_at"]))
+
+        # Datasets: Only the newly added dataset should have published_at updated
+        for dataset in response_json["datasets"]:
+            if dataset["id"] == new_dataset_id:
+                self.assertEqual(self.mock_timestamp, datetime.utcfromtimestamp(dataset["published_at"]))
+                self.assertIsNone(dataset.get("revised_at"))
+            else:
+                self.assertIsNone(dataset.get("published_at"))
+                self.assertEqual(self.mock_timestamp, datetime.utcfromtimestamp(dataset["revised_at"]))
 
     def test__with_revision_and_existing_datasets(self):
         """Publish a revision with the same, existing datasets."""

--- a/tests/unit/backend/corpora/api_server/test_revisions.py
+++ b/tests/unit/backend/corpora/api_server/test_revisions.py
@@ -609,15 +609,22 @@ class TestPublishRevision(BaseRevisionTest):
         }
         self.refresh_datasets()
 
-        # Add some links to the public collection
+        # add new dataset
+        new_dataset_id = self.generate_dataset_with_s3_resources(self.session, collection_id=self.rev_collection.id).id
+        dataset_ids = {ds.id for ds in self.pub_collection.datasets}
+        dataset_ids.add(new_dataset_id)
+
+        # Modify collectoin details
         self.rev_collection.update(**expected_body)
-        pub_s3_objects, _ = self.get_s3_objects_from_collections()
 
-        # Published revision with collection details updated
+        # get revision datasets
+        _, rev_s3_objects = self.get_s3_objects_from_collections()
+
+        # Published revision with collection details updated, new dataset, and refreshed datasets
         response_json = self.publish_collection(self.rev_collection)
-        self.assertPublishedCollectionOK(expected_body, pub_s3_objects)
+        self.assertPublishedCollectionOK(expected_body, rev_s3_objects)
 
-        self.verify_datasets(response_json, {ds.id for ds in self.pub_collection.datasets})
+        self.verify_datasets(response_json, dataset_ids)
 
         # Check published_at and revised_at
         # Collection: Only revised_at should be updated

--- a/tests/unit/backend/fixtures/test_db.py
+++ b/tests/unit/backend/fixtures/test_db.py
@@ -130,6 +130,17 @@ class TestDatabase:
             contact_email="somebody@chanzuckerberg.com",
         )
         self.session.add(collection)
+        collection = DbCollection(
+            id="test_collection_with_link_and_dataset_changes",
+            visibility=CollectionVisibility.PUBLIC.name,
+            owner="test_user_id",
+            name="test_collection_name",
+            description="test_description",
+            data_submission_policy_version="0",
+            contact_name="Some Body",
+            contact_email="somebody@chanzuckerberg.com",
+        )
+        self.session.add(collection)
         self.session.commit()
 
     def _create_test_geneset(self):
@@ -173,8 +184,17 @@ class TestDatabase:
             )
             self.session.add(
                 DbCollectionLink(
-                    id=f"test_publish_revision_with_links__{link_type.value}_link",
+                    id=f"test_publish_revision_with_link__{link_type.value}_link",
                     collection_id="test_collection_with_link",
+                    link_name=f"test_{link_type.value}_link_name",
+                    link_url=f"http://test_link_{link_type.value}_url.place",
+                    link_type=link_type.name,
+                )
+            )
+            self.session.add(
+                DbCollectionLink(
+                    id=f"test_publish_revision_with_link_and_dataset_changes__{link_type.value}_link",
+                    collection_id="test_collection_with_link_and_dataset_changes",
                     link_name=f"test_{link_type.value}_link_name",
                     link_url=f"http://test_link_{link_type.value}_url.place",
                     link_type=link_type.name,

--- a/tests/unit/backend/fixtures/test_db.py
+++ b/tests/unit/backend/fixtures/test_db.py
@@ -122,20 +122,12 @@ class TestDatabase:
         collection = DbCollection(
             id="test_collection_with_link",
             visibility=CollectionVisibility.PUBLIC.name,
-            owner="Someone_else",
+            owner="test_user_id",
             name="test_collection_name",
             description="test_description",
             data_submission_policy_version="0",
-        )
-        self.session.add(collection)
-        collection = DbCollection(
-            id="test_collection_with_link_revision",
-            revision_of="test_collection_with_link",
-            visibility=CollectionVisibility.PRIVATE.name,
-            owner="Someone_else",
-            name="test_collection_name",
-            description="test_description",
-            data_submission_policy_version="0",
+            contact_name="Some Body",
+            contact_email="somebody@chanzuckerberg.com",
         )
         self.session.add(collection)
         self.session.commit()
@@ -183,15 +175,8 @@ class TestDatabase:
                 DbCollectionLink(
                     id=f"test_publish_revision_with_links__{link_type.value}_link",
                     collection_id="test_collection_with_link",
+                    link_name=f"test_{link_type.value}_link_name",
                     link_url=f"http://test_link_{link_type.value}_url.place",
-                    link_type=link_type.name,
-                )
-            )
-            self.session.add(
-                DbCollectionLink(
-                    id=f"test_publish_revision_with_links__revision_{link_type.value}_link",
-                    collection_id="test_collection_with_link_revision",
-                    link_url=f"http://test_link_{link_type.value}_url.place_REVISION",
                     link_type=link_type.name,
                 )
             )


### PR DESCRIPTION

- #TICKET_NUMBER

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- Reorganize publish logic.
- Add __repr__ to make debugging easier
- Add additional publish revision test with refreshed dataset and new links.
- don't change published_at if tombstoned

## QA steps (optional)

## Notes for Reviewer
