### PR TITLE
Updated UI for issue 2675

### DIFF
--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/Organism/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/Organism/index.tsx
@@ -13,7 +13,7 @@ import {
 } from "src/views/WheresMyGene/common/store";
 import { selectOrganism } from "src/views/WheresMyGene/common/store/actions";
 import { Organism as IOrganism } from "src/views/WheresMyGene/common/types";
-import { Label } from "../../style";
+import { Label, labelFontSize } from "../../style";
 import { StyledDropdown, Wrapper } from "./style";
 
 const TEMP_ALLOW_NAME_LIST = ["Homo sapiens", "Mus musculus"];
@@ -71,7 +71,7 @@ export default function Organism({ isLoading }: Props): JSX.Element {
 
   return (
     <Wrapper>
-      <Label>Organism</Label>
+      <Label style={{ fontSize: labelFontSize }}>Organism</Label>
       <StyledDropdown
         label={organism?.name || "Select"}
         options={filteredOrganisms || EMPTY_ARRAY}

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
@@ -21,7 +21,7 @@ import { FixedSizeList, ListChildComponentProps } from "react-window";
 import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
 import { noop } from "src/common/constants/utils";
-import { Label } from "../../style";
+import { Label, labelFontSize } from "../../style";
 import { ButtonWrapper, StyledIconButton, StyledMenuItem } from "./style";
 
 const MAX_ITEMS_TO_SHOW = 9.5;
@@ -221,14 +221,14 @@ export default function QuickSelect<
   return (
     <>
       <ButtonWrapper>
-        <Label>{label}</Label>
+        <Label style={{ fontSize: labelFontSize }}>{label}</Label>
         <StyledIconButton
           disabled={isLoading}
           data-test-id={dataTestId}
           ref={ref}
           onClick={handleClick}
           sdsType="primary"
-          sdsSize="small"
+          sdsSize="medium"
         >
           <Icon sdsIcon="plusCircle" sdsSize="s" sdsType="iconButton" />
         </StyledIconButton>

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/style.ts
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/style.ts
@@ -27,3 +27,5 @@ export const LoadingIndicatorWrapper = styled.div`
   display: flex;
   align-items: center;
 `;
+
+export const labelFontSize = 14;

--- a/frontend/src/views/WheresMyGene/components/GetStarted/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GetStarted/index.tsx
@@ -1,53 +1,20 @@
 import Link from "next/link";
-import { EXTERNAL_LINKS, ROUTES } from "src/common/constants/routes";
-import Step from "./components/Step";
-import { Content, Details, Header, Step3Details } from "./style";
+import { ROUTES } from "src/common/constants/routes";
+import { Details, Header } from "./style";
 
 export default function GetStarted(): JSX.Element {
   return (
     <>
       <Header>Getting Started</Header>
       <Details>
-        Visualize and compare the expression of genes across cell types using a
-        dot plot. A dot plot is an effective way of summarizing expression data
-        for genes across cells in categories. It gives an overview of the data
-        by condensing many single cells into a mean expression (color scale) and
-        percentage of cells (circle size) within each cell type that express
-        each gene. Data are sourced from the{" "}
+        Use the Add Tissue and Add Gene buttons to find where genes are
+        expressed, powered by data from the{" "}
         <Link href={ROUTES.HOMEPAGE} passHref>
           <a href="passHref" rel="noopener" target="_blank">
             cellxgene Data Portal
           </a>
-        </Link>{" "}
-        data corpus.{" "}
+        </Link>
       </Details>
-      <Content>
-        <Step
-          step={1}
-          header="Add Tissues"
-          details="Add tissues you are interested in exploring. Cell types included in these tissues will automatically be added to the visualization. Cell types are defined by the annotations of the original authors."
-        />
-        <Step
-          step={2}
-          header="Add Genes"
-          details="Add genes of interest to the visualization."
-        />
-        <Step
-          step={3}
-          header="Interpret Results"
-          details={
-            <>
-              <Step3Details>
-                Darker dots represent higher relative gene expression. The
-                larger the dot, the more cells express that gene.
-              </Step3Details>
-              <a href={EXTERNAL_LINKS.WMG_DOC} rel="noopener" target="_blank">
-                Learn More
-              </a>
-            </>
-          }
-        />
-      </Content>
     </>
   );
 }

--- a/frontend/src/views/WheresMyGene/components/Main/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Main/index.tsx
@@ -226,6 +226,10 @@ export default function WheresMyGene(): JSX.Element {
     return hasSelectedTissues || hasSelectedGenes;
   }, [hasSelectedTissues, hasSelectedGenes]);
 
+  const shouldEnableSidebars = useMemo(() => {
+    return hasSelectedTissues && hasSelectedGenes;
+  }, [hasSelectedTissues, hasSelectedGenes]);
+
   const handleIsScaledChange = useCallback(() => {
     setIsScaled((prevIsScaled) => !prevIsScaled);
   }, [setIsScaled]);
@@ -238,10 +242,11 @@ export default function WheresMyGene(): JSX.Element {
 
       <SideBar
         label={<SideBarLabel>Filters</SideBarLabel>}
-        isOpen
         SideBarWrapperComponent={SideBarWrapper}
         SideBarPositionerComponent={SideBarPositioner}
         testId="filters-panel"
+        disabled={!shouldEnableSidebars}
+        forceToggle={shouldEnableSidebars}
       >
         <Filters />
       </SideBar>
@@ -249,10 +254,11 @@ export default function WheresMyGene(): JSX.Element {
       <SideBar
         width={INFO_PANEL_WIDTH_PX}
         label={<SideBarLabel>Info</SideBarLabel>}
-        isOpen
         position={Position.RIGHT}
         SideBarWrapperComponent={SideBarWrapper}
         SideBarPositionerComponent={SideBarPositioner}
+        disabled={!shouldEnableSidebars}
+        forceToggle={shouldEnableSidebars}
       >
         <InfoPanel
           isScaled={isScaled}


### PR DESCRIPTION
- #2675 

### Reviewers
**Functional:** 
@signechambers1 
@hthomas-czi 
@tihuan 

**Readability:** 
@tihuan 

---


## Changes
- modified the getting started text
- increased label and button sizes in the search bar
- adjusted sidebar behavior to be disabled when either tissues or genes are unset.
- disabling sidebar automatically closes it
- enabling sidebar automatically opens  it

## QA steps (optional)
- Visual inspection and setting/unsetting the heatmap.

## Screenshots
1) tissues unset, genes unset
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/16548075/173138279-dda194b4-c679-4622-8ae4-95360d978d24.png">
2) tissues set, genes unset
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/16548075/173138411-0b08168e-cf53-4c5d-b675-dc8d2fc09ecb.png">
3) tissues set, genes set
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/16548075/173138379-c7802abf-236b-4c75-a2d2-a634fed4f6bb.png">
