### PR TITLE
chore: set rankit filter to 2

### DIFF
--- a/backend/wmg/data/load_corpus.py
+++ b/backend/wmg/data/load_corpus.py
@@ -31,7 +31,7 @@ GENE_EXPRESSION_COUNT_MIN_THRESHOLD = 500
 # Minimum value for raw expression counts that will be used to filter out computed RankIt values. Details:
 # https://github.com/chanzuckerberg/cellxgene-documentation/blob/main/scExpression/scExpression-documentation.md#removal-of-noisy-ultra-low-expression-values
 # TODO: #2474 remove this and relevant code/unit tests after June 2022
-RANKIT_RAW_EXPR_COUNT_FILTERING_MIN_THRESHOLD = 0
+RANKIT_RAW_EXPR_COUNT_FILTERING_MIN_THRESHOLD = 2
 
 
 def is_dataset_already_loaded(corpus_path: str, dataset_id: str) -> bool:


### PR DESCRIPTION
- #TICKET_NUMBER

### Reviewers
**Functional:** 
- @pablo-gar 
**Readability:** 

---


## Changes

- modify rankit low expression filter to be 2

## QA steps (optional)
- generated full cube for filter of 0, 1, 2, and 3. @pablo-gar inspected all of the above via the scex feature and determined that 2 and 3 give the best results. We decided to go with 2 to reduce the amount of data removed. 
## Notes for Reviewer
