### PR TITLE
chore: reordered dockerfile to improve rebuild speed

### DIFF
--- a/Dockerfile.data_cube_creation
+++ b/Dockerfile.data_cube_creation
@@ -12,12 +12,14 @@ ENV PIP_NO_CACHE_DIR=1
 
 WORKDIR /
 
+ADD backend/wmg/requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
 ADD backend/__init__.py backend/__init__.py
 ADD backend/wmg backend/wmg
 ADD backend/corpora backend/corpora
 ADD backend/ontology_files backend/ontology_files
 
-RUN pip3 install -r backend/wmg/requirements.txt
 
 ARG HAPPY_BRANCH="unknown"
 ARG HAPPY_COMMIT=""


### PR DESCRIPTION
Rebuilding the stack took forever because any changes to the backend code triggers the reinstallation of all the requirements in the `wmg_processing` image. We can fix this by moving the `pip3 install` further up in the `data_cube_creation` Dockerfile. This also means we don't need to push the bulky python dependency layer every time.
### Reviewers
**Functional:** 
@MDunitz 
