### PR TITLE
consolidated some fetches to reduce number of calls to backend

### DIFF
--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -143,7 +143,7 @@ export interface Query {
   filter: Filter;
 }
 
-interface QueryResponse {
+export interface QueryResponse {
   expression_summary: {
     // gene_ontology_term_id
     [geneId: string]: {
@@ -212,6 +212,7 @@ export const USE_QUERY = {
 export function useWMGQuery(
   query: Query | null
 ): UseQueryResult<QueryResponse> {
+  console.log("TRIGGER")
   const dispatch = useContext(DispatchContext);
 
   // (thuang): Refresh query when the snapshotId changes
@@ -307,16 +308,15 @@ export function useFilterDimensions(
       isLoading: false,
     };
   }, [data, isLoading]);
-}
+} 
 
-export function useExpressionSummary(): {
+export function useExpressionSummary(
+  data: QueryResponse | undefined,
+  isLoading: boolean
+): {
   isLoading: boolean;
   data: QueryResponse["expression_summary"];
 } {
-  const requestBody = useWMGQueryRequestBody();
-
-  const { data, isLoading } = useWMGQuery(requestBody);
-
   return useMemo(() => {
     if (isLoading || !data) return { data: EMPTY_OBJECT, isLoading };
 
@@ -333,20 +333,17 @@ export interface CellTypeByTissueName {
   [tissueName: string]: CellType[];
 }
 
-export function useCellTypesByTissueName(): {
+export function useCellTypesByTissueName(
+  data: QueryResponse["expression_summary"],
+  isLoading: boolean,
+  primaryFilterDimensions: PrimaryFilterDimensionsResponse | undefined,
+  isLoadingPrimaryFilterDimensions: boolean,
+  termIdLabels: TermIdLabels,
+  isLoadingTermIdLabels: boolean
+): {
   isLoading: boolean;
   data: CellTypeByTissueName;
 } {
-  const { data, isLoading } = useExpressionSummary();
-
-  const {
-    data: primaryFilterDimensions,
-    isLoading: isLoadingPrimaryFilterDimensions,
-  } = usePrimaryFilterDimensions();
-
-  const { data: termIdLabels, isLoading: isLoadingTermIdLabels } =
-    useTermIdLabels();
-
   return useMemo(() => {
     if (
       isLoading ||
@@ -403,20 +400,18 @@ export interface GeneExpressionSummariesByTissueName {
   [tissueName: string]: { [geneName: string]: GeneExpressionSummary };
 }
 
-export function useGeneExpressionSummariesByTissueName(): {
+export function useGeneExpressionSummariesByTissueName(
+  data: QueryResponse["expression_summary"],
+  isLoading: boolean,
+  primaryFilterDimensions: PrimaryFilterDimensionsResponse | undefined,
+  isLoadingPrimaryFilterDimensions: boolean,
+  termIdLabels: TermIdLabels,
+  isLoadingTermIdLabels: boolean
+): {
   data: GeneExpressionSummariesByTissueName;
   isLoading: boolean;
 } {
-  const { data, isLoading } = useExpressionSummary();
-
-  const {
-    data: primaryFilterDimensions,
-    isLoading: isLoadingPrimaryFilterDimensions,
-  } = usePrimaryFilterDimensions();
-
-  const { data: termIdLabels, isLoading: isLoadingTermIdLabels } =
-    useTermIdLabels();
-
+  
   return useMemo(() => {
     if (
       isLoading ||
@@ -486,20 +481,20 @@ function transformCellTypeGeneExpressionSummaryData(
   };
 }
 
-interface TermIdLabels {
+export interface TermIdLabels {
   cell_types: {
     [tissueID: string]: { [id: string]: { name: string; depth: number } };
   };
   genes: { [id: string]: string };
 }
 
-export function useTermIdLabels(): {
+export function useTermIdLabels(
+  data: QueryResponse | undefined,
+  isLoading: boolean
+): {
   data: TermIdLabels;
   isLoading: boolean;
 } {
-  const requestBody = useWMGQueryRequestBody();
-  const { data, isLoading } = useWMGQuery(requestBody);
-
   return useMemo(() => {
     if (isLoading || !data)
       return {
@@ -550,7 +545,7 @@ const EMPTY_FILTERS: State["selectedFilters"] = {
   sexes: undefined,
 };
 
-function useWMGQueryRequestBody(options = { includeAllFilterOptions: false }) {
+export function useWMGQueryRequestBody(options = { includeAllFilterOptions: false }) {
   const { includeAllFilterOptions } = options;
 
   const {

--- a/frontend/src/views/WheresMyGene/components/Main/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Main/index.tsx
@@ -5,7 +5,12 @@ import {
   CellTypeByTissueName,
   GeneExpressionSummariesByTissueName,
   useCellTypesByTissueName,
-  useGeneExpressionSummariesByTissueName,
+  useExpressionSummary,
+  useTermIdLabels,
+  usePrimaryFilterDimensions,
+  useWMGQuery,
+  useWMGQueryRequestBody,
+  useGeneExpressionSummariesByTissueName
 } from "src/common/queries/wheresMyGene";
 import SideBar from "src/components/common/SideBar";
 import { Position } from "src/components/common/SideBar/style";
@@ -36,10 +41,36 @@ export default function WheresMyGene(): JSX.Element {
 
   const [isScaled, setIsScaled] = useState(true);
 
+  const requestBody = useWMGQueryRequestBody();
+  const { data, isLoading: loading } = useWMGQuery(requestBody);
+
+  const { data: expressionSummaryData, isLoading: expressionSummaryLoading } = useExpressionSummary(
+    data,
+    loading
+  );
+
+  const {
+    data: primaryFilterDimensions,
+    isLoading: isLoadingPrimaryFilterDimensions,
+  } = usePrimaryFilterDimensions();
+
+  const { data: termIdLabels, isLoading: isLoadingTermIdLabels } =
+    useTermIdLabels(
+      data,
+      loading
+    );
+
   const {
     data: rawCellTypesByTissueName,
     isLoading: isLoadingCellTypesByTissueName,
-  } = useCellTypesByTissueName();
+  } = useCellTypesByTissueName(
+    expressionSummaryData,
+    expressionSummaryLoading,
+    primaryFilterDimensions,
+    isLoadingPrimaryFilterDimensions,
+    termIdLabels,
+    isLoadingTermIdLabels    
+  );
 
   const [cellTypesByTissueName, setCellTypesByTissueName] =
     useState<CellTypeByTissueName>(EMPTY_OBJECT);
@@ -56,9 +87,17 @@ export default function WheresMyGene(): JSX.Element {
    * We use `selectedGeneData` to subset the data to only the genes that are
    * currently selected.
    */
-  const { data: rawGeneExpressionSummariesByTissueName, isLoading } =
-    useGeneExpressionSummariesByTissueName();
 
+  const { data: rawGeneExpressionSummariesByTissueName, isLoading } =
+    useGeneExpressionSummariesByTissueName(
+      expressionSummaryData,
+      expressionSummaryLoading,
+      primaryFilterDimensions,
+      isLoadingPrimaryFilterDimensions,
+      termIdLabels,
+      isLoadingTermIdLabels
+    );
+  
   const [
     geneExpressionSummariesByTissueName,
     setGeneExpressionSummariesByTissueName,


### PR DESCRIPTION
- #2740 

Consolidated some fetches to reduce number of calls to the backend. There are still duplicate calls to the `query` and `primary_filter_dimensions` I'm trying to sort out.

I think we need to memo-ize the fetches based on the request body.

