### PR TITLE
fix: update API response schema for Datasets

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -632,10 +632,8 @@ components:
                 $ref: "#/components/schemas/dataset_asset"
             sex:
               $ref: "#/components/schemas/ontology_elements"
-              nullable: true
             ethnicity:
               $ref: "#/components/schemas/ontology_elements"
-              nullable: true
             development_stage:
               $ref: "#/components/schemas/ontology_elements"
               nullable: true
@@ -643,7 +641,6 @@ components:
               $ref: "#/components/schemas/explorer_url"
             cell_type:
               $ref: "#/components/schemas/ontology_elements"
-              nullable: true
             cell_count:
               type: integer
               nullable: true
@@ -699,6 +696,7 @@ components:
           type: string
     ontology_elements:
       type: array
+      default: []
       items:
         $ref: "#/components/schemas/ontology_element"
     problem:

--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -527,6 +527,7 @@ components:
           type: string
         curator_name:
           type: string
+          nullable: true
         revised_at:
           type: number
           nullable: true

--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -517,14 +517,17 @@ components:
           $ref: "#/components/schemas/collection_uuid"
         name:
           type: string
+          nullable: true
         visibility:
           $ref: "#/components/schemas/visibility"
         collection_url:
           type: string
         contact_name:
           type: string
+          nullable: true
         contact_email:
           type: string
+          nullable: true
         curator_name:
           type: string
           nullable: true

--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -711,6 +711,7 @@ components:
       type: string
       description: Processing status for a Dataset or Collection
       enum: [FAILURE, PENDING, SUCCESS]
+      nullable: true
     publisher_metadata:
       type: object
       nullable: true

--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -655,6 +655,8 @@ components:
             schema_version:
               type: string
               nullable: true
+            processing_status:
+              $ref: "#/components/schemas/processing_status"
     dataset_preview:
       type: object
       properties:
@@ -671,8 +673,6 @@ components:
           $ref: "#/components/schemas/ontology_elements"
         organism:
           $ref: "#/components/schemas/ontology_elements"
-        processing_status:
-          $ref: "#/components/schemas/processing_status"
         tombstone:
           type: boolean
     dataset_asset:

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -174,14 +174,16 @@ class Collection(Entity):
         resp_collections = []
         for collection in session.query(cls.table).filter(*filters).all():
             # Add a Collection-level processing status
-            status = ProcessingStatus.SUCCESS
+            status = None
             for dataset in collection.datasets:
                 processing_status = dataset.processing_status
-                if processing_status.processing_status == ProcessingStatus.PENDING:
-                    status = ProcessingStatus.PENDING
-                elif processing_status.processing_status == ProcessingStatus.FAILURE:
-                    status = ProcessingStatus.FAILURE
-                    break
+                if processing_status:
+                    if processing_status.processing_status == ProcessingStatus.PENDING:
+                        status = ProcessingStatus.PENDING
+                    elif processing_status.processing_status == ProcessingStatus.FAILURE:
+                        status = ProcessingStatus.FAILURE
+                    elif processing_status.processing_status == ProcessingStatus.SUCCESS:
+                        status = ProcessingStatus.SUCCESS
             resp_collection = collection.to_dict_keep(collection_columns)
             resp_collection["processing_status"] = status
             resp_collections.append(resp_collection)

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -175,15 +175,18 @@ class Collection(Entity):
         for collection in session.query(cls.table).filter(*filters).all():
             # Add a Collection-level processing status
             status = None
+            has_statuses = False
             for dataset in collection.datasets:
                 processing_status = dataset.processing_status
                 if processing_status:
+                    has_statuses = True
                     if processing_status.processing_status == ProcessingStatus.PENDING:
                         status = ProcessingStatus.PENDING
                     elif processing_status.processing_status == ProcessingStatus.FAILURE:
                         status = ProcessingStatus.FAILURE
-                    elif processing_status.processing_status == ProcessingStatus.SUCCESS:
-                        status = ProcessingStatus.SUCCESS
+                        break
+            if has_statuses and not status:  # At least one dataset processing status exists, and all were SUCCESS
+                status = ProcessingStatus.SUCCESS
             resp_collection = collection.to_dict_keep(collection_columns)
             resp_collection["processing_status"] = status
             resp_collections.append(resp_collection)

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -7,6 +7,7 @@ from ......common.corpora_orm import (
     DbDataset,
     DbDatasetProcessingStatus,
     DbDatasetArtifact,
+    DatasetArtifactFileType,
 )
 
 
@@ -46,7 +47,10 @@ def reshape_for_curation_api_and_is_allowed(collection, token_info, uuid_provide
     if "datasets" in collection:
         for dataset in collection["datasets"]:
             if "artifacts" in dataset:
-                dataset["dataset_assets"] = dataset.pop("artifacts")
+                dataset["dataset_assets"] = []
+                for asset in dataset["artifacts"]:
+                    if asset["filetype"] in (DatasetArtifactFileType.H5AD, DatasetArtifactFileType.RDS):
+                        dataset["dataset_assets"].append(asset)
             if "processing_status" in dataset:
                 if dataset["processing_status"]:
                     dataset["processing_status"] = dataset["processing_status"]["processing_status"]

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -38,6 +38,9 @@ def reshape_for_curation_api_and_is_allowed(collection, token_info, uuid_provide
             if "processing_status" in dataset:
                 if dataset["processing_status"]:
                     dataset["processing_status"] = dataset["processing_status"]["processing_status"]
+            if "organism" in dataset:
+                if not isinstance(dataset["organism"], list):
+                    dataset["organism"] = [dataset["organism"]]
 
     return True
 

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -52,9 +52,8 @@ def reshape_for_curation_api_and_is_allowed(collection, token_info, uuid_provide
                     if asset["filetype"] in (DatasetArtifactFileType.H5AD, DatasetArtifactFileType.RDS):
                         dataset["dataset_assets"].append(asset)
                 del dataset["artifacts"]
-            if "processing_status" in dataset:
-                if dataset["processing_status"]:
-                    dataset["processing_status"] = dataset["processing_status"]["processing_status"]
+            if dataset.get("processing_status"):
+                dataset["processing_status"] = dataset["processing_status"]["processing_status"]
             for ontology_element in DATASET_ONTOLOGY_ELEMENTS:
                 if dataset_ontology_element := dataset.get(ontology_element):
                     if not isinstance(dataset_ontology_element, list):

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -52,9 +52,12 @@ def reshape_for_curation_api_and_is_allowed(collection, token_info, uuid_provide
                     dataset["processing_status"] = dataset["processing_status"]["processing_status"]
             for ontology_element in DATASET_ONTOLOGY_ELEMENTS:
                 if ontology_element in dataset:
-                    if dataset[ontology_element] and not isinstance(dataset[ontology_element], list):
-                        # Package in array
-                        dataset[ontology_element] = [dataset[ontology_element]]
+                    if dataset[ontology_element]:
+                        if not isinstance(dataset[ontology_element], list):
+                            # Package in array
+                            dataset[ontology_element] = [dataset[ontology_element]]
+                    else:
+                        dataset[ontology_element] = []
 
     return True
 

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -51,17 +51,17 @@ def reshape_for_curation_api_and_is_allowed(collection, token_info, uuid_provide
                 for asset in dataset["artifacts"]:
                     if asset["filetype"] in (DatasetArtifactFileType.H5AD, DatasetArtifactFileType.RDS):
                         dataset["dataset_assets"].append(asset)
+                del dataset["artifacts"]
             if "processing_status" in dataset:
                 if dataset["processing_status"]:
                     dataset["processing_status"] = dataset["processing_status"]["processing_status"]
             for ontology_element in DATASET_ONTOLOGY_ELEMENTS:
-                if ontology_element in dataset:
-                    if dataset[ontology_element]:
-                        if not isinstance(dataset[ontology_element], list):
-                            # Package in array
-                            dataset[ontology_element] = [dataset[ontology_element]]
-                    else:
-                        dataset[ontology_element] = []
+                if dataset_ontology_element := dataset.get(ontology_element):
+                    if not isinstance(dataset_ontology_element, list):
+                        # Package in array
+                        dataset[ontology_element] = [dataset_ontology_element]
+                else:
+                    dataset[ontology_element] = []
 
     return True
 

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -10,6 +10,18 @@ from ......common.corpora_orm import (
 )
 
 
+DATASET_ONTOLOGY_ELEMENTS = (
+    "sex",
+    "ethnicity",
+    "development_stage",
+    "cell_type",
+    "tissue",
+    "assay",
+    "disease",
+    "organism",
+)
+
+
 def reshape_for_curation_api_and_is_allowed(collection, token_info, uuid_provided=False):
     """
     Reshape Collection data for the Curation API response.
@@ -38,9 +50,11 @@ def reshape_for_curation_api_and_is_allowed(collection, token_info, uuid_provide
             if "processing_status" in dataset:
                 if dataset["processing_status"]:
                     dataset["processing_status"] = dataset["processing_status"]["processing_status"]
-            if "organism" in dataset:
-                if not isinstance(dataset["organism"], list):
-                    dataset["organism"] = [dataset["organism"]]
+            for ontology_element in DATASET_ONTOLOGY_ELEMENTS:
+                if ontology_element in dataset:
+                    if dataset[ontology_element] and not isinstance(dataset[ontology_element], list):
+                        # Package in array
+                        dataset[ontology_element] = [dataset[ontology_element]]
 
     return True
 

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -36,7 +36,8 @@ def reshape_for_curation_api_and_is_allowed(collection, token_info, uuid_provide
             if "artifacts" in dataset:
                 dataset["dataset_assets"] = dataset.pop("artifacts")
             if "processing_status" in dataset:
-                dataset["processing_status"] = dataset["processing_status"]["processing_status"]
+                if dataset["processing_status"]:
+                    dataset["processing_status"] = dataset["processing_status"]["processing_status"]
 
     return True
 
@@ -77,7 +78,6 @@ class EntityColumns:
         "disease",
         "organism",
         "tombstone",
-        "processing_status",
     ]
 
     dataset_cols = [
@@ -98,6 +98,7 @@ class EntityColumns:
         # "batch_condition",  # TODO: https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1461  # noqa: E501
         "mean_genes_per_cell",
         "schema_version",
+        "processing_status",
     ]
 
     dataset_asset_cols = [


### PR DESCRIPTION
Apparently there exists some data corruption in deployed envs. Allow processing status
entity to be null in response for flexibility. Handle key error.

- #TICKET_NUMBER

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 
@nayib-jose-gloria 
---


## Changes
A number of small tweaks need to be made to make sure the API response schema matches up with the db schema and with the data that actually exist in the deployed environments.

## QA steps (optional)

## Notes for Reviewer
