### PR TITLE
fix(2770): Generate a unique s3_uri for cxg files add to the cellxgene bucket.

### DIFF
--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -564,7 +564,7 @@ def process_cxg(local_filename, dataset_id, cellxgene_bucket):
         metadata = {
             "explorer_url": join(
                 DEPLOYMENT_STAGE_TO_URL[os.environ["DEPLOYMENT_STAGE"]],
-                asset_id + ".cxg",
+                dataset_id + ".cxg",
                 "",
             )
         }

--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -481,13 +481,11 @@ def make_cxg(local_filename):
     return cxg_output_container
 
 
-def copy_cxg_files_to_cxg_bucket(cxg_dir, object_key, cellxgene_bucket):
+def copy_cxg_files_to_cxg_bucket(cxg_dir, s3_uri):
     """
     Copy cxg files to the cellxgene bucket (under the given object key) for access by the explorer
-    returns the s3_uri where the cxg is stored
     """
     command = ["aws"]
-    s3_uri = f"s3://{cellxgene_bucket}/{object_key}.cxg/"
     if os.getenv("BOTO_ENDPOINT_URL"):
         command.append(f"--endpoint-url={os.getenv('BOTO_ENDPOINT_URL')}")
 
@@ -506,7 +504,6 @@ def copy_cxg_files_to_cxg_bucket(cxg_dir, object_key, cellxgene_bucket):
         command,
         check=True,
     )
-    return s3_uri
 
 
 def convert_file_ignore_exceptions(
@@ -548,28 +545,35 @@ def get_bucket_prefix(dataset_id):
 
 
 def process_cxg(local_filename, dataset_id, cellxgene_bucket):
-    bucket_prefix = get_bucket_prefix(dataset_id)
     cxg_dir = convert_file_ignore_exceptions(make_cxg, local_filename, "Issue creating cxg.", dataset_id, "cxg_status")
     if cxg_dir:
-        update_db(dataset_id, processing_status={"cxg_status": ConversionStatus.UPLOADING})
-        s3_uri = copy_cxg_files_to_cxg_bucket(cxg_dir, bucket_prefix, cellxgene_bucket)
-        metadata = {
-            "explorer_url": join(
-                DEPLOYMENT_STAGE_TO_URL[os.environ["DEPLOYMENT_STAGE"]],
-                dataset_id + ".cxg",
-                "",
-            )
-        }
         with db_session_manager() as session:
-            logger.info(f"Updating database with cxg artifact for dataset {dataset_id}. s3_uri is {s3_uri}")
-            DatasetAsset.create(
+            asset = DatasetAsset.create(
                 session,
                 dataset_id=dataset_id,
                 filename="explorer_cxg",
                 filetype=DatasetArtifactFileType.CXG,
                 user_submitted=True,
+                s3_uri="",
+            )
+            asset_id = asset.id
+            bucket_prefix = get_bucket_prefix(asset_id)
+            s3_uri = f"s3://{cellxgene_bucket}/{bucket_prefix}.cxg/"
+        update_db(dataset_id, processing_status={"cxg_status": ConversionStatus.UPLOADING})
+        copy_cxg_files_to_cxg_bucket(cxg_dir, s3_uri)
+        metadata = {
+            "explorer_url": join(
+                DEPLOYMENT_STAGE_TO_URL[os.environ["DEPLOYMENT_STAGE"]],
+                asset_id + ".cxg",
+                "",
+            )
+        }
+        with db_session_manager() as session:
+            DatasetAsset.update(
+                session,
                 s3_uri=s3_uri,
             )
+            logger.info(f"Updating database with cxg artifact for dataset {dataset_id}. s3_uri is {s3_uri}")
         update_db(dataset_id, processing_status={"cxg_status": ConversionStatus.UPLOADED})
 
     else:

--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -536,12 +536,12 @@ def convert_file_ignore_exceptions(
     return file_dir
 
 
-def get_bucket_prefix(dataset_id):
+def get_bucket_prefix(identifier):
     remote_dev_prefix = os.environ.get("REMOTE_DEV_PREFIX", "")
     if remote_dev_prefix:
-        return join(remote_dev_prefix, dataset_id).strip("/")
+        return join(remote_dev_prefix, identifier).strip("/")
     else:
-        return dataset_id
+        return identifier
 
 
 def process_cxg(local_filename, dataset_id, cellxgene_bucket):

--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -570,10 +570,8 @@ def process_cxg(local_filename, dataset_id, cellxgene_bucket):
         }
         with db_session_manager() as session:
             logger.info(f"Updating database with cxg artifact for dataset {dataset_id}. s3_uri is {s3_uri}")
-            DatasetAsset.update(
-                session,
-                s3_uri=s3_uri,
-            )
+            asset = DatasetAsset.get(session, asset_id)
+            asset.update(s3_uri=s3_uri)
         update_db(dataset_id, processing_status={"cxg_status": ConversionStatus.UPLOADED})
 
     else:

--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -569,11 +569,11 @@ def process_cxg(local_filename, dataset_id, cellxgene_bucket):
             )
         }
         with db_session_manager() as session:
+            logger.info(f"Updating database with cxg artifact for dataset {dataset_id}. s3_uri is {s3_uri}")
             DatasetAsset.update(
                 session,
                 s3_uri=s3_uri,
             )
-            logger.info(f"Updating database with cxg artifact for dataset {dataset_id}. s3_uri is {s3_uri}")
         update_db(dataset_id, processing_status={"cxg_status": ConversionStatus.UPLOADED})
 
     else:

--- a/tests/unit/backend/corpora/dataset_processing/test_process.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_process.py
@@ -385,7 +385,7 @@ class TestDatasetProcessing(DataPortalTestCase):
 
         self.assertEqual(len(artifacts), 1)
         self.assertEqual(artifacts[0].dataset_id, dataset_id)
-        self.assertEqual(artifacts[0].s3_uri, f"s3://{explorer_bucket}/{dataset_id}.cxg/")
+        self.assertEqual(artifacts[0].s3_uri, (f"s3://{explorer_bucket}/{artifacts[0].id}.cxg/"))
         self.assertEqual(artifacts[0].filetype, DatasetArtifactFileType.CXG)
 
     @patch("backend.corpora.dataset_processing.process.make_seurat")

--- a/tests/unit/backend/corpora/dataset_processing/test_process.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_process.py
@@ -385,7 +385,7 @@ class TestDatasetProcessing(DataPortalTestCase):
 
         self.assertEqual(len(artifacts), 1)
         self.assertEqual(artifacts[0].dataset_id, dataset_id)
-        self.assertEqual(artifacts[0].s3_uri, (f"s3://{explorer_bucket}/{artifacts[0].id}.cxg/"))
+        self.assertEqual(artifacts[0].s3_uri, f"s3://{explorer_bucket}/{dataset_id}.cxg/")
         self.assertEqual(artifacts[0].filetype, DatasetArtifactFileType.CXG)
 
     @patch("backend.corpora.dataset_processing.process.make_seurat")

--- a/tests/unit/backend/corpora/dataset_processing/test_process.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_process.py
@@ -385,7 +385,7 @@ class TestDatasetProcessing(DataPortalTestCase):
 
         self.assertEqual(len(artifacts), 1)
         self.assertEqual(artifacts[0].dataset_id, dataset_id)
-        self.assertEqual(artifacts[0].s3_uri, f"s3://{explorer_bucket}/{dataset_id}.cxg/")
+        self.assertEqual(artifacts[0].s3_uri, f"s3://{explorer_bucket}/{artifacts[0].id}.cxg/")
         self.assertEqual(artifacts[0].filetype, DatasetArtifactFileType.CXG)
 
     @patch("backend.corpora.dataset_processing.process.make_seurat")


### PR DESCRIPTION
- #2770 

### Reviewers
**Functional:** @danieljhegeman 

**Readability:** @atolopko-czi 

---


## Changes
- new cxg files are upload to the cxg bucket with a unique UUID. This UUID changes whenever ever the dataset is reuploaded.
- The `s3_uri` and the `explorer_url` have been updated to use their own unique UUID.

## QA steps (optional)
1. Create a collection
2. upload a dataset
3. open the explorer and look at the resulting URL path.
   dataset:  https://t2770-explorer.rdev.single-cell.czi.technology/e/391f6c86-950e-49e4-b51c-02e1aaede204.cxg/
4. publish
5. start a revision
    dataset-R: https://t2770-explorer.rdev.single-cell.czi.technology/e/3ee1fa9f-ae40-4662-adad-c1c041a54be1.cxg/
6. update dataset.
    dataset-R':https://t2770-explorer.rdev.single-cell.czi.technology/e/a3053715-359c-4417-bebc-e765ca2f9c68.cxg/
7. update again
   dataset-R'': https://t2770-explorer.rdev.single-cell.czi.technology/e/cc44db47-ec42-484f-9af2-9bb6f78c6689.cxg/
8. publish
    dataset-R'': https://t2770-explorer.rdev.single-cell.czi.technology/e/391f6c86-950e-49e4-b51c-02e1aaede204.cxg/



## Notes for Reviewer
rdev environment https://t2770-frontend.rdev.single-cell.czi.technology