### PR TITLE
feat(scExpression): faster filtering with precomputed graph structure encoding filter relationships

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -9,10 +9,7 @@ from pandas import DataFrame
 from backend.corpora.common.entities import Dataset
 from backend.corpora.common.utils.db_session import db_session_manager
 from backend.wmg.data.ontology_labels import ontology_term_label, gene_term_label
-from backend.wmg.data.query import (
-    WmgQuery,
-    WmgQueryCriteria
-)
+from backend.wmg.data.query import WmgQuery, WmgQueryCriteria
 from backend.wmg.data.snapshot import load_snapshot, WmgSnapshot
 
 # TODO: add cache directives: no-cache (i.e. revalidate); impl etag
@@ -77,27 +74,27 @@ def fetch_datasets_metadata(dataset_ids: Iterable[str]) -> List[Dict]:
 
 
 def find_dim_option_values(criteria: Dict, htable: Dict, dimension: str) -> set:
-    """Find valid options given criteria."""      
+    """Find valid options given criteria."""
     dimension = dimension[:-1] if dimension[-1] == "s" else dimension
-    supersets=[]
+    supersets = []
     for key in criteria:
         attrs = criteria[key]
-        key = key[:-1] if key[-1] == "s" else key        
+        key = key[:-1] if key[-1] == "s" else key
         if key != dimension:
-            if isinstance(attrs,list):
-                if (len(attrs) > 0):
+            if isinstance(attrs, list):
+                if len(attrs) > 0:
                     vals = [key + "__" + val for val in attrs]
                     sets = [set([x for x in htable[v] if dimension in x]) for v in vals]
                     supersets.append(sets[0].union(*sets[1:]))
             else:
                 if attrs != "":
-                    supersets.append(set([x for x in htable[key+"__"+attrs] if dimension in x]))
+                    supersets.append(set([x for x in htable[key + "__" + attrs] if dimension in x]))
 
     if len(supersets) > 1:
         supersets = supersets[0].intersection(*supersets[1:])
     else:
         supersets = supersets[0]
-        
+
     return [i.split("__")[1] for i in supersets]
 
 
@@ -109,15 +106,15 @@ def build_filter_dims_values(criteria: WmgQueryCriteria, htable: Dict) -> Dict:
         "development_stage_ontology_term_id": "",
         "ethnicity_ontology_term_id": "",
     }
-    
+
     criteria = dict(criteria)
-    del criteria['gene_ontology_term_ids']      
-    
+    del criteria["gene_ontology_term_ids"]
+
     for dim in dims:
         dims[dim] = find_dim_option_values(criteria, htable, dim)
 
     response_filter_dims_values = dict(
-        #datasets=fetch_datasets_metadata(dims["dataset_id"]),
+        datasets=fetch_datasets_metadata(dims["dataset_id"]),
         disease_terms=build_ontology_term_id_label_mapping(dims["disease_ontology_term_id"]),
         sex_terms=build_ontology_term_id_label_mapping(dims["sex_ontology_term_id"]),
         development_stage_terms=build_ontology_term_id_label_mapping(dims["development_stage_ontology_term_id"]),

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -74,7 +74,9 @@ def fetch_datasets_metadata(dataset_ids: Iterable[str]) -> List[Dict]:
 
 
 def find_dim_option_values(criteria: Dict, htable: Dict, dimension: str) -> set:
-    """Find valid options given criteria."""
+    """Find values for the specified dimension that satisfy the given filtering criteria,
+    ignoring any criteria specified for the given dimension."""
+
     dimension = dimension[:-1] if dimension[-1] == "s" else dimension
     supersets = []
     for key in criteria:

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -97,7 +97,6 @@ def find_dim_option_values(criteria: Dict, htable: Dict, dimension: str) -> set:
     else:
         valid_options = supersets[0]
 
-    # now, close the loop and make sure that the set of filter options will each yield a valid combination of filters with the existing filters.
     final_options = []
     for v in valid_options:
         loop_back_options = htable[v]

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -93,11 +93,18 @@ def find_dim_option_values(criteria: Dict, htable: Dict, dimension: str) -> set:
                     supersets.append(set([x for x in htable[key + "__" + attrs] if dimension in x]))
 
     if len(supersets) > 1:
-        supersets = supersets[0].intersection(*supersets[1:])
+        valid_options = supersets[0].intersection(*supersets[1:])
     else:
-        supersets = supersets[0]
+        valid_options = supersets[0]
 
-    return [i.split("__")[1] for i in supersets]
+    # now, close the loop and make sure that the set of filter options will each yield a valid combination of filters with the existing filters.
+    final_options = []
+    for v in valid_options:
+        loop_back_options = htable[v]
+        if len(set(loop_back_options).intersection(*supersets)) > 0:
+            final_options.append(v)
+
+    return [i.split("__")[1] for i in final_options]
 
 
 def build_filter_dims_values(criteria: WmgQueryCriteria, htable: Dict) -> Dict:

--- a/backend/wmg/data/wmg_cube.py
+++ b/backend/wmg/data/wmg_cube.py
@@ -282,6 +282,8 @@ def _to_dict(a, b):
     """
     convert a flat key array (a) and a value array (b) into a dictionary with values grouped by keys
     """
+    a = np.array(a)
+    b = np.array(b)
     idx = np.argsort(a)
     a = a[idx]
     b = b[idx]

--- a/backend/wmg/data/wmg_cube.py
+++ b/backend/wmg/data/wmg_cube.py
@@ -52,22 +52,15 @@ def create_cell_count_cube(corpus_path: str):
         df = df.rename(columns={"size": "n_cells"})
 
         mat = np.tile(df.columns[:-1].values[None, :], (df.shape[0], 1)) + "__" + df.iloc[:, :-1].values
-        nodes = np.unique(mat.astype("str"))
-
-        mapper = pd.Series(index=nodes, data=np.arange(nodes.size))
-        r_mapper = pd.Series(index=np.arange(nodes.size), data=nodes)
 
         Xs = []
         Ys = []
         for i in range(mat.shape[0]):
-            ix = mapper[mat[i]].values
-            Xs.extend(np.repeat(ix, ix.size))
-            Ys.extend(np.tile(ix, ix.size))
+            Xs.extend(np.repeat(mat[i], mat[i].size))
+            Ys.extend(np.tile(mat[i], mat[i].size))
         Xs, Ys = np.unique(np.array((Xs, Ys)), axis=1)
         filt = Xs != Ys
         Xs, Ys = Xs[filt], Ys[filt]
-        Xs = r_mapper[Xs].values
-        Ys = r_mapper[Ys].values
         htable = _to_dict(Xs, Ys)
         pickle.dump(htable, open(f"{corpus_path}/filter_graph.p", "wb"))
 

--- a/backend/wmg/data/wmg_cube.py
+++ b/backend/wmg/data/wmg_cube.py
@@ -68,7 +68,7 @@ def create_cell_count_cube(corpus_path: str):
         Xs, Ys = Xs[filt], Ys[filt]
         Xs = r_mapper[Xs].values
         Ys = r_mapper[Ys].values
-        htable = _df_to_dict(Xs, Ys)
+        htable = _to_dict(Xs, Ys)
         pickle.dump(htable, open(f"{corpus_path}/filter_graph.p", "wb"))
 
         create_empty_cube(uri, cell_counts_schema)
@@ -285,7 +285,10 @@ def coo_cube_pass1_into(data, row, col, row_groups, sum_into, nnz_into, min_into
                 max_into[grp_idx, cidx] = val
 
 
-def _df_to_dict(a, b):
+def _to_dict(a, b):
+    """
+    convert a flat key array (a) and a value array (b) into a dictionary with values grouped by keys
+    """
     idx = np.argsort(a)
     a = a[idx]
     b = b[idx]

--- a/frontend/src/pages/landing-page/index.tsx
+++ b/frontend/src/pages/landing-page/index.tsx
@@ -49,7 +49,7 @@ const LandingPage = (): JSX.Element => {
   const scrollSection5 = useRef<HTMLDivElement>(null!);
 
   // HERO NUMBERS. DUMMY DATA TO BE REPLACED.
-  const [cellsHeroNum] = useState("30M+");
+  const [cellsHeroNum] = useState("25M+");
   const [datasetsHeroNum] = useState("436");
   const [donorsHeroNum] = useState("2.7k+");
 
@@ -361,7 +361,7 @@ const LandingPage = (): JSX.Element => {
                         </h2>
                         <p>
                           Visualize the expression of genes and gene sets using
-                          the largest integrated resource of over 30 million
+                          the largest integrated resource of over 25 million
                           cells.
                         </p>
                         <div className={styles.linkContainer}>
@@ -437,7 +437,7 @@ const LandingPage = (): JSX.Element => {
                             </a>
                           </Link>
                           <Link
-                            href={`${ROUTES.HOMEPAGE}/docs/04_Analyze-Public-Data/4_1-Hosted-Tutorials`}
+                            href={`${ROUTES.DOCS}/04__Analyze%20Public%20Data/4_1__Hosted%20Tutorials`}
                             passHref
                           >
                             <a>
@@ -485,9 +485,7 @@ const LandingPage = (): JSX.Element => {
                         <p>
                           Integrate datasets with zero data wrangling. Datasets
                           with standard metadata annotations can be downloaded
-                          in AnnData and Seurat formats and custom cell
-                          selections from the complete corpus can be downloaded
-                          directly from R and Python.
+                          in AnnData and Seurat formats.
                         </p>
                         <div className={styles.linkContainer}>
                           <Link href={ROUTES.COLLECTIONS} passHref>
@@ -498,20 +496,6 @@ const LandingPage = (): JSX.Element => {
                               </span>
                             </a>
                           </Link>
-                          {/* LINK TO BE UPDATED POST-LAUNCH */}
-                          <a href="#">
-                            Download with R
-                            <span className={styles.linkArrow}>
-                              <LinkArrow />
-                            </span>
-                          </a>
-                          {/* LINK TO BE UPDATED POST-LAUNCH */}
-                          <a href="#">
-                            Download with Python
-                            <span className={styles.linkArrow}>
-                              <LinkArrow />
-                            </span>
-                          </a>
                         </div>
                       </div>
                     </div>
@@ -554,7 +538,7 @@ const LandingPage = (): JSX.Element => {
                         <div className={styles.linkContainer}>
                           {/* LINK TO BE UPDATED POST-LAUNCH */}
                           <a href="https://github.com/chanzuckerberg/cellxgene-documentation/blob/main/desktop/quick-start.md">
-                            Learn how it works
+                            Explore CZ Cell×Gene Annotate
                             <span className={styles.linkArrow}>
                               <LinkArrow />
                             </span>

--- a/tests/unit/backend/wmg/fixtures/test_snapshot.py
+++ b/tests/unit/backend/wmg/fixtures/test_snapshot.py
@@ -242,7 +242,7 @@ def create_cubes(
         filt = Xs != Ys
         Xs, Ys = Xs[filt], Ys[filt]
         filter_graph = _to_dict(Xs, Ys)
-        pickle.dump(open(f"{data_dir}/filter_graph.p", "wb"))
+        pickle.dump(filter_graph, open(f"{data_dir}/filter_graph.p", "wb"))
 
     return expression_summary_cube_dir, cell_counts_cube_dir, filter_graph
 


### PR DESCRIPTION
- #2797

Previously, `build_filter_dims_values` runtime ranges from 1-4 seconds. Now it is around 0.02-0.07 seconds.

- added graph creation to the cube creation pipeline. the graph encodes edges between filter labels if they have overlapping sets of cells. it is saved as a hash table pickle file in the snapshot
-  changed `build_filter_dims_values`. Instead of querying `expression_summary`, it is reading the hash table to pull out related filter values

