### PR TITLE
fix(styles): move centering responsive pages to doc layout

### DIFF
--- a/frontend/src/components/Layout/style.ts
+++ b/frontend/src/components/Layout/style.ts
@@ -18,7 +18,6 @@ export const MainWrapper = styled.div`
   display: grid; /* required: ensures any remaining viewport height allocated to main content is observed; ancestor component heights are unspecified and so any height specification will revert to "auto" */
   flex: 1; /* sticks footer to bottom of viewport and initial render of main content is at full viewport height while data is loading. */
   margin-top: ${HEADER_HEIGHT_PX}px; /* positions content below fixed header */
-  justify-content: center; /* Allows for center resizing based on viewport width */
 `;
 
 export const DefaultMainWrapper = styled(MainWrapper)`
@@ -36,6 +35,7 @@ export const SidebarMainWrapper = styled(MainWrapper)`
 `;
 
 export const StyledDocsLayout = styled(MainWrapper)`
+  justify-content: center; /* Allows for center resizing based on viewport width */
   main {
     display: grid;
     grid-template-areas: "leftsidebar content rightsidebar";


### PR DESCRIPTION
- #2827

### Reviewers
**Functional:** @MillenniumFalconMechanic 

---

Moves doc specific styling to the appropriate layout
