### PR TITLE
Revert "feat: Optionally use FARGATE; use FARGATE in rdev"

### DIFF
--- a/.happy/terraform/envs/rdev/main.tf
+++ b/.happy/terraform/envs/rdev/main.tf
@@ -1,4 +1,4 @@
-module "stack" {
+module stack {
   source                       = "./modules/ecs-stack"
   aws_account_id               = var.aws_account_id
   aws_role                     = var.aws_role
@@ -14,7 +14,7 @@ module "stack" {
   batch_container_memory_limit = 28000
   backend_instance_count       = 1
   frontend_instance_count      = 1
-  launch_type                  = "FARGATE"
+  backend_memory               = 1536
 
-  wait_for_steady_state = var.wait_for_steady_state
+  wait_for_steady_state        = var.wait_for_steady_state
 }

--- a/.happy/terraform/modules/ecs-stack/variables.tf
+++ b/.happy/terraform/modules/ecs-stack/variables.tf
@@ -1,128 +1,108 @@
-variable "aws_account_id" {
+variable aws_account_id {
   type        = string
   description = "AWS account ID to apply changes to"
   default     = ""
 }
 
-variable "aws_role" {
+variable aws_role {
   type        = string
   description = "Name of the AWS role to assume to apply changes"
   default     = ""
 }
 
-variable "image_tag" {
-  type        = string
+variable image_tag {
+   type        = string
   description = "Please provide an image tag"
 }
 
-variable "priority" {
+variable priority {
   type        = number
   description = "Listener rule priority number within the given listener"
 }
 
-variable "happymeta_" {
+variable happymeta_ {
   type        = string
   description = "Happy Path metadata. Ignored by actual terraform."
 }
 
-variable "stack_name" {
+variable stack_name {
   type        = string
   description = "Happy Path stack name"
 }
 
-variable "happy_config_secret" {
+variable happy_config_secret {
   type        = string
   description = "Happy Path configuration secret name"
 }
 
-variable "deployment_stage" {
+variable deployment_stage {
   type        = string
   description = "Deployment stage for the app"
 }
 
-variable "delete_protected" {
+variable delete_protected {
   type        = bool
   description = "Whether to protect this stack from being deleted."
   default     = false
 }
 
-variable "require_okta" {
+variable require_okta {
   type        = bool
   description = "Whether the ALB's should be on private subnets"
   default     = true
 }
 
-variable "backend_url" {
+variable backend_url {
   type        = string
   description = "For non-proxied stacks, send in the canonical front/backend URL's"
   default     = ""
 }
 
-variable "frontend_url" {
+variable frontend_url {
   type        = string
   description = "For non-proxied stacks, send in the canonical front/backend URL's"
   default     = ""
 }
 
-variable "stack_prefix" {
+variable stack_prefix {
   type        = string
   description = "Do bucket storage paths and db schemas need to be prefixed with the stack name? (Usually '/{stack_name}' for dev stacks, and '' for staging/prod stacks)"
   default     = ""
 }
 
-variable "wait_for_steady_state" {
+variable wait_for_steady_state {
   type        = bool
   description = "Should terraform block until ECS services reach a steady state?"
   default     = false
 }
 
-variable "batch_container_memory_limit" {
+variable batch_container_memory_limit {
   type        = number
   description = "Memory hard limit for the batch container"
   default     = 28000
 }
 
-variable "frontend_instance_count" {
+variable frontend_instance_count {
   type        = number
   description = "How many frontend tasks to run"
   default     = 2
 }
 
-variable "backend_instance_count" {
+variable backend_instance_count {
   type        = number
   description = "How many backend tasks to run"
   default     = 2
 }
 
-variable "backend_memory" {
+variable backend_memory {
   type        = number
   description = "Memory reservation for the backend task"
-  default     = 2048
+  default     = 1536
 }
 
-variable "backend_cpu" {
+variable frontend_memory {
   type        = number
-  description = "CPU reservation for the backend task"
-  default     = 1024
-}
-
-
-variable "frontend_memory" {
-  type        = number
-  description = "Memory reservation for the frontend task"
+  description = "Memory reservation for the backend task"
   default     = 4096
 }
 
-variable "frontend_cpu" {
-  type        = number
-  description = "CPU reservation for the frontend task"
-  default     = 2048
-}
-
-variable "use_fargate" {
-  type = object({
-    execution_role_arn : string
-  })
-  default     = null
-  description = "Set these values to use Fargate; null if EC2."
-}

--- a/.happy/terraform/modules/service/variables.tf
+++ b/.happy/terraform/modules/service/variables.tf
@@ -115,26 +115,6 @@ variable "memory" {
   default     = 2048
 }
 
-variable "cpu" {
-  type        = number
-  description = "Amount of CPU to allocate to each task"
-  default     = 1024
-}
-
-variable "launch_type" {
-  type        = string
-  description = "Either EC2 or FARGATE"
-  default     = "EC2"
-}
-
-variable "use_fargate" {
-  type = object({
-    execution_role_arn : string
-  })
-  default     = null
-  description = "Set these values to use Fargate; null if EC2."
-}
-
 variable "wait_for_steady_state" {
   type        = bool
   description = "Whether Terraform should block until the service is in a steady state before exiting"


### PR DESCRIPTION
Reverts chanzuckerberg/single-cell-data-portal#2522

- causing issues with deploying happy environments. https://si.prod.tfe.czi.technology/app/happy-singlecell/workspaces/dev-devstack/runs
- `launch_type` does not appear to be used or defined in "./modules/ecs-stack"
- `execution_role_arn` roles for use_fargate aren't yet defined.