### PR TITLE
fix(workflow): don't run push-tests smoke tests in happy container 

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -72,10 +72,12 @@ jobs:
         with:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
-      - run: npm ci
-      - run: npx playwright install --with-deps
-      - name: Run E2E Tests
-        run: npm run e2e
+      - run: |
+          npm ci
+          npx playwright install --with-deps
+          cp src/configs/dev.js src/configs/configs.js
+      - run: npm run dev
+      - run: npm run e2e
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
         with:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -52,6 +52,9 @@ jobs:
 
   smoke-test:
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: frontend
     steps:
       - uses: actions/setup-node@v2
         with:
@@ -69,10 +72,6 @@ jobs:
         with:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
-      # DEBUG
-      # DEBUG
-      # DEBUG
-      - run: cd frontend && ls && pwd
       - run: npm ci
       - run: npx playwright install --with-deps
       - name: Run E2E Tests

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -69,9 +69,9 @@ jobs:
         with:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
+      - run: cd frontend
       - run: npm ci
       - run: npx playwright install --with-deps
-      - name: Run your tests
         run: npm run e2e
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -69,7 +69,10 @@ jobs:
         with:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
-      - run: cd frontend
+      # DEBUG
+      # DEBUG
+      # DEBUG
+      - run: cd frontend && ls && pwd
       - run: npm ci
       - run: npx playwright install --with-deps
       - name: Run E2E Tests

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -76,7 +76,7 @@ jobs:
           npm ci
           npx playwright install --with-deps
           cp src/configs/dev.js src/configs/configs.js
-      - run: npm run dev
+          npm run dev&
       - run: npm run e2e
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: 15
       - name: Configure AWS Credentials
-      - uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: repo,commit,author,eventName,workflow,job,mention
-          mention: 'here'
+          mention: "here"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
@@ -54,7 +54,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "15"
+      - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -69,12 +72,12 @@ jobs:
       - name: Display github.ref
         run: |
           echo '${{ github.ref }}'
-      - name: Run tests in docker-compose
-        run: |
-          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
-          make local-sync
-          sleep 30  # Give frontend some time to finish building
-          make local-smoke-test
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright
+        run: npx playwright install --with-deps
+      - name: Run your tests
+        run: npm run e2e
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
         with:
@@ -87,7 +90,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: repo,commit,author,eventName,workflow,job,mention
-          mention: 'here'
+          mention: "here"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: failure() && github.ref == 'refs/heads/main'
@@ -121,7 +124,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: repo,commit,author,eventName,workflow,job,mention
-          mention: 'here'
+          mention: "here"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
@@ -186,7 +189,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: repo,commit,author,eventName,workflow,job,mention
-          mention: 'here'
+          mention: "here"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
@@ -225,7 +228,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: repo,commit,author,eventName,workflow,job,mention
-          mention: 'here'
+          mention: "here"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
@@ -251,7 +254,7 @@ jobs:
           auto_merge: false
           environment: ${{ env.DEPLOYMENT_STAGE }}
           payload: ${{ env.payload }}
-          required_contexts: ""  # Temporary hack to avoid checking Github Status for the commit
+          required_contexts: "" # Temporary hack to avoid checking Github Status for the commit
           # TODO: Avoid circular dependency on the deploy step; this step hasn't finished yet so
           # it's not considered ready for deploy normally by required_contexts, but we need to
           # deploy for this to be considered ready.

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -72,6 +72,7 @@ jobs:
       - run: cd frontend
       - run: npm ci
       - run: npx playwright install --with-deps
+      - name: Run E2E Tests
         run: npm run e2e
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -53,10 +53,10 @@ jobs:
   smoke-test:
     runs-on: ubuntu-20.04
     steps:
-      - name: Configure AWS Credentials
       - uses: actions/setup-node@v2
         with:
-          node-version: "15"
+          node-version: 15
+      - name: Configure AWS Credentials
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
@@ -69,13 +69,8 @@ jobs:
         with:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
-      - name: Display github.ref
-        run: |
-          echo '${{ github.ref }}'
-      - name: Install dependencies
-        run: npm ci
-      - name: Install Playwright
-        run: npx playwright install --with-deps
+      - run: npm ci
+      - run: npx playwright install --with-deps
       - name: Run your tests
         run: npm run e2e
       - name: Install happy

--- a/frontend/jest-playwright.config.js
+++ b/frontend/jest-playwright.config.js
@@ -30,7 +30,11 @@ const DEFAULT_CONTEXT_CONFIG = {
   userAgent: devices["Desktop Chrome"].userAgent + " czi-checker",
 };
 
+// 'github' for GitHub Actions CI to generate annotations, default otherwise
+const PLAYWRIGHT_REPORTER = process.env.CI ? "github" : "list";
+
 module.exports = {
   contextOptions: DEFAULT_CONTEXT_CONFIG,
   launchOptions: DEFAULT_LAUNCH_CONFIG,
+  reporter: PLAYWRIGHT_REPORTER,
 };


### PR DESCRIPTION
This speeds up smoke test runs for push-tests from ~20 minutes to <5.

We're also experiencing issues with our frontend docker container running smoke tests, so this will both unblock merges to main and allow for deployments.

We'll be attempting to address containerized smoke test runs in a separate PR.