### PR TITLE
fix: reimplement all perf tests in prod

### DIFF
--- a/tests/performance/test_wmg_apis.py
+++ b/tests/performance/test_wmg_apis.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import timeit
 import unittest
 import os
@@ -11,7 +12,7 @@ from tests.functional.backend.wmg.fixtures import (
 
 # Note that these tests share fixtures and general test paths with the wmg api functional tests
 
-
+logger = logging.getLogger(__name__)
 @unittest.skipIf(os.getenv("DEPLOYMENT_STAGE") != "prod", "this test should only run in prod")
 class TestWmgApiPerformanceProd(unittest.TestCase):
     @classmethod
@@ -25,17 +26,18 @@ class TestWmgApiPerformanceProd(unittest.TestCase):
 
     def test_primary_filters(self):
         """
-        Load primary filters in less than 1.5 seconds
+        Load primary filters in less than 1 second
         """
-        MAX_RESPONSE_TIME_SECONDS = 1.5
+        MAX_RESPONSE_TIME_SECONDS = 1
 
         def make_request():
             return requests.get(f"{self.api}/primary_filter_dimensions")
 
         seconds_for_10_runs = timeit.timeit(setup="", stmt=make_request, number=10)
+        logger.info(f"primary filters seconds_for_10_runs: {seconds_for_10_runs}")
         self.assertGreater(MAX_RESPONSE_TIME_SECONDS * 10, seconds_for_10_runs)
 
-    def secondary_filters_common_case(self):
+    def test_secondary_filters_common_case(self):
         """
         1 tissue w/50 cell types, 20 genes, 3 secondary filters specified
         Returns in less than 10 seconds
@@ -49,9 +51,9 @@ class TestWmgApiPerformanceProd(unittest.TestCase):
             return requests.post(f"{self.api}/query", data=json.dumps(data), headers=headers)
 
         seconds_for_10_runs = timeit.timeit(setup="", stmt=make_request, number=10)
+        logger.info(f"secondary filters seconds_for_10_runs: {seconds_for_10_runs}")
         self.assertGreater(MAX_RESPONSE_TIME_SECONDS * 10, seconds_for_10_runs)
 
-    @unittest.skip("Temporarily skipping failing test to get prod deployed")
     def test_secondary_filters_extreme_case(self):
         """
         4 tissues w/largest cell type counts, 400 genes, no secondary filtering
@@ -66,4 +68,5 @@ class TestWmgApiPerformanceProd(unittest.TestCase):
             return requests.post(f"{self.api}/query", data=json.dumps(data), headers=headers)
 
         seconds_for_10_runs = timeit.timeit(setup="", stmt=make_request, number=10)
+        logger.info(f"secondary filters extreme case: seconds_for_10_runs: {seconds_for_10_runs}")
         self.assertGreater(MAX_RESPONSE_TIME_SECONDS * 10, seconds_for_10_runs)

--- a/tests/performance/test_wmg_apis.py
+++ b/tests/performance/test_wmg_apis.py
@@ -13,6 +13,8 @@ from tests.functional.backend.wmg.fixtures import (
 # Note that these tests share fixtures and general test paths with the wmg api functional tests
 
 logger = logging.getLogger(__name__)
+
+
 @unittest.skipIf(os.getenv("DEPLOYMENT_STAGE") != "prod", "this test should only run in prod")
 class TestWmgApiPerformanceProd(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
- #2774 

### Reviewers
**Functional:** 
- @metakuni 
**Readability:** 

---


## Changes

- modify perf tests to run in prod and log run times

## QA steps (optional)
- ran against prod locally. Tests ran within desired time limits
## Notes for Reviewer
