### PR TITLE
fix(scExpression): fix firefox scrolling bug

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
@@ -40,6 +40,7 @@ export const YAxisWrapper = styled.div`
   top: 0;
   left: 0;
   z-index: 1;
+  overflow: hidden;
 
   ${({ height }: { height: number }) => {
     return `
@@ -53,6 +54,7 @@ export const ChartWrapper = styled.div`
   flex-direction: column;
   position: absolute;
   top: 0;
+  
 `;
 
 function xAxisWidth({ width }: { width: number }) {


### PR DESCRIPTION
- Closes #2866 

### Reviewers
**Functional:** 
@tihuan 

## Changes
- added `overflow: hidden` to the Y axis chart to get it to scroll properly. Don't know why this is necessary in Firefox and not in Chrome, but it seems to fix behavior in Firefox without causing a regression in Chrome.