### PR TITLE
fix: only pull slack webhook in prod

### DIFF
--- a/backend/corpora/common/utils/slack.py
+++ b/backend/corpora/common/utils/slack.py
@@ -21,9 +21,9 @@ def notify_slack(data):
     This will only create a slack notification if called in the production env
     In all other envs (and in prod) it will simply log alert data
     """
-    slack_webhook = CorporaConfig().slack_webhook
     logger.info(f"Slack notification function called with message: {data}")
     if os.getenv("DEPLOYMENT_STAGE") == "prod":
+        slack_webhook = CorporaConfig().slack_webhook
         requests.post(slack_webhook, headers={"Content-type": "application/json"}, data=data)
 
 


### PR DESCRIPTION
- #2406 

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes

- modify slack alert to only retrieve webhook in prod env

## QA steps (optional)

## Notes for Reviewer
