### PR TITLE
fix: Handle Dropbox 200 for head req for nonexistent resources

### DIFF
--- a/tests/unit/backend/corpora/api_server/test_v1_collection_upload_link.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_collection_upload_link.py
@@ -67,7 +67,9 @@ class TestCollectionPostUploadLink(BaseAuthAPITest):
             test_url = furl(path=path)
             response = self.app.post(test_url.url, headers=headers, data=json.dumps(body))
             self.assertEqual(400, response.status_code)
-            self.assertEqual("The URL provided causes an error with Dropbox.", json.loads(response.data)["detail"])
+            self.assertEqual(
+                "'content-disposition' not present in the header.", json.loads(response.data)["detail"][-48:]
+            )
 
     @patch(
         "backend.corpora.common.utils.dl_sources.url.DropBoxURL.file_info", return_value={"size": 1, "name": "file.txt"}

--- a/tests/unit/backend/corpora/common/utils/test_dropbox.py
+++ b/tests/unit/backend/corpora/common/utils/test_dropbox.py
@@ -65,18 +65,18 @@ class TestDropbox(unittest.TestCase):
         postive_test.file_info()
 
     def test__get_file_info__neg(self):
-        with self.subTest("404"):
-            negative_test = from_url("https://www.dropbox.com/s/12345678901234/test.h5ad?dl=1")
-            self.assertRaises(HTTPError, negative_test.file_info)
-
         with self.subTest("Missing Headers"):
+            negative_test = from_url("https://www.dropbox.com/s/12345678901234/test.h5ad?dl=1")
+            self.assertRaises(MissingHeaderException, negative_test.file_info)
+
+        with self.subTest("404"):
 
             def make_response():
                 response = requests.Response()
-                response.status_code = 200
+                response.status_code = 404
                 response.headers = {}
                 return response
 
             with mock.patch("requests.head", return_value=make_response()):
                 negative_test = from_url("https://www.dropbox.com/s/12345678901234/test.h5ad?dl=1")
-                self.assertRaises(MissingHeaderException, negative_test.file_info)
+                self.assertRaises(HTTPError, negative_test.file_info)


### PR DESCRIPTION
- unit tests updated
- Dropbox now returns 200 in response to a HEAD request for a resource
that does not exist.

https://czi-sci.slack.com/archives/C023Q1APASK/p1659053375076559

### Reviewers
**Functional:** 
@atolopko-czi @ebezzi 
**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
