### PR TITLE
fix: handle both possible types of error responses from Dropbox

### DIFF
--- a/tests/unit/backend/corpora/api_server/test_v1_collection_upload_link.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_collection_upload_link.py
@@ -67,13 +67,10 @@ class TestCollectionPostUploadLink(BaseAuthAPITest):
             test_url = furl(path=path)
             response = self.app.post(test_url.url, headers=headers, data=json.dumps(body))
             self.assertEqual(400, response.status_code)
-            expected = False
-            if (
+            self.assertTrue(
                 "'content-disposition' not present in the header." in json.loads(response.data)["detail"]
                 or "The URL provided causes an error with Dropbox." == json.loads(response.data)["detail"]
-            ):
-                expected = True
-            self.assertTrue(expected)
+            )
 
     @patch(
         "backend.corpora.common.utils.dl_sources.url.DropBoxURL.file_info", return_value={"size": 1, "name": "file.txt"}

--- a/tests/unit/backend/corpora/api_server/test_v1_collection_upload_link.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_collection_upload_link.py
@@ -67,9 +67,13 @@ class TestCollectionPostUploadLink(BaseAuthAPITest):
             test_url = furl(path=path)
             response = self.app.post(test_url.url, headers=headers, data=json.dumps(body))
             self.assertEqual(400, response.status_code)
-            self.assertEqual(
-                "'content-disposition' not present in the header.", json.loads(response.data)["detail"][-48:]
-            )
+            expected = False
+            if (
+                "'content-disposition' not present in the header." in json.loads(response.data)["detail"]
+                or "The URL provided causes an error with Dropbox." == json.loads(response.data)["detail"]
+            ):
+                expected = True
+            self.assertTrue(expected)
 
     @patch(
         "backend.corpora.common.utils.dl_sources.url.DropBoxURL.file_info", return_value={"size": 1, "name": "file.txt"}


### PR DESCRIPTION
This is nuts but this is the only reasonable solution I can come up with for this situation, the situation being that Dropbox seems to oscillate randomly between two different possible error messages for a nonexistent resource link.

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
