### PR TITLE
fix: track active vs tombstoned datasets correctly for API response

### DIFF
--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -46,7 +46,7 @@ def reshape_for_curation_api_and_is_allowed(collection, token_info, id_provided=
 
     if datasets := collection.get("datasets"):
         active_datasets = []
-        for i, dataset in enumerate(datasets):
+        for dataset in datasets:
             if dataset.get("tombstone"):
                 continue  # Remove tombstoned Datasets
             active_datasets.append(dataset)

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -45,10 +45,11 @@ def reshape_for_curation_api_and_is_allowed(collection, token_info, id_provided=
     collection["collection_url"] = f"{CorporaConfig().collections_base_url}/collections/{collection['id']}"
 
     if datasets := collection.get("datasets"):
+        active_datasets = []
         for i, dataset in enumerate(datasets):
             if dataset.get("tombstone"):
-                datasets.pop(i)  # Remove tombstoned Datasets
-                continue
+                continue  # Remove tombstoned Datasets
+            active_datasets.append(dataset)
             if artifacts := dataset.get("artifacts"):
                 dataset["dataset_assets"] = []
                 for asset in artifacts:
@@ -64,6 +65,7 @@ def reshape_for_curation_api_and_is_allowed(collection, token_info, id_provided=
                         dataset[ontology_element] = [dataset_ontology_element]
                 else:
                     dataset[ontology_element] = []
+        collection["datasets"] = active_datasets
 
     return True
 


### PR DESCRIPTION
- #2978 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- modify algorithm for determining which datasets should be returned. Previous logic had a mistake because it was mutating the list while iterating over it, allowing possibility for datasets to sneak through without being reshaped if tombstoned datasets exist within the collection. cc @brianraymor 

## QA steps (optional)

## Notes for Reviewer
