### PR TITLE
fix: allow partial field updates to Collection metadata

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -98,6 +98,11 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/collection_form_metadata"
+              required:
+                - name
+                - description
+                - contact_name
+                - contact_email
       responses:
         "201":
           description: Created
@@ -743,11 +748,6 @@ components:
     collection_form_metadata:
       type: object
       additionalProperties: false
-      required:
-        - name
-        - description
-        - contact_name
-        - contact_email
       properties:
         name:
           type: string

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
@@ -359,7 +359,7 @@ class TestGetCollectionID(BaseAuthAPITest):
         self.assertEqual("WRITE", res.json["access_type"])
 
 
-class TestPutCollectionID(BaseAuthAPITest):
+class TestPatchCollectionID(BaseAuthAPITest):
     def setUp(self):
         super().setUp()
         self.test_collection = dict(
@@ -407,6 +407,18 @@ class TestPutCollectionID(BaseAuthAPITest):
             headers=self.make_owner_header(),
         )
         self.assertEqual(200, response.status_code)
+
+    def test__update_collection_partial_data__OK(self):
+        collection_id = self.generate_collection(self.session).id
+        metadata = {"name": "A new name, and only a new name"}
+        response = self.app.patch(
+            f"/curation/v1/collections/{collection_id}",
+            data=json.dumps(metadata),
+            headers=self.make_owner_header(),
+        )
+        self.assertEqual(200, response.status_code)
+        response = self.app.get(f"curation/v1/collections/{collection_id}")
+        self.assertEqual(response.json["name"], metadata["name"])
 
     def test__update_collection__Not_Owner(self):
         collection_id = self.generate_collection(self.session, owner="someone else").id


### PR DESCRIPTION
- move 'required' attributes to request body for POST /collections
- add test for partial attribute update for PATCH /collections

- #3010 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
