### PR TITLE
fix(smoke tests): add aws creds to post-deployment smoke tests step, needed to fetch test account creds

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -105,6 +105,24 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.deployment.sha }}
+      - name: Configure AWS Prod Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: github.event.deployment.environment == 'prod'
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_PROD_ROLE_TO_ASSUME }}
+          role-duration-seconds: 2700
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: github.event.deployment.environment != 'prod'
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 2700
       - name: Run Smoke Tests
         working-directory: frontend
         env:


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- re-added aws cred set-up to deployment smoke tests job, to resolve tests failing due to undefined test account secrets to be fetched from AWS

## QA steps (optional)

## Notes for Reviewer
- See failing tests at https://github.com/chanzuckerberg/single-cell-data-portal/runs/7675953815?check_suite_focus=true