### PR TITLE
fix: Curation API - add time zone info to JSON-encoded timestamps

### DIFF
--- a/backend/corpora/common/utils/json.py
+++ b/backend/corpora/common/utils/json.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from json import JSONEncoder
 
@@ -6,13 +6,16 @@ from ..entities.entity import Entity
 from ..corpora_orm import Base
 
 
+time_zone_info = datetime.now(timezone.utc).astimezone().tzinfo  # Get AWS env time zone info
+
+
 class CustomJSONEncoder(JSONEncoder):
     "Add support for serializing DateTime, Enums, and SQLAlchemy Base types into JSON"
 
     def default(self, obj):
-        if isinstance(obj, datetime.timedelta):
+        if isinstance(obj, timedelta):
             return str(obj)
-        elif isinstance(obj, datetime.datetime):
+        elif isinstance(obj, datetime):
             return obj.timestamp()
         elif isinstance(obj, Enum):
             return str(obj.name)
@@ -26,7 +29,7 @@ class CurationJSONEncoder(CustomJSONEncoder):
     "Add support for serializing DateTime into isoformat"
 
     def default(self, obj):
-        if isinstance(obj, datetime.datetime):
-            return obj.isoformat()
+        if isinstance(obj, datetime):
+            return obj.replace(tzinfo=time_zone_info).isoformat()
         else:
             return super().default(obj)

--- a/tests/unit/backend/corpora/common/utils/test_json.py
+++ b/tests/unit/backend/corpora/common/utils/test_json.py
@@ -98,7 +98,8 @@ class TestCustomJSONEncoder(unittest.TestCase):
 class TestCuratorJSONEncoder(unittest.TestCase):
     def test_datetime(self):
         test_datetime_value = datetime.datetime.fromtimestamp(0)
-        expected_datetime = f'"{test_datetime_value.isoformat()}"'
+        # ISO format with UTC time zone; will fail if testing environment time zone is *not* UTC
+        expected_datetime = '"1970-01-01T00:00:00+00:00"'
         self._verify_json_encoding(test_datetime_value, expected_datetime)
 
     def _verify_json_encoding(self, test_value, expected_value):


### PR DESCRIPTION
- Add time zone info to responses.
  - Generally useful
  - Required for 'Expiration' on s3 upload credentials
- Update unit test to test against hardcoded isoformat with tzinfo
- Testing environment must be UTC for unit test to pass (this is good)

- #3051 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 
