### PR TITLE
feat: allow an empty-string doi url to delete an existing doi

### DIFF
--- a/backend/corpora/lambdas/api/v1/curation/collections/collection_id/actions.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/collection_id/actions.py
@@ -87,6 +87,7 @@ def patch(collection_id: str, body: dict, token_info: dict) -> Response:
                 if link["link_type"] != ProjectLinkType.DOI.name:
                     links_no_dois.append(link)
             body["links"] = links_no_dois
+            body["publisher_metadata"] = None
         else:
             # Compute the diff between old and new DOI
             old_doi = collection.get_doi()


### PR DESCRIPTION
https://czi-sci.slack.com/archives/C02UGUV5R3J/p1659994464197199

This would allow deletion of dois if an empty string is passed

Will add test if we decide we want this
