### PR TITLE
fix(collection): 2944 Publish Collection PII cutoff

### DIFF
--- a/frontend/src/components/Collections/components/PublishCollection/components/Policy/components/DirectPersonalIdentifiers/index.tsx
+++ b/frontend/src/components/Collections/components/PublishCollection/components/Policy/components/DirectPersonalIdentifiers/index.tsx
@@ -4,7 +4,7 @@ import {
   PopoverPosition,
 } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
-import { FC } from "react";
+import { FC, useEffect, useRef } from "react";
 import { GRAY } from "src/components/common/theme";
 import {
   BulletWrapper,
@@ -61,8 +61,17 @@ const CATEGORIES = [
 ];
 
 function Content() {
+  const contentWrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (contentWrapperRef.current) {
+      contentWrapperRef.current.scrollTop = 1;
+      contentWrapperRef.current.scrollTop = 0;
+    }
+  });
+
   return (
-    <ContentWrapper>
+    <ContentWrapper ref={contentWrapperRef}>
       <div>
         <FirstSentence>
           <Text>

--- a/frontend/src/components/Collections/components/PublishCollection/components/Policy/components/DirectPersonalIdentifiers/style.ts
+++ b/frontend/src/components/Collections/components/PublishCollection/components/Policy/components/DirectPersonalIdentifiers/style.ts
@@ -6,6 +6,9 @@ export const ContentWrapper = styled.div`
   font-size: 12px;
   width: ${70 * PT_GRID_SIZE_PX}px;
   padding: ${2 * PT_GRID_SIZE_PX}px;
+  /* (thuang): Arbitrary number that works for different vh and zoom levels */
+  height: 50vh;
+  overflow-y: scroll;
 `;
 
 export const FirstSentence = styled.div`


### PR DESCRIPTION
- #2944 

### Reviewers
**Functional:** 
@seve 

**Readability:** 
@hthomas-czi 
---


## Changes
Update PII popover height to be 50vh + scroll overflow, so it works with different zoom levels and viewport heights

## QA steps (optional)
1. Invoke the publish collection modal and hover over the PII target
2. Play with different viewport heights and zoom levels, the content should no longer be cutoff

![demo](https://user-images.githubusercontent.com/6309723/183529562-21f8d314-e41a-45e3-9634-9aa4d6c95f04.gif)


## Notes for Reviewer
