### PR TITLE
fix(GET Collections): Add filter by owner

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -64,6 +64,14 @@ paths:
         - collection
       parameters:
         - $ref: "#/components/parameters/query_visibility"
+        - name: owned
+          description: >-
+            Only show collections owned by the curator.
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: OK

--- a/backend/corpora/lambdas/api/v1/curation/collections/actions.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/actions.py
@@ -1,14 +1,14 @@
 from flask import jsonify, g
 
-from .common import reshape_for_curation_api_and_is_allowed, list_collections_curation
+from .common import reshape_for_curation_api_and_is_allowed, add_collection_level_processing_status
 from .common import EntityColumns
-from ......common.corpora_orm import CollectionVisibility
+from ......common.corpora_orm import CollectionVisibility, DbCollection
 from ......common.utils.http_exceptions import UnauthorizedError
 from backend.corpora.api_server.db import dbconnect
 
 
 @dbconnect
-def get(visibility: str, token_info: dict):
+def get(visibility: str, owned: bool, token_info: dict):
     """
     Collections index endpoint for Curation API. Only return Collection data for which the curator is authorized.
     :param visibility: the CollectionVisibility in string form
@@ -17,10 +17,21 @@ def get(visibility: str, token_info: dict):
     """
     if not token_info and visibility == CollectionVisibility.PRIVATE.name:
         raise UnauthorizedError()
-    collections = list_collections_curation(g.db_session, EntityColumns.columns_for_collections, visibility)
-    allowed_collections = []
-    for collection in collections:
-        if reshape_for_curation_api_and_is_allowed(collection, token_info):
-            allowed_collections.append(collection)
 
-    return jsonify({"collections": allowed_collections})
+    filters = [DbCollection.tombstone == False]  # noqa
+    if visibility == CollectionVisibility.PUBLIC.name:
+        filters.append(DbCollection.visibility == CollectionVisibility.PUBLIC)
+    elif visibility == CollectionVisibility.PRIVATE.name:
+        filters.append(DbCollection.visibility == CollectionVisibility.PRIVATE)
+
+    if token_info and owned:
+        filters.append(DbCollection.owner == token_info["sub"])
+
+    resp_collections = []
+    for collection in g.db_session.query(DbCollection).filter(*filters).all():
+        resp_collection = collection.to_dict_keep(EntityColumns.columns_for_collections)
+        resp_collection["processing_status"] = add_collection_level_processing_status(collection)
+        if reshape_for_curation_api_and_is_allowed(resp_collection, token_info):
+            resp_collections.append(resp_collection)
+
+    return jsonify({"collections": resp_collections})

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
@@ -154,6 +154,20 @@ class TestGetCollections(BaseAuthAPITest):
         self.assertEqual(200, res_public.status_code)
         self.assertEqual(6, len(res_public.json["collections"]))
 
+    def test__get_owned_collections__OK(self):
+        params = {"owned": True}
+        response = self.app.get("/curation/v1/collections", query_string=params, headers=self.make_owner_header())
+        self.assertEqual(200, response.status_code)
+        for col in response.json["collections"]:
+            self.assertEqual("WRITE", col["access_type"])
+
+        # The super curator has no collections they own.
+        response = self.app.get(
+            "/curation/v1/collections", query_string=params, headers=self.make_super_curator_header()
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(0, len(response.json["collections"]))
+
     def test__get_only_public_collections_with_auth__OK(self):
         params = {"visibility": "PUBLIC"}
         res = self.app.get("/curation/v1/collections", query_string=params, headers=self.make_owner_header())


### PR DESCRIPTION
- #2793 

### Reviewers
**Functional:** @danieljhegeman 

**Readability:** 

---


## Changes
- Move list_collections_curation, because it's only used in one place.
- Add query parameter `owned` to get collections to allow filtering collections by the owner. The access token is used to determine the owner.
- Add a test case to only retrieve the collections owned by a user.

## QA steps (optional)

## Notes for Reviewer
- The test leaves something to be desired. Since the owner is not in the collection data returned there is no definitive way to show the collection belongs to the user. Instead, I retrieve all the collections owned by a user and check that they have WRITE permission. In the same test, we retrieve all of the collections owned by the super curator, which should be 0 since the super-curator doesn't own any collection because none were created by the.