### PR TITLE
fix(submission pipe): add upload_failure directory to root of docker …

### DIFF
--- a/Dockerfile.upload_failures
+++ b/Dockerfile.upload_failures
@@ -1,12 +1,10 @@
 FROM public.ecr.aws/lambda/python:3.8
 
-COPY backend/corpora/upload_failures/requirements.txt requirements.txt
+COPY backend/corpora/upload_failure .
 RUN pip3 install -r requirements.txt
 
-COPY backend/corpora/upload_failures ./backend/corpora/upload_failures
 COPY backend/__init__.py ./backend/__init__.py
 COPY backend/corpora/__init__.py ./backend/corpora/__init__.py
-COPY backend/corpora/upload_failures/__init__.py ./backend/corpora/upload_failures/__init__.py
 COPY backend/corpora/common ./backend/corpora/common
 COPY backend/corpora/dataset_processing ./backend/corpora/dataset_processing
 

--- a/backend/corpora/upload_failures/requirements.txt
+++ b/backend/corpora/upload_failures/requirements.txt
@@ -1,7 +1,6 @@
 psycopg2-binary>=2.8.5
 SQLAlchemy>=1.3.17
 requests>=2.22.0
-connexion[swagger-ui]==2.7.0
 pyrsistent
 boto3
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/backend/corpora/upload_success/requirements.txt
+++ b/backend/corpora/upload_success/requirements.txt
@@ -1,7 +1,6 @@
 psycopg2-binary>=2.8.5
 SQLAlchemy>=1.3.17
 requests>=2.22.0
-connexion[swagger-ui]==2.7.0
 pyrsistent
 boto3
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
…image.



- #3092

### Reviewers
**Functional:** @MDunitz  

**Readability:** @danieljhegeman 

---


## Changes
- add the upload_failure directory to the root of the docker image. The upload_failure handler was failing because it couldn't find `app`. This was because `app` was put in the wrong place during docker image location.
- remove extra requirements from the submission handlers. This will shrink the size of the docker image, speed up build time, and reduce the cost of lambda execution.

## QA steps (optional)

## Notes for Reviewer
