### PR TITLE
fix(curation api): fix error returned when a revision already exists

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -253,8 +253,8 @@ paths:
                     $ref: "#/components/schemas/collection_id"
         "401":
           $ref: "#/components/responses/401"
-        "409":
-          $ref: "#/components/responses/409"
+        "403":
+          $ref: "#/components/responses/403"
 
   /v1/collections/{collection_id}/datasets:
     delete:

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -19,7 +19,7 @@ from ....common.entities import Collection
 from .authorization import is_user_owner_or_allowed, owner_or_allowed
 from ....common.utils.http_exceptions import (
     InvalidParametersHTTPException,
-    ConflictException,
+    ForbiddenHTTPException,
 )
 from ....api_server.db import dbconnect
 
@@ -118,9 +118,9 @@ def post_collection_revision_common(collection_id: str, token_info: dict):
     )
     try:
         collection_revision = collection.create_revision()
-    except sqlalchemy.exc.IntegrityError as ex:
+    except sqlalchemy.exc.IntegrityError:
         db_session.rollback()
-        raise ConflictException() from ex
+        raise ForbiddenHTTPException("A revision is already in progess.")
     return collection_revision
 
 

--- a/tests/unit/backend/corpora/api_server/test_revisions.py
+++ b/tests/unit/backend/corpora/api_server/test_revisions.py
@@ -180,7 +180,7 @@ class TestRevision(BaseRevisionTest):
         self.assertEqual("WRITE", res_get_json.pop("access_type"))
         self.verify_unauthed_get_revision(revision_id, res_get_json)
 
-    def test__revision__409(self):
+    def test__revision__403(self):
         """Starting a revision on a revision."""
         collection = self.generate_collection(self.session, visibility=CollectionVisibility.PUBLIC)
         test_url = f"/dp/v1/collections/{collection.id}"
@@ -191,7 +191,7 @@ class TestRevision(BaseRevisionTest):
 
         # Try to start a revision again
         response = self.app.post(test_url, headers=self.headers)
-        self.assertEqual(409, response.status_code)
+        self.assertEqual(403, response.status_code)
 
     def test__revision_nonexistent__403(self):
         """Start a revision on a non-existing collection."""


### PR DESCRIPTION
- #3116 

### Reviewers
**Functional:** @danieljhegeman 

**Readability:** @nayib-jose-gloria 

---


## Changes
- modify the error message returned when a revision already exists.

## QA steps (optional)

## Notes for Reviewer
