### PR TITLE
fix(curation api): If fields are included they cannot be blank for required fields

### DIFF
--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -200,22 +200,22 @@ def verify_collection_links(body: dict, errors: list) -> None:
 
 
 def verify_collection_body(body: dict, errors: list) -> None:
-    def _check_if_blank(key) -> bool:
+    def check_if_blank(key) -> bool:
         if key in body.keys():
             if not body[key]:
                 errors.append({"name": key, "reason": "Cannot be blank."})
             else:
                 return body[key]
 
-    contact_email = _check_if_blank("contact_email")
+    contact_email = check_if_blank("contact_email")
     if contact_email:
         result = email_regex.match(contact_email)
         if not result:
             errors.append({"name": "contact_email", "reason": "Invalid format."})
 
-    _check_if_blank("description")
-    _check_if_blank("name")
-    _check_if_blank("contact_name")
+    check_if_blank("description")
+    check_if_blank("name")
+    check_if_blank("contact_name")
 
     verify_collection_links(body, errors)
 

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -199,19 +199,23 @@ def verify_collection_links(body: dict, errors: list) -> None:
             errors.append(_error_message(index, url))
 
 
-def verify_collection_body(body: dict, errors: list, allow_none: bool = False) -> None:
-    result = email_regex.match(body.get("contact_email", ""))
-    if not result and not allow_none:
-        errors.append({"name": "contact_email", "reason": "Invalid format."})
+def verify_collection_body(body: dict, errors: list) -> None:
+    def _check_if_blank(key) -> bool:
+        if key in body.keys():
+            if not body[key]:
+                errors.append({"name": key, "reason": "Cannot be blank."})
+            else:
+                return body[key]
 
-    if not body.get("description") and not allow_none:  # Check if description is None or 0 length
-        errors.append({"name": "description", "reason": "Cannot be blank."})
+    contact_email = _check_if_blank("contact_email")
+    if contact_email:
+        result = email_regex.match(contact_email)
+        if not result:
+            errors.append({"name": "contact_email", "reason": "Invalid format."})
 
-    if not body.get("name") and not allow_none:  # Check if name is None or 0 length
-        errors.append({"name": "name", "reason": "Cannot be blank."})
-
-    if not body.get("contact_name") and not allow_none:  # Check if contact_name is None or 0 length
-        errors.append({"name": "contact_name", "reason": "Cannot be blank."})
+    _check_if_blank("description")
+    _check_if_blank("name")
+    _check_if_blank("contact_name")
 
     verify_collection_links(body, errors)
 
@@ -288,7 +292,7 @@ def update_collection(collection_id: str, body: dict, token_info: dict):
 
 def get_collection_and_verify_body(db_session: Session, collection_id: str, body: dict, token_info: dict):
     errors = []
-    verify_collection_body(body, errors, allow_none=True)
+    verify_collection_body(body, errors)
     collection = get_collection_else_forbidden(
         db_session,
         collection_id,

--- a/backend/corpora/lambdas/api/v1/curation/collections/collection_id/actions.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/collection_id/actions.py
@@ -63,12 +63,6 @@ def patch(collection_id: str, body: dict, token_info: dict) -> Response:
         keep_links = False  # links have been provided; replace all old links
 
     try:
-        collection = get_collection_else_forbidden(
-            db_session,
-            collection_id,
-            visibility=CollectionVisibility.PRIVATE.name,
-            owner=owner_or_allowed(token_info),
-        )
         collection, errors = get_collection_and_verify_body(db_session, collection_id, body, token_info)
     except ForbiddenHTTPException as err:
         # If the Collection is public, the get_collection_and_verify_body method throws empty ForbiddenHTTPException

--- a/backend/corpora/lambdas/api/v1/curation/collections/collection_id/actions.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/collection_id/actions.py
@@ -63,6 +63,12 @@ def patch(collection_id: str, body: dict, token_info: dict) -> Response:
         keep_links = False  # links have been provided; replace all old links
 
     try:
+        collection = get_collection_else_forbidden(
+            db_session,
+            collection_id,
+            visibility=CollectionVisibility.PRIVATE.name,
+            owner=owner_or_allowed(token_info),
+        )
         collection, errors = get_collection_and_verify_body(db_session, collection_id, body, token_info)
     except ForbiddenHTTPException as err:
         # If the Collection is public, the get_collection_and_verify_body method throws empty ForbiddenHTTPException

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
@@ -556,6 +556,19 @@ class TestPatchCollectionID(BaseAuthAPITest):
         self.assertEqual(links, response.json["links"])
         self.assertEqual(publisher_metadata, response.json["publisher_metadata"])
 
+    def test_update_collection_with_empty_required_fields(self):
+        tests = [dict(description=""), dict(contact_name=""), dict(contact_email=""), dict(name="")]
+
+        collection_id = self.generate_collection(self.session).id
+        for test in tests:
+            with self.subTest(test):
+                response = self.app.patch(
+                    f"/curation/v1/collections/{collection_id}",
+                    data=json.dumps(test),
+                    headers=self.make_owner_header(),
+                )
+                self.assertEqual(400, response.status_code)
+
     def test__update_collection__links_and_doi_management__OK(self):
         name = "partial updates test collection"
         links = [

--- a/tests/unit/backend/corpora/api_server/test_v1_collection.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_collection.py
@@ -1333,27 +1333,28 @@ class TestCollectionsCurators:
 
 
 class TestVerifyCollection(unittest.TestCase):
-    def test_blank_body(self):
+    def test_empty_body(self):
         body = dict()
-        with self.subTest("allow_none=False"):
-            errors = []
-            verify_collection_body(body, errors)
-            self.assertIn({"name": "description", "reason": "Cannot be blank."}, errors)
-            self.assertIn({"name": "name", "reason": "Cannot be blank."}, errors)
-            self.assertIn({"name": "contact_name", "reason": "Cannot be blank."}, errors)
-            self.assertIn({"name": "contact_email", "reason": "Invalid format."}, errors)
-        with self.subTest("allow_none:True"):
-            errors = []
-            verify_collection_body(body, errors, allow_none=True)
-            self.assertFalse(errors)
+        errors = []
+        verify_collection_body(body, errors)
+        self.assertFalse(errors)
+
+    def test_blank_fields(self):
+        errors = []
+        body = dict(name="", contact_name="", description="", contact_email="")
+        verify_collection_body(body, errors)
+        self.assertIn({"name": "description", "reason": "Cannot be blank."}, errors)
+        self.assertIn({"name": "name", "reason": "Cannot be blank."}, errors)
+        self.assertIn({"name": "contact_name", "reason": "Cannot be blank."}, errors)
+        self.assertIn({"name": "contact_email", "reason": "Cannot be blank."}, errors)
 
     def test_invalid_email(self):
-        bad_emails = ["@.", "", "email@.", "@place.com", "email@.com", "email@place."]
-        body = dict(name="something", contact_name="a name", description="description")
+        bad_emails = ["@.", "email@.", "@place.com", "email@.com", "email@place."]
+        body = dict()
 
         for email in bad_emails:
             with self.subTest(email):
-                body["contect_email"] = email
+                body["contact_email"] = email
                 errors = []
                 verify_collection_body(body, errors)
                 self.assertEqual([{"name": "contact_email", "reason": "Invalid format."}], errors)
@@ -1374,7 +1375,7 @@ class TestVerifyCollection(unittest.TestCase):
                 with self.subTest(link_body):
                     errors = []
                     body = dict(links=link_body)
-                    verify_collection_body(body, errors, allow_none=True)
+                    verify_collection_body(body, errors)
                     expected_error = [dict(reason="Invalid URL.", name="links[0]", value=link_body[0]["link_url"])]
                     self.assertEqual(expected_error, errors)
 
@@ -1388,5 +1389,5 @@ class TestVerifyCollection(unittest.TestCase):
                 with self.subTest(link_body):
                     errors = []
                     body = dict(links=link_body)
-                    verify_collection_body(body, errors, allow_none=True)
+                    verify_collection_body(body, errors)
                     self.assertFalse(errors)


### PR DESCRIPTION
- #3118

### Reviewers
**Functional:** @danieljhegeman 

**Readability:** @nayib-jose-gloria 

---


## Changes

- modify the code that verifies the collection body. Required fields cannot be blank, but they can be missing from the response body.

## QA steps (optional)

## Notes for Reviewer
