### PR TITLE
chore: upgrade to anndata 0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic
-anndata==0.7.6
+anndata==0.8.0
 black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
 boto3>=1.11.17
 botocore>=1.14.17


### PR DESCRIPTION
This is likely used by tests (since the dependency is transitively pulled in by the validator), but we should update it regardless.