### PR TITLE
fix: x_approximate_distribution can be None

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -734,7 +734,7 @@ components:
               type: boolean
             x_approximate_distribution:
               "$ref": "#/components/schemas/distribution"
-            X_normalization:
+            x_normalization:
               nullable: true
               type: string
           type: object

--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -780,6 +780,7 @@ components:
         - COUNT
         - NORMAL
       type: string
+      nullable: true
     explorer_url:
       description:
         The url at which a given Dataset may be explored using the cellxgene

--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -734,7 +734,7 @@ components:
               type: boolean
             x_approximate_distribution:
               "$ref": "#/components/schemas/distribution"
-            x_normalization:
+            X_normalization:
               nullable: true
               type: string
           type: object

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
@@ -502,6 +502,13 @@ class TestGetCollectionID(BaseAuthAPITest):
         self.assertEqual("test_collection_id_revision", res.json["id"])
         self.assertEqual("WRITE", res.json["access_type"])
 
+    def test__get_collectoin_with_x_approximate_distribution_none__OK(self):
+        collection = self.generate_collection(self.session)
+        self.generate_dataset(self.session, x_approximate_distribution=None, collection=collection)
+        res = self.app.get(f"/curation/v1/collections/{collection.id}", headers=self.make_owner_header())
+        self.assertEqual(200, res.status_code)
+        self.assertIsNone(res.json["datasets"][0]["x_approximate_distribution"])
+
 
 class TestPatchCollectionID(BaseAuthAPITest):
     def setUp(self):


### PR DESCRIPTION
- #2983 
- #3162

### Reviewers
**Functional:** @atarashansky 

**Readability:** @danieljhegeman 

---


## Changes
- modify allow x_approximate_distribution to be None. If the field is not provided by the user, we want to return it as None in the API request. 

