### PR TITLE
feat: Add extra dimension to integrated corpus, summary cubes, and snapshot of scExpression

### DIFF
--- a/backend/corpus_asset_pipelines/integrated_corpus/job.py
+++ b/backend/corpus_asset_pipelines/integrated_corpus/job.py
@@ -8,7 +8,7 @@ import tiledb
 from backend.corpus_asset_pipelines.integrated_corpus import extract
 from backend.corpus_asset_pipelines.integrated_corpus import load
 from backend.corpus_asset_pipelines.integrated_corpus.transform import (
-    apply_pre_concatenation_filters,
+    apply_pre_concatenation_filters, create_high_level_tissue,
 )
 from backend.corpus_asset_pipelines.integrated_corpus.validate import should_load_dataset, validate_dataset_properties
 from backend.wmg.data.schemas.corpus_schema import INTEGRATED_ARRAY_NAME, OBS_ARRAY_NAME, VAR_ARRAY_NAME
@@ -71,6 +71,7 @@ def process_h5ad_for_corpus(h5ad_path: str, corpus_path: str):
 
     # transform
     apply_pre_concatenation_filters(anndata_object)
+    create_high_level_tissue(anndata_object)
     logger.info(f"loaded: shape={anndata_object.shape}")
     if not validate_dataset_properties(anndata_object):
         return

--- a/backend/corpus_asset_pipelines/integrated_corpus/transform.py
+++ b/backend/corpus_asset_pipelines/integrated_corpus/transform.py
@@ -5,6 +5,7 @@ import time
 import anndata
 import numpy
 import numpy as np
+from pandas import DataFrame
 import scanpy
 import tiledb
 from scipy import sparse
@@ -35,6 +36,32 @@ def apply_pre_concatenation_filters(
         anndata_object.obs["assay_ontology_term_id"].isin(included_assay_ontology_ids), :
     ].copy()
     return anndata_object
+
+
+def create_high_level_tissue(anndata_object: anndata.AnnData):
+    anndata_object.obs["tissue_original"] = anndata_object.obs["tissue"]
+    anndata_object.obs["tissue_original_ontology_term_id"] = anndata_object.obs["tissue_ontology_term_id"]
+    anndata_object.obs = get_high_level_tissue(anndata_object.obs)
+
+
+# TODO finalize this function
+def get_high_level_tissue(obs: DataFrame):
+
+    for i in range(len(obs)):
+
+        if "lung" in obs["tissue"][i]:
+            if "UBERON:0002048" not in obs["tissue_ontology_term_id"].cat.categories:
+                obs["tissue_ontology_term_id"].cat.add_categories("UBERON:0002048", inplace=True)
+                obs["tissue"].cat.add_categories("lung", inplace=True)
+
+            obs["tissue_ontology_term_id"][i] = "UBERON:0002048"
+            obs["tissue"][i] = "lung"
+            continue
+
+        obs["tissue_ontology_term_id"][i] = obs["tissue_original_ontology_term_id"][i]
+        obs["tissue"][i] = obs["tissue_original"][i]
+
+    return obs
 
 
 def transform_dataset_raw_counts_to_rankit(

--- a/backend/corpus_asset_pipelines/summary_cubes/cell_count.py
+++ b/backend/corpus_asset_pipelines/summary_cubes/cell_count.py
@@ -31,6 +31,7 @@ def transform(obs: pd.DataFrame) -> pd.DataFrame:
                 "dataset_id",
                 "cell_type_ontology_term_id",
                 "tissue_ontology_term_id",
+                "tissue_original_ontology_term_id",
                 "assay_ontology_term_id",
                 "development_stage_ontology_term_id",
                 "disease_ontology_term_id",

--- a/backend/corpus_asset_pipelines/summary_cubes/expression_summary/load.py
+++ b/backend/corpus_asset_pipelines/summary_cubes/expression_summary/load.py
@@ -26,6 +26,7 @@ def build_in_mem_cube(
         np.empty((total_vals,), dtype=object),
         np.empty((total_vals,), dtype=object),
         np.empty((total_vals,), dtype=object),
+        np.empty((total_vals,), dtype=object),
     ]
     vals = {
         "sum": np.empty((total_vals,)),
@@ -40,6 +41,7 @@ def build_in_mem_cube(
     for grp in cube_index.to_records():
         (
             tissue_ontology_term_id,
+            tissue_original_ontology_term_id,
             organism_ontology_term_id,
             *attr_values,
             n,
@@ -54,7 +56,8 @@ def build_in_mem_cube(
 
         dims[0][idx : idx + n_vals] = gene_ids.gene_ontology_term_id.values[mask]
         dims[1][idx : idx + n_vals] = tissue_ontology_term_id
-        dims[2][idx : idx + n_vals] = organism_ontology_term_id
+        dims[2][idx : idx + n_vals] = tissue_original_ontology_term_id
+        dims[3][idx : idx + n_vals] = organism_ontology_term_id
 
         vals["sum"][idx : idx + n_vals] = cube_sum[cube_idx, mask]
         vals["nnz"][idx : idx + n_vals] = cube_nnz[cube_idx, mask]

--- a/backend/wmg/data/query.py
+++ b/backend/wmg/data/query.py
@@ -7,8 +7,6 @@ from tiledb import Array
 
 from backend.wmg.data.snapshot import WmgSnapshot
 
-# ASK madison if there's a better way to do this
-INDEXED_DIMENSIONS_TO_IGNORE = ["tissue_original_ontology_term_ids"]
 
 class WmgQueryCriteria(BaseModel):
     gene_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=1)

--- a/backend/wmg/data/query.py
+++ b/backend/wmg/data/query.py
@@ -7,13 +7,14 @@ from tiledb import Array
 
 from backend.wmg.data.snapshot import WmgSnapshot
 
-EMPTY_DIM_VALUES = ""
-
+# ASK madison if there's a better way to do this
+INDEXED_DIMENSIONS_TO_IGNORE = ["tissue_original_ontology_term_ids"]
 
 class WmgQueryCriteria(BaseModel):
     gene_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=1)
     organism_ontology_term_id: str  # required!
     tissue_ontology_term_ids: List[str] = Field(unique_items=True, min_items=1)  # required!
+    tissue_original_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
     dataset_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
     # excluded per product requirements, but keeping in, commented-out, to reduce future head-scratching
     # assay_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
@@ -32,14 +33,15 @@ class WmgQuery:
         return self._query(
             cube=self._snapshot.expression_summary_cube,
             criteria=criteria,
-            indexed_dims=["gene_ontology_term_ids", "tissue_ontology_term_ids", "organism_ontology_term_id"],
+            indexed_dims=["gene_ontology_term_ids", "tissue_ontology_term_ids", "tissue_original_ontology_term_ids",
+                          "organism_ontology_term_id"],
         )
 
     def cell_counts(self, criteria: WmgQueryCriteria) -> DataFrame:
         cell_counts = self._query(
             self._snapshot.cell_counts_cube,
             criteria.copy(exclude={"gene_ontology_term_ids"}),
-            indexed_dims=["tissue_ontology_term_ids", "organism_ontology_term_id"],
+            indexed_dims=["tissue_ontology_term_ids", "tissue_original_ontology_term_ids", "organism_ontology_term_id"],
         )
         cell_counts.rename(columns={"n_cells": "n_total_cells"}, inplace=True)  # expressed & non-expressed cells
         return cell_counts
@@ -63,7 +65,18 @@ class WmgQuery:
 
         attr_cond = tiledb.QueryCondition(query_cond) if query_cond else None
 
-        tiledb_dims_query = tuple([criteria.dict()[dim_name] or EMPTY_DIM_VALUES for dim_name in indexed_dims])
+        tiledb_dims_query = []
+        for dim_name in indexed_dims:
+            # Don't filter on this dimension but return all "original tissues" back
+            if dim_name == "tissue_original_ontology_term_ids":
+                tiledb_dims_query.append([])
+            elif criteria.dict()[dim_name]:
+                tiledb_dims_query.append(criteria.dict()[dim_name])
+            # If an "indexed" dimension is not included in the criteria, this will return an empty data frame
+            else:
+                tiledb_dims_query.append("")
+
+        tiledb_dims_query = tuple(tiledb_dims_query)
 
         # FIXME: HACK of the century. Prevent realloc() error & crash when query returns an empty result. This forces
         #  two queries when there should just one.

--- a/backend/wmg/data/schemas/corpus_schema.py
+++ b/backend/wmg/data/schemas/corpus_schema.py
@@ -69,6 +69,7 @@ obs_labels = [
         for key in [
             "cell_type_ontology_term_id",
             "tissue_ontology_term_id",
+            "tissue_original_ontology_term_id",
         ]
     ],
     *[
@@ -81,6 +82,7 @@ obs_labels = [
             "development_stage_ontology_term_id",
             "disease_ontology_term_id",
             "tissue",
+            "tissue_original",
             "ethnicity",
             "ethnicity_ontology_term_id",
             "sex",

--- a/backend/wmg/data/schemas/cube_schema.py
+++ b/backend/wmg/data/schemas/cube_schema.py
@@ -7,11 +7,13 @@ import tiledb
 cube_indexed_dims = [
     "gene_ontology_term_id",
     "tissue_ontology_term_id",
+    "tissue_original_ontology_term_id",
     "organism_ontology_term_id",
 ]
 
 cube_indexed_dims_no_gene_ontology = [
     "tissue_ontology_term_id",
+    "tissue_original_ontology_term_id",
     "organism_ontology_term_id",
 ]
 
@@ -71,6 +73,7 @@ expression_summary_schema = tiledb.ArraySchema(
 
 cell_counts_indexed_dims = [
     "tissue_ontology_term_id",
+    "tissue_original_ontology_term_id",
     "organism_ontology_term_id",
 ]
 cell_counts_non_indexed_dims = cube_non_indexed_dims

--- a/backend/wmg/data/validation/validation.py
+++ b/backend/wmg/data/validation/validation.py
@@ -132,14 +132,14 @@ class Validation:
     def validate_housekeeping_gene_expression_levels(self, path_to_cell_count_cube):
         with tiledb.open(path_to_cell_count_cube, "r") as cell_count_cube:
             human_ontology_id = fixtures.validation_species_ontologies["human"]
-            cell_count_human = cell_count_cube.df[:, human_ontology_id:human_ontology_id].n_cells.sum()
+            cell_count_human = cell_count_cube.df[:, :, human_ontology_id:human_ontology_id].n_cells.sum()
             with tiledb.open(self.expression_summary_path) as cube:
                 MALAT1_ont_id = fixtures.validation_gene_ontologies["MALAT1"]
                 MALAT1_human_expression_cube = cube.df[
-                    MALAT1_ont_id:MALAT1_ont_id, :, human_ontology_id:human_ontology_id
+                    MALAT1_ont_id:MALAT1_ont_id, :, :, human_ontology_id:human_ontology_id
                 ]
                 ACTB_ont_id = fixtures.validation_gene_ontologies["ACTB"]
-                ACTB_human_expression_cube = cube.df[ACTB_ont_id:ACTB_ont_id, :, human_ontology_id:human_ontology_id]
+                ACTB_human_expression_cube = cube.df[ACTB_ont_id:ACTB_ont_id, :, :, human_ontology_id:human_ontology_id]
                 MALAT1_cell_count = MALAT1_human_expression_cube.nnz.sum()
                 ACTB_cell_count = ACTB_human_expression_cube.nnz.sum()
                 # Most cells should express both genes, more cells should express MALAT1
@@ -168,10 +168,10 @@ class Validation:
             female_ontology_id = fixtures.validation_sex_ontologies["female"]
             male_ontology_id = fixtures.validation_sex_ontologies["male"]
             MALAT1_ont_id = fixtures.validation_gene_ontologies["MALAT1"]
-            human_malat1_cube = cube.df[MALAT1_ont_id:MALAT1_ont_id, :, human_ontology_id:human_ontology_id]
+            human_malat1_cube = cube.df[MALAT1_ont_id:MALAT1_ont_id, :, :, human_ontology_id:human_ontology_id]
             # slice cube by dimensions             gene_ontology      organ (all)          species
             human_XIST_cube = cube.df[
-                sex_marker_gene_ontology_id:sex_marker_gene_ontology_id, :, human_ontology_id:human_ontology_id
+                sex_marker_gene_ontology_id:sex_marker_gene_ontology_id, :, :, human_ontology_id:human_ontology_id
             ]
 
             female_xist_cube = human_XIST_cube.query(f"sex_ontology_term_id == '{female_ontology_id}'")
@@ -213,19 +213,19 @@ class Validation:
         # other cell types
         with tiledb.open(self.expression_summary_path) as cube:
             FCN1_ont_id = fixtures.validation_gene_ontologies["FCN1"]
-            FCN1_human_lung_cube = cube.df[FCN1_ont_id:FCN1_ont_id, lung_ont_id:lung_ont_id, human_ont_id:human_ont_id]
+            FCN1_human_lung_cube = cube.df[FCN1_ont_id:FCN1_ont_id, lung_ont_id:lung_ont_id, :, human_ont_id:human_ont_id]
             self.validate_FCN1(FCN1_human_lung_cube)
 
             TUBB4B_ont_id = fixtures.validation_gene_ontologies["TUBB4B"]
-            TUBB4B_human_lung = cube.df[TUBB4B_ont_id:TUBB4B_ont_id, lung_ont_id:lung_ont_id, human_ont_id:human_ont_id]
+            TUBB4B_human_lung = cube.df[TUBB4B_ont_id:TUBB4B_ont_id, lung_ont_id:lung_ont_id, :, human_ont_id:human_ont_id]
             self.validate_TUBB4B(TUBB4B_human_lung)
 
             CD68_ont_id = fixtures.validation_gene_ontologies["CD68"]
-            CD68_human_lung = cube.df[CD68_ont_id:CD68_ont_id, lung_ont_id:lung_ont_id, human_ont_id:human_ont_id]
+            CD68_human_lung = cube.df[CD68_ont_id:CD68_ont_id, lung_ont_id:lung_ont_id, :, human_ont_id:human_ont_id]
             self.validate_CD68(CD68_human_lung)
 
             AQP5_ont_id = fixtures.validation_gene_ontologies["AQP5"]
-            AQP5_human_lung = cube.df[AQP5_ont_id:AQP5_ont_id, lung_ont_id:lung_ont_id, human_ont_id:human_ont_id]
+            AQP5_human_lung = cube.df[AQP5_ont_id:AQP5_ont_id, lung_ont_id:lung_ont_id, :, human_ont_id:human_ont_id]
             self.validate_AQP5(AQP5_human_lung)
 
     def validate_FCN1(self, FCN1_human_lung_cube):
@@ -328,10 +328,10 @@ class Validation:
         CCL5_ont_id = fixtures.validation_gene_ontologies["CCL5"]
         with tiledb.open(self.expression_summary_path) as cube:
             MALAT1_human_lung_cube = cube.df[
-                MALAT1_ont_id:MALAT1_ont_id, human_lung_int:human_lung_int, human_ont_id:human_ont_id
+                MALAT1_ont_id:MALAT1_ont_id, human_lung_int:human_lung_int, :, human_ont_id:human_ont_id
             ]
             CCL5_human_lung_cube = cube.df[
-                CCL5_ont_id:CCL5_ont_id, human_lung_int:human_lung_int, human_ont_id:human_ont_id
+                CCL5_ont_id:CCL5_ont_id, human_lung_int:human_lung_int, :, human_ont_id:human_ont_id
             ]
 
             MALAT1_expression = MALAT1_human_lung_cube.query(f"dataset_id == '{self.validation_dataset_id}'")

--- a/tests/unit/backend/wmg/fixtures/test_snapshot.py
+++ b/tests/unit/backend/wmg/fixtures/test_snapshot.py
@@ -55,6 +55,8 @@ def semi_real_dimension_values_generator(dimension_name: str, dim_size: int) -> 
         return list(sorted(ontology_labels.gene_term_id_labels.keys()))[:dim_size]
     if dimension_name == "tissue_ontology_term_id":
         return [term_id for term_id in deterministic_term_ids if term_id.startswith("UBERON")][:dim_size]
+    if dimension_name == "tissue_original_ontology_term_id":
+        return [term_id for term_id in deterministic_term_ids if term_id.startswith("UBERON")][:dim_size]
     if dimension_name == "organism_ontology_term_id":
         return [term_id for term_id in deterministic_term_ids if term_id.startswith("NCBITaxon")][:dim_size]
     if dimension_name == "cell_type_ontology_term_id":

--- a/tests/unit/backend/wmg/test_query.py
+++ b/tests/unit/backend/wmg/test_query.py
@@ -11,6 +11,8 @@ from tests.unit.backend.wmg.fixtures.test_snapshot import (
     all_X_cell_counts_values,
 )
 
+ALL_INDEXED_DIMS_FOR_QUERY = ["gene_ontology_term_ids", "tissue_ontology_term_ids",
+                              "tissue_original_ontology_term_ids", "organism_ontology_term_id"]
 
 # TODO: Test build_* methods separately in test_v1.py.  This package's unit tests need only test the raw results of
 #  WmgQuery methods
@@ -61,39 +63,47 @@ class QueryTest(unittest.TestCase):
         # sanity check the expected value of the stats (n_cells, nnz, sum) for each data viz point; if this fails, the
         # cube test fixture may have changed (e.g. TileDB Array schema) or the logic for creating the test cube fixture
         # has changed
-        expected_cell_count_per_cell_type = dim_size ** (len(cube_non_indexed_dims) - 1)
-        assert expected_cell_count_per_cell_type == 729
+        not_used_cube_indexed_dims = [0 if criteria.dict()[dim_name] else 1 for dim_name in ALL_INDEXED_DIMS_FOR_QUERY]
+
+        expected_cell_count_per_cell_type = dim_size ** (len(cube_non_indexed_dims) +
+                                                         sum(not_used_cube_indexed_dims) - 1)
+
+        expected_cell_count_per_tissue = 10 * (dim_size ** (len(cube_non_indexed_dims) +
+                                                            sum(not_used_cube_indexed_dims)))
+
+        assert expected_cell_count_per_cell_type == 2187
+        assert expected_cell_count_per_tissue == 65610
 
         expected = [
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_2",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_2",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_2",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0
             },
         ]
 
@@ -128,132 +138,133 @@ class QueryTest(unittest.TestCase):
         # sanity check the expected value of the stats (n_cells, nnz, sum) for each data viz point; if this fails, the
         # cube test fixture may have changed (e.g. TileDB Array schema) or the logic for creating the test cube fixture
         # has changed
-        expected_cell_count_per_cell_type = dim_size ** (len(cube_non_indexed_dims) - 1)
-        assert expected_cell_count_per_cell_type == 729
+        not_used_cube_indexed_dims = [0 if criteria.dict()[dim_name] else 1 for dim_name in ALL_INDEXED_DIMS_FOR_QUERY]
+        expected_cell_count_per_cell_type = dim_size ** (len(cube_non_indexed_dims) - 1 + 1)
+        expected_cell_count_per_tissue = 10 * (dim_size ** (len(cube_non_indexed_dims) + sum(not_used_cube_indexed_dims)))
 
-        expected_cell_count_per_tissue = 10 * (dim_size ** len(cube_non_indexed_dims))
-        assert expected_cell_count_per_tissue == 21870
+        assert expected_cell_count_per_cell_type == 2187
+        assert expected_cell_count_per_tissue == 65610
 
         expected = [
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_1",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_1",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_1",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_2",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_2",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_2",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_2",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_1",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_2",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_1",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_2",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_1",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_2",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_2",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_2",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_2",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_2",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_2",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
-                "n_cells": 729,
-                "n_cells_cell_type": 7290,
-                "n_cells_tissue": 21870,
-                "nnz": 729,
-                "sum": 729.0,
+                "n_cells": 2187,
+                "n_cells_cell_type": 21870,
+                "n_cells_tissue": 65610,
+                "nnz": 2187,
+                "sum": 2187.0,
             },
         ]
 
@@ -290,13 +301,15 @@ class QueryTest(unittest.TestCase):
             query = WmgQuery(snapshot)
             result = agg_cell_type_counts(query.cell_counts(criteria))
 
-        expected_n_combinations = dim_size ** (len(cube_non_indexed_dims) - 1)
-        assert expected_n_combinations == 729
+        not_used_cube_indexed_dims = [0 if criteria.dict()[dim_name] else 1 for dim_name in ALL_INDEXED_DIMS_FOR_QUERY]
+        expected_n_combinations = dim_size ** (len(cube_non_indexed_dims) + sum(not_used_cube_indexed_dims) - 1)
+
+        assert expected_n_combinations == 2187
 
         # after aggregating, we will get three tissues, and three cell types per tissue,
         # with 729 * expected_count total cells
         expected = (
-            [{"n_cells_cell_type": expected_n_combinations * expected_count}]
+            [{"n_cells_cell_type": 2187 * expected_count}]
             * len(criteria.tissue_ontology_term_ids)
             * dim_size
         )
@@ -324,12 +337,14 @@ class QueryTest(unittest.TestCase):
             query = WmgQuery(snapshot)
             result = agg_tissue_counts(query.cell_counts(criteria))
 
-        expected_n_combinations = dim_size ** (len(cube_non_indexed_dims) - 1)
-        assert expected_n_combinations == 729
+        not_used_cube_indexed_dims = [0 if criteria.dict()[dim_name] else 1 for dim_name in ALL_INDEXED_DIMS_FOR_QUERY]
+        expected_n_combinations = dim_size ** (len(cube_non_indexed_dims) + sum(not_used_cube_indexed_dims) - 1)
+
+        assert expected_n_combinations == 2187
 
         # after aggregating, we will get three tissues,
         # with 729 * expected_count * (# cell types per tissue = 3) total cells
-        expected = [{"n_cells_tissue": expected_n_combinations * expected_count * dim_size}] * len(
+        expected = [{"n_cells_tissue": 2187 * expected_count * dim_size}] * len(
             criteria.tissue_ontology_term_ids
         )
         self.assertEqual(expected, result.to_dict("records"))
@@ -359,42 +374,46 @@ class QueryTest(unittest.TestCase):
         # sanity check the expected value of the stats (n_cells, nnz, sum) for each data viz point; if this fails, the
         # cube test fixture may have changed (e.g. TileDB Array schema) or the logic for creating the test cube fixture
         # has changed
-        expected_cell_count_per_cell_type = dim_size ** (len(cube_non_indexed_dims) - 2)
-        assert expected_cell_count_per_cell_type == 243
 
-        expected_cell_count_per_tissue = 10 * (dim_size ** (len(cube_non_indexed_dims) - 1))
-        assert expected_cell_count_per_tissue == 7290
+        not_used_cube_indexed_dims = [0 if criteria.dict()[dim_name] else 1 for dim_name in ALL_INDEXED_DIMS_FOR_QUERY]
+        expected_cell_count_per_cell_type = dim_size ** (len(cube_non_indexed_dims) - 2 +
+                                                         sum(not_used_cube_indexed_dims))
+        expected_cell_count_per_tissue = 10 * (dim_size ** (len(cube_non_indexed_dims) - 1 +
+                                                            sum(not_used_cube_indexed_dims)))
+
+        assert expected_cell_count_per_cell_type == 729
+        assert expected_cell_count_per_tissue == 21870
 
         expected = [
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_0",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
-                "n_cells": 243,
-                "n_cells_cell_type": 2430,
-                "n_cells_tissue": 7290,
-                "nnz": 243,
-                "sum": 243.0,
+                "n_cells": 729,
+                "n_cells_cell_type": 7290,
+                "n_cells_tissue": 21870,
+                "nnz": 729,
+                "sum": 729.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_0",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
-                "n_cells": 243,
-                "n_cells_cell_type": 2430,
-                "n_cells_tissue": 7290,
-                "nnz": 243,
-                "sum": 243.0,
+                "n_cells": 729,
+                "n_cells_cell_type": 7290,
+                "n_cells_tissue": 21870,
+                "nnz": 729,
+                "sum": 729.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_0",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
-                "n_cells": 243,
-                "n_cells_cell_type": 2430,
-                "n_cells_tissue": 7290,
-                "nnz": 243,
-                "sum": 243.0,
+                "n_cells": 729,
+                "n_cells_cell_type": 7290,
+                "n_cells_tissue": 21870,
+                "nnz": 729,
+                "sum": 729.0,
             },
         ]
 
@@ -430,42 +449,46 @@ class QueryTest(unittest.TestCase):
         # sanity check the expected value of the stats (n_cells, nnz, sum) for each data viz point; if this fails, the
         # cube test fixture may have changed (e.g. TileDB Array schema) or the logic for creating the test cube fixture
         # has changed
-        expected_cell_count_per_cell_type = dim_size ** (len(cube_non_indexed_dims) - 2) * 2
-        assert expected_cell_count_per_cell_type == 486
+        not_used_cube_indexed_dims = [0 if criteria.dict()[dim_name] else 1 for dim_name in ALL_INDEXED_DIMS_FOR_QUERY]
+        expected_cell_count_per_cell_type = dim_size ** (len(cube_non_indexed_dims) - 2 +
+                                                         sum(not_used_cube_indexed_dims)) * 2
 
-        expected_cell_count_per_tissue = 10 * (dim_size ** (len(cube_non_indexed_dims) - 1) * 2)
-        assert expected_cell_count_per_tissue == 14580
+        expected_cell_count_per_tissue = 10 * (dim_size ** (len(cube_non_indexed_dims) - 1 +
+                                                            sum(not_used_cube_indexed_dims)) * 2)
+
+        assert expected_cell_count_per_cell_type == 1458
+        assert expected_cell_count_per_tissue == 43740
 
         expected = [
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_0",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
-                "n_cells": 486,
-                "n_cells_cell_type": 4860,
-                "n_cells_tissue": 14580,
-                "nnz": 486,
-                "sum": 486.0,
+                "n_cells": 1458,
+                "n_cells_cell_type": 14580,
+                "n_cells_tissue": 43740,
+                "nnz": 1458,
+                "sum": 1458.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_0",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
-                "n_cells": 486,
-                "n_cells_cell_type": 4860,
-                "n_cells_tissue": 14580,
-                "nnz": 486,
-                "sum": 486.0,
+                "n_cells": 1458,
+                "n_cells_cell_type": 14580,
+                "n_cells_tissue": 43740,
+                "nnz": 1458,
+                "sum": 1458.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_0",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
-                "n_cells": 486,
-                "n_cells_cell_type": 4860,
-                "n_cells_tissue": 14580,
-                "nnz": 486,
-                "sum": 486.0,
+                "n_cells": 1458,
+                "n_cells_cell_type": 14580,
+                "n_cells_tissue": 43740,
+                "nnz": 1458,
+                "sum": 1458.0,
             },
         ]
 
@@ -502,42 +525,45 @@ class QueryTest(unittest.TestCase):
         # sanity check the expected value of the stats (n_cells, nnz, sum) for each data viz point; if this fails, the
         # cube test fixture may have changed (e.g. TileDB Array schema) or the logic for creating the test cube fixture
         # has changed
-        expected_cell_count_per_cell_type = dim_size ** (len(cube_non_indexed_dims) - 3) * 1 * 2
-        assert expected_cell_count_per_cell_type == 162
+        not_used_cube_indexed_dims = [0 if criteria.dict()[dim_name] else 1 for dim_name in ALL_INDEXED_DIMS_FOR_QUERY]
+        expected_cell_count_per_cell_type = dim_size ** (len(cube_non_indexed_dims) - 3 +
+                                                         sum(not_used_cube_indexed_dims)) * 1 * 2
+        expected_cell_count_per_tissue = 10 * (dim_size ** (len(cube_non_indexed_dims) - 2 +
+                                                            sum(not_used_cube_indexed_dims)) * 1 * 2)
 
-        expected_cell_count_per_tissue = 10 * (dim_size ** (len(cube_non_indexed_dims) - 2) * 1 * 2)
-        assert expected_cell_count_per_tissue == 4860
+        assert expected_cell_count_per_cell_type == 486
+        assert expected_cell_count_per_tissue == 14580
 
         expected = [
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_0",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_0",
-                "n_cells": 162,
-                "n_cells_cell_type": 1620,
-                "n_cells_tissue": 4860,
-                "nnz": 162,
-                "sum": 162.0,
+                "n_cells": 486,
+                "n_cells_cell_type": 4860,
+                "n_cells_tissue": 14580,
+                "nnz": 486,
+                "sum": 486.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_0",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_1",
-                "n_cells": 162,
-                "n_cells_cell_type": 1620,
-                "n_cells_tissue": 4860,
-                "nnz": 162,
-                "sum": 162.0,
+                "n_cells": 486,
+                "n_cells_cell_type": 4860,
+                "n_cells_tissue": 14580,
+                "nnz": 486,
+                "sum": 486.0,
             },
             {
                 "gene_ontology_term_id": "gene_ontology_term_id_0",
                 "tissue_ontology_term_id": "tissue_ontology_term_id_0",
                 "cell_type_ontology_term_id": "cell_type_ontology_term_id_2",
-                "n_cells": 162,
-                "n_cells_cell_type": 1620,
-                "n_cells_tissue": 4860,
-                "nnz": 162,
-                "sum": 162.0,
+                "n_cells": 486,
+                "n_cells_cell_type": 4860,
+                "n_cells_tissue": 14580,
+                "nnz": 486,
+                "sum": 486.0,
             },
         ]
 


### PR DESCRIPTION
Addresses #3084 

### Reviewers
**Functional:** 

@ebezzi (?) Let me know if I should choose someone else

**Readability:** 

@atarashansky 

---


## Changes
- renames integrated corpus and wmg cube **dimension** `tissue_ontology_term_id` to `tissue_original_ontology_term_id`
- renames integrated corpus and wmg cube **attribute** `tissue` to `tissue_original`
- the steps above results in an added dimension and attribute to integrated corpus and cubes 
- `tissue_ontology_term_id` and `tissue` will contain the high-level tissues. For now, only children of `lung` are mapped to `lung`, everything else is untouched, another PR will be submitted for mapping all tissues
- modify querying to snapshot to handle extra dimension and attribute and send correct information to frontend
- update unit tests of querying to account for extra dimension and attribute 

## QA

- Integrated corpus and cubes were manually created with small sets of data AND all data in prod. TileDB objects were inspected manually and everything looks good:
   - Proper addition of dimension `tissue_original_ontology_term_id`
   - Proper addition of attribute `tissue_original`
   - Children of lung were properly mapped to lung in`tissue_ontology_term_id` and `tissue`

- FE is working as tested in rdev -- only lung and none of its children are shown.
