### PR TITLE
feat: surface dataset batch_condition in curation API

### DIFF
--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -20,7 +20,7 @@ ADD requirements.txt requirements-base.txt
 ADD backend/corpora/dataset_processing/requirements.txt requirements-processing.txt
 RUN pip3 install -r requirements-base.txt -r requirements-processing.txt
 
-RUN wget "https://drive.google.com/u/0/uc?id=11agilM4MXzTEF7VBgF4HGtcWL1nV8zST&export=download" -O cellxgene-schema.tar.gz
+RUN wget "https://drive.google.com/u/0/uc?id=1RxbKLbVdmD40dk6DAz4CkpL0MgI4RSms&export=download" -O cellxgene-schema.tar.gz
 RUN pip install cellxgene-schema.tar.gz
 
 ADD tests /single-cell-data-portal/tests

--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -509,6 +509,13 @@ components:
         dataset_id:
           "$ref": "#/components/schemas/dataset_id"
       type: object
+    batch_condition:
+      description: These keys define the batches that a normalization or integration algorithm should be aware of
+      type: array
+      items:
+        type: string
+      nullable: true
+      example: ["patient", "seqBatch"]
     collection_common:
       description: Full Collection metadata
       properties:
@@ -609,6 +616,8 @@ components:
         - properties:
             X_approximate_distribution:
               "$ref": "#/components/schemas/distribution"
+            batch_condition:
+              "$ref": "#/components/schemas/batch_condition"
             cell_count:
               nullable: true
               type: integer

--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -688,10 +688,7 @@ components:
         tissue:
           "$ref": "#/components/schemas/ontology_elements"
         suspension_type:
-          type: array
-          items:
-            type: string
-          nullable: true
+          "$ref": "#/components/schemas/suspension_type"
         tombstone:
           type: boolean
       type: object
@@ -808,6 +805,15 @@ components:
         published_year:
           type: number
       type: object
+    suspension_type:
+      description:
+        List of unique suspension types represented in the dataset, corresponding to dataset's assay(s). 
+        Possible item values are 'nucleus', 'cell', and/or 'na'.
+      type: array
+      items:
+        type: string
+      nullable: true
+      example: ["cell"]
     upload_link:
       description: A user-provided link to the dataset source file.
       type: string

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -168,7 +168,7 @@ class EntityColumns:
         "cell_type",
         "cell_count",
         "x_approximate_distribution",
-        # "batch_condition",  # TODO: https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1461  # noqa: E501
+        "batch_condition",
         "mean_genes_per_cell",
         "schema_version",
         "processing_status",

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
@@ -313,7 +313,7 @@ class TestGetCollectionID(BaseAuthAPITest):
         "datasets": [
             {
                 "assay": [{"label": "test_assay", "ontology_term_id": "test_obo"}],
-                "batch_condition": ['batchA', 'batchB'],
+                "batch_condition": ["batchA", "batchB"],
                 "cell_count": None,
                 "cell_type": [{"label": "test_cell_type", "ontology_term_id": "test_opo"}],
                 "curator_tag": None,

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
@@ -313,7 +313,7 @@ class TestGetCollectionID(BaseAuthAPITest):
         "datasets": [
             {
                 "assay": [{"label": "test_assay", "ontology_term_id": "test_obo"}],
-                "suspension_type": ["nucleus"],
+                "batch_condition": ['batchA', 'batchB'],
                 "cell_count": None,
                 "cell_type": [{"label": "test_cell_type", "ontology_term_id": "test_opo"}],
                 "curator_tag": None,
@@ -340,6 +340,7 @@ class TestGetCollectionID(BaseAuthAPITest):
                     {"label": "test_sex", "ontology_term_id": "test_obo"},
                     {"label": "test_sex2", "ontology_term_id": "test_obp"},
                 ],
+                "suspension_type": ["nucleus"],
                 "tissue": [{"label": "test_tissue", "ontology_term_id": "test_obo"}],
                 "tombstone": False,
                 "x_approximate_distribution": "NORMAL",


### PR DESCRIPTION
- #1461 

### Reviewers
**Functional:** 
@ebezzi 
**Readability:** 

---


## Changes
- surface batch_condition in dataset response object in curation API (scope does NOT include dataset preview object)
- update test
- minor refactor of curation API spec to organize + add descriptions/examples

## QA steps (optional)
- unit tests + rdev

## Notes for Reviewer
- batch_condition metadata is already extracted from dataset submissions and persisted in the db (see #1459 ). Test changes were also made as part of that previous PR. This simply surfaces it in curation API endpoints that return full dataset metadata. 
