### PR TITLE
chore: cherry pick changes from #3172 surface dataset batch_condition in curation API

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -516,6 +516,13 @@ components:
         dataset_id:
           "$ref": "#/components/schemas/dataset_id"
       type: object
+    batch_condition:
+      description: These keys define the batches that a normalization or integration algorithm should be aware of
+      type: array
+      items:
+        type: string
+      nullable: true
+      example: ["patient", "seqBatch"]
     collection_list:
       description: Full Collection metadata
       properties:
@@ -676,6 +683,10 @@ components:
       allOf:
         - "$ref": "#/components/schemas/dataset_preview"
         - properties:
+            X_approximate_distribution:
+              "$ref": "#/components/schemas/distribution"
+            batch_condition:
+              "$ref": "#/components/schemas/batch_condition"
             assay:
               "$ref": "#/components/schemas/ontology_elements"
             cell_count:

--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -683,8 +683,6 @@ components:
       allOf:
         - "$ref": "#/components/schemas/dataset_preview"
         - properties:
-            X_approximate_distribution:
-              "$ref": "#/components/schemas/distribution"
             batch_condition:
               "$ref": "#/components/schemas/batch_condition"
             assay:

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -168,7 +168,7 @@ class EntityColumns:
         "cell_type",
         "cell_count",
         "x_approximate_distribution",
-        # "batch_condition",  # TODO: https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1461  # noqa: E501
+        "batch_condition",
         "mean_genes_per_cell",
         "schema_version",
         "processing_status",

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
@@ -346,6 +346,7 @@ class TestGetCollectionID(BaseAuthAPITest):
         "datasets": [
             {
                 "assay": [{"label": "test_assay", "ontology_term_id": "test_obo"}],
+                "batch_condition": ["batchA", "batchB"],
                 "cell_count": None,
                 "cell_type": [{"label": "test_cell_type", "ontology_term_id": "test_opo"}],
                 "curator_tag": None,


### PR DESCRIPTION
- #1461 

### Reviewers
**Functional:** 
@ebezzi 
**Readability:** 
---


## Changes
- surface batch_condition in dataset response object in curation API (scope does NOT include dataset preview object)
update test

## QA steps (optional)
- unit tests and rdev

## Notes for Reviewer
- Cherry picked from [PR merged into feature/schema-3-0-0.](https://github.com/chanzuckerberg/single-cell-data-portal/pull/3172) Can be released outside of schema 3.0.0 release cycle
