### PR TITLE
chore: use 3.0.0 compliant h5ads for functional and smoke tests

### DIFF
--- a/scripts/smoke_tests/setup.py
+++ b/scripts/smoke_tests/setup.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
         print("Found sufficient published collections for testing, exiting")
         sys.exit(0)
 
-    dataset_dropbox_url = "https://www.dropbox.com/s/qiclvn1slmap351/example_valid.h5ad?dl=0"
+    dataset_dropbox_url = "https://www.dropbox.com/s/ixhjslkiewpdtvz/3_0_0_valid.h5ad?dl=0"
     num_to_create = NUM_TEST_COLLECTIONS - collection_count
     threads = []
     for i in range(num_to_create):

--- a/scripts/smoke_tests/setup.py
+++ b/scripts/smoke_tests/setup.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
         print("Found sufficient published collections for testing, exiting")
         sys.exit(0)
 
-    dataset_dropbox_url = "https://www.dropbox.com/s/ixhjslkiewpdtvz/3_0_0_valid.h5ad?dl=0"
+    dataset_dropbox_url = "https://www.dropbox.com/s/m1ur46nleit8l3w/3_0_0_valid.h5ad?dl=0"
     num_to_create = NUM_TEST_COLLECTIONS - collection_count
     threads = []
     for i in range(num_to_create):

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -92,7 +92,7 @@ class TestApi(BaseFunctionalTestCase):
             for key in updated_data.keys():
                 self.assertEqual(updated_data[key], data[key])
 
-        self.upload_and_wait(collection_id, "https://www.dropbox.com/s/ixhjslkiewpdtvz/3_0_0_valid.h5ad?dl=0")
+        self.upload_and_wait(collection_id, "https://www.dropbox.com/s/m1ur46nleit8l3w/3_0_0_valid.h5ad?dl=0")
 
         # make collection public
         with self.subTest("Test make collection public"):
@@ -188,7 +188,7 @@ class TestApi(BaseFunctionalTestCase):
         self.assertEqual(res.status_code, requests.codes.created)
         self.assertIn("collection_id", data)
 
-        body = {"url": "https://www.dropbox.com/s/ixhjslkiewpdtvz/3_0_0_valid.h5ad?dl=0"}
+        body = {"url": "https://www.dropbox.com/s/m1ur46nleit8l3w/3_0_0_valid.h5ad?dl=0"}
 
         res = self.session.post(
             f"{self.api}/dp/v1/collections/{collection_id}/upload-links", data=json.dumps(body), headers=headers

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -92,7 +92,7 @@ class TestApi(BaseFunctionalTestCase):
             for key in updated_data.keys():
                 self.assertEqual(updated_data[key], data[key])
 
-        self.upload_and_wait(collection_id, "https://www.dropbox.com/s/qiclvn1slmap351/example_valid.h5ad?dl=0")
+        self.upload_and_wait(collection_id, "https://www.dropbox.com/s/ixhjslkiewpdtvz/3_0_0_valid.h5ad?dl=0")
 
         # make collection public
         with self.subTest("Test make collection public"):
@@ -188,7 +188,7 @@ class TestApi(BaseFunctionalTestCase):
         self.assertEqual(res.status_code, requests.codes.created)
         self.assertIn("collection_id", data)
 
-        body = {"url": "https://www.dropbox.com/s/qiclvn1slmap351/example_valid.h5ad?dl=0"}
+        body = {"url": "https://www.dropbox.com/s/ixhjslkiewpdtvz/3_0_0_valid.h5ad?dl=0"}
 
         res = self.session.post(
             f"{self.api}/dp/v1/collections/{collection_id}/upload-links", data=json.dumps(body), headers=headers

--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -46,8 +46,8 @@ class TestRevisions(BaseFunctionalTestCase):
 
         collection_id = self.create_collection(headers)
 
-        dataset_1_dropbox_url = "https://www.dropbox.com/s/ixhjslkiewpdtvz/3_0_0_valid.h5ad?dl=0"
-        dataset_2_dropbox_url = "https://www.dropbox.com/s/ixhjslkiewpdtvz/3_0_0_valid.h5ad?dl=0"
+        dataset_1_dropbox_url = "https://www.dropbox.com/s/m1ur46nleit8l3w/3_0_0_valid.h5ad?dl=0"
+        dataset_2_dropbox_url = "https://www.dropbox.com/s/m1ur46nleit8l3w/3_0_0_valid.h5ad?dl=0"
 
         # Uploads a dataset
         self.upload_and_wait(collection_id, dataset_1_dropbox_url)

--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -46,8 +46,8 @@ class TestRevisions(BaseFunctionalTestCase):
 
         collection_id = self.create_collection(headers)
 
-        dataset_1_dropbox_url = "https://www.dropbox.com/s/qiclvn1slmap351/example_valid.h5ad?dl=0"
-        dataset_2_dropbox_url = "https://www.dropbox.com/s/qiclvn1slmap351/example_valid.h5ad?dl=0"
+        dataset_1_dropbox_url = "https://www.dropbox.com/s/ixhjslkiewpdtvz/3_0_0_valid.h5ad?dl=0"
+        dataset_2_dropbox_url = "https://www.dropbox.com/s/ixhjslkiewpdtvz/3_0_0_valid.h5ad?dl=0"
 
         # Uploads a dataset
         self.upload_and_wait(collection_id, dataset_1_dropbox_url)


### PR DESCRIPTION
- #3182 

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- updated dropbox links to public schema 3.0.0 compliant h5ad, for functional and smoke test uploads

## QA steps (optional)

## Notes for Reviewer
- There is another h5ad test fixture in the data portal, pbmc3k.h5ad, that I did not update. It does not go through the upload pipeline--it is used for a unit test for convert_anndata_category_colors_to_cxg_category_colors, so it should not need to be updated. Unit tests pass, so it should be fine, but let me know if you'd rather I update for consistency's sake. 
- There are also dropbox links for a test.h5ad, but these are exclusively used to unit test functions related to making dropbox requests, and do not process or upload the h5ad. 
