### PR TITLE
feat: Implement tissue mapper function for getting high-level tissues in scExpression

### DIFF
--- a/backend/corpus_asset_pipelines/integrated_corpus/transform.py
+++ b/backend/corpus_asset_pipelines/integrated_corpus/transform.py
@@ -51,6 +51,8 @@ def create_high_level_tissue(anndata_object: anndata.AnnData):
 
 def get_high_level_tissue(obs: DataFrame) -> DataFrame:
 
+    obs = obs.copy()
+
     tissue_mapper = TissueMapper()
 
     tissue_ids_and_labels = obs[["tissue_ontology_term_id", "tissue"]].drop_duplicates().astype(str)
@@ -58,10 +60,10 @@ def get_high_level_tissue(obs: DataFrame) -> DataFrame:
     new_tissue_labels = {}
 
     # Create mapping dictionaries and if needed add new categories to obs.tissue and obs.tissue_ontology_term_id
-    for i in range(len(tissue_ids_and_labels)):
+    for row in tissue_ids_and_labels.iterrows():
 
-        current_id = tissue_ids_and_labels["tissue_ontology_term_id"][i]
-        current_label = tissue_ids_and_labels["tissue"][i]
+        current_id = row[1]["tissue_ontology_term_id"]
+        current_label = row[1]["tissue"]
 
         new_tissue_ids[current_id] = tissue_mapper.get_high_level_tissue(current_id)
         new_tissue_labels[current_label] = tissue_mapper.get_label_from_writable_id(new_tissue_ids[current_id])

--- a/backend/wmg/data/tissue_mapper.py
+++ b/backend/wmg/data/tissue_mapper.py
@@ -149,7 +149,7 @@ class TissueMapper:
 
         # Include this branch of ancestors is under anatomical structure
         if self.ANATOMICAL_STRUCTURE_NAME in branch_ancestors:
-            ancestors = ancestors + branch_ancestors
+            ancestors.extend(branch_ancestors)
 
         # Check if there's at least one top-level entity in the list of ancestors
         # for this entity

--- a/backend/wmg/data/tissue_mapper.py
+++ b/backend/wmg/data/tissue_mapper.py
@@ -1,0 +1,251 @@
+import owlready2
+from typing import List
+
+
+class TissueMapper:
+
+    #TODO: Look for other TODOs: main one is to used the pinned UBERON ontology instead of grabbing it online
+
+    # Name of anatomical structure, used to determine the set of ancestors for a given
+    # entity that we"re interested in.
+    ANATOMICAL_STRUCTURE_NAME = "UBERON_0000061"
+
+    # List of high level tissues, ORDER MATTERS. If for a given tissue there are multiple high-level tissues associated
+    # then `self.get_high_level_tissue()` returns the one that appears first in th this list
+    HIGH_LEVEL_TISSUES = [
+        "UBERON_0000178",  # blood
+        "UBERON_0002048",  # lung
+        "UBERON_0002106",  # spleen
+        "UBERON_0002371",  # bone marrow
+        "UBERON_0002107",  # liver
+        "UBERON_0002113",  # kidney
+        "UBERON_0000955",  # brain
+        "UBERON_0002240",  # spinal cord
+        "UBERON_0000310",  # breast
+        "UBERON_0000948",  # heart
+        "UBERON_0002097",  # skin of body
+        "UBERON_0000970",  # eye
+        "UBERON_0001264",  # pancreas
+        "UBERON_0001043",  # esophagus
+        "UBERON_0001155",  # colon
+        "UBERON_0000059",  # large intestine
+        "UBERON_0002108",  # small intestine
+        "UBERON_0000160",  # intestine
+        "UBERON_0000945",  # stomach
+        "UBERON_0001836",  # saliva
+        "UBERON_0001723",  # tongue
+        "UBERON_0001013",  # adipose tissue
+        "UBERON_0000473",  # testis
+        "UBERON_0002367",  # prostate gland
+        "UBERON_0000057",  # urethra
+        "UBERON_0000056",  # ureter
+        "UBERON_0003889",  # fallopian tube
+        "UBERON_0000995",  # uterus
+        "UBERON_0000992",  # ovary
+        "UBERON_0002110",  # gall bladder
+        "UBERON_0001255",  # urinary bladder
+        "UBERON_0018707",  # bladder organ
+        "UBERON_0000922",  # embryo
+        "UBERON_0004023",  # ganglionic eminence --> this a part of the embryo, remove in case generality is desired
+        "UBERON_0001987",  # placenta
+        "UBERON_0007106",  # chorionic villus
+        "UBERON_0002369",  # adrenal gland
+        "UBERON_0002368",  # endocrine gland
+        "UBERON_0002365",  # exocrine gland
+        "UBERON_0000030",  # lamina propria
+        "UBERON_0000029",  # lymph node
+        "UBERON_0004536",  # lymph vasculature
+        "UBERON_0001015",  # musculature
+        "UBERON_0000004",  # nose
+        "UBERON_0003688",  # omentum
+        "UBERON_0000977",  # pleura
+        "UBERON_0002370",  # thymus
+        "UBERON_0002049",  # vasculature
+        "UBERON_0009472",  # axilla
+        "UBERON_0001087",  # pleural fluid
+        "UBERON_0000344",  # mucosa
+        "UBERON_0001434",  # skeletal system
+        "UBERON_0002228",  # rib
+        "UBERON_0003129",  # skull
+        "UBERON_0004537",  # blood vasculature
+        "UBERON_0002405",  # immune system
+        "UBERON_0001009",  # circulatory system
+        "UBERON_0001007",  # digestive system
+        "UBERON_0001017",  # central nervous system
+        "UBERON_0001008",  # renal system
+        "UBERON_0000990",  # reproductive system
+        "UBERON_0001004",  # respiratory system
+        "UBERON_0000010",  # peripheral nervous system
+        "UBERON_0001032",  # sensory system
+        "UBERON_0002046",  # thyroid gland
+        "UBERON_0004535",  # cardiovascular system
+        "UBERON_0000949",  # endocrine system
+        "UBERON_0002330",  # exocrine system
+        "UBERON_0002390",  # hematopoietic system
+        "UBERON_0000383",  # musculature of body
+        "UBERON_0001465",  # knee
+        "UBERON_0001016",  # nervous system
+        "UBERON_0001348",  # brown adipose tissue
+        "UBERON_0015143",  # mesenteric fat pad
+        "UBERON_0000175",  # pleural effusion
+        "UBERON_0001416",  # skin of abdomen
+        "UBERON_0001868",  # skin of chest
+        "UBERON_0001511",  # skin of leg
+        "UBERON_0002190",  # subcutaneous adipose tissue
+        "UBERON_0035328",  # upper outer quadrant of breast
+        "UBERON_0000014",  # zone of skin
+    ]
+
+    # Terms to ignore when mapping
+    DENY_LIST = [
+        "BFO_0000004",
+        "CARO_0000000",
+        "CARO_0030000",
+        "CARO_0000003",
+        "NCBITaxon_6072",
+        "Thing",
+        "UBERON_0000465",  # material anatomical entity
+        "UBERON_0001062",  # anatomical entity
+    ]
+
+    def __init__(self,  uberon_ontology: str = "http://purl.obolibrary.org/obo/uberon.owl"):
+        # TODO: use the pinned ontology at `single-cell-curation`
+        self._uberon = owlready2.get_ontology(uberon_ontology)
+        self._uberon.load()
+        self._cached_tissues = {}
+        self._cached_labels = {}
+
+    def get_high_level_tissue(self, tissue_ontology_term_id: str) -> str:
+        """
+        Returns the associated high-level tissue ontology term ID from any other ID
+        Edge cases:
+            - If multiple high-level tissues exists for a given tissue, returns the one with higher priority (the first
+            appearance in list self.HIGH_LEVEL_TISSUES.
+            - If no high-level tissue is found, returns the same as input.
+            - If the input tissue is not found in the ontology, return the same as input.
+                - This could happen with something like "UBERON:0002048 (cell culture)"
+        """
+
+        tissue_ontology_term_id = self.make_id_readable(tissue_ontology_term_id)
+
+        if tissue_ontology_term_id in self._cached_tissues:
+            # If we have looked this up already
+            return self._cached_tissues[tissue_ontology_term_id]
+
+        entity = self._get_entity_from_id(tissue_ontology_term_id)
+
+        if not entity:
+            # If not found as an ontology ID return itself
+            result = self.make_id_writable(tissue_ontology_term_id)
+            self._cached_tissues[tissue_ontology_term_id] = result
+            return result
+
+        # List ancestors for this entity, including itself. Ignore any ancestors that
+        # are not descendents of UBERON_0000061 (anatomical structure).
+        ancestors = [entity.name]
+        branch_ancestors = []
+        for is_a in entity.is_a:
+            branch_ancestors = self._list_ancestors(is_a, branch_ancestors)
+
+        # Include this branch of ancestors is under anatomical structure
+        if self.ANATOMICAL_STRUCTURE_NAME in branch_ancestors:
+            ancestors = ancestors + branch_ancestors
+
+        # Check if there's at least one top-level entity in the list of ancestors
+        # for this entity
+        selected_tissue = tissue_ontology_term_id
+        for high_level_tissue in self.HIGH_LEVEL_TISSUES:
+            if high_level_tissue in ancestors:
+                selected_tissue = high_level_tissue
+                break
+
+        result = self.make_id_writable(selected_tissue)
+        self._cached_tissues[tissue_ontology_term_id] = result
+        return result
+
+    def get_label_from_writable_id(self, ontology_term_id: str):
+        """
+        Returns the label from and ontology term id that is in writable form
+        Example: "UBERON:0002048" returns "lung"
+        Example: "UBERON_0002048" raises ValueError because the ID is not in writable form
+        """
+
+        if ontology_term_id in self._cached_labels:
+            return self._cached_labels[ontology_term_id]
+
+        entity = self._get_entity_from_id(self.make_id_readable(ontology_term_id))
+        if entity:
+            result = entity.label[0]
+        else:
+            result = ontology_term_id
+
+        self._cached_labels[ontology_term_id] = result
+        return result
+
+    @staticmethod
+    def make_id_readable(ontology_term_id: str) -> str:
+        """
+        Converts ontology term id string from "UBERON:0002048" to "UBERON_0002048"
+        """
+        if ontology_term_id.count(":") != 1:
+            raise ValueError(f"{ontology_term_id} is an invalid ontology term id, it must contain exactly one ':'")
+        return ontology_term_id.replace(":", "_")
+
+    @staticmethod
+    def make_id_writable(ontology_term_id: str) -> str:
+        """
+        Converts ontology term id string from "UBERON_0002048" to "UBERON:0002048"
+        """
+        if ontology_term_id.count("_") != 1:
+            raise ValueError(f"{ontology_term_id} is an invalid ontology term id, it must contain exactly one '_'")
+        return ontology_term_id.replace("_", ":")
+
+    def _list_ancestors(self, entity: owlready2.entity.ThingClass, ancestors: List[str] = []) -> List[str]:
+        """
+        Recursive function that given an entity of an ontology, it traverses the ontology and returns
+        a list of all ancestors associated with the entity.
+        """
+
+        if self._is_restriction(entity):
+            # Entity is a restriction, check for part_of relationship
+
+            prop = entity.property.name
+            if prop != "BFO_0000050":
+                # BFO_0000050 is "part of"
+                return ancestors
+            ancestors.append(entity.value.name.replace("obo.", ""))
+
+            # Check for ancestors of restriction
+            self._list_ancestors(entity.value, ancestors)
+            return ancestors
+
+        elif self._is_entity(entity) and not self._is_and_object(entity):
+            # Entity is a superclass, check for is_a relationships
+
+            if entity.name in self.DENY_LIST:
+                return ancestors
+            ancestors.append(entity.name)
+
+            # Check for ancestors of superclass
+            for super_entity in entity.is_a:
+                self._list_ancestors(super_entity, ancestors)
+            return ancestors
+
+    def _get_entity_from_id(self, ontology_term_id: str) -> owlready2.entity.ThingClass:
+        """
+        Given a readable ontology term id (e.g. "UBERON_0002048"), it returns the associated ontology entity
+        """
+        # TODO: use the pinned ontology at `single-cell-curation`
+        return self._uberon.search_one(iri=f"http://purl.obolibrary.org/obo/{ontology_term_id}")
+
+    @staticmethod
+    def _is_restriction(entity: owlready2.entity.ThingClass) -> bool:
+        return hasattr(entity, "value")
+
+    @staticmethod
+    def _is_entity(entity: owlready2.entity.ThingClass) -> bool:
+        return hasattr(entity, "name")
+
+    @staticmethod
+    def _is_and_object(entity: owlready2.entity.ThingClass) -> bool:
+        return hasattr(entity, "Classes")

--- a/backend/wmg/data/transform.py
+++ b/backend/wmg/data/transform.py
@@ -139,7 +139,7 @@ def generate_primary_filter_dimensions(snapshot_path: str, corpus_name: str, sna
         ontology_term_ids = set(ontology_term_ids)
         ordered_ontology_term_ids = []
         for tissue in TissueMapper.HIGH_LEVEL_TISSUES:
-            tissue = TissueMapper.make_id_writable(tissue)
+            tissue = TissueMapper.reformat_ontology_term_id(tissue, to_writable=True)
             if tissue in ontology_term_ids:
                 ontology_term_ids.remove(tissue)
                 ordered_ontology_term_ids.append(tissue)

--- a/backend/wmg/data/transform.py
+++ b/backend/wmg/data/transform.py
@@ -132,7 +132,9 @@ def generate_primary_filter_dimensions(snapshot_path: str, corpus_name: str, sna
 
     def order_tissues(ontology_term_ids: Iterable[str]) -> Iterable[str]:
         """
-        Order tissues based on appearance in TissueMapper.HIGH_LEVEL_TISSUES
+        Order tissues based on appearance in TissueMapper.HIGH_LEVEL_TISSUES. This will maintain the priority set in
+        that class which is intended to keep most relevant tissues on top and tissues that are related to be placed
+        sequentially
         """
         ontology_term_ids = set(ontology_term_ids)
         ordered_ontology_term_ids = []

--- a/backend/wmg/data/transform.py
+++ b/backend/wmg/data/transform.py
@@ -130,26 +130,6 @@ def generate_primary_filter_dimensions(snapshot_path: str, corpus_name: str, sna
     def build_ontology_term_id_label_mapping(ontology_term_ids: Iterable[str]) -> List[dict]:
         return [{ontology_term_id: ontology_term_label(ontology_term_id)} for ontology_term_id in ontology_term_ids]
 
-    def order_tissues(ontology_term_ids: Iterable[str]) -> Iterable[str]:
-        """
-        Order tissues based on appearance in TissueMapper.HIGH_LEVEL_TISSUES. This will maintain the priority set in
-        that class which is intended to keep most relevant tissues on top and tissues that are related to be placed
-        sequentially
-        """
-        ontology_term_ids = set(ontology_term_ids)
-        ordered_ontology_term_ids = []
-        for tissue in TissueMapper.HIGH_LEVEL_TISSUES:
-            tissue = TissueMapper.reformat_ontology_term_id(tissue, to_writable=True)
-            if tissue in ontology_term_ids:
-                ontology_term_ids.remove(tissue)
-                ordered_ontology_term_ids.append(tissue)
-
-        if ontology_term_ids:
-            ordered_ontology_term_ids = ordered_ontology_term_ids + list(ontology_term_ids)
-
-        return ordered_ontology_term_ids
-
-
     with tiledb.open(f"{snapshot_path}/{corpus_name}/{EXPRESSION_SUMMARY_CUBE_NAME}") as cube:
 
         # gene terms are grouped by organism, and represented as a nested lists in dict, keyed by organism
@@ -181,3 +161,25 @@ def generate_primary_filter_dimensions(snapshot_path: str, corpus_name: str, sna
 
         with open(f"{snapshot_path}/{PRIMARY_FILTER_DIMENSIONS_FILENAME}", "w") as f:
             json.dump(result, f)
+
+
+def order_tissues(ontology_term_ids: Iterable[str]) -> Iterable[str]:
+    """
+    Order tissues based on appearance in TissueMapper.HIGH_LEVEL_TISSUES. This will maintain the priority set in
+    that class which is intended to keep most relevant tissues on top and tissues that are related to be placed
+    sequentially
+    """
+    ontology_term_ids = set(ontology_term_ids)
+    ordered_ontology_term_ids = []
+    for tissue in TissueMapper.HIGH_LEVEL_TISSUES:
+        tissue = TissueMapper.reformat_ontology_term_id(tissue, to_writable=True)
+        if tissue in ontology_term_ids:
+            ontology_term_ids.remove(tissue)
+            ordered_ontology_term_ids.append(tissue)
+
+    if ontology_term_ids:
+        ordered_ontology_term_ids = ordered_ontology_term_ids + list(ontology_term_ids)
+
+    return ordered_ontology_term_ids
+
+

--- a/backend/wmg/data/validation/fixtures.py
+++ b/backend/wmg/data/validation/fixtures.py
@@ -14,8 +14,6 @@ validation_tissues_with_many_cell_types = {
     "blood": "UBERON:0000178",
     "lymph node": "UBERON:0000029",
     "eye": "UBERON:0000970",
-    "renal medulla": "UBERON:0000362",
-    "nasal cavity": "UBERON:0001707",
 }
 validation_cell_types = {
     "intermediate monocytes": "CL:0002393",

--- a/tests/unit/backend/wmg/test_tissue_mapper.py
+++ b/tests/unit/backend/wmg/test_tissue_mapper.py
@@ -30,13 +30,13 @@ class TissueMapperTest(unittest.TestCase):
         tissue = "UBERON_0008951"
         expected_tissue = "UBERON:0008951"
 
-        self.assertEqual(self.tissue_mapper.make_id_writable(tissue), expected_tissue)
+        self.assertEqual(self.tissue_mapper.reformat_ontology_term_id(tissue, to_writable=True), expected_tissue)
 
     def test__making_ontology_id_readable(self):
         tissue = "UBERON:0008951"
         expected_tissue = "UBERON_0008951"
 
-        self.assertEqual(self.tissue_mapper.make_id_readable(tissue), expected_tissue)
+        self.assertEqual(self.tissue_mapper.reformat_ontology_term_id(tissue, to_writable=False), expected_tissue)
 
     def test__get_label_from_id(self):
         tissue = "UBERON:0008951"

--- a/tests/unit/backend/wmg/test_tissue_mapper.py
+++ b/tests/unit/backend/wmg/test_tissue_mapper.py
@@ -1,6 +1,7 @@
 import unittest
 
 from backend.wmg.data.tissue_mapper import TissueMapper
+from backend.wmg.data.transform import order_tissues
 
 
 class TissueMapperTest(unittest.TestCase):
@@ -43,3 +44,37 @@ class TissueMapperTest(unittest.TestCase):
         expected_label = "left lung lobe"
 
         self.assertEqual(self.tissue_mapper.get_label_from_writable_id(tissue), expected_label)
+
+
+class TissueOrderTest(unittest.TestCase):
+
+    """
+    Tests function used for ordering final tissue list sent to frontend
+    """
+
+    def test__tissue_ordering(self):
+        unordered_tissues = [
+            "UBERON:0002048 (organoid)",  # lung (organoid)
+            "UBERON:0002106",  # spleen
+            "UBERON:0002371",  # bone marrow
+            "UBERON:0002107",  # liver
+            "UBERON:0002113",  # kidney
+            "UBERON:0000178",  # blood
+            "UBERON:0002240",  # spinal cord
+            "UBERON:0002048",  # lung
+            "UBERON:0000955",  # brain
+        ]
+
+        expected_ordered_tissues = [
+            "UBERON:0000178",  # blood
+            "UBERON:0002048",  # lung
+            "UBERON:0002106",  # spleen
+            "UBERON:0002371",  # bone marrow
+            "UBERON:0002107",  # liver
+            "UBERON:0002113",  # kidney
+            "UBERON:0000955",  # brain
+            "UBERON:0002240",  # spinal cord
+            "UBERON:0002048 (organoid)",  # lung (organoid)
+        ]
+
+        self.assertEqual(order_tissues(unordered_tissues), expected_ordered_tissues)

--- a/tests/unit/backend/wmg/test_tissue_mapper.py
+++ b/tests/unit/backend/wmg/test_tissue_mapper.py
@@ -1,0 +1,45 @@
+import unittest
+
+from backend.wmg.data.tissue_mapper import TissueMapper
+
+
+class TissueMapperTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tissue_mapper = TissueMapper()
+
+    def test__high_level_tissue_retrieval_exists(self):
+
+        low_level_tissue = "UBERON:0008951"  # lef lung lobe
+        expected_high_level_tissue = "UBERON:0002048"  # lung
+        self.assertEqual(self.tissue_mapper.get_high_level_tissue(low_level_tissue), expected_high_level_tissue)
+
+    def test__high_level_tissue_retrieval_does_not_exist(self):
+
+        low_level_tissue = "UBERON:noId"
+        expected_high_level_tissue = "UBERON:noId"
+        self.assertEqual(self.tissue_mapper.get_high_level_tissue(low_level_tissue), expected_high_level_tissue)
+
+    def test__high_level_tissue_retrieval_suffix(self):
+
+        low_level_tissue = "UBERON:0008951 (organoid)"  # lef lung lobe
+        expected_high_level_tissue = "UBERON:0008951 (organoid)"  # lung
+        self.assertEqual(self.tissue_mapper.get_high_level_tissue(low_level_tissue), expected_high_level_tissue)
+
+    def test__making_ontology_id_writable(self):
+        tissue = "UBERON_0008951"
+        expected_tissue = "UBERON:0008951"
+
+        self.assertEqual(self.tissue_mapper.make_id_writable(tissue), expected_tissue)
+
+    def test__making_ontology_id_readable(self):
+        tissue = "UBERON:0008951"
+        expected_tissue = "UBERON_0008951"
+
+        self.assertEqual(self.tissue_mapper.make_id_readable(tissue), expected_tissue)
+
+    def test__get_label_from_id(self):
+        tissue = "UBERON:0008951"
+        expected_label = "left lung lobe"
+
+        self.assertEqual(self.tissue_mapper.get_label_from_writable_id(tissue), expected_label)


### PR DESCRIPTION
- #3099 

### Reviewers
**Functional:** 
@ebezzi 
@MillenniumFalconMechanic please review [backend/wmg/data/tissue_mapper.py](https://github.com/chanzuckerberg/single-cell-data-portal/pull/3198/files#diff-40380a401959bb1235f5f11926bb4745053bd377049a825cb21615de34ea916e)

**Readability:** 
@atarashansky 

---


## Changes
- add Class `TissueMapper` with all assets necessary for mapping any tissue to its high-level equivalent
- modify Creation of integrated corpus to use the Class above to add the high-level tissue to dimension `tissue_ontology_term_id` and to attribute `tissue`
- modify Order of tissues that are passed to the FE for better usability, the order is the same as the list of high-level tissues defined in the class `TissueMapper`

## QA steps

- Integrated corpus and cubes were manually created with small sets of data AND all data in prod. TileDB objects were inspected manually and everything looks good:
   - Proper addition of dimension `tissue_original_ontology_term_id`
   - Proper addition of attribute `tissue_original`
   - All tissues were mapped to their high-level equivalent, and those that don't have one (i.e. organoids) were mapped to themselves as expected

- FE is working as tested in rdev 
   - All tissues were mapped to their high-level equivalent, and those that don't have one (i.e. organoids) were mapped to themselves as expected
   - Order of tissues as expected
[https://wmg-tissue-roll-up-rdev-frontend.rdev.single-cell.czi.technology/scExpression](https://wmg-tissue-roll-up-rdev-frontend.rdev.single-cell.czi.technology/scExpression
)
