### PR TITLE
style: remove unused regex and consolidate curator tag logic

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -336,9 +336,7 @@ paths:
               type: object
               additionalProperties: false
               properties:
-                curator_tag:
-                  type: string
-                  description: curator-provided tag
+                $ref: "#/components/schemas/curator_tag"
             example:
               curator_tag: "new/curator_tag"
       responses:
@@ -376,7 +374,7 @@ paths:
               additionalProperties: false
               properties:
                 curator_tag:
-                  type: string
+                  $ref: "#/components/schemas/curator_tag"
                 id:
                   $ref: "#/components/schemas/dataset_id"
                 link:
@@ -518,6 +516,7 @@ components:
           type: array
         curator_tag:
           "$ref": "#/components/schemas/curator_tag"
+          nullable: true
         dataset_id:
           "$ref": "#/components/schemas/dataset_id"
       type: object

--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -336,7 +336,8 @@ paths:
               type: object
               additionalProperties: false
               properties:
-                $ref: "#/components/schemas/curator_tag"
+                curator_tag:
+                  $ref: "#/components/schemas/curator_tag"
             example:
               curator_tag: "new/curator_tag"
       responses:

--- a/backend/corpora/common/utils/regex.py
+++ b/backend/corpora/common/utils/regex.py
@@ -4,23 +4,20 @@ USERNAME_REGEX = r"(?P<username>[\w\-\|]+)"
 ID_REGEX = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
 DATASET_ID_REGEX = f"(?P<dataset_id>{ID_REGEX})"
 COLLECTION_ID_REGEX = f"(?P<collection_id>{ID_REGEX})"
-CURATOR_TAG_PREFIX_REGEX = r"(?P<tag_prefix>.*)"
 CONTROL_CHARS = r"[\x00-\x1f\x7f-\xa0]"
 CURATOR_TAG_REGEX = r"(?P<tag>.*)"
 
 
 def validate_curator_tag(curator_tag: str) -> bool:
     """
-    Verify the correct curator tag format is obeyed.
+    Verify the correct curator tag format is obeyed (i.e., it is not a UUID)
 
     :param curator_tag: the tag name to validate.
-    :return: True if CURATOR_TAG_PREFIX_REGEX is matched.
+    :return: True if CURATOR_TAG_REGEX is matched.
     """
     regex = f"^({DATASET_ID_REGEX}|{CURATOR_TAG_REGEX})$"
     matched = re.match(regex, curator_tag)
-    if matched and (tag := matched.groupdict().get("tag")):
-        if not re.search(ID_REGEX, tag):
-            return
-        else:
-            raise ValueError("Curator tag cannot contain the same shape as a UUID.")
-    raise ValueError("Invalid curator tag.")
+    if matched and matched.groupdict().get("tag"):
+        return True
+    else:
+        raise ValueError("Curator tag cannot assume UUID format.")

--- a/backend/corpora/common/utils/regex.py
+++ b/backend/corpora/common/utils/regex.py
@@ -5,7 +5,7 @@ ID_REGEX = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-f
 DATASET_ID_REGEX = f"(?P<dataset_id>{ID_REGEX})"
 COLLECTION_ID_REGEX = f"(?P<collection_id>{ID_REGEX})"
 CONTROL_CHARS = r"[\x00-\x1f\x7f-\xa0]"
-CURATOR_TAG_REGEX = r"(?P<tag>.*)"
+CURATOR_TAG_REGEX = r"(?P<tag>.+)"
 
 
 def validate_curator_tag(curator_tag: str) -> bool:
@@ -17,7 +17,10 @@ def validate_curator_tag(curator_tag: str) -> bool:
     """
     regex = f"^({DATASET_ID_REGEX}|{CURATOR_TAG_REGEX})$"
     matched = re.match(regex, curator_tag)
-    if matched and matched.groupdict().get("tag"):
-        return True
-    else:
-        raise ValueError("Curator tag cannot assume UUID format.")
+    if matched:
+        matches = matched.groupdict()
+        if matches.get("tag"):
+            return True
+        elif matches.get("dataset_id"):
+            raise ValueError("Curator tag cannot assume UUID format.")
+    raise ValueError("Curator tag cannot be empty.")

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_dataset.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_dataset.py
@@ -88,7 +88,7 @@ class TestPatchDataset(BaseAuthAPITest):
             self.assertIsNone(_dataset.curator_tag)
 
         dataset = self.generate_dataset(self.session, collection=collection)
-        tests = [dataset.id, "prefix" + dataset.id, dataset.id + "suffix", "prefix" + dataset.id + "suffix"]
+        tests = [dataset.id, ""]
         for tag_name in tests:
             with self.subTest(tag_name):
                 _test(tag_name, dataset)


### PR DESCRIPTION
- #3102 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- remove unused regex
- enforce non-empty curator tag in backend validator code
- do not prohibit uuid shape _within_ a curator tag; only prohibit uuid _as_ tag.

## QA steps (optional)

## Notes for Reviewer
