### PR TITLE
feat: Curation API - return revision_of attribute for Datasets

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -721,6 +721,10 @@ components:
             revision:
               nullable: true
               type: integer
+            revision_of:
+              description: the id of the published version of this Dataset
+              nullable: true
+              type: string
             schema_version:
               nullable: true
               type: string

--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -105,10 +105,12 @@ def reshape_dataset_for_curation_api(dataset: dict, preview=False) -> dict:
         else:
             dataset[ontology_element] = []
 
-    if value := dataset.pop("name", None):
-        dataset["title"] = value
-    if value := dataset.pop("is_primary_data", None):
-        dataset["is_primary_data"] = is_primary_data_mapping.get(value)
+    if not preview:  # Add these fields only to full (and not preview) Dataset metadata response
+        dataset["revision_of"] = dataset.pop("original_id", None)
+        dataset["title"] = dataset.pop("name", None)
+        if value := dataset.pop("is_primary_data", None):
+            dataset["is_primary_data"] = is_primary_data_mapping.get(value, [])
+
     return dataset
 
 
@@ -160,6 +162,7 @@ class EntityColumns:
 
     dataset_cols = [
         *dataset_preview_cols,
+        "original_id",
         "name",
         "revision",
         "revised_at",

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
@@ -366,6 +366,7 @@ class TestGetCollectionID(BaseAuthAPITest):
                 "processing_status": "PENDING",
                 "revised_at": None,
                 "revision": 0,
+                "revision_of": None,
                 "schema_version": "2.0.0",
                 "sex": [
                     {"label": "test_sex", "ontology_term_id": "test_obo"},


### PR DESCRIPTION
This commit also streamlines logic for prior code additions that are
also involved in conditionally adding attributes to the Dataset response
object during reshaping

- #3208 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
