### PR TITLE
chore: rename ethnicity to self-reported ethnicity in wmg frontend

### DIFF
--- a/frontend/src/views/WheresMyGene/components/Filters/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/index.tsx
@@ -201,7 +201,7 @@ export default memo(function Filters(): JSX.Element {
           />
           <ComplexFilter
             multiple
-            label="Ethnicity"
+            label="Self-Reported Ethnicity"
             options={ethnicity_terms}
             onChange={handleEthnicitiesChange}
             value={selectedEthnicities}


### PR DESCRIPTION
- [#339
](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell/339)
### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- renamed ethnicity on the WMG Filter Tab

## QA steps (optional)

## Notes for Reviewer
- just going to rename the frontend label for now, leaving var names the same for brevity and consistency with the backend