### PR TITLE
feat: remove '.collections' attribute from GET /collections response

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -83,13 +83,10 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  collections:
-                    type: array
-                    items:
-                      allOf:
-                        - $ref: "#/components/schemas/collection_list"
+                type: array
+                items:
+                  allOf:
+                    - $ref: "#/components/schemas/collection_list"
         "400":
           $ref: "#/components/responses/400"
         "401":

--- a/backend/corpora/lambdas/api/v1/curation/collections/actions.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/actions.py
@@ -39,4 +39,4 @@ def get(visibility: str, token_info: dict, curator: str = None):
         resp_collection = reshape_for_curation_api(db_session, collection, token_info, preview=True)
         resp_collections.append(resp_collection)
 
-    return jsonify({"collections": resp_collections})
+    return jsonify(resp_collections)

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
@@ -136,22 +136,22 @@ class TestGetCollections(BaseAuthAPITest):
     def test__get_collections_no_auth__OK(self):
         res_no_auth = self.app.get("/curation/v1/collections")
         self.assertEqual(200, res_no_auth.status_code)
-        self.assertEqual(6, len(res_no_auth.json["collections"]))
-        [self.assertEqual("PUBLIC", c["visibility"]) for c in res_no_auth.json["collections"]]
+        self.assertEqual(6, len(res_no_auth.json))
+        [self.assertEqual("PUBLIC", c["visibility"]) for c in res_no_auth.json]
 
     def test__get_collections_with_auth__OK(self):
         res_auth = self.app.get("/curation/v1/collections", headers=self.make_owner_header())
         self.assertEqual(200, res_auth.status_code)
-        self.assertEqual(6, len(res_auth.json["collections"]))
+        self.assertEqual(6, len(res_auth.json))
         with self.subTest("The 'revising_in' attribute is None for unauthorized public collections"):
-            for c in res_auth.json["collections"]:
+            for c in res_auth.json:
                 if c["id"] in (
                     "test_collection_id_public_for_revision_one",
                     "test_collection_id_public_for_revision_two",
                 ):
                     self.assertIsNone(c["revising_in"])
         with self.subTest("The 'revising_in' attribute is None for collections which lack a revision"):
-            for c in res_auth.json["collections"]:
+            for c in res_auth.json:
                 if c["id"] in (
                     "test_collection_id_public",
                     "test_collection_with_link",
@@ -159,7 +159,7 @@ class TestGetCollections(BaseAuthAPITest):
                 ):
                     self.assertIsNone(c["revising_in"])
         with self.subTest("The 'revising_in' attribute is equal to the id of the revision Collection"):
-            for c in res_auth.json["collections"]:
+            for c in res_auth.json:
                 if c["id"] == "test_collection_id":
                     self.assertEqual("test_collection_id_revision", c["revising_in"])
 
@@ -172,7 +172,7 @@ class TestGetCollections(BaseAuthAPITest):
         params = {"visibility": "PUBLIC"}
         res_public = self.app.get("/curation/v1/collections", query_string=params)
         self.assertEqual(200, res_public.status_code)
-        self.assertEqual(6, len(res_public.json["collections"]))
+        self.assertEqual(6, len(res_public.json))
 
     def test__get_a_curators_collections(self):
         curator_name = "John Smith"
@@ -183,11 +183,10 @@ class TestGetCollections(BaseAuthAPITest):
         def _test(query_param, headers, expected_number_of_results):
             response = self.app.get("/curation/v1/collections", query_string=query_param, headers=headers)
             self.assertEqual(200, response.status_code)
-            self.assertEqual(expected_number_of_results, len(response.json["collections"]))
-            for collection in response.json["collections"]:
+            self.assertEqual(expected_number_of_results, len(response.json))
+            for collection in response.json:
                 self.assertEqual(curator_name, collection["curator_name"])
 
-        params = {"curator": curator_name, "visibility": "PRIVATE"}
         visibilities = ["PUBLIC", "PRIVATE"]
         for visibility in visibilities:
             params = {"curator": curator_name, "visibility": visibility}
@@ -211,8 +210,8 @@ class TestGetCollections(BaseAuthAPITest):
         params = {"visibility": "PUBLIC"}
         res = self.app.get("/curation/v1/collections", query_string=params, headers=self.make_owner_header())
         self.assertEqual(200, res.status_code)
-        self.assertEqual(6, len(res.json["collections"]))
-        [self.assertEqual("PUBLIC", c["visibility"]) for c in res.json["collections"]]
+        self.assertEqual(6, len(res.json))
+        [self.assertEqual("PUBLIC", c["visibility"]) for c in res.json]
 
     def test__get_only_private_collections_with_auth__OK(self):
         second_collection = self.generate_collection(self.session)
@@ -225,14 +224,14 @@ class TestGetCollections(BaseAuthAPITest):
         params = {"visibility": "PRIVATE"}
         res = self.app.get("/curation/v1/collections", query_string=params, headers=self.make_owner_header())
         with self.subTest("Summary collection-level processing statuses are accurate"):
-            for collection in res.json["collections"]:
+            for collection in res.json:
                 if collection["id"] == second_collection.id:
                     self.assertEqual(collection["processing_status"], "PENDING")
                 else:
                     self.assertEqual(collection["processing_status"], "SUCCESS")
         self.assertEqual(200, res.status_code)
-        self.assertEqual(2, len(res.json["collections"]))
-        [self.assertEqual("PRIVATE", c["visibility"]) for c in res.json["collections"]]
+        self.assertEqual(2, len(res.json))
+        [self.assertEqual("PRIVATE", c["visibility"]) for c in res.json]
 
     def test__verify_expected_public_collection_fields(self):
         collection = self.generate_collection(
@@ -249,7 +248,7 @@ class TestGetCollections(BaseAuthAPITest):
         self.generate_dataset(self.session, collection=collection)
         res = self.app.get("/curation/v1/collections")
         self.assertEqual(200, res.status_code)
-        for resp_collection in res.json["collections"]:
+        for resp_collection in res.json:
             if resp_collection["id"] is collection.id:
                 break
 
@@ -287,7 +286,7 @@ class TestGetCollections(BaseAuthAPITest):
                 subtest_prefix = "not_owner"
             res = self.app.get("/curation/v1/collections", query_string=params, headers=header)
             self.assertEqual(200, res.status_code)
-            for resp_collection in res.json["collections"]:
+            for resp_collection in res.json:
                 if resp_collection["id"] is collection.id:
                     break
 
@@ -328,7 +327,7 @@ class TestGetCollections(BaseAuthAPITest):
         res = self.app.get("/curation/v1/collections", headers=self.make_owner_header())
 
         contains_tombstoned_collection_flag = False
-        for collection in res.json["collections"]:
+        for collection in res.json:
             if collection["id"] == second_collection.id:
                 self.assertEqual(1, len(collection["datasets"]))
             if collection["id"] == tombstoned_collection.id:


### PR DESCRIPTION
This commit returns the array of Collections directly rather than
nesting it under a '.collections' attribute.

- #3203 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
