### PR TITLE
fix: Add result set count to datasets and collections (#3235)

### DIFF
--- a/frontend/src/components/common/Filter/common/entities.ts
+++ b/frontend/src/components/common/Filter/common/entities.ts
@@ -569,6 +569,19 @@ export interface PublisherMetadataCategories {
 }
 
 /**
+ * React table count summary values.
+ */
+export interface TableCountSummary {
+  row: number;
+  total: number;
+}
+
+/**
+ * "tableCountSummary" prop passed to react-table's Header function.
+ */
+export type HeaderPropsValue = { tableCountSummary?: TableCountSummary };
+
+/**
  * "row" prop passed to react-table's Cell function.
  */
 export type RowPropsValue<T extends Categories> = { row: Row<T> };

--- a/frontend/src/components/common/Grid/common/utils.ts
+++ b/frontend/src/components/common/Grid/common/utils.ts
@@ -1,4 +1,28 @@
+import { Row } from "react-table";
+import {
+  Categories,
+  TableCountSummary,
+} from "src/components/common/Filter/common/entities";
 import { DATASET_MAX_CELL_COUNT } from "src/components/common/Grid/common/constants";
+
+/**
+ * Returns table count summary.
+ * @param filteredRows - Filtered result set.
+ * @param originalRows - Original result set before filtering.
+ * @returns Table count summary with filtered rows count and total rows count.
+ */
+export function buildTableCountSummary<T extends Categories>(
+  filteredRows: Row<T>[],
+  originalRows: Row<T>[]
+): TableCountSummary {
+  let rowCount = 0;
+  let totalCount = 0;
+  if (filteredRows?.length && originalRows?.length) {
+    rowCount = filteredRows.length;
+    totalCount = originalRows.length;
+  }
+  return { row: rowCount, total: totalCount };
+}
 
 /**
  * Returns true if cell count is over the max allowable cell count.

--- a/frontend/src/components/common/Grid/components/HeaderCell/index.tsx
+++ b/frontend/src/components/common/Grid/components/HeaderCell/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { TableCountSummary } from "src/components/common/Filter/common/entities";
 import {
   CountAndTotal,
   HeaderCell as Cell,
@@ -6,15 +7,15 @@ import {
 
 interface Props {
   label: string;
-  rowCount?: number;
-  totalCount?: number;
+  tableCountSummary?: TableCountSummary;
 }
 
 export default function HeaderCell({
   label,
-  rowCount,
-  totalCount,
+  tableCountSummary,
 }: Props): JSX.Element {
+  const rowCount = tableCountSummary?.row;
+  const totalCount = tableCountSummary?.total;
   const countAndTotal =
     rowCount && totalCount ? `${rowCount} of ${totalCount}` : "";
   return (

--- a/frontend/src/components/common/Grid/index.tsx
+++ b/frontend/src/components/common/Grid/index.tsx
@@ -1,14 +1,19 @@
 import { TableInstance } from "react-table";
-import { Categories } from "src/components/common/Filter/common/entities";
+import {
+  Categories,
+  TableCountSummary,
+} from "src/components/common/Filter/common/entities";
 import { Grid as StyledGrid } from "./style";
 
 interface Props<T extends Categories> {
   className?: string;
+  tableCountSummary?: TableCountSummary;
   tableInstance: TableInstance<T>;
 }
 
 export default function Grid<T extends Categories>({
   className,
+  tableCountSummary,
   tableInstance,
 }: Props<T>): JSX.Element {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
@@ -26,7 +31,7 @@ export default function Grid<T extends Categories>({
                   column.getHeaderProps();
                 return (
                   <th key={key} {...restColumnHeaderProps}>
-                    {column.render("Header")}
+                    {column.render("Header", { tableCountSummary })}
                   </th>
                 );
               })}


### PR DESCRIPTION
- #3235 

### Reviewers
**Functional:** 

@MillenniumFalconMechanic 

---


## Changes
- Modified column config to with new header prop `tableCountSummary` for display of result set count to datasets and collections.
- Fixes unwanted rerender of column config.

## Notes for Reviewer
