### PR TITLE
chore: update dependencies to match cellxgene-schema 3.0.0 dependencies

### DIFF
--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -19,7 +19,7 @@ ADD requirements.txt requirements-base.txt
 ADD backend/corpora/dataset_processing/requirements.txt requirements-processing.txt
 RUN pip3 install -r requirements-base.txt -r requirements-processing.txt
 
-RUN wget "https://drive.google.com/u/0/uc?id=1RxbKLbVdmD40dk6DAz4CkpL0MgI4RSms&export=download" -O cellxgene-schema.tar.gz
+RUN wget "https://drive.google.com/u/0/uc?id=10JtP6-aYnU1bRJQv5dGEpfYDWndtO7H_&export=download" -O cellxgene-schema.tar.gz
 RUN pip install cellxgene-schema.tar.gz
 
 ADD tests /single-cell-data-portal/tests

--- a/backend/corpora/dataset_processing/requirements.txt
+++ b/backend/corpora/dataset_processing/requirements.txt
@@ -1,4 +1,4 @@
-cellxgene-schema==3.0.0
+cellxgene-schema==2.1.0
 numba==0.56.2
 numpy==1.23.2
 pandas==1.4.4

--- a/backend/corpora/dataset_processing/requirements.txt
+++ b/backend/corpora/dataset_processing/requirements.txt
@@ -1,7 +1,7 @@
-cellxgene-schema==2.1.0
-numba==0.53.1
-numpy==1.21.2
-pandas==1.3.2
+cellxgene-schema==3.0.0
+numba==0.56.2
+numpy==1.23.2
+pandas==1.4.4
 psutil>=5.9.0
 psycopg2-binary>=2.8.5
 pyarrow>=1.0

--- a/backend/wmg/requirements.txt
+++ b/backend/wmg/requirements.txt
@@ -37,13 +37,13 @@ mccabe==0.6.1
 mypy-extensions==0.4.3
 natsort==8.1.0
 networkx==2.7
-numba==0.56.0
+numba==0.56.2
 numexpr==2.8.1
-numpy==1.22.4
+numpy==1.23.2
 openapi-schema-validator==0.2.3
 openapi-spec-validator==0.4.0
 packaging==21.3
-pandas==1.3.2
+pandas==1.4.4
 parso==0.8.3
 pathspec==0.9.0
 patsy==0.5.2

--- a/backend/wmg/requirements.txt
+++ b/backend/wmg/requirements.txt
@@ -76,7 +76,7 @@ s3transfer==0.5.2
 sarif-om==1.0.4
 scanpy==1.9.1
 scikit-learn==1.0.2
-scipy==1.7.3
+scipy==1.9.1
 six==1.16.0
 SQLAlchemy==1.4.31
 stack-data==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ anndata==0.8.0
 black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
 boto3>=1.11.17
 botocore>=1.14.17
-click==8.0.1
+click==8.1.3
 coverage>=2.0.15
 flake8-black==0.3.2  # Must be kept in sync with flake8 version in .pre-commit-config.yaml
 flake8==4.0.1  # Must be kept in sync with flake8 version in .pre-commit-config.yaml


### PR DESCRIPTION
- [#328](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell/328)

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- updated numpy, pandas and numba dependencies to match those in cellxgene-schema 3.0.0 (see [PR](https://github.com/chanzuckerberg/single-cell-curation/pull/339) in single-cell-curation)

## QA steps (optional)
- tests and rdev upload

## Notes for Reviewer
- merging into 3.0.0 feature branch
- any particular known risks with updating the same dependencies for WMG? 