### PR TITLE
feat: don't retry on deterministic dataset processing failures

### DIFF
--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -18,7 +18,17 @@ resource "aws_sfn_state_machine" "state_machine" {
           "JobName": "download-validate",
           "JobQueue": "${var.job_queue_arn}",
           "RetryStrategy": {
-            "Attempts": ${var.max_attempts}
+            "Attempts": ${var.max_attempts},
+            "EvaluateOnExit": [
+              {
+                "Action": "EXIT",
+                "OnExitCode": "1"
+              },
+              {
+                "Action": "RETRY",
+                "OnExitCode": "*"
+              }
+            ]
           },
           "ContainerOverrides": {
             "Environment": [
@@ -33,10 +43,6 @@ resource "aws_sfn_state_machine" "state_machine" {
               {
                 "Name": "STEP_NAME",
                 "Value": "download-validate"
-              },
-              {
-                "Name": "MAX_ATTEMPTS",
-                "Value": "${var.max_attempts}"
               }
             ]
           }
@@ -70,7 +76,17 @@ resource "aws_sfn_state_machine" "state_machine" {
                   "JobName": "cxg",
                   "JobQueue": "${var.job_queue_arn}",
                   "RetryStrategy": {
-                    "Attempts": ${var.max_attempts}
+                    "Attempts": ${var.max_attempts},
+                    "EvaluateOnExit": [
+                      {
+                        "Action": "EXIT",
+                        "OnExitCode": "1"
+                      },
+                      {
+                        "Action": "RETRY",
+                        "OnExitCode": "*"
+                      }
+                    ]
                   },
                   "ContainerOverrides": {
                     "Environment": [
@@ -81,10 +97,6 @@ resource "aws_sfn_state_machine" "state_machine" {
                       {
                         "Name": "STEP_NAME",
                         "Value": "cxg"
-                      },
-                      {
-                        "Name": "MAX_ATTEMPTS",
-                        "Value": "${var.max_attempts}"
                       }
                     ]
                   }
@@ -106,7 +118,17 @@ resource "aws_sfn_state_machine" "state_machine" {
                   "JobName": "seurat",
                   "JobQueue": "${var.job_queue_arn}",
                   "RetryStrategy": {
-                    "Attempts": ${var.max_attempts}
+                    "Attempts": ${var.max_attempts},
+                    "EvaluateOnExit": [
+                      {
+                        "Action": "EXIT",
+                        "OnExitCode": "1"
+                      },
+                      {
+                        "Action": "RETRY",
+                        "OnExitCode": "*"
+                      }
+                    ]
                   },
                   "ContainerOverrides": {
                     "Environment": [
@@ -117,10 +139,6 @@ resource "aws_sfn_state_machine" "state_machine" {
                       {
                         "Name": "STEP_NAME",
                         "Value": "seurat"
-                      },
-                      {
-                        "Name": "MAX_ATTEMPTS",
-                        "Value": "${var.max_attempts}"
                       }
                     ]
                   }


### PR DESCRIPTION
- #2832 

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- added 'EvaluateOnExit' clause to lambda RetryStrategies, which does NOT retry if the exit code on the lambda is '1' (application error). 
- refactored process main function logic to account for this new behavior
- addressed issue where unexpected exceptions might avoid updating the step-specific processing status

## QA steps (optional)
- rdev upload only retries once, database updating as expected

## Notes for Reviewer
- Application errors (exit code 1), whether known issues with validation/conversion or unexpected exceptions related to calling for validation/exception, are deterministic and will not succeed on retries. Therefore we should fail immediately when we see one (most commonly, we fail on deterministic validation or conversion errors)

