### PR TITLE
docs: setting a config is required to run the docs server

### DIFF
--- a/frontend/doc-site/.dev/01__writing-documentation.mdx
+++ b/frontend/doc-site/.dev/01__writing-documentation.mdx
@@ -90,8 +90,8 @@ The first time you run the dev server, you will need to install the necessary to
    1. `nvm install node`
 1. Install NPM packages
    1. `npm install`
-1. (optional) Set a backend with the configuration
-   1. For staging backend: `cp src/configs/staging.js src/configs/configs.js`
+1. Set a backend with the configuration
+   1. e.g. for staging backend: `cp src/configs/staging.js src/configs/configs.js`
 1. Run the dev server
    1. `npm run dev`
 1. View the site on `localhost:3000/docs`


### PR DESCRIPTION
Setting the config is not optional. 

```bash
ambrose@ambrose-MS-7C59:~/projects/single-cell-data-portal/frontend$ npm run dev

> cellxgene-data-portal@0.1.0 dev
> next dev

ready - started server on 0.0.0.0:3000, url: http://localhost:3000
error - Failed to load next.config.js, see more info here https://nextjs.org/docs/messages/next-config-error
Error: Cannot find module '/home/ambrose/projects/single-cell-data-portal/frontend/src/configs/configs.js'
Require stack:
- /home/ambrose/projects/single-cell-data-portal/frontend/next.config.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:955:15)
    at mod._resolveFilename (/home/ambrose/projects/single-cell-data-portal/frontend/node_modules/next/dist/build/webpack/require-hook.js:27:32)
    at mod._resolveFilename (/home/ambrose/projects/single-cell-data-portal/frontend/node_modules/next/dist/build/webpack/require-hook.js:27:32)
    at Module._load (node:internal/modules/cjs/loader:803:27)
    at Module.require (node:internal/modules/cjs/loader:1021:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/home/ambrose/projects/single-cell-data-portal/frontend/next.config.js:1:17)
    at Module._compile (node:internal/modules/cjs/loader:1119:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1173:10)
    at Module.load (node:internal/modules/cjs/loader:997:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/ambrose/projects/single-cell-data-portal/frontend/next.config.js'
  ]
}
```