### PR TITLE
feat: Save the original h5ad as an artifact in the dataset.

### DIFF
--- a/backend/corpora/dataset_processing/common.py
+++ b/backend/corpora/dataset_processing/common.py
@@ -77,7 +77,10 @@ def update_db(dataset_id, metadata: dict = None, processing_status: dict = None)
 
 
 def download_from_s3(
-    bucket_name: str, object_key: str, local_filename: str, callback: typing.Optional[typing.Callable[int]] = None
+    bucket_name: str,
+    object_key: str,
+    local_filename: str,
+    callback: typing.Optional[typing.Callable[[int], None]] = None,
 ):
     logger.info(f"Downloading file {local_filename} from bucket {bucket_name} with object key {object_key}")
     buckets.portal_client.download_file(bucket_name, object_key, local_filename, callback=None)

--- a/backend/corpora/dataset_processing/download.py
+++ b/backend/corpora/dataset_processing/download.py
@@ -9,6 +9,7 @@ from backend.corpora.common.corpora_orm import DbDatasetProcessingStatus, Upload
 from backend.corpora.common.entities import Dataset
 from backend.corpora.common.utils.db_session import db_session_manager
 from backend.corpora.common.utils.math_utils import MB
+from backend.corpora.dataset_processing.common import download_from_s3
 from backend.corpora.dataset_processing.exceptions import ProcessingFailed, ProcessingCancelled
 
 logger = logging.getLogger(__name__)
@@ -18,27 +19,43 @@ class ProgressTracker:
     def __init__(self, file_size: int):
         self.file_size: int = file_size
         self._progress: int = 0
+        self.error: Exception = None  # Track errors
+
+    def progress(self):
+        return self._progress / self.file_size
+
+    def update(self, progress):
+        self._progress += progress
+        self.count += 1
+
+
+class ProgressTrackerS3URI(ProgressTracker):
+    def __init__(self, file_size: int):
+        super(self).__init__(file_size)
+        self.count = 0  # controls update frequency.
+
+    def update(self, progress):
+        super(self).update(progress)
+        self.count += 1
+
+
+class ProgressTrackerThreaded(ProgressTracker):
+    def __init__(self, file_size: int):
+        super(self).__init__(file_size)
         self.progress_lock: threading.Lock = threading.Lock()  # prevent concurrent access of ProgressTracker._progress
         self.stop_updater: threading.Event = threading.Event()  # Stops the update_progress thread
         self.stop_downloader: threading.Event = threading.Event()  # Stops the downloader threads
-        self.error: Exception = None  # Track errors
-        self.tombstoned: bool = False  # Track if dataset tombstoned
 
     def progress(self):
         with self.progress_lock:
-            return self._progress / self.file_size
+            return super(self).progress()
 
     def update(self, progress):
         with self.progress_lock:
-            self._progress += progress
-
-    def cancel(self):
-        self.tombstoned = True
-        self.stop_downloader.set()
-        self.stop_updater.set()
+            super(self).update(progress)
 
 
-class NoOpProgressTracker:
+class NoOpProgressTrackerThreaded(ProgressTrackerThreaded):
     """
     This progress tracker should be used if file_size isn't available.
     It will return a progress of 1 if no errors occurred
@@ -46,11 +63,7 @@ class NoOpProgressTracker:
     """
 
     def __init__(self) -> None:
-        self.progress_lock: threading.Lock = threading.Lock()  # prevent concurrent access of ProgressTracker._progress
-        self.stop_updater: threading.Event = threading.Event()  # Stops the update_progress thread
-        self.stop_downloader: threading.Event = threading.Event()  # Stops the downloader threads
-        self.error: Exception = None  # Track errors
-        self.tombstoned: bool = False  # Track if dataset tombstoned
+        super(self).__init__(0)
 
     def progress(self):
         if self.error:
@@ -60,11 +73,6 @@ class NoOpProgressTracker:
 
     def update(self, progress):
         pass
-
-    def cancel(self):
-        self.tombstoned = True
-        self.stop_downloader.set()
-        self.stop_updater.set()
 
 
 def downloader(url: str, local_path: str, tracker: ProgressTracker, chunk_size: int):
@@ -113,9 +121,7 @@ def updater(processing_status: DbDatasetProcessingStatus, tracker: ProgressTrack
         progress = tracker.progress()
         dataset = Dataset.get(db_session, processing_status.dataset_id, include_tombstones=True)
         if dataset.tombstone:
-            tracker.cancel()
             return
-
         elif tracker.stop_updater.is_set():
             if progress > 1:
                 tracker.stop_downloader.set()
@@ -148,14 +154,43 @@ def _processing_status_updater(processing_status: DbDatasetProcessingStatus, upd
         setattr(processing_status, key, value)
 
 
-def download(
-    dataset_id: str,
-    url: str,
-    local_path: str,
-    file_size: int,
-    chunk_size: int = 10 * MB,
-    update_frequency=3,
-) -> dict:
+def setup_download(session, dataset_id: str, file_size: int):
+    logger.info("Setting up download.")
+    logger.info(f"file_size: {file_size}")
+    if file_size and file_size >= shutil.disk_usage("/")[2]:
+        status_dict = {
+            "upload_status": UploadStatus.FAILED,
+            "upload_message": "Insufficient disk space.",
+        }
+        logger.error(f"Upload failed: {status_dict}")
+        raise ProcessingFailed(status_dict)
+    processing_status = Dataset.get(session, dataset_id).processing_status
+    processing_status.upload_status = UploadStatus.UPLOADING
+    processing_status.upload_progress = 0
+    return processing_status
+
+
+def finish_download(progress_tracker, processing_status):
+    if progress_tracker.tombstoned:
+        raise ProcessingCancelled
+    if progress_tracker.error:
+        status = {
+            "upload_status": UploadStatus.FAILED,
+            "upload_message": str(progress_tracker.error),
+        }
+        _processing_status_updater(processing_status, status)
+
+    status_dict = processing_status.to_dict()
+    if processing_status.upload_status == UploadStatus.FAILED:
+        logger.error(f"Upload failed: {status_dict}")
+        raise ProcessingFailed(status_dict)
+    else:
+        return status_dict
+
+
+def download_url(
+    dataset_id: str, url: str, local_path: str, file_size: int, chunk_size: int = 10 * MB, update_frequency=3
+):
     """
     Download a file from a url and update the processing_status upload fields in the database
 
@@ -169,22 +204,11 @@ def download(
     :return: The current dataset processing status.
     """
     with db_session_manager() as session:
-        logger.info("Setting up download.")
-        logger.info(f"file_size: {file_size}")
-        if file_size and file_size >= shutil.disk_usage("/")[2]:
-            status_dict = {
-                "upload_status": UploadStatus.FAILED,
-                "upload_message": "Insufficient disk space.",
-            }
-            logger.error(f"Upload failed: {status_dict}")
-            raise ProcessingFailed(status_dict)
-        processing_status = Dataset.get(session, dataset_id).processing_status
-        processing_status.upload_status = UploadStatus.UPLOADING
-        processing_status.upload_progress = 0
+        processing_status = setup_download(session, dataset_id, file_size)
         if file_size is not None:
-            progress_tracker = ProgressTracker(file_size)
+            progress_tracker = ProgressTrackerThreaded(file_size)
         else:
-            progress_tracker = NoOpProgressTracker()
+            progress_tracker = NoOpProgressTrackerThreaded()
 
         progress_thread = threading.Thread(
             target=updater,
@@ -198,18 +222,47 @@ def download(
         download_thread.start()
         download_thread.join()  # Wait for the download thread to complete
         progress_thread.join()  # Wait for the progress thread to complete
-        if progress_tracker.tombstoned:
-            raise ProcessingCancelled
-        if progress_tracker.error:
-            status = {
-                "upload_status": UploadStatus.FAILED,
-                "upload_message": str(progress_tracker.error),
-            }
-            _processing_status_updater(processing_status, status)
 
-        status_dict = processing_status.to_dict()
-        if processing_status.upload_status == UploadStatus.FAILED:
-            logger.error(f"Upload failed: {status_dict}")
-            raise ProcessingFailed(status_dict)
-        else:
-            return status_dict
+        return finish_download(progress_tracker, processing_status)
+
+
+def download_s3_uri(
+    dataset_id: str,
+    bucket_name: str,
+    object_key: str,
+    local_path: str,
+    file_size: int,
+    update_frequency=5,
+) -> dict:
+    """
+    Download a file from a url and update the processing_status upload fields in the database
+
+    :param dataset_id: The uuid of the dataset the download will be associated with.
+    :param bucket_name: The bucket where the object exists.
+    :param object_key: The key the object exists at.
+    :param local_path: The local name of the file be downloaded.
+    :param file_size: The size of the file in bytes.
+    :param update_frequency: The frequency in which to update the database in number of chunks read.
+
+    :return: The current dataset processing status.
+    """
+    with db_session_manager() as session:
+        processing_status = setup_download(session, dataset_id, file_size)
+        progress_tracker = ProgressTracker(file_size)
+
+        def update_progress(chunk_size):
+            progress_tracker.update(chunk_size)
+            if not processing_status.count % update_frequency:
+                dataset = Dataset.get(session, processing_status.dataset_id, include_tombstones=True)
+                if dataset.tombstone:
+                    raise ProcessingCancelled()
+                else:
+                    status = {"upload_progress": progress_tracker.progress()}
+                logger.debug("Updating processing_status")
+                _processing_status_updater(processing_status, status)
+                session.commit()
+
+        download_from_s3(
+            bucket_name=bucket_name, object_key=object_key, local_filename=local_path, callback=update_progress
+        )
+        return finish_download(progress_tracker, processing_status)

--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -166,7 +166,7 @@ def log_batch_environment():
         "AWS_BATCH_JOB_ATTEMPT",
         "AWS_BATCH_JOB_ID",
         "STEP_NAME",
-        "DROPBOX_URL",
+        "DROPBOX_URL",  # TODO: Change to SOURCE_URI
         "ARTIFACT_BUCKET",
         "CELLXGENE_BUCKET",
         "DATASET_ID",

--- a/backend/corpora/dataset_processing/process_download_validate.py
+++ b/backend/corpora/dataset_processing/process_download_validate.py
@@ -4,13 +4,11 @@ import typing
 import numpy
 import scanpy
 
-from backend.corpora.common.entities import Dataset
-from backend.corpora.common.utils.db_session import db_session_manager
 from backend.corpora.common.utils.dl_sources.url import from_url
-from backend.corpora.dataset_processing.download import download
+from backend.corpora.dataset_processing.download import download_url, download_s3_uri
 
 from backend.corpora.dataset_processing.exceptions import ValidationFailed
-from backend.corpora.dataset_processing.common import create_artifact, update_db, download_from_s3, get_bucket_prefix
+from backend.corpora.dataset_processing.common import create_artifact, update_db, get_bucket_prefix
 from backend.corpora.dataset_processing.logger import logger
 
 from backend.corpora.common.corpora_orm import (
@@ -18,11 +16,10 @@ from backend.corpora.common.corpora_orm import (
     ProcessingStatus,
     DatasetArtifactFileType,
     ValidationStatus,
-    UploadStatus,
 )
 
 
-def process(dataset_id: str, dropbox_url: str, artifact_bucket: str):
+def process(dataset_id: str, source_uri: str, artifact_bucket: str):
     """
     1. Download the original dataset from Dropbox
     2. Validate and label it
@@ -38,8 +35,8 @@ def process(dataset_id: str, dropbox_url: str, artifact_bucket: str):
     # Download the original dataset from Dropbox
     local_filename = download_from_source_uri(
         dataset_id=dataset_id,
-        source_uri=dropbox_url,
-        local_path="raw.h5ad",
+        source_uri=source_uri,
+        local_path="original.h5ad",
     )
 
     # Validate and label the dataset
@@ -56,6 +53,9 @@ def process(dataset_id: str, dropbox_url: str, artifact_bucket: str):
     bucket_prefix = get_bucket_prefix(dataset_id)
     create_artifact(
         file_with_labels, DatasetArtifactFileType.H5AD, bucket_prefix, dataset_id, artifact_bucket, "h5ad_status"
+    )
+    create_artifact(
+        local_filename, DatasetArtifactFileType.H5AD, bucket_prefix, dataset_id, artifact_bucket, "h5ad_status"
     )
 
 
@@ -181,26 +181,6 @@ def extract_metadata(filename) -> dict:
     return metadata
 
 
-def wrapped_download_from_s3(dataset_id: str, bucket_name: str, object_key: str, local_filename: str):
-    """
-    Wraps download_from_s3() to update the dataset's upload status
-    :param dataset_id:
-    :param bucket_name:
-    :param object_key:
-    :param local_filename:
-    :return:
-    """
-    with db_session_manager() as session:
-        processing_status = Dataset.get(session, dataset_id).processing_status
-        processing_status.upload_status = UploadStatus.UPLOADING
-        download_from_s3(
-            bucket_name=bucket_name,
-            object_key=object_key,
-            local_filename=local_filename,
-        )
-        processing_status.upload_status = UploadStatus.UPLOADED
-
-
 def download_from_source_uri(dataset_id: str, source_uri: str, local_path: str) -> str:
     """Given a source URI, download it to local_path.
     Handles fixing the url so it downloads directly.
@@ -209,21 +189,15 @@ def download_from_source_uri(dataset_id: str, source_uri: str, local_path: str) 
     file_url = from_url(source_uri)
     if not file_url:
         raise ValueError(f"Malformed source URI: {source_uri}")
-
+    file_info = file_url.file_info()
     # This is a bit ugly and should be done polymorphically instead, but Dropbox support will be dropped soon
     if file_url.scheme == "https":
-        file_info = file_url.file_info()
-        status = download(dataset_id, file_url.url, local_path, file_info["size"])
+        status = download_url(dataset_id, file_url.url, local_path, file_info["size"])
         logger.info(status)
     elif file_url.scheme == "s3":
         bucket_name = file_url.netloc
-        key = remove_prefix(file_url.path, "/")
-        wrapped_download_from_s3(
-            dataset_id=dataset_id,
-            bucket_name=bucket_name,
-            object_key=key,
-            local_filename=local_path,
-        )
+        object_key = remove_prefix(file_url.path, "/")
+        download_s3_uri(dataset_id, bucket_name, object_key, local_path, file_info["size"])
     else:
         raise ValueError(f"Download for URI scheme '{file_url.scheme}' not implemented")
 

--- a/tests/unit/backend/corpora/dataset_processing/test_downloader.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_downloader.py
@@ -22,7 +22,7 @@ def start_server(path, port):
     httpd.serve_forever()
 
 
-class TestDownload(DataPortalTestCase):
+class TestDownloadURL(DataPortalTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -48,7 +48,7 @@ class TestDownload(DataPortalTestCase):
         self.addCleanup(self.cleanup_local_file, local_file)
         url = f"http://localhost:{self.port}/upload_test_file.txt"
         file_size = int(requests.head(url).headers["content-length"])
-        status = download.download(
+        status = download.download_url(
             "test_dataset_id",
             url,
             local_file,
@@ -71,7 +71,7 @@ class TestDownload(DataPortalTestCase):
 
         with self.subTest("Bigger"):
             with self.assertRaises(ProcessingFailed):
-                download.download(
+                download.download_url(
                     "test_dataset_id",
                     url,
                     local_file,
@@ -82,7 +82,7 @@ class TestDownload(DataPortalTestCase):
 
         with self.subTest("Smaller"):
             with self.assertRaises(ProcessingFailed):
-                download.download(
+                download.download_url(
                     "test_dataset_id",
                     url,
                     local_file,
@@ -96,7 +96,7 @@ class TestDownload(DataPortalTestCase):
         self.addCleanup(self.cleanup_local_file, local_file)
         url = f"http://localhost:{self.port}/upload_test_file.txt"
 
-        progress_tracker = download.ProgressTracker(
+        progress_tracker = download.ProgressTrackerThreaded(
             1,
         )
         progress_tracker.stop_downloader.set()
@@ -109,7 +109,7 @@ class TestDownload(DataPortalTestCase):
         self.addCleanup(self.cleanup_local_file, local_file)
         url = f"http://localhost:{self.port}/fake.txt"
         with self.assertRaises(ProcessingFailed):
-            download.download(
+            download.download_url(
                 "test_dataset_id",
                 url,
                 local_file,
@@ -124,7 +124,7 @@ class TestDownload(DataPortalTestCase):
         url = f"http://localhost:{self.port}/upload_test_file.txt"
         file_size = int(requests.head(url).headers["content-length"])
         with self.assertRaises(AttributeError):
-            download.download(
+            download.download_url(
                 "test_dataset_id_fake",
                 url,
                 local_file,
@@ -141,4 +141,4 @@ class TestDownload(DataPortalTestCase):
         url = f"http://localhost:{self.port}/upload_test_file.txt"
         file_size = int(requests.head(url).headers["content-length"])
         with self.assertRaises(ProcessingFailed):
-            download.download("test_dataset_id_fake", url, local_file, file_size)
+            download.download_url("test_dataset_id_fake", url, local_file, file_size)

--- a/tests/unit/backend/corpora/dataset_processing/test_process_download_validate.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_process_download_validate.py
@@ -228,7 +228,7 @@ class TestProcessingDownloadValidate(DataPortalTestCase):
                 return
             time.sleep(3)
 
-    @patch("backend.corpora.dataset_processing.download.downloader")
+    @patch("backend.corpora.dataset_processing.download.download_url")
     @patch("backend.corpora.dataset_processing.process_download_validate.from_url")
     def test__dataset_tombstoned_while_uploading(self, mock_from_url, mock_downloader):
         class file_url:
@@ -262,7 +262,7 @@ class TestProcessingDownloadValidate(DataPortalTestCase):
             download_from_source_uri(self.dataset_id, unhandled_uri, "raw.h5ad")
 
     @mock_s3
-    @patch("backend.corpora.dataset_processing.process_download_validate.download_from_s3")
+    @patch("backend.corpora.dataset_processing.process_download_validate.download_s3_uri")
     def test__download_from_source_uri_with_s3_scheme__downloads_from_s3(self, mock_download_from_s3):
         test_dataset_id = self.generate_dataset(self.session).id
 


### PR DESCRIPTION
- #TICKET_NUMBER

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- Add saving of the original h5ad file. The original h5ad is named original.h5ad in the dataset_artifact.filename field.
- Add progressing tracking for downloading S3 files. It updates the same way as a dropbox file would update.

## QA steps (optional)

## Notes for Reviewer
