### PR TITLE
chore: remove extraneous logic checking for processing status in unexpected pipeline errors

### DIFF
--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -220,19 +220,15 @@ def main():
         return_value = 1
     except Exception as e:
         logger.exception(f"An unexpected error occurred while processing the data set: {e}")
-        (status,) = e.args
-        if isinstance(status, dict):
-            update_db(dataset_id, processing_status=status)
-        else:
-            if step_name == "download-validate":
-                update_db(
-                    dataset_id,
-                    processing_status={"upload_status": UploadStatus.FAILED, "upload_message": str(e)},
-                )
-            elif step_name == "seurat":
-                update_db(dataset_id, processing_status={"rds_status": ConversionStatus.FAILED})
-            elif step_name == "cxg":
-                update_db(dataset_id, processing_status={"cxg_status": ConversionStatus.FAILED})
+        if step_name == "download-validate":
+            update_db(
+                dataset_id,
+                processing_status={"upload_status": UploadStatus.FAILED, "upload_message": str(e)},
+            )
+        elif step_name == "seurat":
+            update_db(dataset_id, processing_status={"rds_status": ConversionStatus.FAILED})
+        elif step_name == "cxg":
+            update_db(dataset_id, processing_status={"cxg_status": ConversionStatus.FAILED})
         return_value = 1
 
     return return_value

--- a/tests/unit/processing_container/test_process.py
+++ b/tests/unit/processing_container/test_process.py
@@ -116,18 +116,6 @@ class TestDatasetProcessing(CorporaTestCaseUsingMockAWS):
         }
 
         test_environment["STEP_NAME"] = "download-validate"
-        with self.subTest("process step raises unknown exception with status dict"):
-            mock_process_download_validate.side_effect = Exception(
-                {"validation_status": ValidationStatus.INVALID, "validation_message": "Anndata could not open raw.h5ad"}
-            )
-            dataset = self.generate_dataset(self.session, collection_id="test_collection_id")
-            test_environment["DATASET_ID"] = dataset.id
-            with EnvironmentSetup(test_environment):
-                main()
-                expected_dataset = Dataset.get(self.session, test_environment["DATASET_ID"]).processing_status
-                self.assertEqual(expected_dataset.validation_status, ValidationStatus.INVALID)
-                self.assertEqual(expected_dataset.validation_message, "Anndata could not open raw.h5ad")
-
         with self.subTest("download-validate step raises unknown exception"):
             mock_process_download_validate.side_effect = Exception("unknown failure")
             dataset = self.generate_dataset(self.session, collection_id="test_collection_id")


### PR DESCRIPTION
## Changes
- removed extraneous logic, and associated test

## QA steps (optional)

## Notes for Reviewer
- reviewed processing code and confirmed that all status-bearing exceptions would be named exceptions (e.g. ProcessingFailed, etc.). Also confirmed that all validation-level errors will be caught and named, so we can safely assume only upload errors would fail with unnamed exceptions.
