### PR TITLE
fix: prevent nonprintable chars in Collection name

### DIFF
--- a/backend/corpora/common/utils/regex.py
+++ b/backend/corpora/common/utils/regex.py
@@ -5,7 +5,7 @@ USERNAME_REGEX = r"(?P<username>[\w\-\|]+)"
 ID_REGEX = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
 DATASET_ID_REGEX = f"(?P<dataset_id>{ID_REGEX})"
 COLLECTION_ID_REGEX = f"(?P<collection_id>{ID_REGEX})"
-CONTROL_CHARS = r"[\x00-\x1f\x7f-\xa0]"
+CONTROL_CHARS = r"[\x00-\x1f\x7f\x81\x8d\x8f\x90\x9d\xa0]"
 
 DOI_REGEX_COMPILED = re.compile(r"^10.\d{4,9}/[-._;()/:A-Z0-9]+$", flags=re.I)
 CURIE_REFERENCE_REGEX = r"^\d{2}\.\d{4}.*$"

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -174,7 +174,7 @@ def verify_collection_body(body: dict, errors: list) -> None:
         if key in body.keys():
             if not body[key]:
                 errors.append({"name": key, "reason": "Cannot be blank."})
-            elif control_char_re.search(body[key]):
+            elif key == "name" and control_char_re.search(body[key]):
                 errors.append({"name": key, "reason": "Invalid characters detected."})
             else:
                 return body[key]

--- a/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curator/collection/test_curation_collections.py
@@ -82,25 +82,47 @@ class TestPostCollection(BaseAuthAPITest):
         self.assertEqual(201, response.status_code)
 
     def test__create_collection__InvalidParameters(self):
-        body = dict(
-            name="",
-            description="",
-            contact_name="",
-            contact_email="@email.com",
-            doi="10.111/not_curie_reference_format",
-        )
-        expected_errors = [
-            {"name": "contact_email", "reason": "Invalid format."},
-            {"name": "description", "reason": "Cannot be blank."},
-            {"name": "name", "reason": "Cannot be blank."},
-            {"name": "contact_name", "reason": "Cannot be blank."},
-            {"name": "doi", "reason": "DOI must be a CURIE reference."},
+        requests = [
+            (
+                dict(
+                    name="",
+                    description="",
+                    contact_name="",
+                    contact_email="@email.com",
+                    doi="10.111/not_curie_reference_format",
+                ),
+                [
+                    {"name": "contact_email", "reason": "Invalid format."},
+                    {"name": "description", "reason": "Cannot be blank."},
+                    {"name": "name", "reason": "Cannot be blank."},
+                    {"name": "contact_name", "reason": "Cannot be blank."},
+                    {"name": "doi", "reason": "DOI must be a CURIE reference."},
+                ],
+                5,
+            ),
+            (
+                dict(
+                    name="Nonprintable\x0acharacters\x0bare_NOT_allowed_in_name",
+                    description="But\x0anonprintable\x0acharacters\x0bARE_allowed_in_description",
+                    contact_name="And\x0ain_contact_name",
+                    contact_email="somebody@email.com",
+                    doi="10.111/not_curie_reference_format",
+                ),
+                [
+                    {"name": "name", "reason": "Invalid characters detected."},
+                    {"name": "doi", "reason": "DOI must be a CURIE reference."},
+                ],
+                2,
+            ),
         ]
-        response = self.app.post("/curation/v1/collections", headers=self.make_owner_header(), data=json.dumps(body))
-        print(response.json)
-        self.assertEqual(400, response.status_code)
-        for error in expected_errors:
-            self.assertIn(error, response.json["invalid_parameters"])
+        for body, expected_errors, num_expected_errors in requests:
+            response = self.app.post(
+                "/curation/v1/collections", headers=self.make_owner_header(), data=json.dumps(body)
+            )
+            self.assertEqual(400, response.status_code)
+            for error in expected_errors:
+                self.assertIn(error, response.json["invalid_parameters"])
+            self.assertEqual(len(response.json["invalid_parameters"]), num_expected_errors)
 
 
 class TestGetCollections(BaseAuthAPITest):

--- a/tests/unit/backend/corpora/api_server/test_v1_collection.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_collection.py
@@ -1350,18 +1350,16 @@ class TestVerifyCollection(unittest.TestCase):
         self.assertIn({"name": "contact_email", "reason": error_message}, errors)
 
     def test_invalid_characters_in_field(self):
-        errors = []
         invalid_strings = [b"\x00some data", b"text\x1f", b"text\x01", b"\x7ftext"]
         for test_string in invalid_strings:
             with self.subTest(test_string):
+                errors = []
                 string = test_string.decode(encoding="utf-8")
-                body = dict(name=string, contact_name=string, description=string, contact_email=string)
+                body = dict(name=string, contact_name=string, description=string, contact_email="email@email.com")
                 verify_collection_body(body, errors)
                 error_message = "Invalid characters detected."
-                self.assertIn({"name": "description", "reason": error_message}, errors)
+                self.assertEqual(1, len(errors))
                 self.assertIn({"name": "name", "reason": error_message}, errors)
-                self.assertIn({"name": "contact_name", "reason": error_message}, errors)
-                self.assertIn({"name": "contact_email", "reason": error_message}, errors)
 
     def test_invalid_email(self):
         bad_emails = ["@.", "email@.", "@place.com", "email@.com", "email@place."]


### PR DESCRIPTION
- Undo previous solution which was applied to `contact_name` and `description` as well; these fields should permit such characters
- Primary focus was to disallow characters that did not get a valid grapheme representation *when used for a hyperlink*, which is important for Collection names

- #3134 

### Reviewers
**Functional:** 
@Bento007
**Readability:** 
@nayib-jose-gloria 
---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
