### PR TITLE
fix: typo in list of assays to include in gene expression

### DIFF
--- a/backend/wmg/data/constants.py
+++ b/backend/wmg/data/constants.py
@@ -15,7 +15,7 @@ INCLUDED_ASSAYS = {
     "EFO:0009899": "10x 3' v2",
     "EFO:0009900": "10x 5' v2",
     "EFO:0009922": "10x 3' v3",
-    "EFO_0030003": "10x 3' transcription profiling",
+    "EFO:0030003": "10x 3' transcription profiling",
     "EFO:0030004": "10x 5' transcription profiling",
     "EFO:0008919": "Seq-Well",
     "EFO:0008995": "10x technology",


### PR DESCRIPTION
fixes: typo in list of assays to include in gene expression. 

About 400K cells from "10x 3' transcription profiling" are currently not included because of this typo.