### PR TITLE
fix: proceed with processing if status is INITIALIZED

### DIFF
--- a/backend/corpora/common/upload.py
+++ b/backend/corpora/common/upload.py
@@ -79,6 +79,7 @@ def upload(
         if dataset.processing_status.processing_status not in [
             ProcessingStatus.SUCCESS,
             ProcessingStatus.FAILURE,
+            ProcessingStatus.INITIALIZED,
         ]:
             raise InvalidProcessingStateException(
                 f"Unable to reprocess dataset {dataset_id}: {dataset.processing_status.processing_status=}"


### PR DESCRIPTION
This commit ensures that INITIALIZED Datasets -- those created using the Curation API -- will proceed with processing rather than erroneously throwing an InvalidProcessingStateException

- #TICKET_NUMBER

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
