### PR TITLE
docs: access token required for POST /datasets

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -297,6 +297,8 @@ paths:
       description: |
         Create a new empty Dataset and return the `id`. The `id` is used when uploading a datafile 
         to S3 to identify what Dataset the file belongs to.
+
+        * Required: provide your access token in the request header as `Authentication: bearer <access_token>`.
       operationId: backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.actions.post
       security:
         - curatorAccess: []


### PR DESCRIPTION
- #3212 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- add note in description for `POST /datasets` per @brianraymor 's [mention in the issue](https://github.com/chanzuckerberg/single-cell-data-portal/issues/3212#issuecomment-1254306628)

## QA steps (optional)

## Notes for Reviewer
