### PR TITLE
fix: remove '/private' from Collection url in Slack notification

### DIFF
--- a/backend/corpora/common/utils/slack.py
+++ b/backend/corpora/common/utils/slack.py
@@ -50,7 +50,7 @@ def format_dataset_processing_failure_slack_message(dataset_id):
                     "type": "mrkdwn",
                     "text": f"Dataset processing job failed! @sc-oncall-eng\n"
                     f"*Owner*: {collection_owner}\n"
-                    f"*Collection*: https://cellxgene.cziscience.com/collections/{collection_id}/private\n"
+                    f"*Collection*: https://cellxgene.cziscience.com/collections/{collection_id}\n"
                     f"*Processing Status*:\n",
                 },
             },


### PR DESCRIPTION
Alright, here it is. After countless hours of untangling our pipeline and re-deriving various fundamentals of binary-encoded data theory, this is what I've come up with for this previously-thought-to-be-unsolvable ticket. Even [Emanuele was stumped](https://github.com/chanzuckerberg/single-cell-data-portal/issues/2031#issuecomment-1224093938) by this one.

- #2031 

### Reviewers
**Functional:** 
@Bento007 @seve @metakuni 
**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
