### PR TITLE
Tsmith/3342 expired key

### DIFF
--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -48,7 +48,10 @@ def assert_authorized_token(token: str, audience: str = None) -> dict:
                 token, public_key, algorithms=algorithms, audience=use_audience, issuer=issuer, options=options
             )
         except ExpiredSignatureError:
-            raise
+            raise UnauthorizedError(
+                detail="Your authentication credentials have expired. Please provide updated "
+                "credentials before trying again."
+            )
         except JWTClaimsError:
             raise UnauthorizedError(detail="Incorrect claims, please check the audience and issuer.")
         except Exception:

--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -4,12 +4,10 @@ from functools import lru_cache
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util import Retry
-from jose import jwt
-from jose.exceptions import ExpiredSignatureError, JWTError, JWTClaimsError
 
 from .corpora_config import CorporaAuthConfig
 from backend.corpora.common.utils.http_exceptions import UnauthorizedError
-
+from .utils.jwt import jwt_decode, get_unverified_header
 
 auth0_session_with_retry = requests.Session()
 retry_config = Retry(total=3, backoff_factor=1, status_forcelist=CorporaAuthConfig().retry_status_forcelist)
@@ -22,10 +20,7 @@ def assert_authorized_token(token: str, audience: str = None) -> dict:
     :param token: The token
     :return: The decoded access token and userinfo.
     """
-    try:
-        unverified_header = jwt.get_unverified_header(token)
-    except JWTError:
-        raise UnauthorizedError(detail="Unable to parse authentication token.")
+    unverified_header = get_unverified_header(token)
     auth_config = CorporaAuthConfig()
     auth0_domain = auth_config.internal_url
     # If we're using an id_token (for userinfo), we need a difference audience, which gets passed in.
@@ -43,20 +38,9 @@ def assert_authorized_token(token: str, audience: str = None) -> dict:
             os.environ.get("DEPLOYMENT_STAGE") == "test" and (not public_key.get("n") or not public_key.get("e"))
         ):
             options = {"verify_signature": False, "verify_iss": False, "verify_at_hash": False}
-        try:
-            payload = jwt.decode(
-                token, public_key, algorithms=algorithms, audience=use_audience, issuer=issuer, options=options
-            )
-        except ExpiredSignatureError:
-            raise UnauthorizedError(
-                detail="Your authentication credentials have expired. Please provide updated "
-                "credentials before trying again."
-            )
-        except JWTClaimsError:
-            raise UnauthorizedError(detail="Incorrect claims, please check the audience and issuer.")
-        except Exception:
-            raise UnauthorizedError(detail="Unable to parse authentication token.")
-
+        payload = jwt_decode(
+            token, public_key, algorithms=algorithms, audience=use_audience, issuer=issuer, options=options
+        )
         return payload
 
     raise UnauthorizedError(detail="Unable to find appropriate key")

--- a/backend/corpora/common/utils/api_key.py
+++ b/backend/corpora/common/utils/api_key.py
@@ -1,7 +1,8 @@
 import time
-from jose import jws, jwt
+from jose import jws
 from jose.constants import ALGORITHMS
 
+from backend.corpora.common.utils.jwt import jwt_decode
 
 seconds_in_day = 86400
 
@@ -14,4 +15,4 @@ def generate(user_id: str, secret: str, days_to_live: int = 1) -> str:
 
 
 def verify(token: str, secret: str):
-    return jwt.decode(token, secret, algorithms=["HS256"])
+    return jwt_decode(token, secret, algorithms=["HS256"])

--- a/backend/corpora/common/utils/jwt.py
+++ b/backend/corpora/common/utils/jwt.py
@@ -1,0 +1,25 @@
+from jose import ExpiredSignatureError, jwt
+from jose.exceptions import JWTClaimsError, JWTError
+
+from backend.corpora.common.utils.http_exceptions import UnauthorizedError
+
+
+def jwt_decode(*args, **kwargs) -> dict:
+    try:
+        return jwt.decode(*args, **kwargs)
+    except ExpiredSignatureError:
+        raise UnauthorizedError(
+            detail="Your authentication credentials have expired. Please provide updated "
+            "credentials before trying again."
+        )
+    except JWTClaimsError:
+        raise UnauthorizedError(detail="Incorrect claims, please check the audience and issuer.")
+    except Exception:
+        raise UnauthorizedError(detail="Unable to parse authentication token.")
+
+
+def get_unverified_header(token: str) -> dict:
+    try:
+        return jwt.get_unverified_header(token)
+    except JWTError:
+        raise UnauthorizedError(detail="Unable to parse authentication token.")


### PR DESCRIPTION
- #3342

### Reviewers
**Functional:** @danieljhegeman 

**Readability:** @nayib-jose-gloria 

---


## Changes
- add error message when the curator API key has expired
- encapsulated JWT-related code, so error messages are returned consistently.

## QA steps (optional)

## Notes for Reviewer
