### PR TITLE
fix: Curation API - standardize 'id' response structures

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -141,7 +141,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  collection_id:
+                  id:
                     $ref: "#/components/schemas/collection_id"
         "400":
           $ref: "#/components/responses/400"
@@ -284,7 +284,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  revision_id:
+                  id:
                     $ref: "#/components/schemas/collection_id"
         "401":
           $ref: "#/components/responses/401"

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -238,7 +238,8 @@ def create_collection(body: dict, user: str):
     if doi_node := get_doi_link_node(body, errors):
         if doi_url := portal_get_normalized_doi_url(doi_node, errors):
             doi_node["link_url"] = doi_url
-    return create_collection_common(body, user, doi_url, errors)
+    collection_id = create_collection_common(body, user, doi_url, errors)
+    return make_response(jsonify({"collection_id": collection_id}), 201)
 
 
 @dbconnect
@@ -266,7 +267,7 @@ def create_collection_common(body: dict, user: str, doi: str, errors: list):
         publisher_metadata=publisher_metadata,
     )
 
-    return make_response(jsonify({"collection_id": collection.id}), 201)
+    return collection.id
 
 
 @dbconnect

--- a/backend/corpora/lambdas/api/v1/curation/collections/actions.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/actions.py
@@ -1,4 +1,4 @@
-from flask import jsonify, g
+from flask import jsonify, g, make_response
 from .common import reshape_for_curation_api
 from ...authorization import is_super_curator, owner_or_allowed
 from ...collection import create_collection_common, curation_get_normalized_doi_url
@@ -52,7 +52,8 @@ def post(body: dict, user: str):
             links.append({"link_type": ProjectLinkType.DOI.name, "link_url": doi_url})
             body["links"] = links
     try:
-        return create_collection_common(body, user, doi_url, errors)
+        collection_id = create_collection_common(body, user, doi_url, errors)
+        return make_response(jsonify({"id": collection_id}), 201)
     except InvalidParametersHTTPException as ex:
         ex.ext = dict(invalid_parameters=ex.detail)
         ex.detail = InvalidParametersHTTPException._default_detail

--- a/backend/corpora/lambdas/api/v1/curation/collections/collection_id/datasets/actions.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/collection_id/datasets/actions.py
@@ -44,7 +44,7 @@ def post(token_info: dict, collection_id: str):
     dataset = Dataset.create(
         db_session, collection=collection, processing_status={"processing_status": ProcessingStatus.INITIALIZED}
     )
-    return make_response(jsonify({"dataset_id": dataset.id}), 201)
+    return make_response(jsonify({"id": dataset.id}), 201)
 
 
 def put(collection_id: str, dataset_id: str, body: dict, token_info: dict):

--- a/backend/corpora/lambdas/api/v1/curation/collections/collection_id/revision.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/collection_id/revision.py
@@ -7,4 +7,4 @@ from backend.corpora.lambdas.api.v1.collection import post_collection_revision_c
 @dbconnect
 def post_collection_revision(collection_id: str, token_info: dict):
     collection_revision = post_collection_revision_common(collection_id, token_info)
-    return make_response(jsonify({"revision_id": collection_revision.id}), 201)
+    return make_response(jsonify({"id": collection_revision.id}), 201)

--- a/tests/unit/backend/corpora/api_server/curation/collection/test_curation_collections.py
+++ b/tests/unit/backend/corpora/api_server/curation/collection/test_curation_collections.py
@@ -79,6 +79,7 @@ class TestPostCollection(BaseAuthAPITest):
         response = self.app.post(
             "/curation/v1/collections", headers=self.make_owner_header(), data=json.dumps(self.test_collection)
         )
+        self.assertIn("id", response.json.keys())
         self.assertEqual(201, response.status_code)
 
     def test__create_collection__InvalidParameters(self):

--- a/tests/unit/backend/corpora/api_server/curation/collection/test_curation_revision.py
+++ b/tests/unit/backend/corpora/api_server/curation/collection/test_curation_revision.py
@@ -31,11 +31,11 @@ class TestPostRevision(BaseAuthAPITest):
             headers=self.make_owner_header(),
         )
         self.assertEqual(201, response.status_code)
-        self.assertNotEqual(collection_id, response.json["revision_id"])
+        self.assertNotEqual(collection_id, response.json["id"])
 
     def test__post_revision__Super_Curator(self):
         collection_id = self.generate_collection(self.session, visibility=CollectionVisibility.PUBLIC.name).id
         headers = self.make_super_curator_header()
         response = self.app.post(f"/curation/v1/collections/{collection_id}/revision", headers=headers)
         self.assertEqual(201, response.status_code)
-        self.assertNotEqual(collection_id, response.json["revision_id"])
+        self.assertNotEqual(collection_id, response.json["id"])

--- a/tests/unit/backend/corpora/api_server/curation/collection/test_dataset.py
+++ b/tests/unit/backend/corpora/api_server/curation/collection/test_dataset.py
@@ -90,7 +90,7 @@ class TestPostDataset(BaseAuthAPITest):
         headers = self.make_owner_header()
         response = self.app.post(test_url, headers=headers)
         self.assertEqual(201, response.status_code)
-        self.assertTrue(response.json["dataset_id"])
+        self.assertTrue(response.json["id"])
 
     def test_post_datasets_super(self):
         collection = self.generate_collection(self.session)


### PR DESCRIPTION
- return "collection_id" as "id"
- return "revision_id" as "id"
- return "dataset_id" as "id"

- #3345 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
