### PR TITLE
fix: add service platforms to docker-compose

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -208,7 +208,7 @@ jobs:
             export DEPLOYMENT_STAGE=staging
           fi
           echo DEPLOYMENT_STAGE ${DEPLOYMENT_STAGE}
-          docker-compose up --no-deps -d backend
+          docker compose up --no-deps -d backend
           BOTO_ENDPOINT_URL= make local-functional-test
       ### Need to write success failure way because Github API doesn't allow doing
       ### "if: always(), state: ${{ success() }}:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -37,10 +37,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Lint Python
         run: |
-          docker-compose run --no-deps --rm backend make -C /single-cell-data-portal lint
+          docker compose run --no-deps --rm backend make -C /single-cell-data-portal lint
       - name: Lint frontend
         run: |
-          docker-compose run --no-deps --rm frontend make lint
+          docker compose run --no-deps --rm frontend make lint
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
@@ -198,7 +198,7 @@ jobs:
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make local-rebuild-backend
-      - name: Run tests in docker-compose
+      - name: Run tests in docker compose
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make local-init-test-data
@@ -244,7 +244,7 @@ jobs:
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make local-rebuild-processing
-      - name: Run tests in docker-compose
+      - name: Run tests in docker compose
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make local-init-test-data
@@ -290,7 +290,7 @@ jobs:
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make local-rebuild-processing
-      - name: Run tests in docker-compose
+      - name: Run tests in docker compose
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make local-unit-test-wmg-processing

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -99,7 +99,7 @@ jobs:
 
   build-extra-images:
     runs-on: ubuntu-20.04
-    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
+    #if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -122,14 +122,14 @@ jobs:
         shell: bash
         run: |
           happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} upload_failures upload_success dataset_submissions processing wmg_processing
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,commit,author,eventName,workflow,job,mention
-          mention: "here"
+      #- uses: 8398a7/action-slack@v3
+     ##  with:
+      #    status: ${{ job.status }}
+      #    fields: repo,commit,author,eventName,workflow,job,mention
+      #    mention: "here"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-        if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
+      #  if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
 
   push-prod-images:
     needs:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -79,7 +79,7 @@ db/local/load-schema:
 
 db/dump_schema:
 ifeq ($(DEPLOYMENT_STAGE),test)
-	docker-compose exec database pg_dump --schema-only --dbname=corpora --username corpora
+	docker compose exec database pg_dump --schema-only --dbname=corpora --username corpora
 else
 	$(eval DB_PW = $(shell aws secretsmanager get-secret-value --secret-id corpora/backend/${DEPLOYMENT_STAGE}/database --region us-west-2 | jq -r '.SecretString | match(":([^:]*)@").captures[0].string'))
 	$(MAKE) db/tunnel/up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   database:
     image: postgres:13.0
@@ -37,6 +35,8 @@ services:
     image: "${DOCKER_REPO}corpora-frontend"
     platform: linux/amd64
     build:
+      platforms:
+        - linux/amd64
       context: frontend
       cache_from:
         - "${DOCKER_REPO}corpora-frontend:branch-main"
@@ -69,6 +69,8 @@ services:
     image: "${DOCKER_REPO}corpora-upload-failures"
     platform: linux/amd64
     build:
+      platforms:
+        - linux/amd64
       context: .
       cache_from:
         - "${DOCKER_REPO}corpora-upload-failures:branch-main"
@@ -104,6 +106,8 @@ services:
     image: "${DOCKER_REPO}corpora-upload-success"
     platform: linux/amd64
     build:
+      platforms:
+        - linux/amd64
       context: .
       cache_from:
         - "${DOCKER_REPO}corpora-upload-success:branch-main"
@@ -139,6 +143,8 @@ services:
     image: "${DOCKER_REPO}dataset-submissions"
     platform: linux/amd64
     build:
+      platforms:
+        - linux/amd64
       context: .
       cache_from:
         - "${DOCKER_REPO}dataset-submissions:branch-main"
@@ -173,6 +179,8 @@ services:
     image: "${DOCKER_REPO}corpora-upload"
     platform: linux/amd64
     build:
+      platforms:
+        - linux/amd64
       context: .
       cache_from:
         - "${DOCKER_REPO}corpora-upload:branch-main"
@@ -208,6 +216,8 @@ services:
     image: "${DOCKER_REPO}wmg-processing"
     platform: linux/amd64
     build:
+      platforms:
+        - linux/amd64
       context: .
       cache_from:
         - "${DOCKER_REPO}wmg-processing:branch-main"
@@ -241,6 +251,8 @@ services:
     image: "${DOCKER_REPO}corpora-backend"
     platform: linux/amd64
     build:
+      platforms:
+        - linux/amd64
       context: .
       cache_from:
         - "${DOCKER_REPO}corpora-backend:branch-main"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,8 +143,8 @@ services:
     image: "${DOCKER_REPO}dataset-submissions"
     platform: linux/amd64
     build:
-      platforms:
-        - linux/amd64
+        platforms:
+          - linux/amd64
       context: .
       cache_from:
         - "${DOCKER_REPO}dataset-submissions:branch-main"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,8 +143,8 @@ services:
     image: "${DOCKER_REPO}dataset-submissions"
     platform: linux/amd64
     build:
-        platforms:
-          - linux/amd64
+      platforms:
+        - linux/amd64
       context: .
       cache_from:
         - "${DOCKER_REPO}dataset-submissions:branch-main"

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -47,7 +47,7 @@ e2e:
 
 .PHONY: e2e-on-local-dev
 e2e-on-local-dev:
-	docker-compose exec frontend make smoke-test-with-local-dev
+	docker compose exec frontend make smoke-test-with-local-dev
 
 .PHONY: smoke-test-with-local-dev
 smoke-test-with-local-dev:

--- a/frontend/src/configs/config.js
+++ b/frontend/src/configs/config.js
@@ -1,0 +1,9 @@
+const { PLAUSIBLE_DATA_DOMAIN_STAGING } = require("./common");
+
+const configs = {
+  API_URL: "https://wmg-test-backend.rdev.single-cell.czi.technology",
+  PLAUSIBLE_DATA_DOMAIN: PLAUSIBLE_DATA_DOMAIN_STAGING,
+  SENTRY_DEPLOYMENT_ENVIRONMENT: "staging",
+};
+
+if (typeof module !== "undefined") module.exports = configs;


### PR DESCRIPTION
- #TICKET_NUMBER

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- add
service.build.platforms to each service.build in the docker compose to fix a new error introduced by Docker Compose 2.11:

`service.platform should be part of the service.build.platforms: "linux/amd64"`

## Notes for Reviewer

It looks like Ubuntu 20.04 has upgraded their version of docker:

* Before: https://github.com/actions/runner-images/blob/ubuntu20/20220905.1/images/linux/Ubuntu2004-Readme.md
* After: https://github.com/actions/runner-images/blob/ubuntu20/20220922.2/images/linux/Ubuntu2004-Readme.md

As part of the upgraded image, docker compose now throw an error when the service.build.platforms array is not specified in the docker-compose.yml file if it is also specified in the service.platform attribute.