### PR TITLE
fix: Remove platform references, and use DOCKER_DEFAULT_PLATFORM env

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -17,7 +17,6 @@ env:
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1
   DOCKER_REPO: ${{ secrets.ECR_REPO }}/
-  DOCKER_DEFAULT_PLATFORM: linux/amd64
 
 jobs:
   lint:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           happy_version: "0.23.0"
       - name: Push images
-        #if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
         run: |
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
           echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
@@ -100,7 +100,7 @@ jobs:
 
   build-extra-images:
     runs-on: ubuntu-20.04
-    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
+    #if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -88,18 +88,18 @@ jobs:
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
           echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
           happy push --docker-compose-env-file envfile --aws-profile "" --tag sha-${GITHUB_SHA:0:8} frontend backend
-      # - uses: 8398a7/action-slack@v3
-      #   with:
-      #     status: ${{ job.status }}
-      #     fields: repo,commit,author,eventName,workflow,job,mention
-      #     mention: "here"
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-      #   if: failure() && github.ref == 'refs/heads/main'
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,eventName,workflow,job,mention
+          mention: "here"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure() && github.ref == 'refs/heads/main'
 
   build-extra-images:
     runs-on: ubuntu-20.04
-    #if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
+    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -17,6 +17,7 @@ env:
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1
   DOCKER_REPO: ${{ secrets.ECR_REPO }}/
+  DOCKER_DEFAULT_PLATFORM: linux/amd64
 
 jobs:
   lint:
@@ -83,19 +84,19 @@ jobs:
         with:
           happy_version: "0.23.0"
       - name: Push images
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
+        #if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
         run: |
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
           echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
           happy push --docker-compose-env-file envfile --aws-profile "" --tag sha-${GITHUB_SHA:0:8} frontend backend
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,commit,author,eventName,workflow,job,mention
-          mention: "here"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-        if: failure() && github.ref == 'refs/heads/main'
+      # - uses: 8398a7/action-slack@v3
+      #   with:
+      #     status: ${{ job.status }}
+      #     fields: repo,commit,author,eventName,workflow,job,mention
+      #     mention: "here"
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+      #   if: failure() && github.ref == 'refs/heads/main'
 
   build-extra-images:
     runs-on: ubuntu-20.04

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
           - localstack.corporanet.local
   frontend:
     image: "${DOCKER_REPO}corpora-frontend"
-    platform: linux/amd64
     build:
       context: frontend
       cache_from:
@@ -67,7 +66,6 @@ services:
           - frontend.corporanet.local
   upload_failures:
     image: "${DOCKER_REPO}corpora-upload-failures"
-    platform: linux/amd64
     build:
       context: .
       cache_from:
@@ -102,7 +100,6 @@ services:
           - uploadfailures.corporanet.local
   upload_success:
     image: "${DOCKER_REPO}corpora-upload-success"
-    platform: linux/amd64
     build:
       context: .
       cache_from:
@@ -137,7 +134,6 @@ services:
           - uploadsuccess.corporanet.local
   dataset_submissions:
     image: "${DOCKER_REPO}dataset-submissions"
-    platform: linux/amd64
     build:
       context: .
       cache_from:
@@ -171,7 +167,6 @@ services:
           - dataset_submissions.corporanet.local
   processing:
     image: "${DOCKER_REPO}corpora-upload"
-    platform: linux/amd64
     build:
       context: .
       cache_from:
@@ -206,7 +201,6 @@ services:
           - processing.corporanet.local
   wmg_processing:
     image: "${DOCKER_REPO}wmg-processing"
-    platform: linux/amd64
     build:
       context: .
       cache_from:
@@ -239,7 +233,6 @@ services:
           - processing.corporanet.local
   backend:
     image: "${DOCKER_REPO}corpora-backend"
-    platform: linux/amd64
     build:
       context: .
       cache_from:


### PR DESCRIPTION
# Description

Currently, there is a bug in Docker Compose where the latest version (2.11, which Github has automatically upgraded to in our Github Actions) requires that the service.build.platforms argument be provided in the docker-compose.yml. Github autopopulates this field with "linux/arm64". This is normally fine by default because we specify the service.platform attribute in each of our images. However, there is another Docker Compose bug that is not properly picking up these platform attributes. Due to that, our Github Action is failing because it doesn't think a platform matches the list of provided platforms. To make things worse, this latest version of Docker Compose is not available on Mac yet. Ideally, we'd add the service.build.platforms attribute, such as in [this test PR](https://github.com/chanzuckerberg/single-cell-data-portal/pull/3349/files), but since Mac's aren't on the latest docker compose version, locally we get this error:

`services.backend.build Additional property platforms is not allowed`.

The proposed solution requires removing all the platforms tags. This works to unblock the deployments, however, locally images on M1 Apple might have trouble building their images. In order to build these images locally on Mac M1, make sure you have the following environment variable set (in `~/.zshrc` or `~/.bashrc`):

`export DOCKER_DEFAULT_PLATFORM ="linux/amd64"`


## Changes
* service.build.platforms to each service.build in the docker compose to fix a new error introduced by Docker Compose 2.11:

`service.platform should be part of the service.build.platforms: "linux/amd64"`

## Notes for Reviewer

It looks like Ubuntu 20.04 has upgraded their version of docker:

* Before: https://github.com/actions/runner-images/blob/ubuntu20/20220905.1/images/linux/Ubuntu2004-Readme.md
* After: https://github.com/actions/runner-images/blob/ubuntu20/20220922.2/images/linux/Ubuntu2004-Readme.md

As part of the upgraded image, docker compose now throw an error when the service.build.platforms array is not specified in the docker-compose.yml file if it is also specified in the service.platform attribute.