### PR TITLE
feat: remove dataset_id from /{dataset_id}/assets response

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -557,8 +557,6 @@ components:
                 type: string
             type: object
           type: array
-        dataset_id:
-          $ref: "#/components/schemas/dataset_id"
       type: object
     asset_filetype:
       enum:


### PR DESCRIPTION
- #3345 

The `dataset_id` is in the url of the request. Returning it in the response is redundant.

### Reviewers
**Functional:** 
@nayib-jose-gloria @Bento007 
**Readability:** 

---


## Changes
- remove `dataset_id` from the `GET /{dataset_id}/assets` response

## QA steps (optional)

## Notes for Reviewer
