### PR TITLE
chore: update cellxgene-schema version to 3.0.0

### DIFF
--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -19,9 +19,6 @@ ADD requirements.txt requirements-base.txt
 ADD backend/corpora/dataset_processing/requirements.txt requirements-processing.txt
 RUN pip3 install -r requirements-base.txt -r requirements-processing.txt
 
-RUN wget "https://drive.google.com/u/0/uc?id=10JtP6-aYnU1bRJQv5dGEpfYDWndtO7H_&export=download" -O cellxgene-schema.tar.gz
-RUN pip install cellxgene-schema.tar.gz
-
 ADD tests /single-cell-data-portal/tests
 ADD backend/__init__.py backend/__init__.py
 ADD backend/corpora/__init__.py backend/corpora/__init__.py

--- a/backend/corpora/dataset_processing/requirements.txt
+++ b/backend/corpora/dataset_processing/requirements.txt
@@ -1,4 +1,4 @@
-cellxgene-schema==2.1.0
+cellxgene-schema==3.0.0
 numba==0.56.2
 numpy==1.23.2
 pandas==1.4.4


### PR DESCRIPTION
- https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell/337

## Changes
- make cellxgene-schema 3.0.0 a requirement for dataset processing + wmg processing
- remove rc workaround in processing dockerfile

## QA steps (optional)

## Notes for Reviewer
