### PR TITLE
chore: add remastering jupyter notebook

### DIFF
--- a/scripts/remaster_cxg_v0.3.0.ipynb
+++ b/scripts/remaster_cxg_v0.3.0.ipynb
@@ -5,7 +5,8 @@
    "id": "ae699abe",
    "metadata": {},
    "source": [
-    "# Batch dataset upgrade\n",
+    "# Batch CXG dataset upgrade\n",
+    "Upgrades all *production* CXG datasets to 0.3.0 specification, in-place.\n"
     "This notebook should be in the root directory of `single-cell-data-portal`."
    ]
   },

--- a/scripts/remaster_cxg_v0.3.0.ipynb
+++ b/scripts/remaster_cxg_v0.3.0.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ae699abe",
+   "metadata": {},
+   "source": [
+    "# Batch dataset upgrade\n",
+    "This notebook should be in the root directory of `single-cell-data-portal`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe2162b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir -p ~/cxg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a2e33ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import backend.corpora.dataset_processing.remaster_cxg as rm\n",
+    "import pickle, os, tiledb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3d71c6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -rf ~/cxg/*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f223e24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!aws s3 ls s3://hosted-cellxgene-prod > cxgs.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b7c9e43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = open('cxgs.txt','r').read()\n",
+    "X = X.split('\\n')[:-1]\n",
+    "cxgs = [i.split('PRE ')[-1][:-1].split('.cxg')[0] for i in X]\n",
+    "\n",
+    "bucket_name = \"hosted-cellxgene-prod\"\n",
+    "local_path = \"/home/ubuntu/cxg/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdf7d75d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # for restarts\n",
+    "    COMPLETED_DATASETS = pickle.load(open('completed_datasets.p','rb'))\n",
+    "    FAILED_DATASETS = pickle.load(open('failed_datasets.p','rb'))    \n",
+    "    z = pickle.load(open('dataset_counter.p','rb'))\n",
+    "except:\n",
+    "    COMPLETED_DATASETS=[]\n",
+    "    FAILED_DATASETS=[]   \n",
+    "    z=0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77507196",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(z)\n",
+    "for cxg in cxgs[z:]:\n",
+    "    if cxg not in COMPLETED_DATASETS and cxg not in FAILED_DATASETS:\n",
+    "        print(cxg)\n",
+    "        try:\n",
+    "            rm.process(cxg,\n",
+    "                       bucket_name,\n",
+    "                       local_path=local_path,\n",
+    "                       dry_run=False)\n",
+    "            COMPLETED_DATASETS.append(cxg)\n",
+    "        except Exception as e:\n",
+    "            os.system(f\"rm -rf {local_path}/*\")\n",
+    "            FAILED_DATASETS.append(cxg)\n",
+    "            print(e)\n",
+    "        z+=1\n",
+    "        pickle.dump(FAILED_DATASETS,open('failed_datasets.p','wb'))\n",
+    "        pickle.dump(COMPLETED_DATASETS,open('completed_datasets.p','wb'))  \n",
+    "        pickle.dump(z,open('dataset_counter.p','wb'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06a90c19",
+   "metadata": {},
+   "source": [
+    "# Retrospective - Make sure all datasets are remastered"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d0ac2f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.system(\"rm -rf ~/cxg/*\")\n",
+    "not_upgraded = []\n",
+    "for i,cxg in enumerate(cxgs):\n",
+    "    if i%50==0:\n",
+    "        print(i)\n",
+    "    os.system(f\"aws s3 sync s3://hosted-cellxgene-prod/{cxg}.cxg/cxg_group_metadata ~/cxg/group --quiet\")\n",
+    "    A = tiledb.open(\"~/cxg/group\")\n",
+    "    if A.meta['cxg_version']!=\"0.3.0\":\n",
+    "        print(\"CXG not upgraded\",cxg)\n",
+    "        not_upgraded.append(cxg)\n",
+    "    os.system(\"rm -rf ~/cxg/*\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds the remastering notebook used to update the CXGs from v0.2.0 to v0.3.0 to `scripts/`.