### PR TITLE
fix: report Collection status as PENDING with INITIALIZED Datasets

### DIFF
--- a/backend/corpora/lambdas/api/v1/curation/collections/common.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/common.py
@@ -272,8 +272,8 @@ def add_collection_level_processing_status(collection: DbCollection) -> str:
     for dataset in collection.datasets:
         if processing_status := dataset.processing_status:
             status = processing_status.processing_status
-            if status == ProcessingStatus.PENDING:
-                return_status = status
+            if status in (ProcessingStatus.PENDING, ProcessingStatus.INITIALIZED):
+                return_status = ProcessingStatus.PENDING
             elif status == ProcessingStatus.FAILURE:
                 return status
     return return_status


### PR DESCRIPTION
- #3366 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- modify logic for Collection-level processing status so that `PENDING` is returned if the Collection contains any Datasets with a status of `INITIALIZED` (new, empty Datasets).

## QA steps (optional)

## Notes for Reviewer
