### PR TITLE
fix: cloudfront log message

### DIFF
--- a/backend/corpora/common/utils/cloudfront.py
+++ b/backend/corpora/common/utils/cloudfront.py
@@ -34,7 +34,7 @@ def _create_invalidation(distribution: str, paths: List[str]):
             "CallerReference": invalidation_id,
         },
     )
-    logging.info(dict(body=response.json, status_code=response.status_code))
+    logging.info(response)
 
 
 def create_invalidation_for_index_paths():


### PR DESCRIPTION
- #TICKET_NUMBER

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
fixing this error
```{
    "levelname": "ERROR",
    "asctime": "2022-10-04T20:30:27.004Z",
    "name": "corpora-api-dev",
    "message": "InternalServerError",
    "lineno": 184,
    "pathname": "/single-cell-data-portal/backend/corpora/api_server/app.py",
    "request_id": "fe85c64d-c218-432c-8323-5df61ccbbd8b",
    "exc_info": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.10/dist-packages/flask/app.py\", line 1820, in full_dispatch_request\n    rv = self.dispatch_request()\n  File \"/usr/local/lib/python3.10/dist-packages/flask/app.py\", line 1796, in dispatch_request\n    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)\n  File \"/usr/local/lib/python3.10/dist-packages/connexion/decorators/decorator.py\", line 68, in wrapper\n    response = function(request)\n  File \"/usr/local/lib/python3.10/dist-packages/connexion/security/security_handler_factory.py\", line 388, in wrapper\n    return function(request)\n  File \"/usr/local/lib/python3.10/dist-packages/connexion/decorators/uri_parsing.py\", line 149, in wrapper\n    response = function(request)\n  File \"/usr/local/lib/python3.10/dist-packages/connexion/decorators/validation.py\", line 196, in wrapper\n    response = function(request)\n  File \"/usr/local/lib/python3.10/dist-packages/connexion/decorators/validation.py\", line 399, in wrapper\n    return function(request)\n  File \"/usr/local/lib/python3.10/dist-packages/connexion/decorators/response.py\", line 112, in wrapper\n    response = function(request)\n  File \"/usr/local/lib/python3.10/dist-packages/connexion/decorators/parameter.py\", line 116, in wrapper\n    return function(**kwargs)\n  File \"/single-cell-data-portal/backend/corpora/api_server/db.py\", line 12, in wrapper\n    return func(*args, **kwargs)\n  File \"/single-cell-data-portal/backend/corpora/lambdas/api/v1/collection_id/publish.py\", line 30, in post\n    cloudfront.create_invalidation_for_index_paths()\n  File \"/single-cell-data-portal/backend/corpora/common/utils/cloudfront.py\", line 41, in create_invalidation_for_index_paths\n    return create_invalidation([\"/dp/v1/datasets/index\", \"/dp/v1/collections/index\"])\n  File \"/single-cell-data-portal/backend/corpora/common/utils/cloudfront.py\", line 21, in create_invalidation\n    return _create_invalidation(distribution, paths)\n  File \"/single-cell-data-portal/backend/corpora/common/utils/cloudfront.py\", line 37, in _create_invalidation\n    logging.info(dict(body=response.json, status_code=response.status_code))\nAttributeError: 'dict' object has no attribute 'json'"
}
```

## QA steps (optional)

## Notes for Reviewer
