### PR TITLE
fix: remove dataset_id from 'GET /assets' response

### DIFF
--- a/backend/corpora/lambdas/api/v1/curation/collections/collection_id/assets.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/collection_id/assets.py
@@ -44,6 +44,6 @@ def get(collection_id: str, dataset_id=None):
             result["presigned_url"] = presigned_url
         asset_list.append(result)
 
-    response = dict(dataset_id=dataset.id, assets=asset_list)
+    response = dict(assets=asset_list)
     status_code = 202 if error_flag else 200
     return make_response(jsonify(**response), status_code)

--- a/tests/unit/backend/corpora/api_server/curation/collection/test_assets.py
+++ b/tests/unit/backend/corpora/api_server/curation/collection/test_assets.py
@@ -17,13 +17,11 @@ class TestAsset(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         self.create_s3_object(s3_file_name, bucket, content=content)
 
         expected_body = dict(
-            dataset_id=self.test_dataset_id,
             assets=[dict(filename="test_filename", filesize=len(content), filetype="H5AD")],
         )
 
         response = self.app.get(
             f"/curation/v1/collections/test_collection_id/datasets/{self.test_dataset_id}/assets",
-            query_string=dict(dataset_id=self.test_dataset_id),
         )
         self.assertEqual(200, response.status_code)
         actual_body = response.json
@@ -32,9 +30,7 @@ class TestAsset(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         self.assertEqual(expected_body, actual_body)
 
     def test__get_dataset_asset__file_error(self):
-        expected_body = dict(
-            dataset_id=self.test_dataset_id, assets=[dict(filename="test_filename", filesize=-1, filetype="H5AD")]
-        )
+        expected_body = dict(assets=[dict(filename="test_filename", filesize=-1, filetype="H5AD")])
 
         response = self.app.get(
             f"/curation/v1/collections/test_collection_id/datasets/{self.test_dataset_id}/assets",


### PR DESCRIPTION
- #3345 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
This PR actually makes the necessary code changes to remove `dataset_id` from the `GET /assets` response.

## QA steps (optional)

## Notes for Reviewer
