### PR TITLE
refactor: return list of assets for 'GET /assets'

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -541,23 +541,20 @@ paths:
 components:
   schemas:
     asset_response:
-      properties:
-        assets:
-          items:
-            properties:
-              filename:
-                $ref: "#/components/schemas/asset_filename"
-              filesize:
-                description: the size of the file in bytes.
-                type: number
-              filetype:
-                $ref: "#/components/schemas/asset_filetype"
-              presigned_url:
-                description: A URL to download this asset.
-                type: string
-            type: object
-          type: array
-      type: object
+      items:
+        properties:
+          filename:
+            $ref: "#/components/schemas/asset_filename"
+          filesize:
+            description: the size of the file in bytes.
+            type: number
+          filetype:
+            $ref: "#/components/schemas/asset_filetype"
+          presigned_url:
+            description: A URL to download this asset.
+            type: string
+        type: object
+      type: array
     asset_filetype:
       enum:
         - H5AD

--- a/backend/corpora/lambdas/api/v1/curation/collections/collection_id/assets.py
+++ b/backend/corpora/lambdas/api/v1/curation/collections/collection_id/assets.py
@@ -44,6 +44,6 @@ def get(collection_id: str, dataset_id=None):
             result["presigned_url"] = presigned_url
         asset_list.append(result)
 
-    response = dict(assets=asset_list)
+    response = asset_list
     status_code = 202 if error_flag else 200
-    return make_response(jsonify(**response), status_code)
+    return make_response(jsonify(response), status_code)

--- a/tests/unit/backend/corpora/api_server/curation/collection/test_assets.py
+++ b/tests/unit/backend/corpora/api_server/curation/collection/test_assets.py
@@ -16,28 +16,26 @@ class TestAsset(BaseAuthAPITest, CorporaTestCaseUsingMockAWS):
         content = "Hello world!"
         self.create_s3_object(s3_file_name, bucket, content=content)
 
-        expected_body = dict(
-            assets=[dict(filename="test_filename", filesize=len(content), filetype="H5AD")],
-        )
+        expected_body = [dict(filename="test_filename", filesize=len(content), filetype="H5AD")]
 
         response = self.app.get(
             f"/curation/v1/collections/test_collection_id/datasets/{self.test_dataset_id}/assets",
         )
         self.assertEqual(200, response.status_code)
         actual_body = response.json
-        presign_url = actual_body["assets"][0].pop("presigned_url")
+        presign_url = actual_body[0].pop("presigned_url")
         self.assertIsNotNone(presign_url)
         self.assertEqual(expected_body, actual_body)
 
     def test__get_dataset_asset__file_error(self):
-        expected_body = dict(assets=[dict(filename="test_filename", filesize=-1, filetype="H5AD")])
+        expected_body = [dict(filename="test_filename", filesize=-1, filetype="H5AD")]
 
         response = self.app.get(
             f"/curation/v1/collections/test_collection_id/datasets/{self.test_dataset_id}/assets",
         )
         self.assertEqual(202, response.status_code)
         actual_body = response.json
-        presign_url = actual_body["assets"][0].pop("presigned_url", None)
+        presign_url = actual_body[0].pop("presigned_url", None)
         self.assertIsNone(presign_url)
         self.assertEqual(expected_body, actual_body)
 


### PR DESCRIPTION
- #3392 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 

---


## Changes
- instead of nesting under `.assets` in a top-level object, simply return assets array directly (since `dataset_id` is no longer included as a sibling top-level attr)

## QA steps (optional)

## Notes for Reviewer
