### PR TITLE
fix: Genes display properly if selected first

### DIFF
--- a/frontend/src/views/WheresMyGene/components/GetStarted/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GetStarted/index.tsx
@@ -28,6 +28,7 @@ export default function GetStarted({
   if (!geneHasLoadedOnce && geneSelected && !isLoading) {
     geneHasLoadedOnce = true;
   }
+
   return (
     <Wrapper
       style={
@@ -40,11 +41,11 @@ export default function GetStarted({
         </StyledStepOne>
       </ColumnOne>
 
-      <ColumnTwo style={geneHasLoadedOnce ? { visibility: "hidden" } : {}}>
-        <StyledStepTwo>
+      <ColumnTwo>
+        <StyledStepTwo style={geneHasLoadedOnce ? { visibility: "hidden" } : {}}>
           <Step step={2} details="Add Genes" />
         </StyledStepTwo>
-        <StyledStepThree>
+        <StyledStepThree style={geneHasLoadedOnce && tissueHasLoadedOnce ? { visibility: "hidden" } : {}}>
           <Step step={3} details="Explore Gene Expression" />
         </StyledStepThree>
       </ColumnTwo>

--- a/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
@@ -109,7 +109,7 @@ export default memo(function HeatMap({
 
     return result;
   }, [selectedGeneExpressionSummariesByTissueName, geneNameToIndex]);
-
+  console.log(sortedGeneNames)
   return (
     <Container {...{ className }}>
       {isLoadingAPI || isAnyTissueLoading(isLoading) ? <Loader /> : null}

--- a/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
@@ -109,7 +109,7 @@ export default memo(function HeatMap({
 
     return result;
   }, [selectedGeneExpressionSummariesByTissueName, geneNameToIndex]);
-  console.log(sortedGeneNames)
+
   return (
     <Container {...{ className }}>
       {isLoadingAPI || isAnyTissueLoading(isLoading) ? <Loader /> : null}

--- a/frontend/src/views/WheresMyGene/components/Main/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Main/index.tsx
@@ -226,7 +226,7 @@ export default function WheresMyGene(): JSX.Element {
   const hasSelectedGenes = selectedGenes.length > 0;
 
   const shouldShowHeatMap = useMemo(() => {
-    return hasSelectedTissues;
+    return hasSelectedTissues || hasSelectedGenes;
   }, [hasSelectedTissues, hasSelectedGenes]);
 
   const handleIsScaledChange = useCallback(() => {


### PR DESCRIPTION
Fixes #3398 
I also adjusted the landing page behavior such that if genes are selected first, Step 3 does not disappear until both tissues and genes are selected.

<img width="813" alt="image" src="https://user-images.githubusercontent.com/16548075/194185971-3fe776a4-2217-4482-954e-b327b1aa592d.png">
