### PR TITLE
docs: Curation API - "Authentication" header should be "Authorization"

### DIFF
--- a/backend/config/curation-api.yml
+++ b/backend/config/curation-api.yml
@@ -24,7 +24,7 @@ paths:
       tags:
         - authentication
       description: |
-        Returns a bearer access token that must be passed in an Authentication header to requests that
+        Returns a bearer access token that must be passed in an Authorization header to requests that
         require authorization such as creating a new Collection.
       operationId: backend.corpora.lambdas.api.v1.curation.auth.token.post
       parameters:
@@ -61,12 +61,12 @@ paths:
 
         When the visibility parameter is set to PRIVATE, a list of all private Collections or private revisions of 
         public Collections that the user is authorized to access is returned. An access token MUST be set in the request
-        header as: `Authentication: Bearer <access_token>`
+        header as: `Authorization: Bearer <access_token>`
 
         If a Collection in the list is a private revision of a public Collection, then it is annotated with 
         `revision_of`.
 
-        * Optional: provide your access token in the request header as `Authentication: Bearer <access_token>`.
+        * Optional: provide your access token in the request header as `Authorization: Bearer <access_token>`.
       operationId: backend.corpora.lambdas.api.v1.curation.collections.actions.get
       security:
         - curatorAccessLenient: []
@@ -116,7 +116,7 @@ paths:
       description: >
         Create a new private Collection
 
-        * Required: provide your access token in the request header as `Authentication: Bearer <access_token>`.
+        * Required: provide your access token in the request header as `Authorization: Bearer <access_token>`.
       operationId: backend.corpora.lambdas.api.v1.curation.collections.actions.post
       tags:
         - collection
@@ -154,9 +154,9 @@ paths:
       description: >
         Fetch full metadata for the Collection and its Datasets.
 
-        An Authentication token must be provided in order to retrieve the id of an associated Revision for this Collection (the `revising_in` field), if such a Revision currently exists.
+        An Authorization token must be provided in order to retrieve the id of an associated Revision for this Collection (the `revising_in` field), if such a Revision currently exists.
 
-        * Optional: provide your access token in the request header as `Authentication: Bearer <access_token>`.
+        * Optional: provide your access token in the request header as `Authorization: Bearer <access_token>`.
       operationId: backend.corpora.lambdas.api.v1.curation.collections.collection_id.actions.get
       security:
         - curatorAccessLenient: []
@@ -184,7 +184,7 @@ paths:
         metadata of the DOI such as the list of authors. If the DOI has not been submitted to Crossref by its 
         publisher, then the request returns a 400 (BAD REQUEST).
 
-        * Required: provide your access token in the request header as `Authentication: Bearer <access_token>`.
+        * Required: provide your access token in the request header as `Authorization: Bearer <access_token>`.
       operationId: backend.corpora.lambdas.api.v1.curation.collections.collection_id.actions.patch
       security:
         - curatorAccess: []
@@ -240,7 +240,7 @@ paths:
       description: |
         Delete a private Collection or cancel a Revision.
 
-        * Required: provide your access token in the request header as `Authentication: Bearer <access_token>`.
+        * Required: provide your access token in the request header as `Authorization: Bearer <access_token>`.
       operationId: backend.corpora.lambdas.api.v1.curation.collections.collection_id.actions.delete
       security:
         - curatorAccess: []
@@ -268,7 +268,7 @@ paths:
 
         All methods of updating or adding Datasets and metadata to a Revision work the same as for a private Collection.
 
-        * Required: provide your access token in the request header as `Authentication: Bearer <access_token>`.
+        * Required: provide your access token in the request header as `Authorization: Bearer <access_token>`.
       operationId: backend.corpora.lambdas.api.v1.curation.collections.collection_id.revision.post_collection_revision
       security:
         - curatorAccess: []
@@ -298,7 +298,7 @@ paths:
         Create a new empty Dataset and return the `id`. The `id` is used when uploading a datafile 
         to S3 to identify what Dataset the file belongs to.
 
-        * Required: provide your access token in the request header as `Authentication: bearer <access_token>`.
+        * Required: provide your access token in the request header as `Authorization: bearer <access_token>`.
       operationId: backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.actions.post
       security:
         - curatorAccess: []
@@ -334,7 +334,7 @@ paths:
         If the Dataset is being processed, then this endpoint will cancel processing and delete the Dataset. While 
         the cancellation process is occurring, the Dataset may still appear as part of the Collection for a few minutes, but will eventually be removed.
 
-        * Required: provide your access token in the request header as `Authentication: bearer <access_token>`.
+        * Required: provide your access token in the request header as `Authorization: bearer <access_token>`.
       operationId: backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.actions.delete
       tags:
         - collection
@@ -388,7 +388,7 @@ paths:
         Dataset will be uploaded from the provided `link` which MUST either be a presigned AWS S3 URL or Dropbox shared
         file URL.
 
-        * Required: provide your access token in the request header as `Authentication: Bearer <access_token>`.
+        * Required: provide your access token in the request header as `Authorization: Bearer <access_token>`.
       operationId: backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.actions.put
       tags:
         - collection
@@ -473,7 +473,7 @@ paths:
         A Dataset uploaded directly to S3 in this manner will appear in the Collection only once the Dataset has started
         processing.
 
-        * Required: provide your access token in the request header as `Authentication: Bearer <access_token>`.
+        * Required: provide your access token in the request header as `Authorization: Bearer <access_token>`.
       security:
         - curatorAccess: []
       operationId: backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.upload_s3.get
@@ -811,7 +811,7 @@ components:
         self_reported_ethnicity:
           description: |
             [self reported ethnicity label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.0.0/schema.md#self_reported_ethnicity)
-          default: [ ]
+          default: []
           items:
             $ref: "#/components/schemas/ontology_element"
           type: array
@@ -901,8 +901,7 @@ components:
       nullable: true
       type: string
     donor_id:
-      description:
-        Free-text that identifies a unique individual that data were derived from.
+      description: Free-text that identifies a unique individual that data were derived from.
       type: array
       items:
         type: string
@@ -1022,7 +1021,7 @@ components:
       type: object
     suspension_type:
       description:
-        List of unique suspension types represented in the dataset, corresponding to dataset's assay(s). 
+        List of unique suspension types represented in the dataset, corresponding to dataset's assay(s).
         Possible item values are 'nucleus', 'cell', and/or 'na'.
       type: array
       items:


### PR DESCRIPTION
- #3432 

### Reviewers
**Functional:** 
@nayib-jose-gloria @Bento007 
**Readability:** 

---


## Changes
- modify doc reference for header for including Bearer token in Curation API

## QA steps (optional)

## Notes for Reviewer
