### PR TITLE
fix: update validation status and message when files exceed size limit

### DIFF
--- a/backend/corpora/common/upload.py
+++ b/backend/corpora/common/upload.py
@@ -63,7 +63,7 @@ def upload(
     # Check if file size is within max size limit
     max_file_size_gb = CorporaConfig().upload_max_file_size_gb * GB
     if file_size is not None and file_size > max_file_size_gb:
-        error_message = f"The file exceeds the maximum allowed size of {max_file_size_gb} GB"
+        error_message = f"The file exceeds the maximum allowed size of {max_file_size_gb} bytes"
         if dataset:
             dataset.update(
                 processing_status={

--- a/backend/corpora/common/upload.py
+++ b/backend/corpora/common/upload.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from backend.corpora.common.corpora_config import CorporaConfig
 import os
 
-from backend.corpora.common.corpora_orm import CollectionVisibility, ProcessingStatus
+from backend.corpora.common.corpora_orm import CollectionVisibility, ProcessingStatus, ValidationStatus
 from backend.corpora.common.entities import Collection, Dataset
 from backend.corpora.common.utils.authorization_checks import owner_or_allowed
 from backend.corpora.common.utils.exceptions import (
@@ -52,9 +52,26 @@ def upload(
     scope: str = None,
     dataset_id: str = None,
 ) -> str:
+    # Check if a dataset already exists
+    if dataset_id:
+        dataset = Dataset.get(db_session, dataset_id, collection_id=collection_id)
+        if not dataset:
+            raise NonExistentDatasetException(f"Dataset {dataset_id} does not exist")
+    else:
+        dataset = None
+
+    # Check if file size is within max size limit
     max_file_size_gb = CorporaConfig().upload_max_file_size_gb * GB
     if file_size is not None and file_size > max_file_size_gb:
-        raise MaxFileSizeExceededException(f"{url} exceeds the maximum allowed file size of {max_file_size_gb} Gb")
+        error_message = f"The file exceeds the maximum allowed size of {max_file_size_gb} GB"
+        if dataset:
+            dataset.update(
+                processing_status={
+                    "validation_status": ValidationStatus.INVALID,
+                    "validation_message": error_message,
+                }
+            )
+        raise MaxFileSizeExceededException(error_message)
 
     # Check if datasets can be added to the collection
     collection = Collection.get_collection(
@@ -65,14 +82,6 @@ def upload(
     )
     if not collection:
         raise NonExistentCollectionException(f"Collection {collection_id} does not exist")
-
-    # Check if a dataset already exists
-    if dataset_id:
-        dataset = Dataset.get(db_session, dataset_id, collection_id=collection_id)
-        if not dataset:
-            raise NonExistentDatasetException(f"Dataset {dataset_id} does not exist")
-    else:
-        dataset = None
 
     if dataset:
         # Update dataset

--- a/backend/corpora/common/upload.py
+++ b/backend/corpora/common/upload.py
@@ -61,9 +61,9 @@ def upload(
         dataset = None
 
     # Check if file size is within max size limit
-    max_file_size_gb = CorporaConfig().upload_max_file_size_gb * GB
-    if file_size is not None and file_size > max_file_size_gb:
-        error_message = f"The file exceeds the maximum allowed size of {max_file_size_gb} bytes"
+    max_file_size_gb = CorporaConfig().upload_max_file_size_gb
+    if file_size is not None and file_size > max_file_size_gb * GB:
+        error_message = f"The file exceeds the maximum allowed size of {max_file_size_gb} GB"
         if dataset:
             dataset.update(
                 processing_status={

--- a/tests/unit/backend/corpora/dataset_processing/test_common.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_common.py
@@ -18,9 +18,12 @@ from backend.corpora.common.corpora_orm import (
     UploadStatus,
     ValidationStatus,
 )
+from backend.corpora.common.corpora_config import CorporaConfig
 from backend.corpora.common.entities.collection import Collection
 from backend.corpora.common.entities.dataset import Dataset
-from backend.corpora.common.utils.exceptions import CorporaException
+from backend.corpora.common.upload import upload
+from backend.corpora.common.utils.exceptions import CorporaException, MaxFileSizeExceededException
+from backend.corpora.common.utils.math_utils import GB
 from backend.corpora.dataset_processing.exceptions import ProcessingCancelled, ConversionFailed
 from backend.corpora.dataset_processing.common import convert_file, create_artifact, get_bucket_prefix
 
@@ -206,3 +209,22 @@ class TestCommon(DataPortalTestCase):
 
         with self.assertRaises(ConversionFailed):
             convert_file(converter, self.h5ad_filename, "error", "fake_id", "h5ad_status")
+
+    def test__filesize_exceeds_limit(self):
+        collection = self.generate_collection(self.session)
+        dataset = self.generate_dataset(self.session, collection_id=collection.id)
+        max_file_size = CorporaConfig().upload_max_file_size_gb * GB
+        with self.assertRaises(MaxFileSizeExceededException):
+            upload(
+                self.session,
+                collection.id,
+                "download_url_placeholder",
+                max_file_size + 1,  # Purport to exceed the max file size
+                "test_user",
+                dataset_id=dataset.id,
+            )
+        self.assertEqual(dataset.processing_status.validation_status, ValidationStatus.INVALID)
+        self.assertEqual(
+            dataset.processing_status.validation_message,
+            f"The file exceeds the maximum allowed size of {max_file_size} bytes",
+        )

--- a/tests/unit/backend/corpora/dataset_processing/test_common.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_common.py
@@ -213,18 +213,18 @@ class TestCommon(DataPortalTestCase):
     def test__filesize_exceeds_limit(self):
         collection = self.generate_collection(self.session)
         dataset = self.generate_dataset(self.session, collection_id=collection.id)
-        max_file_size = CorporaConfig().upload_max_file_size_gb * GB
+        max_file_size_gb = CorporaConfig().upload_max_file_size_gb
         with self.assertRaises(MaxFileSizeExceededException):
             upload(
                 self.session,
                 collection.id,
                 "download_url_placeholder",
-                max_file_size + 1,  # Purport to exceed the max file size
+                max_file_size_gb * GB + 1,  # Purport to exceed the max file size
                 "test_user",
                 dataset_id=dataset.id,
             )
         self.assertEqual(dataset.processing_status.validation_status, ValidationStatus.INVALID)
         self.assertEqual(
             dataset.processing_status.validation_message,
-            f"The file exceeds the maximum allowed size of {max_file_size} bytes",
+            f"The file exceeds the maximum allowed size of {max_file_size_gb} GB",
         )


### PR DESCRIPTION
- #3451 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 
@nayib-jose-gloria 
---


## Changes
Populate the `dataset_processing_status.validation_status` and `dataset_processing_status.validation_message` when a file is encountered that is too large for processing.

## QA steps (optional)

## Notes for Reviewer
