### PR TITLE
[DO NOT MERGE - testing GHA] test(push-test): Update push-test.yml

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "16.14.2"
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -70,35 +71,47 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 1800
+
       - name: Login to ECR
         uses: docker/login-action@v1
         with:
           registry: ${{ secrets.ECR_REPO }}
+
       - uses: actions/checkout@v2
-      - name: Install dependencies
+
+      - name: Display github.ref
         run: |
-          npm ci
-          npx playwright install --with-deps
-          cp src/configs/dev.js src/configs/configs.js
-          npm run dev&
-      - name: Run E2E tests
-        run: DEBUG=pw:api npm run e2e
+          echo '${{ github.ref }}'
+
+      - name: Start app in containers
+        run: |
+          cd ..
+          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          make local-sync
+          sleep 30  # Give frontend some time to finish building
+
+      - name: Run E2E tests against local containers
+        run: make local-smoke-test
+
       - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: test-results
           path: frontend/playwright-report/
           retention-days: 30
+
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
         with:
           happy_version: "0.23.0"
+
       - name: Push images
         if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
         run: |
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
           echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
           happy push --docker-compose-env-file envfile --aws-profile "" --tag sha-${GITHUB_SHA:0:8} frontend backend
+
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -55,7 +55,7 @@ e2e-on-local-dev:
 
 .PHONY: smoke-test-with-local-dev
 smoke-test-with-local-dev:
-	npm run e2e-happy; \
+	DEBUG=pw:api npm run e2e-happy; \
 	test_result=$$?; \
 	cp src/configs/local.js src/configs/configs.js; \
 	exit $$test_result

--- a/frontend/tests/common/constants.ts
+++ b/frontend/tests/common/constants.ts
@@ -20,11 +20,27 @@ const TEST_ENV_TO_TEST_URL = {
 };
 
 export const TEST_URL = TEST_ENV_TO_TEST_URL[TEST_ENV];
-export const TEST_USERNAME =
-  TEST_ENV === "happy"
-    ? (process.env.TEST_ACCOUNT_USER as string)
-    : "user@example.com";
-export const TEST_PASSWORD = process.env.TEST_ACCOUNT_PASS || "";
+
+// (thuang): From oauth/users.json
+const LOCAL_TEST_USERNAME = "User1";
+const LOCAL_TEST_PASSWORD = "pwd";
+
+const DEPLOYED_TEST_USERNAME = "user@example.com";
+
+const USERNAMES = {
+  dev: DEPLOYED_TEST_USERNAME,
+  happy: LOCAL_TEST_USERNAME,
+  local: LOCAL_TEST_USERNAME,
+  localProd: LOCAL_TEST_USERNAME,
+  prod: DEPLOYED_TEST_USERNAME,
+  rdev: DEPLOYED_TEST_USERNAME,
+  staging: DEPLOYED_TEST_USERNAME,
+};
+
+export const TEST_USERNAME = USERNAMES[TEST_ENV] || DEPLOYED_TEST_USERNAME;
+
+export const TEST_PASSWORD =
+  process.env.TEST_ACCOUNT_PASS || LOCAL_TEST_PASSWORD;
 
 export const BLUEPRINT_SAFE_TYPE_OPTIONS = { delay: 50 };
 

--- a/frontend/tests/features/collection/collection.test.ts
+++ b/frontend/tests/features/collection/collection.test.ts
@@ -5,7 +5,6 @@ import { sortByCellCountDescending } from "src/components/Collection/components/
 import { INVALID_DOI_ERROR_MESSAGE } from "src/components/CreateCollectionModal/components/Content/common/constants";
 import { BLUEPRINT_SAFE_TYPE_OPTIONS, TEST_URL } from "tests/common/constants";
 import {
-  describeIfDeployed,
   describeIfDevStaging,
   goToPage,
   login,
@@ -37,7 +36,7 @@ type CollectionFormInput = Pick<
 >;
 
 describe("Collection", () => {
-  describeIfDeployed("Logged In Tests", () => {
+  describe("Logged In Tests", () => {
     test("creates and deletes a collection", async ({ page }) => {
       const timestamp = Date.now();
       await login(page);

--- a/frontend/tests/utils/helpers.ts
+++ b/frontend/tests/utils/helpers.ts
@@ -33,7 +33,11 @@ export async function goToPage(
 export async function login(page: Page): Promise<void> {
   await goToPage(undefined, page);
 
-  expect(process.env.TEST_ACCOUNT_PASS).toBeDefined();
+  // (thuang): Testing a deployed environment requires a test password as env
+  // var `TEST_ACCOUNT_PASS`
+  if (!TEST_ENV.includes("local") || !TEST_ENV.includes("happy")) {
+    expect(process.env.TEST_ACCOUNT_PASS).toBeDefined();
+  }
 
   const cookies = await (await page.context()).cookies();
 


### PR DESCRIPTION
- #TICKET_NUMBER

Restore E2E tests to hit local containers again instead of dev BE. But building containers is so slow though. Not sure if we should do this along with better Docker layer caching?

context: https://github.com/chanzuckerberg/single-cell-data-portal/pull/2853#pullrequestreview-1039667667

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
