### PR TITLE
fix(Invalid DOI e2e tests): e2e test specifies which response it is waiting for before evaluating test assertions

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -86,8 +86,8 @@ const config: PlaywrightTestConfig = {
     viewport: VIEWPORT,
   },
 
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Opt out of parallel tests. */
+  workers: 1,
 
   /* Run your local dev server before starting the tests */
   // webServer: {

--- a/frontend/tests/features/collection/collection.test.ts
+++ b/frontend/tests/features/collection/collection.test.ts
@@ -1,6 +1,7 @@
 import { expect, Page, test } from "@playwright/test";
 import { ROUTES } from "src/common/constants/routes";
 import { Collection } from "src/common/entities";
+import { API_URL } from "src/configs/configs";
 import { sortByCellCountDescending } from "src/components/Collection/components/CollectionDatasetsGrid/components/DatasetsGrid/common/util";
 import { INVALID_DOI_ERROR_MESSAGE } from "src/components/CreateCollectionModal/components/Content/common/constants";
 import { BLUEPRINT_SAFE_TYPE_OPTIONS, TEST_URL } from "tests/common/constants";
@@ -114,7 +115,7 @@ describe("Collection", () => {
         await populatePublicationDOI("INVALID_FORMAT", page);
 
         // Attempt submit, confirm error message is displayed.
-        const [response] = await submitCreateForm(page);
+        const [response] = await submitCreateFormInvalid(page);
         expect(response.status()).toEqual(400);
         await expect(page).toHaveSelector(getText(INVALID_DOI_ERROR_MESSAGE));
       });
@@ -139,7 +140,7 @@ describe("Collection", () => {
         await populatePublicationDOI(VALID_FORMAT_BUT_NON_EXISTENT_DOI, page);
 
         // Attempt submit, confirm error message is displayed.
-        const [response] = await submitCreateForm(page);
+        const [response] = await submitCreateFormInvalid(page);
         expect(response.status()).toEqual(400);
         await expect(page).toHaveSelector(getText(INVALID_DOI_ERROR_MESSAGE));
       });
@@ -180,12 +181,23 @@ async function showCreateForm(page: Page) {
 }
 
 /**
+ * Submit create invalid collection form.
+ * @returns Form submit invalid parameters error response (400).
+ */
+async function submitCreateFormInvalid(page: Page) {
+  return await Promise.all([
+    page.waitForResponse(response => response.url() === `${API_URL}/dp/v1/collections` && response.status() === 400),
+    page.click(getTestID("create-button")),
+  ]);
+}
+
+/**
  * Submit create collection form.
  * @returns Form submit response.
  */
 async function submitCreateForm(page: Page) {
   return await Promise.all([
-    page.waitForEvent("response"),
+    page.waitForResponse(response => response.url() === `${API_URL}/dp/v1/collections` && response.status() === 200),
     page.click(getTestID("create-button")),
   ]);
 }


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

- #3412

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- Made default # of workers for local e2e test runs 1, to more closely match CI pipeline post-deployment test environment when testing locally
- Updated Invalid DOI tests to wait for specific response (URL, status code) they want to evaluate against, they were previously evaluating after the first response event on the page, which is not necessarily always the response they are actually testing (led to flakiness)

## QA steps (optional)
- Locally ran e2e tests against dev env

## Notes for Reviewer
- On true failures, invalid DOI tests will now timeout waiting for a 400 response (3 min) rather than fail quickly on evaluation like before. This is a trade-off, however, I find it preferable to quicker tests with a larger chance for false negatives.