### PR TITLE
fix: apply functional test retry config towards POST requests

### DIFF
--- a/tests/functional/backend/common.py
+++ b/tests/functional/backend/common.py
@@ -31,7 +31,12 @@ class BaseFunctionalTestCase(unittest.TestCase):
         cls.deployment_stage = os.environ["DEPLOYMENT_STAGE"]
         cls.config = CorporaAuthConfig()
         cls.session = requests.Session()
-        retry_config = Retry(total=7, backoff_factor=2, status_forcelist=[500, 502, 503, 504])
+        retry_config = Retry(
+            total=7,
+            backoff_factor=2,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=frozenset({"DELETE", "GET", "HEAD", "OPTIONS", "PUT", "TRACE", "POST"}),
+        )
         cls.session.mount("https://", HTTPAdapter(max_retries=retry_config))
         token = cls.get_auth_token(cls.config.test_account_username, cls.config.test_account_password)
         cls.curator_cookie = cls.make_cookie(token)

--- a/tests/functional/backend/common.py
+++ b/tests/functional/backend/common.py
@@ -31,11 +31,13 @@ class BaseFunctionalTestCase(unittest.TestCase):
         cls.deployment_stage = os.environ["DEPLOYMENT_STAGE"]
         cls.config = CorporaAuthConfig()
         cls.session = requests.Session()
+        # apply retry config to idempotent http methods we use + POST requests, which are currently all either
+        # idempotent (wmg queries) or low risk to rerun in dev/staging. Update if this changes in functional tests.
         retry_config = Retry(
             total=7,
             backoff_factor=2,
             status_forcelist=[500, 502, 503, 504],
-            allowed_methods=frozenset({"DELETE", "GET", "HEAD", "OPTIONS", "PUT", "TRACE", "POST"}),
+            allowed_methods={"DELETE", "GET", "HEAD", "PUT" "POST"},
         )
         cls.session.mount("https://", HTTPAdapter(max_retries=retry_config))
         token = cls.get_auth_token(cls.config.test_account_username, cls.config.test_account_password)


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

- #3490

## Changes
- Updated Retry config object in BaseFunctionalTest class to apply retry logic on POST requests

## QA steps (optional)

## Notes for Reviewer
By default, the Retry config object we pass into the requests.Session for our functional tests only applies towards a limited set of HTTP methods (see docs [here](https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#module-urllib3.util.retry)), which does not include 'POST' requests because they are not idempotent by default. As a result, we are not retrying POST requests in our functional tests, which increases flakiness on transient server/gateway errors and/or busy queues. Because our solution in these cases of false negatives is to retry the entire functional test suite anyway until it works, it should be fine to add 'POST' requests to the whitelist of retry config allowed methods (some of our POST requests, such as the WMG query endpoints, are idempotent anyway). In the worst-case scenario, we upload 7 repeat collections/datasets in the dev or staging environment (as functional tests don't run in prod), which we also do for smoke tests.

Please flag if you think this is dangerous, or would prefer a separate set of retry config values be applied to POST requests (i.e. lower max retries, longer backoff, etc.)