### PR TITLE
feat: Schema 3.0.0 Migration Changes for Gene Expression query API [Do Not Merge]

### DIFF
--- a/backend/wmg/api/query.py
+++ b/backend/wmg/api/query.py
@@ -18,7 +18,7 @@ class WmgQueryCriteria(BaseModel):
     # assay_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
     development_stage_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
     disease_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
-    ethnicity_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+    self_reported_ethnicity_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
     sex_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
 
 

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -95,7 +95,7 @@ def build_filter_dims_values(criteria: WmgQueryCriteria, query: WmgQuery, expres
         "disease_ontology_term_id": "",
         "sex_ontology_term_id": "",
         "development_stage_ontology_term_id": "",
-        "ethnicity_ontology_term_id": "",
+        "self_reported_ethnicity_ontology_term_id": "",
     }
     for dim in dims:
         if len(criteria.dict()[dim + "s"]) == 0:
@@ -108,7 +108,9 @@ def build_filter_dims_values(criteria: WmgQueryCriteria, query: WmgQuery, expres
         disease_terms=build_ontology_term_id_label_mapping(dims["disease_ontology_term_id"]),
         sex_terms=build_ontology_term_id_label_mapping(dims["sex_ontology_term_id"]),
         development_stage_terms=build_ontology_term_id_label_mapping(dims["development_stage_ontology_term_id"]),
-        ethnicity_terms=build_ontology_term_id_label_mapping(dims["ethnicity_ontology_term_id"]),
+        self_reported_ethnicity_terms=build_ontology_term_id_label_mapping(
+            dims["self_reported_ethnicity_ontology_term_id"]
+        ),
     )
 
     return response_filter_dims_values

--- a/backend/wmg/api/wmg-api.yml
+++ b/backend/wmg/api/wmg-api.yml
@@ -81,7 +81,7 @@ paths:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
                     development_ontology_stage_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
-                    ethnicity_ontology_term_ids:
+                    self_reported_ethnicity_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
                 include_filter_dims:
                   type: boolean
@@ -308,7 +308,7 @@ paths:
                         $ref: "#/components/schemas/wmg_ontology_term_id_label_list"
                       development_stage_terms:
                         $ref: "#/components/schemas/wmg_ontology_term_id_label_list"
-                      ethnicity_terms:
+                      self_reported_ethnicity_terms:
                         $ref: "#/components/schemas/wmg_ontology_term_id_label_list"
 
 components:

--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -135,7 +135,7 @@ interface Filter {
   disease_ontology_term_ids: string[];
   sex_ontology_term_ids: string[];
   development_stage_ontology_term_ids: string[];
-  ethnicity_ontology_term_ids: string[];
+  self_reported_ethnicity_ontology_term_ids: string[];
 }
 
 export interface Query {
@@ -160,7 +160,7 @@ interface QueryResponse {
     disease_terms: { [id: string]: string }[];
     sex_terms: { [id: string]: string }[];
     development_stage_terms: { [id: string]: string }[];
-    ethnicity_terms: { [id: string]: string }[];
+    self_reported_ethnicity_terms: { [id: string]: string }[];
   };
   snapshot_id: string;
   term_id_labels: {
@@ -242,7 +242,7 @@ const EMPTY_FILTER_DIMENSIONS = {
   datasets: [],
   development_stage_terms: [],
   disease_terms: [],
-  ethnicity_terms: [],
+  self_reported_ethnicity_terms: [],
   sex_terms: [],
 };
 
@@ -257,7 +257,7 @@ export interface FilterDimensions {
   datasets: RawDataset[];
   development_stage_terms: { id: string; name: string }[];
   disease_terms: { id: string; name: string }[];
-  ethnicity_terms: { id: string; name: string }[];
+  self_reported_ethnicity_terms: { id: string; name: string }[];
   sex_terms: { id: string; name: string }[];
 }
 
@@ -286,7 +286,7 @@ export function useFilterDimensions(
       datasets,
       development_stage_terms,
       disease_terms,
-      ethnicity_terms,
+      self_reported_ethnicity_terms,
       sex_terms,
     } = filter_dims;
 
@@ -302,7 +302,7 @@ export function useFilterDimensions(
         })),
         development_stage_terms: development_stage_terms.map(toEntity),
         disease_terms: disease_terms.map(toEntity),
-        ethnicity_terms: ethnicity_terms.map(toEntity),
+        self_reported_ethnicity_terms: self_reported_ethnicity_terms.map(toEntity),
         sex_terms: sex_terms.map(toEntity),
       },
       isLoading: false,
@@ -605,7 +605,7 @@ function useWMGQueryRequestBody(options = { includeAllFilterOptions: false }) {
         dataset_ids: datasets,
         development_stage_ontology_term_ids: developmentStages,
         disease_ontology_term_ids: diseases,
-        ethnicity_ontology_term_ids: ethnicities,
+        self_reported_ethnicity_ontology_term_ids: ethnicities,
         gene_ontology_term_ids,
         organism_ontology_term_id: selectedOrganismId,
         sex_ontology_term_ids: sexes,

--- a/tests/functional/backend/wmg/fixtures.py
+++ b/tests/functional/backend/wmg/fixtures.py
@@ -436,7 +436,7 @@ secondary_filter_common_case_request_data = {
     "filter": {
         "dataset_ids": [],
         "disease_ontology_term_ids": ["MONDO:0005812", "MONDO:0100096", "PATO:0000461"],
-        "ethnicity_ontology_term_ids": ["HANCESTRO:0010", "HANCESTRO:0014"],
+        "self_reported_ethnicity_ontology_term_ids": ["HANCESTRO:0010", "HANCESTRO:0014"],
         "gene_ontology_term_ids": list(genes_20_count.keys()),
         "organism_ontology_term_id": "NCBITaxon:9606",
         "sex_ontology_term_ids": ["PATO:0000383"],
@@ -448,7 +448,7 @@ secondary_filter_extreme_case_request_data = {
     "filter": {
         "dataset_ids": [],
         "disease_ontology_term_ids": [],
-        "ethnicity_ontology_term_ids": [],
+        "self_reported_ethnicity_ontology_term_ids": [],
         "gene_ontology_term_ids": list(genes_400_count.keys()),
         "organism_ontology_term_id": "NCBITaxon:9606",
         "sex_ontology_term_ids": [],

--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -553,7 +553,7 @@ class WmgApiV1Tests(unittest.TestCase):
                 sex_ontology_term_ids=["sex_ontology_term_id_0"],
                 # these matter for the expected result
                 development_stage_ontology_term_ids=["development_stage_ontology_term_id_0"],
-                ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_0"],
+                self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
             )
 
             filter_0_request = dict(
@@ -576,7 +576,9 @@ class WmgApiV1Tests(unittest.TestCase):
                     {"development_stage_ontology_term_id_0": "development_stage_ontology_term_id_0_label"}
                 ],
                 "disease_terms": [{"disease_ontology_term_id_0": "disease_ontology_term_id_0_label"}],
-                "ethnicity_terms": [{"ethnicity_ontology_term_id_0": "ethnicity_ontology_term_id_0_label"}],
+                "self_reported_ethnicity_terms": [
+                    {"self_reported_ethnicity_ontology_term_id_0": "self_reported_ethnicity_ontology_term_id_0_label"}
+                ],
                 "sex_terms": [{"sex_ontology_term_id_0": "sex_ontology_term_id_0_label"}],
             }
             self.assertEqual(json.loads(response.data)["filter_dims"], expected_filters)
@@ -616,7 +618,7 @@ class WmgApiV1Tests(unittest.TestCase):
                     sex_ontology_term_ids=["sex_ontology_term_id_0"],
                     # these matter for the expected result
                     development_stage_ontology_term_ids=["development_stage_ontology_term_id_0"],
-                    ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_0"],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
                 )
 
                 filter_0_request = dict(
@@ -635,7 +637,7 @@ class WmgApiV1Tests(unittest.TestCase):
                     sex_ontology_term_ids=["sex_ontology_term_id_0"],
                     # these matter for the expected result
                     development_stage_ontology_term_ids=[],
-                    ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_0"],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
                 )
                 filter_0_no_dev_stage_request = dict(filter=filter_0_no_dev_stage_filter, include_filter_dims=True)
 
@@ -649,14 +651,16 @@ class WmgApiV1Tests(unittest.TestCase):
                     sex_ontology_term_ids=["sex_ontology_term_id_0"],
                     # these matter for the expected result
                     development_stage_ontology_term_ids=["development_stage_ontology_term_id_0"],
-                    ethnicity_ontology_term_ids=[],
+                    self_reported_ethnicity_ontology_term_ids=[],
                 )
                 filter_0_no_ethnicity_request = dict(filter=filter_0_no_ethnicity_filter, include_filter_dims=True)
                 # the values for dev_stage terms when a dev stage filter is included should match the values returned
                 # if no filter is passed in for dev stage
                 response = self.app.post("/wmg/v1/query", json=filter_0_request)
                 dev_stage_terms = json.loads(response.data)["filter_dims"]["development_stage_terms"]
-                ethnicity_terms = json.loads(response.data)["filter_dims"]["ethnicity_terms"]
+                self_reported_ethnicity_terms = json.loads(response.data)["filter_dims"][
+                    "self_reported_ethnicity_terms"
+                ]
 
                 no_dev_stage_filter_response = self.app.post("/wmg/v1/query", json=filter_0_no_dev_stage_request)
                 dev_stage_terms_if_no_dev_stage_filters = json.loads(no_dev_stage_filter_response.data)["filter_dims"][
@@ -664,13 +668,13 @@ class WmgApiV1Tests(unittest.TestCase):
                 ]
 
                 no_ethnicity_filter_response = self.app.post("/wmg/v1/query", json=filter_0_no_ethnicity_request)
-                ethnictiy_terms_if_no_dev_stage_filters = json.loads(no_ethnicity_filter_response.data)["filter_dims"][
-                    "ethnicity_terms"
-                ]
+                self_reported_ethnicity_terms_if_no_dev_stage_filters = json.loads(no_ethnicity_filter_response.data)[
+                    "filter_dims"
+                ]["self_reported_ethnicity_terms"]
 
                 # filter options for dev_stage
                 self.assertEqual(dev_stage_terms, dev_stage_terms_if_no_dev_stage_filters)
-                self.assertEqual(ethnicity_terms, ethnictiy_terms_if_no_dev_stage_filters)
+                self.assertEqual(self_reported_ethnicity_terms, self_reported_ethnicity_terms_if_no_dev_stage_filters)
 
             with self.subTest(
                 "when a secondary dimension has criteria, the remaining filter values for other "
@@ -684,112 +688,132 @@ class WmgApiV1Tests(unittest.TestCase):
 
                 # filtering for ethnicity_0 should return all dev stages
                 # not filtering for dev should return all ethnicities
-                ethnicity_0_filter = dict(
+                self_reported_ethnicity_0_filter = dict(
                     # these don't matter for the expected result
                     gene_ontology_term_ids=["gene_ontology_term_id_0"],
                     organism_ontology_term_id="organism_ontology_term_id_0",
                     tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
                     # these matter for the expected result
                     development_stage_ontology_term_ids=[],
-                    ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_0"],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
                 )
                 all_development_stage_terms = [
                     {"development_stage_ontology_term_id_0": "development_stage_ontology_term_id_0_label"},
                     {"development_stage_ontology_term_id_1": "development_stage_ontology_term_id_1_label"},
                     {"development_stage_ontology_term_id_2": "development_stage_ontology_term_id_2_label"},
                 ]
-                all_ethnicity_terms = [
-                    {"ethnicity_ontology_term_id_0": "ethnicity_ontology_term_id_0_label"},
-                    {"ethnicity_ontology_term_id_1": "ethnicity_ontology_term_id_1_label"},
-                    {"ethnicity_ontology_term_id_2": "ethnicity_ontology_term_id_2_label"},
+                all_self_reported_ethnicity_terms = [
+                    {"self_reported_ethnicity_ontology_term_id_0": "self_reported_ethnicity_ontology_term_id_0_label"},
+                    {"self_reported_ethnicity_ontology_term_id_1": "self_reported_ethnicity_ontology_term_id_1_label"},
+                    {"self_reported_ethnicity_ontology_term_id_2": "self_reported_ethnicity_ontology_term_id_2_label"},
                 ]
-                ethnicity_0_request = dict(filter=ethnicity_0_filter, include_filter_dims=True)
-                response = self.app.post("/wmg/v1/query", json=ethnicity_0_request)
+                self_reported_ethnicity_0_request = dict(
+                    filter=self_reported_ethnicity_0_filter, include_filter_dims=True
+                )
+                response = self.app.post("/wmg/v1/query", json=self_reported_ethnicity_0_request)
                 dev_stage_terms = json.loads(response.data)["filter_dims"]["development_stage_terms"]
-                ethnicity_terms = json.loads(response.data)["filter_dims"]["ethnicity_terms"]
+                self_reported_ethnicity_terms = json.loads(response.data)["filter_dims"][
+                    "self_reported_ethnicity_terms"
+                ]
                 self.assertEqual(all_development_stage_terms, dev_stage_terms)
-                self.assertEqual(all_ethnicity_terms, ethnicity_terms)
+                self.assertEqual(all_self_reported_ethnicity_terms, self_reported_ethnicity_terms)
 
                 # filtering for ethnicity_1 should return dev_stage_0 (even when filtering for dev_stage_1 or 2)
-                ethnicity_1_filter = dict(
+                self_reported_ethnicity_1_filter = dict(
                     # these don't matter for the expected result
                     gene_ontology_term_ids=["gene_ontology_term_id_0"],
                     organism_ontology_term_id="organism_ontology_term_id_0",
                     tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
                     # these matter for the expected result
                     development_stage_ontology_term_ids=[],
-                    ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_1"],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_1"],
                 )
                 # since secondary filters should not affect term options for their own category, filtering (or not
                 # filtering) for dev stage 1 should not affect the terms returned
                 expected_development_stage_terms = [
                     {"development_stage_ontology_term_id_0": "development_stage_ontology_term_id_0_label"},
                 ]
-                expected_ethnicity_term = [{"ethnicity_ontology_term_id_0": "ethnicity_ontology_term_id_0_label"}]
-                ethnicity_1_request = dict(filter=ethnicity_1_filter, include_filter_dims=True)
-                response = self.app.post("/wmg/v1/query", json=ethnicity_1_request)
+                expected_self_reported_ethnicity_term = [
+                    {"self_reported_ethnicity_ontology_term_id_0": "self_reported_ethnicity_ontology_term_id_0_label"}
+                ]
+                self_reported_ethnicity_1_request = dict(
+                    filter=self_reported_ethnicity_1_filter, include_filter_dims=True
+                )
+                response = self.app.post("/wmg/v1/query", json=self_reported_ethnicity_1_request)
                 dev_stage_terms_no_dev_filter = json.loads(response.data)["filter_dims"]["development_stage_terms"]
-                ethnicity_terms_no_dev_filter = json.loads(response.data)["filter_dims"]["ethnicity_terms"]
+                self_reported_ethnicity_terms_no_dev_filter = json.loads(response.data)["filter_dims"][
+                    "self_reported_ethnicity_terms"
+                ]
                 self.assertEqual(expected_development_stage_terms, dev_stage_terms_no_dev_filter)
-                self.assertEqual(all_ethnicity_terms, ethnicity_terms_no_dev_filter)
+                self.assertEqual(all_self_reported_ethnicity_terms, self_reported_ethnicity_terms_no_dev_filter)
 
-                ethnicity_1_dev_1_filter = dict(
+                self_reported_ethnicity_1_dev_1_filter = dict(
                     # these don't matter for the expected result
                     gene_ontology_term_ids=["gene_ontology_term_id_0"],
                     organism_ontology_term_id="organism_ontology_term_id_0",
                     tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
                     # these matter for the expected result
                     development_stage_ontology_term_ids=["development_stage_ontology_term_id_1"],
-                    ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_1"],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_1"],
                 )
-                ethnicity_1_dev_1_request = dict(filter=ethnicity_1_dev_1_filter, include_filter_dims=True)
+                self_reported_ethnicity_1_dev_1_request = dict(
+                    filter=self_reported_ethnicity_1_dev_1_filter, include_filter_dims=True
+                )
 
-                response = self.app.post("/wmg/v1/query", json=ethnicity_1_dev_1_request)
+                response = self.app.post("/wmg/v1/query", json=self_reported_ethnicity_1_dev_1_request)
                 dev_stage_terms_dev_filter = json.loads(response.data)["filter_dims"]["development_stage_terms"]
-                ethnicity_terms_dev_filter = json.loads(response.data)["filter_dims"]["ethnicity_terms"]
+                self_reported_ethnicity_terms_dev_filter = json.loads(response.data)["filter_dims"][
+                    "self_reported_ethnicity_terms"
+                ]
 
                 self.assertEqual(expected_development_stage_terms, dev_stage_terms_dev_filter)
                 self.assertEqual(dev_stage_terms_no_dev_filter, dev_stage_terms_dev_filter)
-                self.assertEqual(expected_ethnicity_term, ethnicity_terms_dev_filter)
-                self.assertNotEqual(ethnicity_terms_no_dev_filter, ethnicity_terms_dev_filter)
+                self.assertEqual(expected_self_reported_ethnicity_term, self_reported_ethnicity_terms_dev_filter)
+                self.assertNotEqual(
+                    self_reported_ethnicity_terms_no_dev_filter, self_reported_ethnicity_terms_dev_filter
+                )
 
                 # filtering for ethnicity_2 should return dev_stage_0 (even when filtering for dev_stage_1 or 2)
-                ethnicity_2_filter = dict(
+                self_reported_ethnicity_2_filter = dict(
                     # these don't matter for the expected result
                     gene_ontology_term_ids=["gene_ontology_term_id_0"],
                     organism_ontology_term_id="organism_ontology_term_id_0",
                     tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
                     # these matter for the expected result
                     development_stage_ontology_term_ids=[],
-                    ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_2"],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_2"],
                 )
-                ethnicity_2_dev_2_filter = dict(
+                self_reported_ethnicity_2_dev_2_filter = dict(
                     # these don't matter for the expected result
                     gene_ontology_term_ids=["gene_ontology_term_id_0"],
                     organism_ontology_term_id="organism_ontology_term_id_0",
                     tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
                     # these matter for the expected result
                     development_stage_ontology_term_ids=["development_stage_ontology_term_id_2"],
-                    ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_2"],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_2"],
                 )
-                ethnicity_2_request = dict(filter=ethnicity_2_filter, include_filter_dims=True)
-                eth_2_dev_2_request = dict(filter=ethnicity_2_dev_2_filter, include_filter_dims=True)
-                response = self.app.post("/wmg/v1/query", json=ethnicity_2_request)
+                self_reported_ethnicity_2_request = dict(
+                    filter=self_reported_ethnicity_2_filter, include_filter_dims=True
+                )
+                eth_2_dev_2_request = dict(filter=self_reported_ethnicity_2_dev_2_filter, include_filter_dims=True)
+                response = self.app.post("/wmg/v1/query", json=self_reported_ethnicity_2_request)
                 dev_stage_terms_eth_2_no_dev_filter = json.loads(response.data)["filter_dims"][
                     "development_stage_terms"
                 ]
-                ethnicity_terms_eth_2_no_dev_filter = json.loads(response.data)["filter_dims"]["ethnicity_terms"]
+                self_reported_ethnicity_terms_eth_2_no_dev_filter = json.loads(response.data)["filter_dims"][
+                    "self_reported_ethnicity_terms"
+                ]
                 self.assertEqual(expected_development_stage_terms, dev_stage_terms_eth_2_no_dev_filter)
-                self.assertEqual(all_ethnicity_terms, ethnicity_terms_eth_2_no_dev_filter)
+                self.assertEqual(all_self_reported_ethnicity_terms, self_reported_ethnicity_terms_eth_2_no_dev_filter)
 
                 response = self.app.post("/wmg/v1/query", json=eth_2_dev_2_request)
                 dev_stage_terms_eth_2_dev_2 = json.loads(response.data)["filter_dims"]["development_stage_terms"]
-                eth_stage_terms_eth_2_dev_2 = json.loads(response.data)["filter_dims"]["ethnicity_terms"]
+                eth_stage_terms_eth_2_dev_2 = json.loads(response.data)["filter_dims"]["self_reported_ethnicity_terms"]
 
                 self.assertEqual(expected_development_stage_terms, dev_stage_terms_eth_2_dev_2)
-                self.assertEqual(expected_ethnicity_term, eth_stage_terms_eth_2_dev_2)
+                self.assertEqual(expected_self_reported_ethnicity_term, eth_stage_terms_eth_2_dev_2)
                 self.assertEqual(dev_stage_terms_eth_2_dev_2, dev_stage_terms_eth_2_no_dev_filter)
-                self.assertNotEqual(eth_stage_terms_eth_2_dev_2, ethnicity_terms_eth_2_no_dev_filter)
+                self.assertNotEqual(eth_stage_terms_eth_2_dev_2, self_reported_ethnicity_terms_eth_2_no_dev_filter)
 
             with self.subTest("Additional queries are not performed when the secondary dimensions are not set"):
                 with patch("backend.wmg.api.v1.find_dim_option_values") as mock_dims:
@@ -802,7 +826,7 @@ class WmgApiV1Tests(unittest.TestCase):
                         disease_ontology_term_ids=["disease_ontology_term_id_0"],
                         sex_ontology_term_ids=["sex_ontology_term_id_0"],
                         development_stage_ontology_term_ids=["development_stage_ontology_term_id_0"],
-                        ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_0"],
+                        self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
                     )
 
                     full_filters_request = dict(
@@ -821,7 +845,7 @@ class WmgApiV1Tests(unittest.TestCase):
                         disease_ontology_term_ids=[],
                         sex_ontology_term_ids=[],
                         development_stage_ontology_term_ids=[],
-                        ethnicity_ontology_term_ids=[],
+                        self_reported_ethnicity_ontology_term_ids=[],
                     )
 
                     no_secondary_filters_request = dict(
@@ -841,7 +865,7 @@ class WmgApiV1Tests(unittest.TestCase):
                         disease_ontology_term_ids=[],
                         sex_ontology_term_ids=[],
                         development_stage_ontology_term_ids=["development_stage_ontology_term_id_0"],
-                        ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_0"],
+                        self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
                     )
                     two_secondary_filters_request = dict(
                         filter=two_secondary_filters,

--- a/tests/unit/backend/wmg/test_query.py
+++ b/tests/unit/backend/wmg/test_query.py
@@ -519,7 +519,9 @@ class QueryTest(unittest.TestCase):
             gene_ontology_term_ids=["gene_ontology_term_id_0"],
             organism_ontology_term_id="organism_ontology_term_id_0",
             tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
-            ethnicity_ontology_term_ids=["ethnicity_ontology_term_id_1"],  # <-- non-indexed dim, single-valued
+            self_reported_ethnicity_ontology_term_ids=[
+                "self_reported_ethnicity_ontology_term_id_1"
+            ],  # <-- non-indexed dim, single-valued
             dataset_ids=["dataset_id_1", "dataset_id_0"],  # <-- non-indexed dim, multi-valued
         )
 


### PR DESCRIPTION
- https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell/339

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- update WMG API to comply with schema 3.0.0 datasets

## QA steps (optional)
-functional tests after 

## Notes for Reviewer
- Must only be merged after schema 3.0.0 migration, after WMG cube generation schema 3.0.0 changes are merged and a new cube is generated
