### PR TITLE
fix: re-add config.js copy before running post-deploy e2e tests

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -140,7 +140,6 @@ jobs:
           cd frontend
           npm ci
           npx playwright install --with-deps
-          cp src/configs/${DEPLOYMENT_STAGE}.js src/configs/configs.js
           DEBUG=pw:api npm run e2e-${DEPLOYMENT_STAGE}
       - uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -140,6 +140,7 @@ jobs:
           cd frontend
           npm ci
           npx playwright install --with-deps
+        ### config.js set-up required due to transient test dependencies on API_URL
           cp src/configs/${DEPLOYMENT_STAGE}.js src/configs/configs.js
           DEBUG=pw:api npm run e2e-${DEPLOYMENT_STAGE}
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -140,6 +140,7 @@ jobs:
           cd frontend
           npm ci
           npx playwright install --with-deps
+          cp src/configs/${DEPLOYMENT_STAGE}.js src/configs/configs.js
           DEBUG=pw:api npm run e2e-${DEPLOYMENT_STAGE}
       - uses: actions/upload-artifact@v2
         if: always()

--- a/frontend/tests/features/collection/collection.test.ts
+++ b/frontend/tests/features/collection/collection.test.ts
@@ -4,7 +4,6 @@ import { ROUTES } from "src/common/constants/routes";
 import { Collection } from "src/common/entities";
 import { sortByCellCountDescending } from "src/components/Collection/components/CollectionDatasetsGrid/components/DatasetsGrid/common/util";
 import { INVALID_DOI_ERROR_MESSAGE } from "src/components/CreateCollectionModal/components/Content/common/constants";
-import { API_URL } from "src/configs/configs";
 import { BLUEPRINT_SAFE_TYPE_OPTIONS, TEST_URL } from "tests/common/constants";
 import {
   goToPage,
@@ -187,7 +186,7 @@ async function showCreateForm(page: Page) {
   await page.click(getText("Create Collection"));
 }
 
-const collectionEndpoint = `${API_URL}/dp/v1/collections`;
+const collectionEndpointPath = `/dp/v1/collections`;
 
 /**
  * Submit create invalid collection form.
@@ -197,7 +196,7 @@ async function submitCreateFormInvalid(page: Page) {
   return await Promise.all([
     page.waitForResponse(
       (response) =>
-        response.url() === collectionEndpoint &&
+        response.url().includes(collectionEndpointPath) &&
         response.status() === HTTP_STATUS_CODE.BAD_REQUEST
     ),
     page.click(getTestID("create-button")),
@@ -212,7 +211,7 @@ async function submitCreateForm(page: Page) {
   return await Promise.all([
     page.waitForResponse(
       (response) =>
-        response.url() === collectionEndpoint &&
+        response.url().includes(collectionEndpointPath) &&
         response.status() === HTTP_STATUS_CODE.OK
     ),
     page.click(getTestID("create-button")),


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

### Reviewers
**Functional:** 
@tihuan  
**Readability:** 

---


## Changes
- copy config.js over from <deployment_stage>.js before running post-deploy e2e tests

## QA steps (optional)

## Notes for Reviewer
- post deploy e2e [tests failed](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/3386128595) due to imported dependency on API_URL from config.js, which we removed in [this commit](https://github.com/chanzuckerberg/single-cell-data-portal/commit/e1a2d7487a2a1d05e6567f87f981f0b3def4c39d). 
- Re-adding config.js for simplicity, it doesn't really affect clarity or performance so I think we should just add it back in vs. trying to remove dependency on it entirely. If you disagree however, let me know
