### PR TITLE
fix: wait until prod image tag is pushed before creating deployment

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -144,7 +144,7 @@ jobs:
 
   push-prod-images:
     needs:
-      - push-image
+      - add-image-tags
     runs-on: ubuntu-20.04
     if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
     steps:
@@ -314,7 +314,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
 
-  push-image:
+  add-image-tags:
     needs:
       - backend-unit-test
       - processing-unit-test
@@ -342,7 +342,7 @@ jobs:
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
         with:
           happy_version: "0.23.0"
-      - name: Docker build, push, and tag
+      - name: Docker re-tag
         shell: bash
         run: |
           happy addtags --aws-profile "" --source-tag sha-${GITHUB_SHA:0:8} --dest-tag branch-$(echo ${GITHUB_REF#refs/heads/} | sed 's/[\+\/]/-/g')

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -144,7 +144,12 @@ jobs:
 
   push-prod-images:
     needs:
-      - add-image-tags
+      - backend-unit-test
+      - processing-unit-test
+      - wmg-processing-unit-test
+      - e2e-test
+      - lint
+      - build-extra-images
     runs-on: ubuntu-20.04
     if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
     steps:
@@ -164,7 +169,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ${{ secrets.ECR_REPO_PROD }}
-      - name: push lambda upload image
+      - name: push docker images to prod ecr repo
+        if: ( github.ref == 'refs/heads/prod' )
         shell: bash
         run: |
           docker pull ${{ secrets.ECR_REPO }}/corpora-upload-failures:sha-${GITHUB_SHA:0:8}

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -358,7 +358,7 @@ jobs:
   create_deployment:
     if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod' )
     needs:
-      - push-image
+      - push-prod-images
     runs-on: ubuntu-20.04
     steps:
       - name: Generate payload


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

- #3509

## Changes
- wait until prod image is pushed/tagged before creating deployment, as it was consistently causing the first prod upgrade attempt to fail + require a manual retry 
- rename push-images step to add-image-tags to better reflect what its actually doing (adding branch-<main/staging/prod> tag to latest pushed docker images)
- update push-prod-images to only push prod images for prod branch merges. Still runs in dev/staging as a no-op due to limitations with GHA workflow conditional statements

## QA steps (optional)

## Notes for Reviewer
- Unfortunately, GHA does not support conditional "needs" statements, so I chose to implement this wait for all environments. Alternatively, I can make a separate, duplicate 'create_deployment' job called "create_prod_deployment" and differentiate behavior per environment. However, that seemed like it might sacrifice workflow clarity to save about 1 extra min of deployment time. 
- Another alternative: do we even need to run push-prod-images on dev/staging? Can we change it to a prod-only step? Currently it runs in all envs. 
