### PR TITLE
feat: Track Tissues and Genes in Image Download

### DIFF
--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveImage/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveImage/index.tsx
@@ -108,7 +108,7 @@ export default function SaveImage({
       }
       link.click();
       link.remove();
-      track(EVENTS.WMG_DOWNLOAD_COMPLETE, { file_type: fileType });
+      track(EVENTS.WMG_DOWNLOAD_COMPLETE, { file_type: fileType , tissues: selectedTissues.toString(), genes: selectedGenes.toString() });
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
- #3486

## Changes
Added 'tissues' and 'genes' to analytics upon image download in WMG for better understanding of usefulness.

## QA steps
I printed out to console while locally testing - on image download, this is now what is being sent to plausible:
`WMG_DOWNLOAD_COMPLETE {file_type: 'png', tissues: 'blood,lung,spleen', genes: 'TSPAN6,TNMD,DPM1'}`

