### PR TITLE
fix: update FMG cube schema to be schema 3.0.0 compliant

### DIFF
--- a/backend/wmg/data/schemas/marker_genes_cube_schema.py
+++ b/backend/wmg/data/schemas/marker_genes_cube_schema.py
@@ -20,7 +20,7 @@ expression_summary_fmg_non_indexed_dims = [
     "assay_ontology_term_id",
     "development_stage_ontology_term_id",
     "disease_ontology_term_id",
-    "ethnicity_ontology_term_id",
+    "self_reported_ethnicity_ontology_term_id",
     "sex_ontology_term_id",
 ]
 
@@ -30,7 +30,7 @@ expression_summary_fmg_non_indexed_dims_no_gene_ontology = [
     "assay_ontology_term_id",
     "development_stage_ontology_term_id",
     "disease_ontology_term_id",
-    "ethnicity_ontology_term_id",
+    "self_reported_ethnicity_ontology_term_id",
     "sex_ontology_term_id",
 ]
 

--- a/tests/unit/wmg_processing/test_schemas.py
+++ b/tests/unit/wmg_processing/test_schemas.py
@@ -112,7 +112,7 @@ class TestFmgSummaryCubeSchema(unittest.TestCase):
             self.assertTrue(summary_cube_schema.has_attr("assay_ontology_term_id"))
             self.assertTrue(summary_cube_schema.has_attr("development_stage_ontology_term_id"))
             self.assertTrue(summary_cube_schema.has_attr("disease_ontology_term_id"))
-            self.assertTrue(summary_cube_schema.has_attr("ethnicity_ontology_term_id"))
+            self.assertTrue(summary_cube_schema.has_attr("self_reported_ethnicity_ontology_term_id"))
             self.assertTrue(summary_cube_schema.has_attr("sex_ontology_term_id"))
             self.assertTrue(summary_cube_schema.has_attr("nnz"))
             self.assertTrue(summary_cube_schema.has_attr("sum"))


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

## Changes
- 'ethnicity' -> self_reported_ethnicity to be schema 3.0.0 compliant

## QA steps (optional)

## Notes for Reviewer
