### PR TITLE
fix: filter out raw.h5ad from wmg cube dataset processing

### DIFF
--- a/backend/common/entities/dataset_asset.py
+++ b/backend/common/entities/dataset_asset.py
@@ -114,7 +114,7 @@ class DatasetAsset(Entity):
         return DatasetAsset.make_s3_uri(artifact_bucket, bucket_prefix, file_base)
 
     @classmethod
-    def s3_uris_for_datasets(cls, session, dataset_ids, file_type=None) -> typing.Dict:
+    def s3_uris_for_datasets(cls, session, dataset_ids, file_type=None, file_name=None) -> typing.Dict:
         """
         Returns a dictionary of dataset_id : s3_uri for a given list of dataset ids
         also filters on file_type if specified
@@ -122,4 +122,6 @@ class DatasetAsset(Entity):
         s3_uris = session.query(cls.table.dataset_id, cls.table.s3_uri).filter(cls.table.dataset_id.in_(dataset_ids))
         if file_type:
             s3_uris = s3_uris.filter(cls.table.filetype == file_type)
+        if file_name:
+            s3_uris = s3_uris.filter(cls.table.filename == file_name)
         return {x[0]: x[1] for x in s3_uris.all()}

--- a/backend/wmg/pipeline/integrated_corpus/extract.py
+++ b/backend/wmg/pipeline/integrated_corpus/extract.py
@@ -51,7 +51,7 @@ def get_dataset_s3_uris() -> Dict:
                 if len(organisms) < 2:
                     dataset_ids.append(dataset_id)
 
-        s3_uris = DatasetAsset.s3_uris_for_datasets(session, dataset_ids, DatasetArtifactFileType.H5AD)
+        s3_uris = DatasetAsset.s3_uris_for_datasets(session, dataset_ids, DatasetArtifactFileType.H5AD, "local.h5ad")
     return s3_uris
 
 

--- a/tests/unit/backend/wmg/pipelines/test_extract.py
+++ b/tests/unit/backend/wmg/pipelines/test_extract.py
@@ -159,7 +159,7 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
         for dataset in expected_datasets:
             assets = dataset.get_assets()
             for asset in assets:
-                if asset.filetype == DatasetArtifactFileType.H5AD:
+                if asset.filetype == DatasetArtifactFileType.H5AD and asset.filename == "local.h5ad":
                     expected_s3_uris.append(asset.s3_uri)
 
         s3_uris = set(backend.wmg.pipeline.integrated_corpus.extract.get_dataset_s3_uris().values())


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

## Changes
- add optional arg to filter dataset assets by filename when mapping dataset assets in db to s3_uri, in order to filter out raw.h5ads (originally uploaded, non-labeled h5ads) from wmg cube processing. raw.h5ads should not be included in wmg cube, only the processed local.h5ads

## QA steps (optional)

## Notes for Reviewer
