### PR TITLE
test(smoketest): 3466-clean-up-e2e-test-commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,6 @@ prod-performance-test:
 local-backend:
 	$(MAKE) local-server -C ./backend/api_server
 
-.PHONY: smoke-test-prod-build
-smoke-test-prod-build:
-	$(MAKE) smoke-test-prod-build -C ./frontend
-
-.PHONY: smoke-test-with-local-backend
-smoke-test-with-local-backend:
-	$(MAKE) smoke-test-with-local-backend -C ./frontend
-
 .PHONY: e2e
 e2e:
 	$(MAKE) e2e -C ./frontend DEPLOYMENT_STAGE=$(DEPLOYMENT_STAGE)
@@ -225,13 +217,6 @@ local-functional-test: ## Run functional tests in the dev environment
 .PHONY: local-smoke-test
 local-smoke-test: ## Run frontend/e2e tests in the dev environment
 	docker-compose $(COMPOSE_OPTS) run --rm -T frontend make smoke-test-with-local-dev
-
-.PHONY: local-e2e
-local-e2e: ## Run frontend/e2e tests
-	if [ -n "$${BOTO_ENDPOINT_URL+set}" ]; then \
-		EXTRA_ARGS="-e BOTO_ENDPOINT_URL"; \
-	fi; \
-	docker-compose $(COMPOSE_OPTS) run --no-deps -e DEPLOYMENT_STAGE -e AWS_REGION -e AWS_DEFAULT_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN $${EXTRA_ARGS} -T frontend make e2e
 
 .PHONY: local-dbconsole
 local-dbconsole: ## Connect to the local postgres database.

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -37,21 +37,9 @@ retrieve-vars:
 upload-vars:
 	aws s3 cp .env.production $(S3_ENVIRONMENT_FILE)
 
-.PHONY: smoke-test-prod-build
-smoke-test-prod-build:
-	npm run smoke-test-prod-build
-
-.PHONY: smoke-test-with-local-backend
-smoke-test-with-local-backend:
-	npm run smoke-test-with-local-backend
-
 .PHONY: e2e
 e2e:
 	TEST_ENV=$(DEPLOYMENT_STAGE) npm run e2e
-
-.PHONY: e2e-on-local-dev
-e2e-on-local-dev:
-	docker-compose exec frontend make smoke-test-with-local-dev
 
 .PHONY: smoke-test-with-local-dev
 smoke-test-with-local-dev:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,8 +99,6 @@
     "serve": "next start",
     "test": "playwright test",
     "e2e": "playwright test",
-    "e2e-localProd": "TEST_ENV=localProd npm run-script e2e",
-    "e2e-localProd-ci": "DEBUG=pw:api TEST_ENV=localProd npm run-script e2e",
     "e2e-dev": "TEST_ENV=dev npm run-script e2e",
     "e2e-staging": "TEST_ENV=staging npm run-script e2e",
     "e2e-prod": "TEST_ENV=prod npm run-script e2e",
@@ -109,11 +107,7 @@
     "type-check": "tsc --noEmit",
     "lint": "concurrently \"node_modules/.bin/next lint\" \"node_modules/.bin/stylelint --fix '**/*.{js,ts,tsx,css}'\"  \"npm run type-check\"",
     "prettier-check": "npx prettier --check .",
-    "build-and-start-prod": "npm run build && npm run serve",
-    "build-and-start-local-backend": "DEPLOYMENT_STAGE=test AWS_PROFILE=single-cell-dev npm run _build-and-start-local-backend",
-    "smoke-test": "start-server-and-test start :3000 e2e",
-    "smoke-test-prod-build": "start-server-and-test build-and-start-prod :9000 e2e-localProd",
-    "smoke-test-with-local-backend": "start-server-and-test build-and-start-local-backend :5000 build-and-start-prod :9000 e2e-localProd"
+    "build-and-start-prod": "npm run build && npm run serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- #TICKET_NUMBER

### Reviewers
**Functional:** 
@seve 

**Readability:** 
@nayib-jose-gloria 
---

## Changes
1. Remove commands we don't use
2. Originally I added a few test commands to build the FE app in prod mode and run tests against it, but since we don't have Server Side Rendering (SSR) like CZ Meta, we don't really need to run e2e tests against prod mode FE. Will probably need to revisit if we start having SSR

## QA steps (optional)

## Notes for Reviewer
