### PR TITLE
fix: unblock wmg pipeline by forcing validation series to have same indices

### DIFF
--- a/backend/common/utils/exceptions.py
+++ b/backend/common/utils/exceptions.py
@@ -21,3 +21,7 @@ class InvalidProcessingStateException(CorporaException):
 
 class NonExistentDatasetException(CorporaException):
     pass
+
+
+class CubeValidationException(Exception):
+    pass

--- a/backend/wmg/data/load_cube.py
+++ b/backend/wmg/data/load_cube.py
@@ -56,8 +56,8 @@ def remove_oldest_datasets(timestamp):
 
 
 @log_func_runtime
-def upload_artifacts_to_s3(snapshot_path, timestamp):
-    sync_command = ["aws", "s3", "sync", snapshot_path, f"{_get_wmg_bucket_path()}/{timestamp}"]
+def upload_artifacts_to_s3(snapshot_path, s3_key):
+    sync_command = ["aws", "s3", "sync", snapshot_path, f"{_get_wmg_bucket_path()}/{s3_key}"]
     subprocess.run(sync_command)
 
 

--- a/backend/wmg/data/validation/validation.py
+++ b/backend/wmg/data/validation/validation.py
@@ -420,6 +420,13 @@ class Validation:
             # drop ccl5 cell types with expression value of zero (to match pipeline processing)
             expected_ccl5_by_cell_type = expected_ccl5_by_cell_type[expected_ccl5_by_cell_type != 0]
 
+            # temporary log statements to inspect the two series that are breaking validation
+            logger.info(expected_ccl5_by_cell_type)
+            logger.info(ccl5_expression_sum_by_cell_type)
+            # temporary solution is to make sure that both series have the same exact index ordering
+            expected_malat1_by_cell_type = expected_malat1_by_cell_type[malat1_expression_sum_by_cell_type.index]
+            expected_ccl5_by_cell_type = expected_ccl5_by_cell_type[ccl5_expression_sum_by_cell_type.index]
+
             malat1_comparison = expected_malat1_by_cell_type.compare(malat1_expression_sum_by_cell_type)
             ccl5_comparison = expected_ccl5_by_cell_type.compare(ccl5_expression_sum_by_cell_type)
             logger.info(malat1_comparison)

--- a/backend/wmg/data/validation/validation.py
+++ b/backend/wmg/data/validation/validation.py
@@ -420,10 +420,7 @@ class Validation:
             # drop ccl5 cell types with expression value of zero (to match pipeline processing)
             expected_ccl5_by_cell_type = expected_ccl5_by_cell_type[expected_ccl5_by_cell_type != 0]
 
-            # temporary log statements to inspect the two series that are breaking validation
-            logger.info(expected_ccl5_by_cell_type)
-            logger.info(ccl5_expression_sum_by_cell_type)
-            # temporary solution is to make sure that both series have the same exact index ordering
+            # ensure that both series have the same exact index ordering
             expected_malat1_by_cell_type = expected_malat1_by_cell_type[malat1_expression_sum_by_cell_type.index]
             expected_ccl5_by_cell_type = expected_ccl5_by_cell_type[ccl5_expression_sum_by_cell_type.index]
 

--- a/backend/wmg/pipeline/cube_pipeline.py
+++ b/backend/wmg/pipeline/cube_pipeline.py
@@ -50,7 +50,13 @@ def load_data_and_create_cube(
     corpus_path = f"{snapshot_path}/{corpus_name}"
 
     integrated_corpus.run(path_to_h5ad_datasets, corpus_path, extract_data)
-    summary_cubes.run(corpus_path, validate_cube)
+    try:
+        summary_cubes.run(corpus_path, validate_cube)
+    except CubeValidationException as e:
+        upload_artifacts_to_s3(snapshot_path, 'latest_validation_failed_snapshot')
+        logger.exception(e)
+        sys.exit("Exiting due to cube validation failure")
+
     stats = dict(
         dataset_count=len(get_all_dataset_ids(corpus_path)),
         gene_count=get_expression_summary_cube_gene_count(f"{corpus_path}/{EXPRESSION_SUMMARY_CUBE_NAME}"),

--- a/backend/wmg/pipeline/cube_pipeline.py
+++ b/backend/wmg/pipeline/cube_pipeline.py
@@ -9,6 +9,7 @@ from backend.common.utils.result_notification import (
     gen_wmg_pipeline_success_message,
     gen_wmg_pipeline_failure_message,
 )
+from backend.common.utils.exceptions import CubeValidationException
 from backend.wmg.pipeline import integrated_corpus, summary_cubes
 
 from backend.wmg.data.load_cube import upload_artifacts_to_s3, make_snapshot_active
@@ -53,7 +54,7 @@ def load_data_and_create_cube(
     try:
         summary_cubes.run(corpus_path, validate_cube)
     except CubeValidationException as e:
-        upload_artifacts_to_s3(snapshot_path, 'latest_validation_failed_snapshot')
+        upload_artifacts_to_s3(snapshot_path, "latest_validation_failed_snapshot")
         logger.exception(e)
         sys.exit("Exiting due to cube validation failure")
 

--- a/backend/wmg/pipeline/summary_cubes/__init__.py
+++ b/backend/wmg/pipeline/summary_cubes/__init__.py
@@ -5,7 +5,7 @@ from backend.common.utils.result_notification import (
     notify_slack,
     gen_wmg_pipeline_failure_message,
 )
-
+from backend.common.utils.exceptions import CubeValidationException
 from backend.wmg.pipeline.summary_cubes.expression_summary.job import create_expression_summary_cube
 from backend.wmg.pipeline.summary_cubes.expression_summary_fmg.job import create_expression_summary_fmg_cube
 from backend.wmg.data.validation.validation import Validation
@@ -23,10 +23,14 @@ def run(corpus_path: str, validate_cube: bool) -> dict:
     create_expression_summary_fmg_cube(corpus_path)
     create_cell_count_cube(corpus_path)
     if validate_cube:
-        if Validation(corpus_path).validate_cube() is False:
+        try:
+            is_valid = Validation(corpus_path).validate_cube()
+        except Exception as e:
+            raise CubeValidationException(e)
+        if is_valid is False:
             pipeline_failure_message = gen_wmg_pipeline_failure_message(
                 "Issue with cube validation, see logs for more detail"
             )
             data = format_failed_batch_issue_slack_alert(pipeline_failure_message)
             notify_slack(data)
-            sys.exit("Exiting due to cube validation failure")
+            raise CubeValidationException

--- a/backend/wmg/pipeline/summary_cubes/__init__.py
+++ b/backend/wmg/pipeline/summary_cubes/__init__.py
@@ -1,5 +1,3 @@
-import sys
-
 from backend.common.utils.result_notification import (
     format_failed_batch_issue_slack_alert,
     notify_slack,


### PR DESCRIPTION
Ticket: #3427

Changes:
- Force indices to match when comparing single gene expression expected vs. cube actual datasets in validation.py
- Add logic to upload snapshots to s3 that 1) create cubes then 2) fail validation. This will help with future debugging, as generating a cube takes a long time and we'll be able to debug validation failures faster with the failed cube to inspect.