### PR TITLE
feat: How does a user select an organ from another system when a syst…

### DIFF
--- a/frontend/src/common/hooks/useCategoryFilter/common/curatedOntologyUtils.ts
+++ b/frontend/src/common/hooks/useCategoryFilter/common/curatedOntologyUtils.ts
@@ -183,6 +183,7 @@ export function buildCuratedOntologyCategoryValueView(
       label: ontologyNode.label,
       selected: false,
       selectedPartial: false,
+      visible: true,
     };
   }
 
@@ -199,6 +200,7 @@ export function buildCuratedOntologyCategoryValueView(
       ...view,
       selected: categoryValue.selected,
       selectedPartial: false,
+      visible: true,
     };
   }
 
@@ -217,6 +219,7 @@ export function buildCuratedOntologyCategoryValueView(
     children,
     selected: categoryValue.selected,
     selectedPartial: false,
+    visible: true,
   };
 }
 

--- a/frontend/src/common/hooks/useCategoryFilter/common/multiPanelOntologyUtils.ts
+++ b/frontend/src/common/hooks/useCategoryFilter/common/multiPanelOntologyUtils.ts
@@ -331,8 +331,13 @@ function buildOntologyPanelCategoryViews(
     // If panel is filtered (that is, there are selected values in this panel's parents), only include values in this
     // panel that are descendants of the selected parent values. If there are no selected values in parent panels,
     // include all values in this panel.
+
+    // Get all UI Nodes configured for this panel.
     const panelUINodes = listPanelUINodes(panelIndex, categoryFilterUIState);
-    const includeUINodes = selectedParentUINodes.length
+
+    // Get the UINodes to be displayed in the panel based on the
+    // selected nodes in parent panels.
+    const visibleUINodeIds = selectedParentUINodes.length
       ? filterPanelUINodes(
           panelUINodes,
           selectedParentUINodes,
@@ -341,8 +346,14 @@ function buildOntologyPanelCategoryViews(
         )
       : panelUINodes;
 
-    // Collect the select category values for the values to be included.
-    const selectCategoryValues = includeUINodes
+    // Create a set of visibleNodeIds to use in the next step where
+    // we mark each node as visible or not.
+    const visibleSet = new Set(
+      visibleUINodeIds.map((node) => node.categoryValueId)
+    );
+
+    // Collect the SelectCategoryValues for the UINodes to be included.
+    const selectCategoryValues = panelUINodes
       .map((uiNode: MultiPanelUINode) =>
         categoryValuesByValue.get(uiNode.categoryValueId)
       )
@@ -352,11 +363,13 @@ function buildOntologyPanelCategoryViews(
         ): selectCategoryValue is SelectCategoryValue => !!selectCategoryValue
       );
 
-    // Build views for each selected category value to be included.
+    // Build the SelectCategoryValueViews for all configured SelectCategoryValues, mark the
+    // ones not filtered out by parent panels as visible=true.
     const panelViews: SelectCategoryValueView[] = buildSelectCategoryValueViews(
       config,
       selectCategoryValues,
-      ontologyTermLabelsById
+      ontologyTermLabelsById,
+      visibleSet
     );
 
     // Apply non-specific labels to values that appear in this panel as well as parent panels.

--- a/frontend/src/common/hooks/useCategoryFilter/common/selectUtils.ts
+++ b/frontend/src/common/hooks/useCategoryFilter/common/selectUtils.ts
@@ -120,11 +120,14 @@ export function buildNextSelectCategoryFilters<T extends Categories>(
  * @param config - Config model of category to build category value views for.
  * @param selectCategoryValues - Values to build view models from.
  * @param ontologyTermLabelsById - Set of ontology term labels keyed by term ID, used to determine labels for ontology
+ * @param visibleUINodeIds - an optional set of visibleNode ids used when creating SelectCategoryValueViews for the multi panel ontology filters.
+ * @returns an array of SelectCategoryValueViews for a category filter.
  */
 export function buildSelectCategoryValueViews(
   config: CategoryFilterConfig,
   selectCategoryValues: SelectCategoryValue[],
-  ontologyTermLabelsById: Map<string, string>
+  ontologyTermLabelsById: Map<string, string>,
+  visibleUINodeIds?: Set<string>
 ): SelectCategoryValueView[] {
   return selectCategoryValues.map(
     ({
@@ -143,6 +146,9 @@ export function buildSelectCategoryValueViews(
         ),
         selected,
         selectedPartial,
+        visible: visibleUINodeIds
+          ? visibleUINodeIds.has(categoryValueId)
+          : true,
       };
     }
   );

--- a/frontend/src/components/common/Filter/common/entities.ts
+++ b/frontend/src/components/common/Filter/common/entities.ts
@@ -701,6 +701,7 @@ export interface SelectCategoryValueView {
   label: string;
   selected: boolean;
   selectedPartial: boolean;
+  visible: boolean;
 }
 
 /**

--- a/frontend/src/components/common/Filter/components/FilterContent/components/FilterViews/components/FilterSinglePanelCategoryView/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterContent/components/FilterViews/components/FilterSinglePanelCategoryView/index.tsx
@@ -19,6 +19,7 @@ interface Props {
 
 /**
  * Returns filtered select category views where category label includes search value.
+ * If there is no search value, only "visible" views are returned.
  * @param views - Select category value views model for a given category.
  * @param searchValue - Search string to filter select category views.
  * @returns array of category views filtered by the given search value.
@@ -31,8 +32,9 @@ function filterViews(
     return views.filter(({ label }) =>
       label.toLowerCase().includes(searchValue)
     );
+  } else {
+    return views.filter((view) => view.visible);
   }
-  return views;
 }
 
 export default function FilterSinglePanelCategoryView({

--- a/frontend/tests/features/filter/useCategoryFilter.test.ts
+++ b/frontend/tests/features/filter/useCategoryFilter.test.ts
@@ -489,6 +489,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: INFERRED_HEMATOPOIETIC_SYSTEM,
+      visible: true,
     };
 
     const INFERRED_IMMUNE_CATEGORY_VALUE_VIEW = {
@@ -498,6 +499,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: INFERRED_IMMUNE_SYSTEM,
+      visible: true,
     };
 
     const INFERRED_BLOOD_CATEGORY_VALUE_VIEW = {
@@ -507,6 +509,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: INFERRED_BLOOD,
+      visible: true,
     };
 
     const INFERRED_BONE_MARROW_CATEGORY_VALUE_VIEW = {
@@ -516,6 +519,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: INFERRED_BONE_MARROW,
+      visible: true,
     };
 
     const INFERRED_LYMPH_NODE_CATEGORY_VALUE_VIEW = {
@@ -525,6 +529,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: INFERRED_LYMPH_NODE,
+      visible: true,
     };
 
     const INFERRED_SPLEEN_CATEGORY_VALUE_VIEW = {
@@ -534,6 +539,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: INFERRED_SPLEEN,
+      visible: true,
     };
 
     const INFERRED_THYMUS_CATEGORY_VALUE_VIEW = {
@@ -543,6 +549,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: INFERRED_THYMUS,
+      visible: true,
     };
 
     const EXPLICIT_BLOOD_CATEGORY_VALUE_VIEW = {
@@ -552,6 +559,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: EXPLICIT_BLOOD,
+      visible: true,
     };
 
     const EXPLICIT_BONE_MARROW_CATEGORY_VALUE_VIEW = {
@@ -561,6 +569,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: EXPLICIT_BONE_MARROW,
+      visible: true,
     };
 
     const EXPLICIT_SPLEEN_CATEGORY_VALUE_VIEW = {
@@ -570,6 +579,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: EXPLICIT_SPLEEN,
+      visible: true,
     };
 
     const EXPLICIT_THYMUS_CATEGORY_VALUE_VIEW = {
@@ -579,6 +589,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: EXPLICIT_THYMUS,
+      visible: true,
     };
 
     const EXPLICIT_UMBILICAL_CORD_CATEGORY_VALUE_VIEW = {
@@ -588,6 +599,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: EXPLICIT_UMBILICAL_CORD_BLOOD,
+      visible: true,
     };
 
     const EXPLICIT_VENOUS_BLOOD_CATEGORY_VALUE_VIEW = {
@@ -597,6 +609,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: EXPLICIT_VENOUS_BLOOD,
+      visible: true,
     };
 
     const EXPLICIT_THORACIC_LYMPH_NODE_VALUE_VIEW = {
@@ -606,6 +619,7 @@ describe("useCategoryFilter", () => {
       selected: false,
       selectedPartial: false,
       value: EXPLICIT_THORACIC_LYMPH_NODE,
+      visible: true,
     };
 
     const VALUE_VIEWS_BY_CATEGORY_VALUE_ID = new Map<
@@ -2137,7 +2151,9 @@ describe("useCategoryFilter", () => {
           const tissuePanelViews =
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above
             categoryView.panels[PANEL_INDEX_TISSUE]!.views;
-          expect(tissuePanelViews.length).toEqual(3);
+          expect(
+            tissuePanelViews.filter((view) => view.visible).length
+          ).toEqual(3);
           const tissueCategoryValueIds = listCategoryValueIds(tissuePanelViews);
           [
             EXPLICIT_BLOOD,
@@ -2209,7 +2225,9 @@ describe("useCategoryFilter", () => {
 
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above
           const organPanelViews = categoryView.panels[PANEL_INDEX_ORGAN]!.views;
-          expect(organPanelViews.length).toEqual(4);
+          expect(organPanelViews.filter((view) => view.visible).length).toEqual(
+            4
+          );
           const organCategoryValueIds = listCategoryValueIds(organPanelViews);
           [
             INFERRED_BONE_MARROW,
@@ -2223,7 +2241,9 @@ describe("useCategoryFilter", () => {
           const tissuePanelViews =
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above
             categoryView.panels[PANEL_INDEX_TISSUE]!.views;
-          expect(tissuePanelViews.length).toEqual(3);
+          expect(
+            tissuePanelViews.filter((view) => view.visible).length
+          ).toEqual(3);
           const tissueCategoryValueIds = listCategoryValueIds(tissuePanelViews);
           [EXPLICIT_BONE_MARROW, EXPLICIT_SPLEEN, EXPLICIT_THYMUS].forEach(
             (categoryValueId) =>
@@ -2309,7 +2329,9 @@ describe("useCategoryFilter", () => {
           const tissuePanelViews =
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above
             categoryView.panels[PANEL_INDEX_TISSUE]!.views;
-          expect(tissuePanelViews.length).toEqual(3);
+          expect(
+            tissuePanelViews.filter((view) => view.visible).length
+          ).toEqual(3);
           const tissueCategoryValueIds = listCategoryValueIds(tissuePanelViews);
           [
             EXPLICIT_BLOOD,
@@ -2391,7 +2413,9 @@ describe("useCategoryFilter", () => {
 
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above
           const organPanelViews = categoryView.panels[PANEL_INDEX_ORGAN]!.views;
-          expect(organPanelViews.length).toEqual(4);
+          expect(organPanelViews.filter((view) => view.visible).length).toEqual(
+            4
+          );
           const organCategoryValueIds = listCategoryValueIds(organPanelViews);
           [
             INFERRED_BLOOD,
@@ -2405,7 +2429,9 @@ describe("useCategoryFilter", () => {
           const tissuePanelViews =
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above
             categoryView.panels[PANEL_INDEX_TISSUE]!.views;
-          expect(tissuePanelViews.length).toEqual(3);
+          expect(
+            tissuePanelViews.filter((view) => view.visible).length
+          ).toEqual(3);
           const tissueCategoryValueIds = listCategoryValueIds(tissuePanelViews);
           [
             EXPLICIT_BLOOD,
@@ -2497,7 +2523,9 @@ describe("useCategoryFilter", () => {
           const tissuePanelViews =
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above
             categoryView.panels[PANEL_INDEX_TISSUE]!.views;
-          expect(tissuePanelViews.length).toEqual(2);
+          expect(
+            tissuePanelViews.filter((view) => view.visible).length
+          ).toEqual(2);
           const tissueCategoryValueIds = listCategoryValueIds(tissuePanelViews);
           [EXPLICIT_BLOOD, EXPLICIT_BONE_MARROW].forEach((categoryValueId) =>
             tissueCategoryValueIds.includes(categoryValueId)
@@ -2554,14 +2582,18 @@ describe("useCategoryFilter", () => {
 
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above
           const organPanelViews = categoryView.panels[PANEL_INDEX_ORGAN]!.views;
-          expect(organPanelViews.length).toEqual(1);
+          expect(organPanelViews.filter((view) => view.visible).length).toEqual(
+            1
+          );
           const organCategoryValueIds = listCategoryValueIds(organPanelViews);
           expect(organCategoryValueIds.includes(INFERRED_KIDNEY)).toBeTruthy();
 
           const tissuePanelViews =
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above
             categoryView.panels[PANEL_INDEX_TISSUE]!.views;
-          expect(tissuePanelViews.length).toEqual(5);
+          expect(
+            tissuePanelViews.filter((view) => view.visible).length
+          ).toEqual(5);
           const tissueCategoryValueIds = listCategoryValueIds(tissuePanelViews);
           [
             EXPLICIT_BLADDER_LUMEN,


### PR DESCRIPTION
…em is already selected? (#316)

- #TICKET_NUMBER
#3164

### Reviewers
**Functional:** 
@tihuan  

---


## Changes
Previously, SelectCategoryValueViews were filtered before sending to the FilterCategoryViewPanels to remove any SelectCategoryValueViews that were filtered out by selections in parent panels. For example, in the “Tissue” filter,  if a system is selected, then only organs and tissues under the system are passed through to the FilterCategoryViewPanels.

To support the updated functionality, all SelectCategoryValueViews are now sent to the  FilterCategoryViewPanels with a “visible” flag to indicate if they are filtered out by selections in parent panels. 

The FilterCategoryViewPanels shows only “visible” SelectCategoryValueViews unless an “omnisearch” search term is present in the search box. If a search term is present, the FilterCategoryViewPanel shows all SelectCategoryValueViews matching the search term regardless of the visibility state of the SelectCategoryValueViews. 


