### PR TITLE
feat: add button to easily clear filter search bars (#3612)

### DIFF
--- a/frontend/src/components/common/Filter/components/FilterContent/components/FilterViews/components/FilterMultiPanelCategoryView/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterContent/components/FilterViews/components/FilterMultiPanelCategoryView/style.ts
@@ -15,5 +15,9 @@ export const Search = styled(FilterSearch)`
     .${Classes.ICON} {
       left: 6px;
     }
+
+    .${Classes.INPUT_ACTION} {
+      right: 14px;
+    }
   }
 `;

--- a/frontend/src/components/common/Filter/components/FilterSearch/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterSearch/index.tsx
@@ -2,6 +2,7 @@ import { IconNames } from "@blueprintjs/icons";
 import { SetSearchValueFn } from "src/components/common/Filter/components/FilterSearch/common/useFilterSearch";
 import { ClearIconButton, ViewSearch } from "./style";
 import { Icon } from "czifui";
+import { useRef } from "react";
 
 interface Props {
   className?: string;
@@ -14,24 +15,35 @@ export default function FilterSearch({
   searchValue,
   setSearchValue,
 }: Props): JSX.Element {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  /**
+   * Clears search value and sets focus on the search input element.
+   */
+  const onClearSearch = (): void => {
+    setSearchValue("");
+    inputRef?.current?.focus();
+  };
+
   return (
     <ViewSearch
       autoFocus
       className={className}
+      inputRef={inputRef}
       leftIcon={IconNames.SEARCH}
       onChange={(changeEvent) => setSearchValue(changeEvent.target.value)}
       placeholder="Search"
       rightElement={
         searchValue ? (
           <ClearIconButton
-            onClick={() => setSearchValue("")}
+            onClick={onClearSearch}
+            {...{
+              // TODO(cc) move this back to explicit prop={value} after upgrading SDS to enable type checking again
+              sdsSize: "small",
+            }}
             sdsType="secondary"
           >
-            <Icon
-              sdsIcon="xMarkCircle"
-              sdsSize="s" // maximum available IconNameToSize for xMarkCircle icon.
-              sdsType="iconButton"
-            />
+            <Icon sdsIcon="xMarkCircle" sdsSize="s" sdsType="iconButton" />
           </ClearIconButton>
         ) : undefined
       }

--- a/frontend/src/components/common/Filter/components/FilterSearch/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterSearch/index.tsx
@@ -1,6 +1,7 @@
 import { IconNames } from "@blueprintjs/icons";
 import { SetSearchValueFn } from "src/components/common/Filter/components/FilterSearch/common/useFilterSearch";
-import { ViewSearch } from "./style";
+import { ClearIconButton, ViewSearch } from "./style";
+import { Icon } from "czifui";
 
 interface Props {
   className?: string;
@@ -20,6 +21,20 @@ export default function FilterSearch({
       leftIcon={IconNames.SEARCH}
       onChange={(changeEvent) => setSearchValue(changeEvent.target.value)}
       placeholder="Search"
+      rightElement={
+        searchValue ? (
+          <ClearIconButton
+            onClick={() => setSearchValue("")}
+            sdsType="secondary"
+          >
+            <Icon
+              sdsIcon="xMarkCircle"
+              sdsSize="s" // maximum available IconNameToSize for xMarkCircle icon.
+              sdsType="iconButton"
+            />
+          </ClearIconButton>
+        ) : undefined
+      }
       value={searchValue}
     />
   );

--- a/frontend/src/components/common/Filter/components/FilterSearch/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterSearch/style.ts
@@ -47,7 +47,7 @@ export const ClearIconButton = styled(IconButton)`
   }
 
   .MuiSvgIcon-root {
-    height: 16px; // overrides icon size specification - xMarkCircle IconNameToSizes maximum available sdsSize is "s"
-    width: 16px; // overrides icon size specification - xMarkCircle IconNameToSizes maximum available sdsSize is "s"
+    height: 16px; // overrides IconNameToSizes "s" size specification
+    width: 16px; // overrides IconNameToSizes "s" size specification
   }
 `;

--- a/frontend/src/components/common/Filter/components/FilterSearch/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterSearch/style.ts
@@ -40,18 +40,17 @@ export const ViewSearch = styled(InputGroup)`
 export const ClearIconButton = styled(IconButton)`
   ${(props) => {
     const colors = getColors(props);
-    const textPrimary = props.theme.palette?.text?.primary;
+    const palette = props.theme.palette;
     return css`
       color: ${colors?.gray[400]};
 
       &:hover {
-        color: ${textPrimary};
+        color: ${palette?.text?.primary};
       }
     `;
-  }};
-
+  }}
   .MuiSvgIcon-root {
-    height: 16px; // overrides IconNameToSizes "s" size specification
-    width: 16px; // overrides IconNameToSizes "s" size specification
+    height: 16px; /* overrides IconNameToSizes "s" size specification */
+    width: 16px; /* overrides IconNameToSizes "s" size specification */
   }
 `;

--- a/frontend/src/components/common/Filter/components/FilterSearch/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterSearch/style.ts
@@ -1,6 +1,7 @@
 import { Classes, InputGroup } from "@blueprintjs/core";
 import styled from "@emotion/styled";
 import { GRAY, LIGHT_GRAY, PT_TEXT_COLOR } from "src/components/common/theme";
+import { getColors, IconButton } from "czifui";
 
 export const ViewSearch = styled(InputGroup)`
   &.${Classes.INPUT_GROUP} {
@@ -26,5 +27,27 @@ export const ViewSearch = styled(InputGroup)`
         opacity: 0.6;
       }
     }
+
+    .${Classes.INPUT_ACTION} {
+      right: 8px;
+    }
+  }
+`;
+
+export const ClearIconButton = styled(IconButton)`
+  ${(props) => {
+    const colors = getColors(props);
+    return `
+      color: ${colors?.gray[400]};
+      `;
+  }};
+
+  &:hover {
+    color: black;
+  }
+
+  .MuiSvgIcon-root {
+    height: 16px; // overrides icon size specification - xMarkCircle IconNameToSizes maximum available sdsSize is "s"
+    width: 16px; // overrides icon size specification - xMarkCircle IconNameToSizes maximum available sdsSize is "s"
   }
 `;

--- a/frontend/src/components/common/Filter/components/FilterSearch/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterSearch/style.ts
@@ -2,6 +2,7 @@ import { Classes, InputGroup } from "@blueprintjs/core";
 import styled from "@emotion/styled";
 import { GRAY, LIGHT_GRAY, PT_TEXT_COLOR } from "src/components/common/theme";
 import { getColors, IconButton } from "czifui";
+import { css } from "@emotion/react";
 
 export const ViewSearch = styled(InputGroup)`
   &.${Classes.INPUT_GROUP} {
@@ -30,6 +31,8 @@ export const ViewSearch = styled(InputGroup)`
 
     .${Classes.INPUT_ACTION} {
       right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
     }
   }
 `;
@@ -37,14 +40,15 @@ export const ViewSearch = styled(InputGroup)`
 export const ClearIconButton = styled(IconButton)`
   ${(props) => {
     const colors = getColors(props);
-    return `
+    const textPrimary = props.theme.palette?.text?.primary;
+    return css`
       color: ${colors?.gray[400]};
-      `;
-  }};
 
-  &:hover {
-    color: black;
-  }
+      &:hover {
+        color: ${textPrimary};
+      }
+    `;
+  }};
 
   .MuiSvgIcon-root {
     height: 16px; // overrides IconNameToSizes "s" size specification


### PR DESCRIPTION
- #3612 

### Reviewers
**Functional:** 
@tihuan 

---


## Changes
- Added clear button to filter search as per [mock](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=4261%3A37785&t=BHyMIN9m4P1kvKj6-4) and implemented as per [slack discussion](https://clevercanary.slack.com/archives/C02CF7MQPGV/p1669055439987369?thread_ts=1668452415.971099&cid=C02CF7MQPGV).