### PR TITLE
chore: move local FE and BE servers to HTTPS

### DIFF
--- a/DEV_ENV.md
+++ b/DEV_ENV.md
@@ -5,7 +5,7 @@
 1. [install docker](https://docs.docker.com/get-docker/). If brew is installed run `brew install docker`. If you have a Mac, [install Docker Desktop](https://www.docker.com/products/docker-desktop) and open it so it's running on your machine. Note: If you have a Mac M1 (arm64 CPU), follow instructions in [`docker-compose.yml`](docker-compose.yml) under `oidc` service, for manually building the oidc-server-mock images for the M1 architecture.
 1. [install chamber](https://github.com/segmentio/chamber). If brew is installed run `brew install chamber`. (This is needed for running functional tests.)
 1. From the root of this repository, run `make local-init` to build and run the dev environment. The first build takes awhile, but subsequent runs will use cached artifacts. Note: If Docker reports a conflict for port 5000, and you are on a Mac, you should turn off Control Center's "Airplay Receiver" in the "Sharing" System Preferences ([details](https://developer.apple.com/forums/thread/682332)).
-1. Visit [http://backend.corporanet.local:5000](http://backend.corporanet.local:5000) to view the backend, and [http://frontend.corporanet.local:3000](http://frontend.corporanet.local:3000) for the frontend.
+1. Visit [https://backend.corporanet.local:5000](https://backend.corporanet.local:5000) to view the backend, and [https://frontend.corporanet.local:3000](https://frontend.corporanet.local:3000) for the frontend.
 1. `make local-dbconsole` starts a connection with the local postgresql db.
 1. **Open the source code and start editing!**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ ENV COMMIT_SHA=${HAPPY_COMMIT}
 ENV COMMIT_BRANCH=${HAPPY_BRANCH}
 
 # Note: Using just 1 worker for dev/test env. Multiple workers are used in deployment envs, as defined in Terraform code.
-CMD gunicorn --worker-class gevent --workers 1 --bind 0.0.0.0:5000 backend.api_server.app:app --max-requests 10000 --timeout 180 --keep-alive 5 --log-level info
+CMD gunicorn --certfile /tmp/pkcs12/server.crt --keyfile /tmp/pkcs12/server.key --worker-class gevent --workers 1 --bind 0.0.0.0:5000 backend.api_server.app:app --max-requests 10000 --timeout 180 --keep-alive 5 --log-level info

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,4 @@ LABEL commit=${HAPPY_COMMIT}
 ENV COMMIT_SHA=${HAPPY_COMMIT}
 ENV COMMIT_BRANCH=${HAPPY_BRANCH}
 
-# Note: Using just 1 worker for dev/test env. Multiple workers are used in deployment envs, as defined in Terraform code.
-CMD gunicorn --certfile /tmp/pkcs12/server.crt --keyfile /tmp/pkcs12/server.key --worker-class gevent --workers 1 --bind 0.0.0.0:5000 backend.api_server.app:app --max-requests 10000 --timeout 180 --keep-alive 5 --log-level info
+ENTRYPOINT ["./container_init.sh"]

--- a/backend/api_server/app.py
+++ b/backend/api_server/app.py
@@ -68,7 +68,7 @@ def configure_flask_app(flask_app):
     allowed_origins = []
     deployment_stage = os.environ["DEPLOYMENT_STAGE"]
     if deployment_stage not in ["prod"]:
-        allowed_origins.extend([r"http://.*\.corporanet\.local:\d+", r"^http://localhost:\d+"])
+        allowed_origins.extend([r"https?://.*\.corporanet\.local:\d+", r"^https?://localhost:\d+"])
     if os.getenv("FRONTEND_URL"):
         allowed_origins.append(os.getenv("FRONTEND_URL"))
     if deployment_stage != "test":  # pragma: no cover

--- a/backend/common/corpora_config.py
+++ b/backend/common/corpora_config.py
@@ -18,7 +18,7 @@ class CorporaConfig(SecretConfig):
         else:
             deployment_stage = os.environ.get("DEPLOYMENT_STAGE")
             if deployment_stage == "test":
-                collections_base_url = "http://frontend.corporanet.local:3000"
+                collections_base_url = "https://frontend.corporanet.local:3000"
             elif deployment_stage == "prod":
                 collections_base_url = "https://cellxgene.cziscience.com"
             else:

--- a/container_init.sh
+++ b/container_init.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+echo
+echo " ====="
+echo "| starting backend container"
+echo " ====="
+echo
+
+# If user passed a command line, run it in place of the server
+if [ $# -ne 0 ]; then
+  exec "$@"
+fi
+
+if [ "${DEPLOYMENT_STAGE}" == "test" ]; then
+  # Use locally-generated cert for HTTPS in containerized local environment; deployed envs use ELB
+  HTTPS_CERT_AND_KEY="--certfile /tmp/pkcs12/server.crt --keyfile /tmp/pkcs12/server.key"
+fi
+# Note: Using just 1 worker for dev/test env. Multiple workers are used in deployment envs, as defined in Terraform code.
+exec gunicorn ${HTTPS_CERT_AND_KEY} --worker-class gevent --workers 1 --bind 0.0.0.0:5000 backend.api_server.app:app \
+  --max-requests 10000 --timeout 180 --keep-alive 5 --log-level info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     volumes:
       - ./frontend:/corpora-frontend
       - /corpora-frontend/node_modules/
+      - ./oauth/pkcs12:/tmp/pkcs12:ro
     networks:
       corporanet:
         aliases:
@@ -265,6 +266,7 @@ services:
       - .:/single-cell-data-portal
       # SecretsManager population relies on oauth json
       - ./oauth/users.json:/oauth/users.json
+      - ./oauth/pkcs12:/tmp/pkcs12:ro
     networks:
       corporanet:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,6 +244,7 @@ services:
         - HAPPY_BRANCH
         - HAPPY_TAG
     restart: always
+    command: [ "./container_init.sh" ]
     depends_on:
       - localstack
       - database

--- a/frontend/container_init.sh
+++ b/frontend/container_init.sh
@@ -21,7 +21,6 @@ fi
 
 # Build and run without dev mode in remote dev env.
 if [ "${DEPLOYMENT_STAGE}" == "test" ]; then
-  npm install next-dev-https
   mkdir -p ./node_modules/.next-dev-mobile
   cp -r /tmp/pkcs12/* ./node_modules/.next-dev-mobile
   # next-dev-https looks for cert.pem and key.pem in node_modules/.next-dev-mobile/ (otherwise generates anew 👎)

--- a/frontend/container_init.sh
+++ b/frontend/container_init.sh
@@ -21,6 +21,13 @@ fi
 
 # Build and run without dev mode in remote dev env.
 if [ "${DEPLOYMENT_STAGE}" == "test" ]; then
+  npm install next-dev-https
+  mkdir -p ./node_modules/.next-dev-mobile
+  cp -r /tmp/pkcs12/* ./node_modules/.next-dev-mobile
+  # next-dev-https looks for cert.pem and key.pem in node_modules/.next-dev-mobile/ (otherwise generates anew 👎)
+  # We want the dev server to find this key and cert because they've already been added to our keychain
+  mv ./node_modules/.next-dev-mobile/server.crt ./node_modules/.next-dev-mobile/cert.pem
+  mv ./node_modules/.next-dev-mobile/server.key ./node_modules/.next-dev-mobile/key.pem
   exec npm run dev
 else
   # We need "-- --" because `npm run build-and-start-prod`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@loadable/component": "^5.15.0",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
-        "@material-ui/lab": "*",
+        "@material-ui/lab": "latest",
         "@types/d3-scale-chromatic": "^3.0.0",
         "@vgrid/sass-inline-svg": "^1.0.1",
         "client-zip": "^2.2.2",
@@ -75,6 +75,7 @@
         "eslint-plugin-sonarjs": "^0.15.0",
         "expect-playwright": "^0.8.0",
         "gray-matter": "^4.0.3",
+        "next-dev-https": "^0.1.1",
         "next-mdx-remote": "^4.1.0",
         "playwright": "^1.27.0",
         "prettier": "^2.4.1",
@@ -3409,6 +3410,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -8958,6 +8965,24 @@
         }
       }
     },
+    "node_modules/next-dev-https": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/next-dev-https/-/next-dev-https-0.1.1.tgz",
+      "integrity": "sha512-iP/YkEETLSgUSwqkMBsazjWsOH1Nz0AJWhKkiZ3VCpMsqGp9E6C5C3ePLVJlViNcfRek0EkmVVKkkIEwLvQK3Q==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^5.0.2",
+        "qrcode-terminal": "^0.12.0",
+        "selfsigned": "^2.1.1"
+      },
+      "bin": {
+        "next-dev-https": "bin.js"
+      },
+      "peerDependencies": {
+        "next": ">=12.0.0",
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/next-mdx-remote": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-4.1.0.tgz",
@@ -9024,6 +9049,15 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.13.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.6",
@@ -10010,6 +10044,15 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "dev": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10931,6 +10974,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/selfsigned": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
+      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
+      "dev": true,
+      "dependencies": {
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver": {
@@ -15487,6 +15542,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -19459,6 +19520,17 @@
         "use-sync-external-store": "1.2.0"
       }
     },
+    "next-dev-https": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/next-dev-https/-/next-dev-https-0.1.1.tgz",
+      "integrity": "sha512-iP/YkEETLSgUSwqkMBsazjWsOH1Nz0AJWhKkiZ3VCpMsqGp9E6C5C3ePLVJlViNcfRek0EkmVVKkkIEwLvQK3Q==",
+      "dev": true,
+      "requires": {
+        "arg": "^5.0.2",
+        "qrcode-terminal": "^0.12.0",
+        "selfsigned": "^2.1.1"
+      }
+    },
     "next-mdx-remote": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-4.1.0.tgz",
@@ -19507,6 +19579,12 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "dev": true
     },
     "node-releases": {
       "version": "2.0.6",
@@ -20239,6 +20317,12 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
     },
+    "qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "dev": true
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -20894,6 +20978,15 @@
       "requires": {
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
+      }
+    },
+    "selfsigned": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
+      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
+      "dev": true,
+      "requires": {
+        "node-forge": "^1"
       }
     },
     "semver": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-sonarjs": "^0.15.0",
     "expect-playwright": "^0.8.0",
     "gray-matter": "^4.0.3",
-    "next-dev-https": "^0.1.1",
+    "next-dev-https": "0.1.1",
     "next-mdx-remote": "^4.1.0",
     "playwright": "^1.27.0",
     "prettier": "^2.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-sonarjs": "^0.15.0",
     "expect-playwright": "^0.8.0",
     "gray-matter": "^4.0.3",
+    "next-dev-https": "^0.1.1",
     "next-mdx-remote": "^4.1.0",
     "playwright": "^1.27.0",
     "prettier": "^2.4.1",
@@ -91,7 +92,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next-dev-https --https --port 3000",
     "build": "NODE_OPTIONS=\"--max_old_space_size=2048\" next build",
     "start": "next start",
     "develop": "next dev",

--- a/frontend/src/configs/local.js
+++ b/frontend/src/configs/local.js
@@ -4,7 +4,7 @@ const { PLAUSIBLE_DATA_DOMAIN_STAGING } = require("./common");
 // to a new file named `configs.js` in this directory.
 
 const configs = {
-  API_URL: "http://backend.corporanet.local:5000",
+  API_URL: "https://backend.corporanet.local:5000",
   PLAUSIBLE_DATA_DOMAIN: PLAUSIBLE_DATA_DOMAIN_STAGING,
 };
 

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -43,13 +43,13 @@ All the E2E test commands can be found in `frontend/Makefile` and `frontend/pack
    1. In `frontend/` directory, run `npm i`
    2. Ensure your playwright config is connected to a working BE API service.
 
-      1. For BE running in Docker containers, `frontend/src/configs/configs.js` should point to `API_URL: "http://backend.corporanet.local:5000"`
+      1. For BE running in Docker containers, `frontend/src/configs/configs.js` should point to `API_URL: "https://backend.corporanet.local:5000"`
 
       2. To run against Deployed BEs,`frontend/src/configs/configs.js` should point to `API_URL: "https://api.cellxgene.dev.single-cell.czi.technology"`, or any other deployed BE API base url
 
 1. local -> local (app started with `npm run dev`)
 
-   1. Make sure you have your local app running already on http://localhost:3000. If not, in `frontend/` directory, run `npm run dev`
+   1. Make sure you have your local app running already on https://localhost:3000. If not, in `frontend/` directory, run `npm run dev`
 
    1. In `frontend/` directory, run `npm run e2e`
    
@@ -57,7 +57,7 @@ All the E2E test commands can be found in `frontend/Makefile` and `frontend/pack
 
 1. local -> local container (app started with `make local-init`)
 
-   1. Make sure you have your local app running already on http://frontend.corporanet.local:3000. If not, in the root directory of the repo, run `make local-init` to start all containers
+   1. Make sure you have your local app running already on https://frontend.corporanet.local:3000. If not, in the root directory of the repo, run `make local-init` to start all containers
 
    1. In `frontend/` directory, run `npm run e2e`
 

--- a/frontend/tests/common/constants.ts
+++ b/frontend/tests/common/constants.ts
@@ -11,8 +11,8 @@ export const TEST_ENV: TEST_ENV = (process.env.TEST_ENV as TEST_ENV) || "local";
 
 const TEST_ENV_TO_TEST_URL = {
   dev: "https://cellxgene.dev.single-cell.czi.technology",
-  happy: "http://frontend.corporanet.local:3000",
-  local: "http://localhost:3000",
+  happy: "https://frontend.corporanet.local:3000",
+  local: "https://localhost:3000",
   localProd: "http://localhost:9000",
   prod: "https://cellxgene.cziscience.com",
   rdev: process.env.RDEV_LINK || "",

--- a/oauth/clients-config.json
+++ b/oauth/clients-config.json
@@ -5,8 +5,7 @@
     "Description": "Client for client credentials flow",
     "AllowedGrantTypes": ["authorization_code"],
     "RedirectUris": [
-      "https://backend.corporanet.local:5000/dp/v1/oauth2/callback",
-      "http://backend.corporanet.local:5000/dp/v1/oauth2/callback"
+      "https://backend.corporanet.local:5000/dp/v1/oauth2/callback"
     ],
     "AllowedScopes": [
       "openid",

--- a/oauth/pkcs12/generate_cert.sh
+++ b/oauth/pkcs12/generate_cert.sh
@@ -1,9 +1,9 @@
 if [ ! -f server.crt ]; then
-  openssl req -x509 -newkey rsa:4096 -sha256 -days 3560 -nodes -keyout server.key -out server.crt -subj '/CN=oidc.corporanet.local' -extensions san -nodes -config <( \
+  openssl req -x509 -newkey rsa:4096 -sha256 -days 3560 -nodes -keyout server.key -out server.crt -subj '/CN=*.corporanet.local' -extensions san -nodes -config <( \
     echo '[req]'; \
     echo 'distinguished_name=req'; \
     echo '[san]'; \
-    echo 'subjectAltName=DNS:oidc')
+    echo 'subjectAltName=DNS:*.corporanet.local')
 else
     echo "Cert already exists, skipping"
 fi

--- a/scripts/setup_dev_data.sh
+++ b/scripts/setup_dev_data.sh
@@ -4,8 +4,8 @@ export AWS_DEFAULT_REGION=us-west-2
 export AWS_ACCESS_KEY_ID=nonce
 export AWS_SECRET_ACCESS_KEY=nonce
 
-export FRONTEND_URL=http://frontend.corporanet.local:3000
-export BACKEND_URL=http://backend.corporanet.local:5000
+export FRONTEND_URL=https://frontend.corporanet.local:3000
+export BACKEND_URL=https://backend.corporanet.local:5000
 
 # NOTE: This script is intended to run INSIDE the dockerized dev environment!
 # If you need to run it directly on your laptop for some reason, change

--- a/tests/functional/backend/common.py
+++ b/tests/functional/backend/common.py
@@ -13,7 +13,7 @@ API_URL = {
     "prod": "https://api.cellxgene.cziscience.com",
     "staging": "https://api.cellxgene.staging.single-cell.czi.technology",
     "dev": "https://api.cellxgene.dev.single-cell.czi.technology",
-    "test": "http://localhost:5000",
+    "test": "https://localhost:5000",
 }
 
 AUDIENCE = {

--- a/tests/unit/backend/api_server/curation/collection/test_curation_collections.py
+++ b/tests/unit/backend/api_server/curation/collection/test_curation_collections.py
@@ -364,7 +364,7 @@ class TestGetCollections(BaseAuthAPITest):
 
 class TestGetCollectionID(BaseAuthAPITest):
     expected_body = {
-        "collection_url": "http://frontend.corporanet.local:3000/collections/test_collection_id",
+        "collection_url": "https://frontend.corporanet.local:3000/collections/test_collection_id",
         "contact_email": "somebody@chanzuckerberg.com",
         "contact_name": "Some Body",
         "curator_name": "",


### PR DESCRIPTION
- #3598 

### Reviewers
**Functional:** 
@tihuan @Bento007 
**Readability:** 
@atarashansky 
---


## Changes
- Introduce [next-dev-https](https://www.npmjs.com/package/next-dev-https) for our local dev server for serving the FE
- Move BE to HTTPS as well (required for compatibility)
- Share cert/key generated by the oidc container (legacy code from Jessica) with the FE and the BE containers so that (it continues to be true that) **only one** cert has to be added to the local keychain.

## QA steps (optional)

## Notes for Reviewer
