### PR TITLE
feat: create a database migration to add a consortia field to collect…

### DIFF
--- a/backend/common/corpora_orm.py
+++ b/backend/common/corpora_orm.py
@@ -263,6 +263,28 @@ class DatasetArtifactFileType(enum.Enum):
     CXG = "cxg"
 
 
+class CollectionConsortia(enum.Enum):
+    """
+    Enumerates Consortia names.
+
+    """
+    ALLEN_INSTITUTE_FOR_BRAIN_SCIENCE = "Allen Institute for Brain Science"
+    BRAIN_INITIATIVE = "BRAIN Initiative"
+    CZ_BIOHUB = "CZ Biohub"
+    CZI_NDCN = "CZI Neurodegeneration Challenge Network"
+    CZI_SCB = "CZI Single-Cell Biology"
+    EU_HORIZON_2020 = "European Union’s Horizon 2020"
+    GUDMAP = "GenitoUrinary Development Molecular Anatomy Project (GUDMAP)"
+    GUT_CELL_ATLAS = "Gut Cell Atlas"
+    HUBMAP= "Human BioMolecular Atlas Program (HuBMAP)"
+    HPAP = "Human Pancreas Analysis Program (HPAP)"
+    HTAN = "Human Tumor Atlas Network (HTAN)"
+    KPMP = "Kidney Precision Medicine Project (KPMP)"
+    LUNG_MAP = "LungMAP"
+    SEA_AD = "SEA-AD"
+    WELCOME_HCA_STRATEGIC_SCIENCE_SUPPORT = "Wellcome HCA Strategic Science Support"
+
+
 class DbCollection(Base, AuditMixin, TimestampMixin):
     """
     A Corpora collection represents an in progress or live submission of a lab experiment.
@@ -283,6 +305,7 @@ class DbCollection(Base, AuditMixin, TimestampMixin):
     tombstone = Column(Boolean, default=False, nullable=False)
     publisher_metadata = Column(JSON, nullable=True)
     revision_of = Column(String, ForeignKey("project.id"), nullable=True, unique=True)
+    consortia = Column(Enum(CollectionConsortia), nullable=True)
 
     # Relationships
     revision = relationship("DbCollection", cascade="all, delete-orphan", uselist=False)

--- a/backend/database/versions/33_af2afa1f73e7_add_consortia_column_to_collection.py
+++ b/backend/database/versions/33_af2afa1f73e7_add_consortia_column_to_collection.py
@@ -1,0 +1,25 @@
+"""add_consortia_column_to_collection
+
+Revision ID: 33_af2afa1f73e7
+Revises: 32_c27083d1a76d
+Create Date: 2022-11-28 23:20:52.397594
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '33_af2afa1f73e7'
+down_revision = '32_c27083d1a76d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("project", sa.Column("consortia", postgresql.ARRAY(sa.String()), nullable=True))
+
+
+def downgrade():
+    op.drop_column("project", "consortia")


### PR DESCRIPTION
…ions

- #TICKET_NUMBER
#3639 
### Reviewers
**Functional:** 
@ebezzi 

---


## Changes
- added a migration to add a consortia field to collections. This is an optional field that may have zero or more values. 
- added a `consortia` column to the `DbCollection` class.
- added a `CollectionConsortia` class to enumerate the allowed consortia names. 

## Notes
- have not yet been able to run the local upgrade/downgrade tests.

