### PR TITLE
feat: Add consortia to collection endpoints for the BE Data Portal API

### DIFF
--- a/backend/common/corpora_orm.py
+++ b/backend/common/corpora_orm.py
@@ -305,7 +305,7 @@ class DbCollection(Base, AuditMixin, TimestampMixin):
     tombstone = Column(Boolean, default=False, nullable=False)
     publisher_metadata = Column(JSON, nullable=True)
     revision_of = Column(String, ForeignKey("project.id"), nullable=True, unique=True)
-    consortia = Column(Enum(CollectionConsortia), nullable=True)
+    consortia = Column(ARRAY(String), nullable=True)
 
     # Relationships
     revision = relationship("DbCollection", cascade="all, delete-orphan", uselist=False)

--- a/backend/common/corpora_orm.py
+++ b/backend/common/corpora_orm.py
@@ -265,8 +265,7 @@ class DatasetArtifactFileType(enum.Enum):
 
 class CollectionConsortia(enum.Enum):
     """
-    Enumerates Consortia names.
-
+    Enumerates consortia names.
     """
 
     ALLEN_INSTITUTE_FOR_BRAIN_SCIENCE = "Allen Institute for Brain Science"

--- a/backend/common/entities/collection.py
+++ b/backend/common/entities/collection.py
@@ -38,6 +38,7 @@ class Collection(Entity):
         links: list = None,
         data_submission_policy_version: str = "",
         publisher_metadata: dict = None,
+        consortia: list = None,
         **kwargs,
     ) -> "Collection":
         """
@@ -57,6 +58,7 @@ class Collection(Entity):
             contact_email=contact_email,
             data_submission_policy_version=data_submission_policy_version,
             publisher_metadata=publisher_metadata,
+            consortia=consortia,
             **kwargs,
         )
         new_db_object.links = [DbCollectionLink(collection_id=new_db_object.id, **link) for link in links]
@@ -239,6 +241,8 @@ class Collection(Entity):
             Dataset.transform_organism_for_schema_2_0_0(dataset)
 
         result["datasets"] = datasets
+
+        result["consortia"] = result["consortia"] if result["consortia"] else []
         return result
 
     def publish(self, data_submission_policy_version):

--- a/backend/common/entities/collection.py
+++ b/backend/common/entities/collection.py
@@ -239,10 +239,11 @@ class Collection(Entity):
 
             Dataset.transform_sex_for_schema_2_0_0(dataset)
             Dataset.transform_organism_for_schema_2_0_0(dataset)
-
         result["datasets"] = datasets
 
-        result["consortia"] = result["consortia"] if result["consortia"] else []
+        if "consortia" not in result:
+            result["consortia"] = []
+
         return result
 
     def publish(self, data_submission_policy_version):

--- a/backend/portal/api/app/portal-api.yml
+++ b/backend/portal/api/app/portal-api.yml
@@ -102,10 +102,7 @@ paths:
                   type: string
                   description: name of the curator of the collection.
                 consortia:
-                  type: array
-                  items:
-                    type: string
-                  description: TBD
+                  $ref: "#/components/schemas/consortia"
                 links:
                   $ref: "#/components/schemas/links"
       responses:
@@ -986,6 +983,11 @@ components:
           link_type:
             type: string
             enum: [PROTOCOL, RAW_DATA, DOI, LAB_WEBSITE, OTHER, DATA_SOURCE]
+    consortia:
+      type: array
+      items:
+        type: string
+        description: TBD
     collection:
       type: object
       required:
@@ -1016,6 +1018,8 @@ components:
           $ref: "#/components/schemas/visibility"
         links:
           $ref: "#/components/schemas/links"
+        consortia:
+          $ref: "#/components/schemas/consortia"
         contact_name:
           type: string
         contact_email:

--- a/backend/portal/api/app/portal-api.yml
+++ b/backend/portal/api/app/portal-api.yml
@@ -445,6 +445,10 @@ paths:
                       type: number
                     revised_at:
                       type: number
+                    consortia:
+                      type: array
+                      items:
+                        type: string
         "400":
           $ref: "#/components/responses/400"
 

--- a/backend/portal/api/app/portal-api.yml
+++ b/backend/portal/api/app/portal-api.yml
@@ -101,6 +101,11 @@ paths:
                 curator_name:
                   type: string
                   description: name of the curator of the collection.
+                consortia:
+                  type: array
+                  items:
+                    type: string
+                  description: TBD
                 links:
                   $ref: "#/components/schemas/links"
       responses:

--- a/backend/portal/api/app/portal-api.yml
+++ b/backend/portal/api/app/portal-api.yml
@@ -448,9 +448,7 @@ paths:
                     revised_at:
                       type: number
                     consortia:
-                      type: array
-                      items:
-                        type: string
+                        $ref: "#/components/schemas/consortia"
         "400":
           $ref: "#/components/responses/400"
 
@@ -987,7 +985,7 @@ components:
       type: array
       items:
         type: string
-        description: TBD
+        description: The broader research groups which contributed to this collection of datasets.
     collection:
       type: object
       required:

--- a/backend/portal/api/app/v1/collections/actions.py
+++ b/backend/portal/api/app/v1/collections/actions.py
@@ -23,7 +23,6 @@ def get(from_date: int = None, to_date: int = None, token_info: Optional[dict] =
             DbCollection.owner,
             DbCollection.created_at,
             DbCollection.revision_of,
-            DbCollection.consortia,
         ],
     )
 
@@ -31,13 +30,16 @@ def get(from_date: int = None, to_date: int = None, token_info: Optional[dict] =
     for coll_dict in all_collections:
         visibility = coll_dict["visibility"]
         owner = coll_dict["owner"]
+        consortia = coll_dict["consortia"]
+
         if visibility == CollectionVisibility.PUBLIC:
-            collections.append(dict(id=coll_dict["id"], created_at=coll_dict["created_at"], visibility=visibility.name))
+            collections.append(dict(id=coll_dict["id"], consortia=consortia, created_at=coll_dict["created_at"], visibility=visibility.name))
         elif is_user_owner_or_allowed(token_info, owner):
             collections.append(
                 dict(
                     id=coll_dict["id"],
                     created_at=coll_dict["created_at"],
+                    consortia=consortia,
                     visibility=visibility.name,
                     revision_of=coll_dict["revision_of"],
                 )

--- a/backend/portal/api/app/v1/collections/actions.py
+++ b/backend/portal/api/app/v1/collections/actions.py
@@ -23,6 +23,7 @@ def get(from_date: int = None, to_date: int = None, token_info: Optional[dict] =
             DbCollection.owner,
             DbCollection.created_at,
             DbCollection.revision_of,
+            DbCollection.consortia,
         ],
     )
 

--- a/backend/portal/api/app/v1/collections/actions.py
+++ b/backend/portal/api/app/v1/collections/actions.py
@@ -31,10 +31,17 @@ def get(from_date: int = None, to_date: int = None, token_info: Optional[dict] =
     for coll_dict in all_collections:
         visibility = coll_dict["visibility"]
         owner = coll_dict["owner"]
-        consortia = coll_dict["consortia"]
+        consortia = coll_dict["consortia"] if coll_dict["consortia"] else []
 
         if visibility == CollectionVisibility.PUBLIC:
-            collections.append(dict(id=coll_dict["id"], consortia=consortia, created_at=coll_dict["created_at"], visibility=visibility.name))
+            collections.append(
+                dict(
+                    id=coll_dict["id"],
+                    consortia=consortia,
+                    created_at=coll_dict["created_at"],
+                    visibility=visibility.name,
+                )
+            )
         elif is_user_owner_or_allowed(token_info, owner):
             collections.append(
                 dict(

--- a/backend/portal/api/app/v1/collections/index.py
+++ b/backend/portal/api/app/v1/collections/index.py
@@ -18,6 +18,7 @@ def get():
             DbCollection.name,
             DbCollection.published_at,
             DbCollection.revised_at,
+            DbCollection.consortia,
             DbCollection.publisher_metadata,
         ],
     )

--- a/backend/portal/api/app/v1/collections/index.py
+++ b/backend/portal/api/app/v1/collections/index.py
@@ -25,7 +25,9 @@ def get():
 
     # Remove entries where the value is None
     updated_collection = []
+    # TODO (noopdog) this seems to break "house style" where empty values are returned
     for d in filtered_collection:
+        d["consortia"] = d["consortia"] if d["consortia"] else []
         updated_collection.append({k: v for k, v in d.items() if v is not None})
 
     return make_response(jsonify(updated_collection), 200)

--- a/backend/portal/api/collections_common.py
+++ b/backend/portal/api/collections_common.py
@@ -126,6 +126,7 @@ def create_collection_common(body: dict, user: str, doi: str, errors: list):
         contact_email=body["contact_email"],
         curator_name=body.get("curator_name", ""),
         publisher_metadata=publisher_metadata,
+        consortia=body.get("consortia", []),
     )
 
     return collection.id

--- a/frontend/src/components/CreateCollectionModal/components/Content/common/constants.ts
+++ b/frontend/src/components/CreateCollectionModal/components/Content/common/constants.ts
@@ -4,7 +4,7 @@ export enum CONSORTIA {
   CZ_BIOHUB = "CZ Biohub",
   CZI_NDCN = "CZI Neurodegeneration Challenge Network",
   CZI_SCB = "CZI Single-Cell Biology",
-  EU_HORIZON_2020 = "European Union's Horizon 2020",
+  EU_HORIZON_2020 = "European Union’s Horizon 2020",
   GUDMAP = "GenitoUrinary Development Molecular Anatomy Project (GUDMAP)",
   GUT_CELL_ATLAS = "Gut Cell Atlas",
   HUBMAP = "Human BioMolecular Atlas Program (HuBMAP)",

--- a/frontend/src/components/CreateCollectionModal/components/Content/common/utils.ts
+++ b/frontend/src/components/CreateCollectionModal/components/Content/common/utils.ts
@@ -38,7 +38,7 @@ export function sortConsortia(
   consortia: DropdownValue
 ): DefaultMenuSelectOption[] {
   if (Array.isArray(consortia)) {
-    return [...consortia].sort(({ name: c0 }, { name: c1 }) => {
+    return consortia.sort(({ name: c0 }, { name: c1 }) => {
       if (c0 > c1) {
         return 1;
       }

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -115,11 +115,21 @@ const Content: FC<Props> = (props) => {
 
   // Null / tombstone checking is type safety netting.  We shouldn't be getting to these lines/cases since we can't open the modal if the collection is tombstoned/doesn't exist.
   if (isTombstonedCollection(data)) data = null;
-  const { name, description, contact_email, contact_name } = data || {};
+  const {
+    name,
+    description,
+    contact_email,
+    contact_name,
+    consortia: collectionConsortia,
+  } = data || {};
 
-  const [consortia, setConsortia] = useState<DefaultMenuSelectOption[]>(
-    buildConsortiaOptions(data?.consortia || [])
-  );
+  const [consortia, setConsortia] = useState<DefaultMenuSelectOption[]>([]);
+
+  useEffect(() => {
+    if (collectionConsortia) {
+      setConsortia(buildConsortiaOptions(collectionConsortia));
+    }
+  }, [collectionConsortia]);
 
   const [links, setLinks] = useState<Link[]>(
     data?.links.map((link, index) => {

--- a/frontend/src/components/common/Form/Dropdown/index.tsx
+++ b/frontend/src/components/common/Form/Dropdown/index.tsx
@@ -75,6 +75,7 @@ export default function Dropdown({
             {...props}
           />
         )}
+        value={value}
       />
     </DropdownForm>
   );

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -209,7 +209,7 @@ const Collection: FC = () => {
         </CollectionHero>
         {/* Collection consortia, description and metadata */}
         <CollectionDetail>
-          {collectionConsortia?.length > 0 && (
+          {collectionConsortia.length > 0 && (
             <CollectionConsortia>
               {collectionConsortia.join(", ")}
             </CollectionConsortia>


### PR DESCRIPTION
- #TICKET_NUMBER
[3641](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/3641)
### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- Add consortia[] to the GET /v1/collections response
backend.portal.api.app.v1.collections.actions.get

- Add consortia[] to the GET /v1/collections/{collection_id} response
backend.portal.api.app.v1.collections.collection_id.actions.get

- Add consortia[] to the GET /v1/collections/index response
backend.portal.api.app.v1.collections.index.get

- Add optional consortia[] to the PUT /v1/collections/{collection_id} request and store in the database.
- Add consortia[] to the PUT /v1/collections/{collection_id} successful (200) response.
- Add consortia[] to the POST /v1/collections/{collection_id} successful (~~200~~ 201) response.
backend.portal.api.app.v1.collections.actions.post

## QA steps (optional)

## Notes for Reviewer
