### PR TITLE
fix: source datasets filter appropriately when no datasets selected

### DIFF
--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/SourceData/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/SourceData/index.tsx
@@ -23,7 +23,7 @@ export default function SourceData(): JSX.Element {
   } = useContext(StateContext);  
   const { data: filterDimensions } = useFilterDimensions();
   let { datasets = [] } = filterDimensions;
-  datasets = datasets.filter((dataset) => selectedFilters.datasets.includes(dataset.id));
+  if (selectedFilters.datasets.length > 0) datasets = datasets.filter((dataset) => selectedFilters.datasets.includes(dataset.id));
   const collections: Collections = useMemo(() => {
     return aggregateCollectionsFromDatasets(datasets);
   }, [datasets]);


### PR DESCRIPTION
Fixing this for the second time...somehow the previous fix got reverted, though I'm not sure how.