### PR TITLE
test(smoketest): Extract common shared Playwright context options

### DIFF
--- a/frontend/playwright-globalSetup.ts
+++ b/frontend/playwright-globalSetup.ts
@@ -1,5 +1,6 @@
 import { chromium } from "@playwright/test";
 import { SKIP_LOGIN, TEST_URL } from "tests/common/constants";
+import { COMMON_PLAYWRIGHT_CONTEXT } from "tests/common/context";
 import featureFlags from "tests/common/featureFlags";
 import { login } from "tests/utils/helpers";
 
@@ -12,6 +13,7 @@ module.exports = async () => {
       // One time auth
       const browser = await chromium.launch();
       const browserContext = await browser.newContext({
+        ...COMMON_PLAYWRIGHT_CONTEXT,
         storageState: featureFlags,
       });
       const page = await browserContext.newPage();

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -7,22 +7,15 @@ import {
 import { matchers } from "expect-playwright";
 import fs from "fs";
 import { LOGIN_STATE_FILENAME } from "tests/common/constants";
+import { COMMON_PLAYWRIGHT_CONTEXT } from "tests/common/context";
 import featureFlags from "./tests/common/featureFlags";
 
 expect.extend(matchers);
-
-const isHeadful =
-  process.env.HEADFUL === "true" || process.env.HEADLESS === "false";
 
 // 'github' for GitHub Actions CI to generate annotations, default otherwise
 const PLAYWRIGHT_REPORTER = process.env.CI
   ? ([["github"], ["line"], ["allure-playwright"]] as ReporterDescription[])
   : "list";
-
-const VIEWPORT = {
-  height: 1080,
-  width: 1920,
-};
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -78,20 +71,8 @@ const config: PlaywrightTestConfig = {
   timeout: 3 * 60 * 1000,
 
   use: {
-    acceptDownloads: true,
-    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 0,
-    headless: !isHeadful,
-    ignoreHTTPSErrors: true,
-    screenshot: "only-on-failure",
+    ...COMMON_PLAYWRIGHT_CONTEXT,
     storageState: getStorageState(),
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "retain-on-failure",
-    video: {
-      mode: "retain-on-failure",
-      size: VIEWPORT,
-    },
-    viewport: VIEWPORT,
   },
 
   /* Opt out of parallel tests. */

--- a/frontend/tests/common/context.ts
+++ b/frontend/tests/common/context.ts
@@ -1,0 +1,25 @@
+import { Config } from "@playwright/test";
+
+const isHeadful =
+  process.env.HEADFUL === "true" || process.env.HEADLESS === "false";
+
+const VIEWPORT = {
+  height: 1080,
+  width: 1920,
+};
+
+export const COMMON_PLAYWRIGHT_CONTEXT: Config["use"] = {
+  acceptDownloads: true,
+  /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+  actionTimeout: 0,
+  headless: !isHeadful,
+  ignoreHTTPSErrors: true,
+  screenshot: "only-on-failure",
+  /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+  trace: "retain-on-failure",
+  video: {
+    mode: "retain-on-failure",
+    size: VIEWPORT,
+  },
+  viewport: VIEWPORT,
+};


### PR DESCRIPTION
This PR fixes HTTPS error when running smoke test against https localhost, because the global setup playwright context didn't have config option `ignoreHTTPSErrors: true`

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
