### PR TITLE
chore: add backwards compatibility to prevent transient outages (will be reverted after prod deployment)

### DIFF
--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -106,7 +106,13 @@ def _load_snapshot(new_snapshot_identifier) -> WmgSnapshot:
 
 
 def _open_cube(cube_uri) -> Array:
-    return tiledb.open(cube_uri, ctx=create_ctx(json.loads(WmgConfig().tiledb_config_overrides)))
+    try:
+        return tiledb.open(cube_uri, ctx=create_ctx(json.loads(WmgConfig().tiledb_config_overrides)))
+    except Exception as e:
+        if "marker_genes" in cube_uri:
+            return None
+        else:
+            raise e
 
 
 def _load_cell_type_order(snapshot_identifier: str) -> DataFrame:

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -109,6 +109,9 @@ def _open_cube(cube_uri) -> Array:
     try:
         return tiledb.open(cube_uri, ctx=create_ctx(json.loads(WmgConfig().tiledb_config_overrides)))
     except Exception as e:
+        # if marker_genes cube fails to load, it is because the processing pipeline has not run
+        # for the first time since merging the FMG changes. This try/except block is temporary
+        # until the pipeline finishes running for the first time.
         if "marker_genes" in cube_uri:
             return None
         else:

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -109,6 +109,7 @@ def _open_cube(cube_uri) -> Array:
     try:
         return tiledb.open(cube_uri, ctx=create_ctx(json.loads(WmgConfig().tiledb_config_overrides)))
     except Exception as e:
+        # todo (alec): remove this once the pipeline has run for the first time
         # if marker_genes cube fails to load, it is because the processing pipeline has not run
         # for the first time since merging the FMG changes. This try/except block is temporary
         # until the pipeline finishes running for the first time.


### PR DESCRIPTION
To prevent outages when deploying the FMG changes to prod (as snapshot will need to be updated by wmg processing pipeline to generate `marker_genes` cube), a temporary backwards compatibility patch is added. 

