### PR TITLE
fix: help and documentation dropdown hides on blur

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -77,7 +77,7 @@
         "eslint-plugin-sonarjs": "^0.15.0",
         "expect-playwright": "^0.8.0",
         "gray-matter": "^4.0.3",
-        "next-dev-https": "^0.1.1",
+        "next-dev-https": "0.1.1",
         "next-mdx-remote": "^4.1.0",
         "playwright": "^1.27.0",
         "prettier": "^2.4.1",

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -128,7 +128,7 @@ const Header: FC = () => {
               search={false}
               options={FOOTER_OPTIONS}
               onChange={handleHelpClick}
-              onBlur={handleOnBlur}
+              onClose={handleHelpClose}
             />
           </StyledPopper>
 
@@ -137,10 +137,6 @@ const Header: FC = () => {
       </MainWrapper>
     </Wrapper>
   );
-
-  function handleOnBlur() {
-    setDropdownOpen(false);
-  }
 
   function handleHelpOpen(event: React.MouseEvent<HTMLElement>) {
     if (!anchorEl) {
@@ -158,9 +154,11 @@ const Header: FC = () => {
     _: React.ChangeEvent<unknown>,
     newValue: (DefaultMenuSelectOption & { id: number; value: string }) | null
   ) {
-    let link = newValue!.value;
+    if (!newValue) return;
 
-    if (newValue!.id === 1) {
+    let link = newValue.value;
+
+    if (newValue.id === 1) {
       track(EVENTS.DOCUMENTATION_CLICK_NAV);
 
       link = isRouteActive(pathname, ROUTES.WHERE_IS_MY_GENE)
@@ -170,6 +168,10 @@ const Header: FC = () => {
 
     window.open(link, "_blank", "noopener,noreferrer");
 
+    setDropdownOpen(false);
+  }
+
+  function handleHelpClose() {
     setDropdownOpen(false);
   }
 

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -128,6 +128,7 @@ const Header: FC = () => {
               search={false}
               options={FOOTER_OPTIONS}
               onChange={handleHelpClick}
+              onBlur={handleOnBlur}
             />
           </StyledPopper>
 
@@ -136,6 +137,10 @@ const Header: FC = () => {
       </MainWrapper>
     </Wrapper>
   );
+
+  function handleOnBlur() {
+    setDropdownOpen(false);
+  }
 
   function handleHelpOpen(event: React.MouseEvent<HTMLElement>) {
     if (!anchorEl) {


### PR DESCRIPTION
- #3688 

### Reviewers
**Functional:** @tihuan @seve @atarashansky 

**Readability:** @tihuan @seve @atarashansky 

---


## Changes
- add
- remove
- modify
    - Help and Documentation dropdown closes when clicked out

![demo](https://user-images.githubusercontent.com/6309723/207177002-aa592908-8c49-4634-817d-e408cb721a7d.gif)


## QA steps (optional)

## Notes for Reviewer


