### PR TITLE
fix: Dataset collection metadata emits 'two children with the same key' warning (#3713)

### DIFF
--- a/frontend/src/components/Collection/components/CollectionMetadata/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionMetadata/index.tsx
@@ -22,8 +22,8 @@ export default function CollectionMetadata({
 }: Props): JSX.Element {
   return (
     <Metadata>
-      {collectionMetadataLinks.map(({ label, testId, url, value }) => (
-        <React.Fragment key={label}>
+      {collectionMetadataLinks.map(({ label, testId, url, value }, i) => (
+        <React.Fragment key={`${value}${i}`}>
           <MetadataLabel>{label}</MetadataLabel>
           <Link href={url} passHref>
             <MetadataValue


### PR DESCRIPTION
- #3713 

### Reviewers
**Functional:** 

@tihuan 

---


## Changes
- modified `CollectionMetadata` component to map over metadata with unique key value.
