### PR TITLE
feat: dynamic sitemap and robots.txt file

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -81,3 +81,7 @@ yarn-error.log
 /allure-results/
 storageState.json
 loginState.json
+
+# Sitemap + robots.txt
+public/sitemap*
+public/robots.txt

--- a/frontend/next-sitemap.config.js
+++ b/frontend/next-sitemap.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  siteUrl: "https://cellxgene.cziscience.com/",
+  generateRobotsTxt: true,
+  exclude: ["/collections-sitemap.xml"], // add additional directories or pages here if they should be excluded from the sitemap
+  robotsTxtOptions: {
+    policies: [
+      // {userAgent: "*", disallow: "/folderToExclude/fileToExclude"} <-- use this option if you wish to exclude certain pages or folders from robots.txt
+      { userAgent: "*", allow: "/" },
+    ],
+    additionalSitemaps: [
+      "https://cellxgene.cziscience.com/collections-sitemap.xml",
+    ],
+  },
+  siteMapSize: 50000,
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "ml-hclust": "^3.1.0",
         "next": "^12.2.5",
         "next-secure-headers": "^2.1.0",
+        "next-sitemap": "^3.1.32",
         "papaparse": "^5.3.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -1505,11 +1506,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1709,6 +1710,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.29",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.29.tgz",
+      "integrity": "sha512-q/yVUnqckA8Do+EvAfpy7RLdumnBy9ZsducMUtZTvpdbJC7azEf1hGtnYYxm0QfphYxjwggv6XtH64prvS1W+A=="
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.10.2",
@@ -2152,14 +2158,14 @@
       }
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-alpha.106",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.106.tgz",
-      "integrity": "sha512-xJQQtwPCPwr6hGWTBdvDwHYwExn3Bw7nPQkN8Fuz8kHpZqoMVWQvvaFS557AIkkI2AFLV3DxVIMjbCvrIntBWg==",
+      "version": "5.0.0-alpha.110",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.110.tgz",
+      "integrity": "sha512-q4TH9T3sTBknTXXTEf2zO8F3nbHg5iGgiaRx9XErTbXvHrmLrQXbQ4hmrLERocSTBFCFWkKyne/qZj0diWlPtA==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
+        "@babel/runtime": "^7.20.6",
         "@emotion/is-prop-valid": "^1.2.0",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.14",
+        "@mui/types": "^7.2.3",
+        "@mui/utils": "^5.11.0",
         "@popperjs/core": "^2.11.6",
         "clsx": "^1.2.1",
         "prop-types": "^15.8.1",
@@ -2189,20 +2195,20 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.14.tgz",
-      "integrity": "sha512-qLgIJNOR9Dre8JiZ/neVzOf4jf88J6YtOkQqugtMrleLjbfRVUSS4LWl9CSOjNq76quYdmYWnSDgfQqOooT2cQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.0.tgz",
+      "integrity": "sha512-Bmogung451ezVv2YI1RvweOIVsTj2RQ4Fk61+e/+8LFPLTFEwVGbL0YhNy1VB5tri8pzGNV228kxtWVTFooQkg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.14.tgz",
-      "integrity": "sha512-qtH60slQa+7MZRn6kyui8rKuoGDglPqaHX+pzBKNvd8JCOlrnfY5DmGGDdToTXyXl8xJ8nhANZbrbpg7UVKq/Q==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.11.0.tgz",
+      "integrity": "sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1"
+        "@babel/runtime": "^7.20.6"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2223,15 +2229,15 @@
       }
     },
     "node_modules/@mui/lab": {
-      "version": "5.0.0-alpha.108",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.108.tgz",
-      "integrity": "sha512-dn/TrBv5o/XH7vx0VVsOlwH5CzqBsLeBnWv7yAdahnyc6bCYaRz0TS0ylBRa9JLpSaV4KjC91VurH0G9t4PV/Q==",
+      "version": "5.0.0-alpha.112",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.112.tgz",
+      "integrity": "sha512-XKxxUevHup9l9THXWhPcWxm8LZj+E8KDOz6cWqXOnXfSZwFYsvK/nB2R4PCiy/wobURk/+qxIAzryBA9pnSk2g==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/base": "5.0.0-alpha.106",
-        "@mui/system": "^5.10.14",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.14",
+        "@babel/runtime": "^7.20.6",
+        "@mui/base": "5.0.0-alpha.110",
+        "@mui/system": "^5.11.0",
+        "@mui/types": "^7.2.3",
+        "@mui/utils": "^5.11.0",
         "clsx": "^1.2.1",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
@@ -2269,16 +2275,16 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/material": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.10.14.tgz",
-      "integrity": "sha512-HWzKVAykePMx54WtxVwZyL1W4k3xlHYIqwMw0CaXAvgB3UE9yjABZuuGr8vG5Z6CSNWamzd+s1x8u7pQPFl9og==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.11.0.tgz",
+      "integrity": "sha512-8Zl34lb89rLKTTi50Kakki675/LLHMKKnkp8Ee3rAZ2qmisQlRODsGh1MBjENKp0vwhQnNSvlsCfJteVTfotPQ==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/base": "5.0.0-alpha.106",
-        "@mui/core-downloads-tracker": "^5.10.14",
-        "@mui/system": "^5.10.14",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.14",
+        "@babel/runtime": "^7.20.6",
+        "@mui/base": "5.0.0-alpha.110",
+        "@mui/core-downloads-tracker": "^5.11.0",
+        "@mui/system": "^5.11.0",
+        "@mui/types": "^7.2.3",
+        "@mui/utils": "^5.11.0",
         "@types/react-transition-group": "^4.4.5",
         "clsx": "^1.2.1",
         "csstype": "^3.1.1",
@@ -2318,12 +2324,12 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.10.14.tgz",
-      "integrity": "sha512-3aIBe8WK65CwAPDY8nB11hYnzE1CZMymi76UnaFrA/DdGDwl5Y8F6uB+StKrkVmsqF1po7Mp2odqVkHj320gXw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.11.0.tgz",
+      "integrity": "sha512-UFQLb9x5Sj4pg2GhhCGw3Ls/y1Hw/tz9RsBrULvUF0Vgps1z19o7XTq2xqUvp7pN7fJTW7eVIT2gwVg2xlk8PQ==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/utils": "^5.10.14",
+        "@babel/runtime": "^7.20.6",
+        "@mui/utils": "^5.11.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -2344,11 +2350,11 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.10.14.tgz",
-      "integrity": "sha512-bgKdM57ExogWpIfhL/ngSlzF4FhbH00vYF+Y5VALTob4uslFqje0xzoWmbfcCn4cZt2NXxZJIwhsq4vzo5itlw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.11.0.tgz",
+      "integrity": "sha512-AF06K60Zc58qf0f7X+Y/QjaHaZq16znliLnGc9iVrV/+s8Ln/FCoeNuFvhlCbZZQ5WQcJvcy59zp0nXrklGGPQ==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
+        "@babel/runtime": "^7.20.6",
         "@emotion/cache": "^11.10.5",
         "csstype": "^3.1.1",
         "prop-types": "^15.8.1"
@@ -2375,15 +2381,15 @@
       }
     },
     "node_modules/@mui/styles": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.10.14.tgz",
-      "integrity": "sha512-efmROE5O+9qV1Wj7Q/Cz3ZplsuqSwqWRFTUWwTuTedoLetAO6ExgV4vGD1bkFsr9+VkAfJV/Zy4KPM0ouok7aA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.11.0.tgz",
+      "integrity": "sha512-Y4Qz/uoWz9NUC7AN+Ybzv8LF3RjlKs85yayLsdXJz0kZxqIJshOMZ4G1Hb5omNwVx9oCePmO9a+zemXZS76ATw==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
+        "@babel/runtime": "^7.20.6",
         "@emotion/hash": "^0.9.0",
-        "@mui/private-theming": "^5.10.14",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.14",
+        "@mui/private-theming": "^5.11.0",
+        "@mui/types": "^7.2.3",
+        "@mui/utils": "^5.11.0",
         "clsx": "^1.2.1",
         "csstype": "^3.1.1",
         "hoist-non-react-statics": "^3.3.2",
@@ -2415,15 +2421,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.10.14.tgz",
-      "integrity": "sha512-2de7XCjRb1j8Od0Stmo0LwFMLpOMNT4wzfINuExXI1TVSuyxXIXUxiC5FEgJW3GMvf/a7SUR8VOiMoKlKWzukw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.11.0.tgz",
+      "integrity": "sha512-HFUT7Dlmyq6Wfuxsw8QBXZxXDYIQQaJ4YHaZd7s+nDMcjerLnILxjh2g3a6umtOUM+jEcRaFJAtvLZvlGfa5fw==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/private-theming": "^5.10.14",
-        "@mui/styled-engine": "^5.10.14",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.14",
+        "@babel/runtime": "^7.20.6",
+        "@mui/private-theming": "^5.11.0",
+        "@mui/styled-engine": "^5.11.0",
+        "@mui/types": "^7.2.3",
+        "@mui/utils": "^5.11.0",
         "clsx": "^1.2.1",
         "csstype": "^3.1.1",
         "prop-types": "^15.8.1"
@@ -2454,9 +2460,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.1.tgz",
-      "integrity": "sha512-c5mSM7ivD8EsqK6HUi9hQPr5V7TJ/IRThUQ9nWNYPdhCGriTSQV4vL6DflT99LkM+wLiIS1rVjphpEWxERep7A==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.3.tgz",
+      "integrity": "sha512-tZ+CQggbe9Ol7e/Fs5RcKwg/woU+o8DCtOnccX6KmbBc7YrfqMYEYuaIcXHuhpT880QwNkZZ3wQwvtlDFA2yOw==",
       "peerDependencies": {
         "@types/react": "*"
       },
@@ -2467,11 +2473,11 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.10.14.tgz",
-      "integrity": "sha512-12p59+wDZpA++XVJmKwqsZmrA1nmUQ5d0a1yQWtcDjxNyER1EDzozYN/db+FY2i5ceQh2TynPTEwGms2mXDwFg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.11.0.tgz",
+      "integrity": "sha512-DP/YDaVVCVzJpZ5FFPLKNmaJkeaYRviTyIZkL/D5/FmPXQiA6ecd6z0/+VwoNQtp7aXAQWaRhvz4FM25yqFlHA==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
+        "@babel/runtime": "^7.20.6",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.8.1",
@@ -4687,9 +4693,9 @@
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/czifui": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/czifui/-/czifui-12.0.1.tgz",
-      "integrity": "sha512-iqqrmol8ZqjH4HANDrduWMQ/siJp5TeD6rpH/SZ3RKar+pKxs22TvvEnrtYQMbKZ+eH+OxcBD5ZDA0S9oYdwfg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/czifui/-/czifui-12.1.0.tgz",
+      "integrity": "sha512-NmzBYU0PbyVyG+TwlEQJqFnEWKPU5hP1jSXH7hrPkLUw0BGRZCEWQOH6nYmeJwAM+jH1ootWNhBbO43Jo/ykEg==",
       "peerDependencies": {
         "@emotion/css": "^11.1.3",
         "@emotion/react": "^11.1.5",
@@ -8957,9 +8963,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -9196,6 +9205,31 @@
       "integrity": "sha512-C7OfZ9JdSJyYMz2ZBMI/WwNbt0qNjlFWX9afUp8nEUzbz6ez3JbeopdyxSZJZJAzVLIAfyk6n73rFpd4e22jRg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/next-sitemap": {
+      "version": "3.1.43",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-3.1.43.tgz",
+      "integrity": "sha512-TshDAP69OjHwvszedQ/jBvOjzqy7Gm9NU3ZIP30X3e1qXsNVOVF5uzi9kQOI6v0uBG08QUOk9wKNSIk3zI/wjQ==",
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.29",
+        "minimist": "^1.2.7"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "@next/env": "*",
+        "next": "*"
       }
     },
     "node_modules/no-case": {
@@ -14341,11 +14375,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "requires": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/runtime-corejs3": {
@@ -14499,6 +14533,11 @@
           "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
+    },
+    "@corex/deepmerge": {
+      "version": "4.0.29",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.29.tgz",
+      "integrity": "sha512-q/yVUnqckA8Do+EvAfpy7RLdumnBy9ZsducMUtZTvpdbJC7azEf1hGtnYYxm0QfphYxjwggv6XtH64prvS1W+A=="
     },
     "@emotion/babel-plugin": {
       "version": "11.10.2",
@@ -14839,14 +14878,14 @@
       }
     },
     "@mui/base": {
-      "version": "5.0.0-alpha.106",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.106.tgz",
-      "integrity": "sha512-xJQQtwPCPwr6hGWTBdvDwHYwExn3Bw7nPQkN8Fuz8kHpZqoMVWQvvaFS557AIkkI2AFLV3DxVIMjbCvrIntBWg==",
+      "version": "5.0.0-alpha.110",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.110.tgz",
+      "integrity": "sha512-q4TH9T3sTBknTXXTEf2zO8F3nbHg5iGgiaRx9XErTbXvHrmLrQXbQ4hmrLERocSTBFCFWkKyne/qZj0diWlPtA==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
+        "@babel/runtime": "^7.20.6",
         "@emotion/is-prop-valid": "^1.2.0",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.14",
+        "@mui/types": "^7.2.3",
+        "@mui/utils": "^5.11.0",
         "@popperjs/core": "^2.11.6",
         "clsx": "^1.2.1",
         "prop-types": "^15.8.1",
@@ -14861,28 +14900,28 @@
       }
     },
     "@mui/core-downloads-tracker": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.14.tgz",
-      "integrity": "sha512-qLgIJNOR9Dre8JiZ/neVzOf4jf88J6YtOkQqugtMrleLjbfRVUSS4LWl9CSOjNq76quYdmYWnSDgfQqOooT2cQ=="
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.0.tgz",
+      "integrity": "sha512-Bmogung451ezVv2YI1RvweOIVsTj2RQ4Fk61+e/+8LFPLTFEwVGbL0YhNy1VB5tri8pzGNV228kxtWVTFooQkg=="
     },
     "@mui/icons-material": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.14.tgz",
-      "integrity": "sha512-qtH60slQa+7MZRn6kyui8rKuoGDglPqaHX+pzBKNvd8JCOlrnfY5DmGGDdToTXyXl8xJ8nhANZbrbpg7UVKq/Q==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.11.0.tgz",
+      "integrity": "sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==",
       "requires": {
-        "@babel/runtime": "^7.20.1"
+        "@babel/runtime": "^7.20.6"
       }
     },
     "@mui/lab": {
-      "version": "5.0.0-alpha.108",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.108.tgz",
-      "integrity": "sha512-dn/TrBv5o/XH7vx0VVsOlwH5CzqBsLeBnWv7yAdahnyc6bCYaRz0TS0ylBRa9JLpSaV4KjC91VurH0G9t4PV/Q==",
+      "version": "5.0.0-alpha.112",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.112.tgz",
+      "integrity": "sha512-XKxxUevHup9l9THXWhPcWxm8LZj+E8KDOz6cWqXOnXfSZwFYsvK/nB2R4PCiy/wobURk/+qxIAzryBA9pnSk2g==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/base": "5.0.0-alpha.106",
-        "@mui/system": "^5.10.14",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.14",
+        "@babel/runtime": "^7.20.6",
+        "@mui/base": "5.0.0-alpha.110",
+        "@mui/system": "^5.11.0",
+        "@mui/types": "^7.2.3",
+        "@mui/utils": "^5.11.0",
         "clsx": "^1.2.1",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
@@ -14896,16 +14935,16 @@
       }
     },
     "@mui/material": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.10.14.tgz",
-      "integrity": "sha512-HWzKVAykePMx54WtxVwZyL1W4k3xlHYIqwMw0CaXAvgB3UE9yjABZuuGr8vG5Z6CSNWamzd+s1x8u7pQPFl9og==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.11.0.tgz",
+      "integrity": "sha512-8Zl34lb89rLKTTi50Kakki675/LLHMKKnkp8Ee3rAZ2qmisQlRODsGh1MBjENKp0vwhQnNSvlsCfJteVTfotPQ==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/base": "5.0.0-alpha.106",
-        "@mui/core-downloads-tracker": "^5.10.14",
-        "@mui/system": "^5.10.14",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.14",
+        "@babel/runtime": "^7.20.6",
+        "@mui/base": "5.0.0-alpha.110",
+        "@mui/core-downloads-tracker": "^5.11.0",
+        "@mui/system": "^5.11.0",
+        "@mui/types": "^7.2.3",
+        "@mui/utils": "^5.11.0",
         "@types/react-transition-group": "^4.4.5",
         "clsx": "^1.2.1",
         "csstype": "^3.1.1",
@@ -14922,36 +14961,36 @@
       }
     },
     "@mui/private-theming": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.10.14.tgz",
-      "integrity": "sha512-3aIBe8WK65CwAPDY8nB11hYnzE1CZMymi76UnaFrA/DdGDwl5Y8F6uB+StKrkVmsqF1po7Mp2odqVkHj320gXw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.11.0.tgz",
+      "integrity": "sha512-UFQLb9x5Sj4pg2GhhCGw3Ls/y1Hw/tz9RsBrULvUF0Vgps1z19o7XTq2xqUvp7pN7fJTW7eVIT2gwVg2xlk8PQ==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/utils": "^5.10.14",
+        "@babel/runtime": "^7.20.6",
+        "@mui/utils": "^5.11.0",
         "prop-types": "^15.8.1"
       }
     },
     "@mui/styled-engine": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.10.14.tgz",
-      "integrity": "sha512-bgKdM57ExogWpIfhL/ngSlzF4FhbH00vYF+Y5VALTob4uslFqje0xzoWmbfcCn4cZt2NXxZJIwhsq4vzo5itlw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.11.0.tgz",
+      "integrity": "sha512-AF06K60Zc58qf0f7X+Y/QjaHaZq16znliLnGc9iVrV/+s8Ln/FCoeNuFvhlCbZZQ5WQcJvcy59zp0nXrklGGPQ==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
+        "@babel/runtime": "^7.20.6",
         "@emotion/cache": "^11.10.5",
         "csstype": "^3.1.1",
         "prop-types": "^15.8.1"
       }
     },
     "@mui/styles": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.10.14.tgz",
-      "integrity": "sha512-efmROE5O+9qV1Wj7Q/Cz3ZplsuqSwqWRFTUWwTuTedoLetAO6ExgV4vGD1bkFsr9+VkAfJV/Zy4KPM0ouok7aA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.11.0.tgz",
+      "integrity": "sha512-Y4Qz/uoWz9NUC7AN+Ybzv8LF3RjlKs85yayLsdXJz0kZxqIJshOMZ4G1Hb5omNwVx9oCePmO9a+zemXZS76ATw==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
+        "@babel/runtime": "^7.20.6",
         "@emotion/hash": "^0.9.0",
-        "@mui/private-theming": "^5.10.14",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.14",
+        "@mui/private-theming": "^5.11.0",
+        "@mui/types": "^7.2.3",
+        "@mui/utils": "^5.11.0",
         "clsx": "^1.2.1",
         "csstype": "^3.1.1",
         "hoist-non-react-statics": "^3.3.2",
@@ -14967,32 +15006,32 @@
       }
     },
     "@mui/system": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.10.14.tgz",
-      "integrity": "sha512-2de7XCjRb1j8Od0Stmo0LwFMLpOMNT4wzfINuExXI1TVSuyxXIXUxiC5FEgJW3GMvf/a7SUR8VOiMoKlKWzukw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.11.0.tgz",
+      "integrity": "sha512-HFUT7Dlmyq6Wfuxsw8QBXZxXDYIQQaJ4YHaZd7s+nDMcjerLnILxjh2g3a6umtOUM+jEcRaFJAtvLZvlGfa5fw==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/private-theming": "^5.10.14",
-        "@mui/styled-engine": "^5.10.14",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.14",
+        "@babel/runtime": "^7.20.6",
+        "@mui/private-theming": "^5.11.0",
+        "@mui/styled-engine": "^5.11.0",
+        "@mui/types": "^7.2.3",
+        "@mui/utils": "^5.11.0",
         "clsx": "^1.2.1",
         "csstype": "^3.1.1",
         "prop-types": "^15.8.1"
       }
     },
     "@mui/types": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.1.tgz",
-      "integrity": "sha512-c5mSM7ivD8EsqK6HUi9hQPr5V7TJ/IRThUQ9nWNYPdhCGriTSQV4vL6DflT99LkM+wLiIS1rVjphpEWxERep7A==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.3.tgz",
+      "integrity": "sha512-tZ+CQggbe9Ol7e/Fs5RcKwg/woU+o8DCtOnccX6KmbBc7YrfqMYEYuaIcXHuhpT880QwNkZZ3wQwvtlDFA2yOw==",
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.10.14",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.10.14.tgz",
-      "integrity": "sha512-12p59+wDZpA++XVJmKwqsZmrA1nmUQ5d0a1yQWtcDjxNyER1EDzozYN/db+FY2i5ceQh2TynPTEwGms2mXDwFg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.11.0.tgz",
+      "integrity": "sha512-DP/YDaVVCVzJpZ5FFPLKNmaJkeaYRviTyIZkL/D5/FmPXQiA6ecd6z0/+VwoNQtp7aXAQWaRhvz4FM25yqFlHA==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
+        "@babel/runtime": "^7.20.6",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.8.1",
@@ -16627,9 +16666,9 @@
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "czifui": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/czifui/-/czifui-12.0.1.tgz",
-      "integrity": "sha512-iqqrmol8ZqjH4HANDrduWMQ/siJp5TeD6rpH/SZ3RKar+pKxs22TvvEnrtYQMbKZ+eH+OxcBD5ZDA0S9oYdwfg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/czifui/-/czifui-12.1.0.tgz",
+      "integrity": "sha512-NmzBYU0PbyVyG+TwlEQJqFnEWKPU5hP1jSXH7hrPkLUw0BGRZCEWQOH6nYmeJwAM+jH1ootWNhBbO43Jo/ykEg==",
       "requires": {}
     },
     "d3-color": {
@@ -19654,9 +19693,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -19832,6 +19871,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/next-secure-headers/-/next-secure-headers-2.2.0.tgz",
       "integrity": "sha512-C7OfZ9JdSJyYMz2ZBMI/WwNbt0qNjlFWX9afUp8nEUzbz6ez3JbeopdyxSZJZJAzVLIAfyk6n73rFpd4e22jRg=="
+    },
+    "next-sitemap": {
+      "version": "3.1.43",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-3.1.43.tgz",
+      "integrity": "sha512-TshDAP69OjHwvszedQ/jBvOjzqy7Gm9NU3ZIP30X3e1qXsNVOVF5uzi9kQOI6v0uBG08QUOk9wKNSIk3zI/wjQ==",
+      "requires": {
+        "@corex/deepmerge": "^4.0.29",
+        "minimist": "^1.2.7"
+      }
     },
     "no-case": {
       "version": "3.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "ml-hclust": "^3.1.0",
     "next": "^12.2.5",
     "next-secure-headers": "^2.1.0",
+    "next-sitemap": "^3.1.32",
     "papaparse": "^5.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -111,7 +112,8 @@
     "type-check": "tsc --noEmit",
     "lint": "concurrently \"node_modules/.bin/next lint\" \"node_modules/.bin/stylelint '**/*.{js,ts,tsx,css}'\"  \"npm run type-check\"",
     "prettier-check": "npx prettier --check .",
-    "build-and-start-prod": "npm run build && npm run serve"
+    "build-and-start-prod": "npm run build && npm run serve",
+    "postbuild": "next-sitemap"
   },
   "repository": {
     "type": "git",

--- a/frontend/src/common/theme.ts
+++ b/frontend/src/common/theme.ts
@@ -1,4 +1,4 @@
-import createTheme from "@mui/material/styles/createTheme";
+import { createTheme } from "@mui/material/styles";
 import { defaultAppTheme, makeThemeOptions } from "czifui";
 
 const { fontWeights } = defaultAppTheme;

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -8,6 +8,7 @@ import { FC, useRef, useState } from "react";
 import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
 import { ROUTES } from "src/common/constants/routes";
+import { noop } from "src/common/constants/utils";
 import { get } from "src/common/featureFlags";
 import { FEATURES } from "src/common/featureFlags/features";
 import { BOOLEAN } from "src/common/localStorage/set";
@@ -114,6 +115,10 @@ const Header: FC = () => {
             ref={dropdownRef}
             open={dropdownOpen}
             anchorEl={anchorEl}
+            // (thuang): MUI types require `onResize` and `onResizeCapture` for
+            // some reason. Please recheck if we can remove them in the future
+            onResize={noop}
+            onResizeCapture={noop}
           >
             <MenuSelect
               search={false}

--- a/frontend/src/pages/collections-sitemap.xml/index.tsx
+++ b/frontend/src/pages/collections-sitemap.xml/index.tsx
@@ -1,0 +1,35 @@
+import { GetServerSideProps } from "next";
+import { getServerSideSitemap, ISitemapField } from "next-sitemap";
+
+// function to convert epoch/unix timestamp to YYYY-MM-DD format
+function unixToYYYYMMDD(date: string) {
+  let myDate = new Date(parseFloat(date) * 1000);
+
+  let dateStr =
+    myDate.getFullYear() +
+    "-" +
+    (myDate.getMonth() + 1) +
+    "-" +
+    myDate.getDate();
+
+  return dateStr;
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const response = await fetch(
+    "https://api.cellxgene.cziscience.com/dp/v1/collections/index"
+  );
+
+  const collections: any[] = await response.json();
+
+  const fields: ISitemapField[] = collections.map((collection) => ({
+    loc: `https://www.cellxgene.cziscience.com/collections/${collection.id}`,
+    lastmod: collection.revised_at
+      ? unixToYYYYMMDD(collection.revised_at)
+      : unixToYYYYMMDD(collection.published_at),
+  }));
+
+  return getServerSideSitemap(context, fields);
+};
+
+export default function Site() {}


### PR DESCRIPTION
## Notes for Reviewer

This uses the [next-sitemap package](https://www.npmjs.com/package/next-sitemap) in order to add a dynamic xml sitemap and accompanying robots.txt file for SEO purposes as a post-build process.

- Edits can be made in the `next-sitemap.config.js` file in order to exclude pages or directories from the generated sitemap.xml file and/or robots.txt file (I've included comments for clarity)

- sitemap size has been set to 50,000 max entries as specified in the task requirements

- `pages/collections-sitemap.xml` has been excluded from the sitemap itself. The purpose of this page is to generate a sitemap of each collection based on the ID's and "revised_at" dates (or "published_at" date if revision is not present) that are returned from the [API](https://api.cellxgene.cziscience.com/dp/v1/collections/index)