### PR TITLE
chore: add curator name

### DIFF
--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -215,7 +215,7 @@ class PortalApi:
                 "contact_email": collection.metadata.contact_email,
                 "contact_name": collection.metadata.contact_name,
                 "created_at": collection.created_at,
-                "curator_name": "",  # TODO
+                "curator_name": collection.metadata.curator_name,
                 "data_submission_policy_version": "1.0",  # TODO
                 "datasets": [
                     self._dataset_to_response(
@@ -307,6 +307,7 @@ class PortalApi:
             body["description"],
             body["contact_name"],
             body["contact_email"],
+            body.get("curator_name"),
             [self._link_from_request(node) for node in body.get("links", [])],
         )
 

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -204,6 +204,7 @@ class CollectionMetadata:
     description: str
     contact_name: str
     contact_email: str
+    curator_name: Optional[str]
     links: List[Link]
 
     def strip_fields(self):
@@ -211,6 +212,7 @@ class CollectionMetadata:
         self.description = self.description.strip()
         self.contact_name = self.contact_name.strip()
         self.contact_email = self.contact_email.strip()
+        self.curator_name = self.curator_name.strip() if self.curator_name is not None else None
         for link in self.links:
             link.strip_fields()
 

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -154,7 +154,7 @@ class TestCollection(BaseAPIPortalTest):
             "contact_email": "john.doe@email.com",
             "contact_name": "john doe",
             "created_at": mock.ANY,
-            "curator_name": "",
+            "curator_name": "John Doe",
             "data_submission_policy_version": "1.0",
             "datasets": [
                 {

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -78,7 +78,7 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
         )
 
         self.sample_collection_metadata = CollectionMetadata(
-            "test collection 1", "description of test collection 1", "scientist", "scientist@czi.com", []
+            "test collection 1", "description of test collection 1", "scientist", "scientist@czi.com", "Curator Name", []
         )
 
         self.sample_dataset_metadata = DatasetMetadata(

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -78,7 +78,12 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
         )
 
         self.sample_collection_metadata = CollectionMetadata(
-            "test collection 1", "description of test collection 1", "scientist", "scientist@czi.com", "Curator Name", []
+            "test collection 1",
+            "description of test collection 1",
+            "scientist",
+            "scientist@czi.com",
+            "Curator Name",
+            [],
         )
 
         self.sample_dataset_metadata = DatasetMetadata(

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -127,7 +127,7 @@ class BaseTest(unittest.TestCase):
         self, owner="test_user_id", links: List[Link] = [], add_datasets: int = 0
     ) -> CollectionVersion:
 
-        metadata = CollectionMetadata("test_collection", "described", "john doe", "john.doe@email.com", links)
+        metadata = CollectionMetadata("test_collection", "described", "john doe", "john.doe@email.com", "John Doe", links)
 
         collection = self.business_logic.create_collection(owner, metadata)
 

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -127,7 +127,9 @@ class BaseTest(unittest.TestCase):
         self, owner="test_user_id", links: List[Link] = [], add_datasets: int = 0
     ) -> CollectionVersion:
 
-        metadata = CollectionMetadata("test_collection", "described", "john doe", "john.doe@email.com", "John Doe", links)
+        metadata = CollectionMetadata(
+            "test_collection", "described", "john doe", "john.doe@email.com", "John Doe", links
+        )
 
         collection = self.business_logic.create_collection(owner, metadata)
 


### PR DESCRIPTION
Adds curator_name to collection metadata. Apparently the field is now optional so I left it as optional - if we want to make it mandatory, we just need to fix the tests and add an explicit validation to it.