### PR TITLE
fix: Fix the re-tagging issue due to invalid registryId

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -425,7 +425,7 @@ jobs:
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
         with:
-          happy_version: "0.23.0"
+          happy_version: "0.42.1"
       - name: Docker re-tag
         shell: bash
         run: |


### PR DESCRIPTION
Fixes the following error in Docker re-tag:

```
[ERROR]: error getting Image: operation error ECR: BatchGetImage, https response error StatusCode: 400, RequestID: f00322e8-7a33-4e28-a07f-93f2bdaa25bb, InvalidParameterException: Invalid parameter at 'registryId' failed to satisfy constraint: 'must satisfy regular expression [0-9]{12}'
```
