### PR TITLE
fix: support for collection partial updates

### DIFF
--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -388,12 +388,17 @@ class PortalApi:
         if version is None or not UserInfo(token_info).is_user_owner_or_allowed(version.owner):
             raise ForbiddenHTTPException()
 
+        if body.get("links") is not None:
+            update_links = [self._link_from_request(node) for node in body["links"]]
+        else:
+            update_links = None
+
         payload = CollectionMetadataUpdate(
             body.get("name"),
             body.get("description"),
             body.get("contact_name"),
             body.get("contact_email"),
-            [self._link_from_request(node) for node in body.get("links", [])],
+            update_links,
         )
 
         self.business_logic.update_collection_version(CollectionVersionId(collection_id), payload)

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -954,6 +954,24 @@ class TestUpdateCollection(BaseAPIPortalTest):
         for field in test_fields:
             self.assertEqual(expected_body[field], actual_body[field])
 
+    def test__update_collection_partial__OK(self):
+        collection = self.generate_unpublished_collection(links=[Link("Link 1", "DOI", "http://doi.org/123")])
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
+
+        payload = {
+            "name": "new collection name",
+        }
+
+        response = self.app.put(f"/dp/v1/collections/{collection.version_id.id}", data=json.dumps(payload), headers=headers)
+        self.assertEqual(200, response.status_code)
+        actual_body = json.loads(response.data)
+
+        self.assertEqual(actual_body["name"], "new collection name")
+        self.assertEqual(actual_body["description"], collection.metadata.description)
+        self.assertEqual(actual_body["contact_name"], collection.metadata.contact_name)
+        self.assertEqual(actual_body["contact_email"], collection.metadata.contact_email)
+        self.assertEqual(actual_body["links"], [{"link_name": l.name, "link_type": l.type, "link_url": l.uri} for l in collection.metadata.links])
+        
     # ✅
     def test__update_collection__403(self):
         collection = self.generate_unpublished_collection(owner="someone else")

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -962,7 +962,9 @@ class TestUpdateCollection(BaseAPIPortalTest):
             "name": "new collection name",
         }
 
-        response = self.app.put(f"/dp/v1/collections/{collection.version_id.id}", data=json.dumps(payload), headers=headers)
+        response = self.app.put(
+            f"/dp/v1/collections/{collection.version_id.id}", data=json.dumps(payload), headers=headers
+        )
         self.assertEqual(200, response.status_code)
         actual_body = json.loads(response.data)
 
@@ -970,8 +972,14 @@ class TestUpdateCollection(BaseAPIPortalTest):
         self.assertEqual(actual_body["description"], collection.metadata.description)
         self.assertEqual(actual_body["contact_name"], collection.metadata.contact_name)
         self.assertEqual(actual_body["contact_email"], collection.metadata.contact_email)
-        self.assertEqual(actual_body["links"], [{"link_name": l.name, "link_type": l.type, "link_url": l.uri} for l in collection.metadata.links])
-        
+        self.assertEqual(
+            actual_body["links"],
+            [
+                {"link_name": link.name, "link_type": link.type, "link_url": link.uri}
+                for link in collection.metadata.links
+            ],
+        )
+
     # ✅
     def test__update_collection__403(self):
         collection = self.generate_unpublished_collection(owner="someone else")


### PR DESCRIPTION
Even if partial updates aren't currently used by the FE, the endpoint supports it. This fixes an issue where links would not be updated correctly in case of a partial update.