### PR TITLE
fix: functional tests portal redesign compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ functional-test: local-functional-test
 .PHONY: container-functionaltest
 container-functionaltest:
 	# This target is intended to be run INSIDE a container
-	python3 -m unittest discover --start-directory tests/functional --top-level-directory . --verbose
+	python3 -m unittest discover --start-directory tests/functional/backend/corpora --top-level-directory . --verbose
 
 .PHONY: prod-performance-test
 prod-performance-test:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ functional-test: local-functional-test
 .PHONY: container-functionaltest
 container-functionaltest:
 	# This target is intended to be run INSIDE a container
-	python3 -m unittest discover --start-directory tests/functional/backend/corpora --top-level-directory . --verbose
+	python3 -m unittest discover --start-directory tests/functional/ --top-level-directory . --verbose
 
 .PHONY: prod-performance-test
 prod-performance-test:

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ If you need to make a change to the CELLxGENE Discover database, see [CELLxGENE 
 
 ### Running Functional Tests
 
-1. Set `DEPLOYMENT_STAGE` to deployed environment you want to run tests, as written locally, against (dev, staging, or  prod)
-2. Run a specific suite of tests using `DEPLOYMENT_STAGE=<deployed_env> python3 -m unittest <path_to_functional_test>`. For example, `DEPLOYMENT_STAGE=dev python3 -m unittest tests/functional/backend/corpora/test_revisions.py`
-3. Run all functional tests by using `DEPLOYMENT_STAGE=<deployed_env> python3 -m unittest discover tests/functional/backend`
+1. Set `AWS_PROFILE`.
+2. Set `DEPLOYMENT_STAGE` to deployed environment you want to run tests, as written locally, against (dev, staging, or  prod)
+3. Run a specific suite of tests using `DEPLOYMENT_STAGE=<deployed_env> python3 -m unittest <path_to_functional_test>`. For example, `DEPLOYMENT_STAGE=dev python3 -m unittest tests/functional/backend/corpora/test_revisions.py`
+4. Run all functional tests by using `DEPLOYMENT_STAGE=<deployed_env> python3 -m unittest discover tests/functional/backend`
 
 ### Upload processing container
 

--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -182,6 +182,7 @@ class PortalApi:
                 "organism": None
                 if dataset.metadata is None
                 else self._ontology_term_ids_to_response(dataset.metadata.organism),
+                "original_id": None if not is_in_published_collection else dataset.dataset_id,
                 "processing_status": self._dataset_processing_status_to_response(dataset.status, dataset.version_id.id),
                 "published": True,  # TODO
                 "published_at": dataset.canonical_dataset.published_at,

--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -182,7 +182,7 @@ class PortalApi:
                 "organism": None
                 if dataset.metadata is None
                 else self._ontology_term_ids_to_response(dataset.metadata.organism),
-                "original_id": None if not is_in_published_collection else dataset.dataset_id,
+                "original_id": None if not is_in_published_collection else dataset.dataset_id.id,
                 "processing_status": self._dataset_processing_status_to_response(dataset.status, dataset.version_id.id),
                 "published": True,  # TODO
                 "published_at": dataset.canonical_dataset.published_at,

--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -304,6 +304,9 @@ class PortalApi:
         if doi_node := doi.get_doi_link_node(body, errors):
             if doi_url := doi.portal_get_normalized_doi_url(doi_node, errors):
                 doi_node["link_url"] = doi_url
+        curator_name = body.get("curator_name")
+        if curator_name is None:
+            errors.append("Create Collection body is missing field 'curator_name'")
         if errors:
             raise InvalidParametersHTTPException(detail=errors)  # TODO: rewrite this exception?
 
@@ -314,8 +317,6 @@ class PortalApi:
             body["contact_email"],
             [self._link_from_request(node) for node in body.get("links", [])],
         )
-
-        curator_name = body["curator_name"]
 
         try:
             version = self.business_logic.create_collection(user, curator_name, metadata)

--- a/backend/portal/api/app/portal-api.yml
+++ b/backend/portal/api/app/portal-api.yml
@@ -119,23 +119,6 @@ paths:
           $ref: "#/components/responses/401"
 
   /v1/collections/{collection_id}:
-    delete:
-      tags:
-        - collections
-      summary: Delete a collection
-      security:
-        - cxguserCookie: [ ]
-      description: >-
-        Deletes an entire private collection from cellxgene data-portal, including any generated artifacts/assets and
-        deployments.
-      operationId: backend.portal.api.app.v1.collections.collection_id.actions.delete
-      parameters:
-        - $ref: "#/components/parameters/path_collection_id"
-      responses:
-        "204":
-          $ref: "#/components/responses/204"
-        "401":
-          $ref: "#/components/responses/401"
     get:
       tags:
         - collections
@@ -236,7 +219,6 @@ paths:
           $ref: "#/components/responses/401"
         "403":
           $ref: "#/components/responses/403"
-
     delete:
       tags:
         - collections

--- a/backend/portal/api/app/portal-api.yml
+++ b/backend/portal/api/app/portal-api.yml
@@ -936,6 +936,9 @@ components:
     collection_id:
       description: A unique identifier of a Collection.
       type: string
+    original_dataset_id:
+      description: A unique identifier of a published Dataset, used for linking to an Explorer url
+      type: string
     dataset_id:
       description: A unique identifier of a Dataset.
       type: string
@@ -1076,6 +1079,8 @@ components:
       properties:
         id:
           $ref: "#/components/schemas/dataset_id"
+        original_id:
+          $ref: "#/components/schemas/original_dataset_id"
         assay:
           $ref: "#/components/schemas/ontology_element_array"
         tissue:

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -263,5 +263,5 @@ class TestApi(BaseFunctionalTestCase):
             res = self.session.get(f"{self.api}/dp/v1/collections/{collection_id}", headers=headers)
             data = json.loads(res.content)
             datasets = data["datasets"]
-            dataset_ids = [dataset.get('id') for dataset in datasets]
+            dataset_ids = [dataset.get("id") for dataset in datasets]
             self.assertNotIn(dataset_id, dataset_ids)

--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -63,7 +63,12 @@ class TestRevisions(BaseFunctionalTestCase):
             res.raise_for_status()
             self.assertStatusCode(requests.codes.accepted, res)
 
-        dataset_id = self.session.get(f"{self.api}/dp/v1/collections/{collection_id}").json()["datasets"][0]["id"]
+        # get canonical collection id, post-publish
+        res = self.session.get(f"{self.api}/dp/v1/collections/{collection_id}", headers=headers)
+        data = json.loads(res.content)
+        canonical_collection_id = data["id"]
+
+        dataset_id = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()["datasets"][0]["id"]
         explorer_url = self.create_explorer_url(dataset_id)
 
         meta_payload_before_revision_res = self.session.get(f"{self.api}/dp/v1/datasets/meta?url={explorer_url}")
@@ -73,11 +78,13 @@ class TestRevisions(BaseFunctionalTestCase):
         # Endpoint is eventually consistent
         schema_before_revision = self.get_schema_with_retries(dataset_id).json()
 
+        # Start a revision
+        res = self.session.post(f"{self.api}/dp/v1/collections/{canonical_collection_id}", headers=headers)
+        self.assertStatusCode(201, res)
+        data = json.loads(res.content)
+        revision_id = data["id"]
+
         with self.subTest("Test updating a dataset in a revision does not effect the published dataset"):
-            # Start a revision
-            res = self.session.post(f"{self.api}/dp/v1/collections/{collection_id}", headers=headers)
-            self.assertStatusCode(201, res)
-            revision_id = res.json()["id"]
             private_dataset_id = res.json()["datasets"][0]["id"]
 
             meta_payload_res = self.session.get(f"{self.api}/dp/v1/datasets/meta?url={explorer_url}")
@@ -126,65 +133,64 @@ class TestRevisions(BaseFunctionalTestCase):
 
             # TODO: add `And the explorer url redirects appropriately`
 
+        # Start a new revision
+        res = self.session.post(f"{self.api}/dp/v1/collections/{canonical_collection_id}", headers=headers)
+        revision_id = res.json()["id"]
+        self.assertStatusCode(201, res)
+
+        # Get datasets for the collection (before uploading)
+        public_datasets_before = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()[
+            "datasets"
+        ]
+
+        # Upload a new dataset
+        another_dataset_id = self.upload_and_wait(revision_id, dataset_1_dropbox_url)
+
         with self.subTest("Adding a dataset to a revision does not impact public datasets in that collection"):
-
-            # Get datasets for the collection (before uploading)
-            public_datasets_before = self.session.get(f"{self.api}/dp/v1/collections/{collection_id}").json()[
-                "datasets"
-            ]
-
-            # Start a revision
-            res = self.session.post(f"{self.api}/dp/v1/collections/{collection_id}", headers=headers)
-            revision_id = res.json()["id"]
-            self.assertStatusCode(201, res)
-
-            # Upload a new dataset
-            another_dataset_id = self.upload_and_wait(revision_id, dataset_1_dropbox_url)
-
             # Get datasets for the collection (after uploading)
-            public_datasets_after = self.session.get(f"{self.api}/dp/v1/collections/{collection_id}").json()["datasets"]
+            public_datasets_after = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()["datasets"]
             self.assertCountEqual(public_datasets_before, public_datasets_after)
+
+        # Publish the revision
+        body = {"data_submission_policy_version": "1.0"}
+        res = self.session.post(
+            f"{self.api}/dp/v1/collections/{revision_id}/publish", headers=headers, data=json.dumps(body)
+        )
+        res.raise_for_status()
+        self.assertStatusCode(requests.codes.accepted, res)
 
         with self.subTest(
             "Publishing a revision that contains a new dataset updates "
             "the collection page for the data portal (with the new dataset)"
         ):
-            # Publish the revision
-            body = {"data_submission_policy_version": "1.0"}
-            res = self.session.post(
-                f"{self.api}/dp/v1/collections/{revision_id}/publish", headers=headers, data=json.dumps(body)
-            )
-            res.raise_for_status()
-            self.assertStatusCode(requests.codes.accepted, res)
-
             # Check if the last updated dataset_id is among the public datasets
-            public_datasets = self.session.get(f"{self.api}/dp/v1/collections/{collection_id}").json()["datasets"]
+            public_datasets = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()["datasets"]
             self.assertEqual(len(public_datasets), 2)
             ids = [dataset["id"] for dataset in public_datasets]
             self.assertIn(another_dataset_id, ids)
 
+        # Start a revision
+        res = self.session.post(f"{self.api}/dp/v1/collections/{canonical_collection_id}", headers=headers)
+        self.assertStatusCode(201, res)
+        revision_id = res.json()["id"]
+
+        # This only works if you pick the non replaced dataset.
+        dataset_to_delete = res.json()["datasets"][1]
+        deleted_dataset_id = dataset_to_delete["id"]
+        canonical_dataset_id = dataset_to_delete["original_id"]
+        original_explorer_url = self.create_explorer_url(canonical_dataset_id)
+
+        # Delete a dataset within the revision
+        res = self.session.delete(f"{self.api}/dp/v1/datasets/{deleted_dataset_id}", headers=headers)
+        self.assertStatusCode(202, res)
+
         with self.subTest("Deleting a dataset does not effect the published dataset"):
-            # Start a revision
-            res = self.session.post(f"{self.api}/dp/v1/collections/{collection_id}", headers=headers)
-            self.assertStatusCode(201, res)
-            revision_id = res.json()["id"]
-
-            # This only works if you pick the non replaced dataset.
-            dataset_to_delete = res.json()["datasets"][1]
-            deleted_dataset_id = dataset_to_delete["id"]
-            original_dataset_id = dataset_to_delete["original_id"]
-            original_explorer_url = self.create_explorer_url(original_dataset_id)
-
-            # Delete a dataset within the revision
-            res = self.session.delete(f"{self.api}/dp/v1/datasets/{deleted_dataset_id}", headers=headers)
-            self.assertStatusCode(202, res)
-
             # Check if the dataset is still available
             res = self.session.get(f"{self.api}/dp/v1/datasets/meta?url={original_explorer_url}")
             self.assertStatusCode(200, res)
 
             # Endpoint is eventually consistent
-            res = self.get_schema_with_retries(original_dataset_id)
+            res = self.get_schema_with_retries(canonical_dataset_id)
             self.assertStatusCode(200, res)
 
         with self.subTest("Publishing a revision that deletes a dataset removes it from the data portal"):
@@ -202,10 +208,10 @@ class TestRevisions(BaseFunctionalTestCase):
             datasets = [dataset["id"] for dataset in res.json()["datasets"]]
             self.assertEqual(1, len(datasets))
             self.assertNotIn(deleted_dataset_id, datasets)
-            self.assertNotIn(original_dataset_id, datasets)
+            self.assertNotIn(canonical_dataset_id, datasets)
 
             # Endpoint is eventually consistent. This redirects to the collection page, so the status we want is 302
-            res = self.get_schema_with_retries(original_dataset_id, desired_http_status_code=302)
+            res = self.get_schema_with_retries(canonical_dataset_id, desired_http_status_code=302)
             self.assertStatusCode(302, res)
 
     def get_schema_with_retries(self, dataset_id, desired_http_status_code=requests.codes.ok):

--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -21,6 +21,7 @@ class TestRevisions(BaseFunctionalTestCase):
         data = {
             "contact_email": "lisbon@gmail.com",
             "contact_name": "Madrid Sparkle",
+            "curator_name": "John Smith",
             "description": "Well here are some words",
             "links": [{"link_name": "a link to somewhere", "link_type": "PROTOCOL", "link_url": "http://protocol.com"}],
             "name": "my2collection",

--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -68,7 +68,9 @@ class TestRevisions(BaseFunctionalTestCase):
         data = json.loads(res.content)
         canonical_collection_id = data["id"]
 
-        dataset_id = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()["datasets"][0]["id"]
+        dataset_id = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()["datasets"][0][
+            "id"
+        ]
         explorer_url = self.create_explorer_url(dataset_id)
 
         meta_payload_before_revision_res = self.session.get(f"{self.api}/dp/v1/datasets/meta?url={explorer_url}")
@@ -148,7 +150,9 @@ class TestRevisions(BaseFunctionalTestCase):
 
         with self.subTest("Adding a dataset to a revision does not impact public datasets in that collection"):
             # Get datasets for the collection (after uploading)
-            public_datasets_after = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()["datasets"]
+            public_datasets_after = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()[
+                "datasets"
+            ]
             self.assertCountEqual(public_datasets_before, public_datasets_after)
 
         # Publish the revision
@@ -164,7 +168,9 @@ class TestRevisions(BaseFunctionalTestCase):
             "the collection page for the data portal (with the new dataset)"
         ):
             # Check if the last updated dataset_id is among the public datasets
-            public_datasets = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()["datasets"]
+            public_datasets = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()[
+                "datasets"
+            ]
             self.assertEqual(len(public_datasets), 2)
             ids = [dataset["id"] for dataset in public_datasets]
             self.assertIn(another_dataset_id, ids)

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -47,62 +47,6 @@ def generate_mock_publisher_metadata(journal_override=None):
 
 class TestCollection(BaseAPIPortalTest):
 
-    # TODO: does not belong here
-    def validate_collections_response_structure(self, body):
-        self.assertIn("collections", body)
-        self.assertTrue(all(k in ["collections", "from_date", "to_date"] for k in body))
-
-        for collection in body["collections"]:
-            self.assertListEqual(sorted(collection.keys()), ["created_at", "id", "visibility"])
-            self.assertEqual(collection["visibility"], "PUBLIC")
-            self.assertGreaterEqual(datetime.fromtimestamp(collection["created_at"]).year, 1969)
-
-    # TODO: does not belong here
-    def validate_collection_id_response_structure(self, body):
-        required_keys = [
-            "name",
-            "description",
-            "id",
-            "visibility",
-            "links",
-            "datasets",
-            "created_at",
-            "updated_at",
-            "contact_email",
-            "contact_name",
-            "curator_name",
-            "access_type",
-        ]
-        self.assertListEqual(sorted(body.keys()), sorted(required_keys))
-        self.assertGreaterEqual(datetime.fromtimestamp(body["created_at"]).year, 1969)
-        self.assertGreaterEqual(datetime.fromtimestamp(body["updated_at"]).year, 1969)
-
-        for link in body["links"]:
-            self.assertListEqual(sorted(link.keys()), ["link_name", "link_type", "link_url"])
-
-        for dataset in body["datasets"]:
-            required_keys = [
-                "id",
-                "assay",
-                "tissue",
-                "disease",
-                "sex",
-                "self_reported_ethnicity",
-                "organism",
-                "development_stage",
-                "name",
-                "revision",
-                "dataset_deployments",
-                "dataset_assets",
-                "processing_status",
-                "created_at",
-                "updated_at",
-                "collection_id",
-                "is_valid",
-                "cell_count",
-            ]
-            self.assertListEqual(sorted(dataset.keys()), sorted(required_keys))
-
     # ✅
     def test__list_collection_options__allow(self):
         origin = "http://localhost:3000"
@@ -131,7 +75,6 @@ class TestCollection(BaseAPIPortalTest):
             response = self.app.get(test_url.url, headers=headers)
             self.assertEqual(200, response.status_code)
             actual_body = json.loads(response.data)
-            # self.validate_collections_response_structure(actual_body) # TODO: maybe later
             self.assertIn(expected_id, [p["id"] for p in actual_body["collections"]])
             self.assertEqual(None, actual_body.get("to_date"))
             self.assertEqual(None, actual_body.get("from_date"))
@@ -172,6 +115,7 @@ class TestCollection(BaseAPIPortalTest):
                     "mean_genes_per_cell": 0.5,
                     "name": "test_dataset_name",
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
+                    "original_id": mock.ANY,
                     "processing_status": {
                         "created_at": 0,
                         "cxg_status": "NA",
@@ -222,6 +166,7 @@ class TestCollection(BaseAPIPortalTest):
                     "mean_genes_per_cell": 0.5,
                     "name": "test_dataset_name",
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
+                    "original_id": mock.ANY,
                     "processing_status": {
                         "created_at": 0,
                         "cxg_status": "NA",


### PR DESCRIPTION
## Changes
- re-introduced 'original_id' to datasets API response object, using canonical dataset id. Needed to access the original dataset associated with a private revision of a published dataset 
- remove duplicated 'delete' path in portal-api definition yaml
- raise a descriptive error if curator_name is not provided for a collection

## QA steps (optional)

## Notes for Reviewer
