### PR TITLE
fix: only add original_ids on unpublished revisions of published datasets

### DIFF
--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -182,7 +182,9 @@ class PortalApi:
                 "organism": None
                 if dataset.metadata is None
                 else self._ontology_term_ids_to_response(dataset.metadata.organism),
-                "original_id": None if not is_in_published_collection else dataset.dataset_id.id,
+                "original_id": dataset.dataset_id.id  # only provided on unpublished revisions of published datasets
+                if (not is_in_published_collection and dataset.canonical_dataset.published_at is not None)
+                else None,
                 "processing_status": self._dataset_processing_status_to_response(dataset.status, dataset.version_id.id),
                 "published": True,  # TODO
                 "published_at": dataset.canonical_dataset.published_at,

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -115,7 +115,6 @@ class TestCollection(BaseAPIPortalTest):
                     "mean_genes_per_cell": 0.5,
                     "name": "test_dataset_name",
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
-                    "original_id": mock.ANY,
                     "processing_status": {
                         "created_at": 0,
                         "cxg_status": "NA",
@@ -166,7 +165,6 @@ class TestCollection(BaseAPIPortalTest):
                     "mean_genes_per_cell": 0.5,
                     "name": "test_dataset_name",
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
-                    "original_id": mock.ANY,
                     "processing_status": {
                         "created_at": 0,
                         "cxg_status": "NA",
@@ -1676,12 +1674,15 @@ class TestRevision(BaseAPIPortalTest):
         path = f"/dp/v1/collections/{published_collection.collection_id.id}"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
         response = self.app.post(path, headers=headers)
-        print(response.data)
         self.assertEqual(201, response.status_code)
         response_post_json = json.loads(response.data)
 
         # Retrieves the version_id from the response
         revision_id = response_post_json["id"]
+        # Ensure the revision datasets provide 'original IDs' equal to the published dataset canonical IDs
+        original_ids = [dataset['original_id'] for dataset in response_post_json['datasets']]
+        canonical_dataset_ids = [dataset.dataset_id.id for dataset in published_collection.datasets]
+        self.assertCountEqual(original_ids, canonical_dataset_ids)
 
         # Ensures that getting the version has:
         # - PRIVATE visibility (since it's unpublished)

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1680,7 +1680,7 @@ class TestRevision(BaseAPIPortalTest):
         # Retrieves the version_id from the response
         revision_id = response_post_json["id"]
         # Ensure the revision datasets provide 'original IDs' equal to the published dataset canonical IDs
-        original_ids = [dataset['original_id'] for dataset in response_post_json['datasets']]
+        original_ids = [dataset["original_id"] for dataset in response_post_json["datasets"]]
         canonical_dataset_ids = [dataset.dataset_id.id for dataset in published_collection.datasets]
         self.assertCountEqual(original_ids, canonical_dataset_ids)
 

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -10,6 +10,7 @@ from backend.layers.business.business import BusinessLogic
 from backend.layers.common.entities import (
     CollectionMetadata,
     CollectionVersion,
+    CollectionVersionWithDatasets,
     DatasetMetadata,
     DatasetStatusGeneric,
     DatasetStatusKey,
@@ -137,7 +138,7 @@ class BaseTest(unittest.TestCase):
         links: List[Link] = [],
         add_datasets: int = 0,
         metadata=None,
-    ) -> CollectionVersion:
+    ) -> CollectionVersionWithDatasets:
         links = links if links else []
         if not metadata:
             metadata = copy.deepcopy(self.sample_collection_metadata)
@@ -155,7 +156,6 @@ class BaseTest(unittest.TestCase):
         return self.business_logic.get_collection_version(collection.version_id)
 
     # Public collections need to have at least one dataset!
-    # Public collections need to have at least one dataset!
     def generate_published_collection(
         self,
         owner="test_user_id",
@@ -163,14 +163,14 @@ class BaseTest(unittest.TestCase):
         add_datasets: int = 1,
         curator_name: str = "Jane Smith",
         metadata=None,
-    ) -> CollectionVersion:
+    ) -> CollectionVersionWithDatasets:
         unpublished_collection = self.generate_unpublished_collection(
             owner, curator_name, links, add_datasets=add_datasets, metadata=metadata
         )
         self.business_logic.publish_collection_version(unpublished_collection.version_id)
         return self.business_logic.get_collection_version(unpublished_collection.version_id)
 
-    def generate_revision(self, collection_id: str) -> CollectionVersion:
+    def generate_revision(self, collection_id: str) -> CollectionVersionWithDatasets:
         revision = self.business_logic.create_collection_version(collection_id)
         return self.business_logic.get_collection_version(revision.version_id)
 
@@ -231,7 +231,7 @@ class BaseTest(unittest.TestCase):
         # TODO: implement as needed
         return body
 
-    def generate_collection(self, links: List[dict] = None, **kwargs) -> CollectionVersion:
+    def generate_collection(self, links: List[dict] = None, **kwargs) -> CollectionVersionWithDatasets:
         """Generated a collection
         Adding to for compatibility with old tests
         """
@@ -243,7 +243,7 @@ class BaseTest(unittest.TestCase):
         else:
             return self.generate_unpublished_collection(links=links, **kwargs)
 
-    def generate_collection_revision(self, owner="test_user_id") -> CollectionVersion:
+    def generate_collection_revision(self, owner="test_user_id") -> CollectionVersionWithDatasets:
         published_collection = self.generate_published_collection(owner)
         return self.business_logic.create_collection_version(published_collection.collection_id)
 


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

## Changes
- modified logic to add original ids onto dataset API response objects--now, we add original IDs when the dataset is part of an unpublished collection revision, and its canonical dataset has been published before.
- minor type hinting fixes to test methods
- added assert for original ID logic in revisions unit test

## QA steps (optional)
- locally ran functional tests

## Notes for Reviewer
- Named Original ID to map to existing API, but points to the canonical dataset ID. Used for building explorer URL perma link 
