### PR TITLE
fix: for portal API dataset status and delete endpoints, fetch latest collection version

### DIFF
--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -122,15 +122,10 @@ class TestRevisions(BaseFunctionalTestCase):
                 dataset_meta_payload["s3_uri"].startswith(f"s3://hosted-cellxgene-{os.environ['DEPLOYMENT_STAGE']}/")
             )
             self.assertTrue(dataset_meta_payload["s3_uri"].endswith(".cxg/"))
-            self.assertNotIn(
+            self.assertIn(
                 dataset_meta_payload["dataset_id"],
                 dataset_meta_payload["s3_uri"],
-                "The id of the S3_URI should be different from the revised dataset id.",
-            )
-            self.assertNotIn(
-                dataset_id,
-                dataset_meta_payload["s3_uri"],
-                "The id of the S3_URI should be different from the original dataset id.",
+                "The id of the S3_URI should be the revised dataset id.",
             )
 
             # TODO: add `And the explorer url redirects appropriately`


### PR DESCRIPTION
## Changes
- we have existing portal API endpoints that only provide a dataset_id; however, in our data model, dataset_ids can belong to both 1 published collection version and 1 unpublished revision of that collection version. We need to fetch the collection version associated with a dataset for these actions in order to determine 1) ownership and 2) for deletes, which to delete from. By default, we were fetching the published collection version in all cases and then enforcing a rule that datasets in published collections cannot be deleted, which was blocking deletes of those datasets from the private revisions they were also associated with. As a quick fix without changing the API contract, I've updated the dataset ID endpoint logic to fetch the latest collection version (either an unpublished revision or the first unpublished version if it exists, else the published version) before running the rest of the logic. This will fix deletes while maintaining existing logic about when deletes can happen. 
- Removed a function test assertion that is no longer relevant in the new data model (that is, s3_uris in the meta endpoint not matching the dataset version ID)

## QA steps (optional)

## Notes for Reviewer
