### PR TITLE
fix: remove original_id and fix post-deploy tests

### DIFF
--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -182,9 +182,6 @@ class PortalApi:
                 "organism": None
                 if dataset.metadata is None
                 else self._ontology_term_ids_to_response(dataset.metadata.organism),
-                "original_id": dataset.dataset_id.id  # only provided on unpublished revisions of published datasets
-                if (not is_in_published_collection and dataset.canonical_dataset.published_at is not None)
-                else None,
                 "processing_status": self._dataset_processing_status_to_response(dataset.status, dataset.version_id.id),
                 "published": True,  # TODO
                 "published_at": dataset.canonical_dataset.published_at,

--- a/backend/portal/api/app/portal-api.yml
+++ b/backend/portal/api/app/portal-api.yml
@@ -936,9 +936,6 @@ components:
     collection_id:
       description: A unique identifier of a Collection.
       type: string
-    original_dataset_id:
-      description: A unique identifier of a published Dataset, used for linking to an Explorer url
-      type: string
     dataset_id:
       description: A unique identifier of a Dataset.
       type: string
@@ -1079,8 +1076,6 @@ components:
       properties:
         id:
           $ref: "#/components/schemas/dataset_id"
-        original_id:
-          $ref: "#/components/schemas/original_dataset_id"
         assay:
           $ref: "#/components/schemas/ontology_element_array"
         tissue:

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1679,10 +1679,6 @@ class TestRevision(BaseAPIPortalTest):
 
         # Retrieves the version_id from the response
         revision_id = response_post_json["id"]
-        # Ensure the revision datasets provide 'original IDs' equal to the published dataset canonical IDs
-        original_ids = [dataset["original_id"] for dataset in response_post_json["datasets"]]
-        canonical_dataset_ids = [dataset.dataset_id.id for dataset in published_collection.datasets]
-        self.assertCountEqual(original_ids, canonical_dataset_ids)
 
         # Ensures that getting the version has:
         # - PRIVATE visibility (since it's unpublished)


### PR DESCRIPTION
## Changes
-  remove original_id, deprecated use case given our new data model (revised datasets keep the original dataset version id as their id)

## QA steps (optional)

## Notes for Reviewer
