### PR TITLE
chore: reintroduce wmg unit tests + migrate to redesign

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -186,6 +186,7 @@ jobs:
   push-prod-images:
     needs:
       - backend-unit-test
+      - backend-unit-wmg-test
       - backend-integration-test
       - processing-unit-test
       - wmg-processing-unit-test
@@ -273,6 +274,56 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
+
+
+  backend-wmg-unit-test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Login to ECR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.ECR_REPO }}
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v23.1
+        with:
+          files: |
+            Dockerfile*
+            **/Dockerfile
+            requirements*.txt
+            **/requirements*.txt
+      - name: Run unit tests
+        run: |
+          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          make local-unit-test-wmg-backend
+
+      # Upload Allure results as an artifact
+      - uses: actions/upload-artifact@v3
+        with:
+          name: allure-results
+          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/allure-results
+          retention-days: 20
+
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,eventName,workflow,job,mention
+          mention: "here"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
+
 
   processing-unit-test:
     runs-on: ubuntu-20.04
@@ -432,6 +483,7 @@ jobs:
   publish-test-report:
     needs:
       - backend-unit-test
+      - backend-unit-wmg-test
       - e2e-test
     runs-on: ubuntu-20.04
     steps:
@@ -476,6 +528,7 @@ jobs:
   add-image-tags:
     needs:
       - backend-unit-test
+      - backend-unit-wmg-test
       - backend-integration-test
       - processing-unit-test
       - wmg-processing-unit-test

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -186,7 +186,7 @@ jobs:
   push-prod-images:
     needs:
       - backend-unit-test
-      - backend-unit-wmg-test
+      - backend-wmg-unit-test
       - backend-integration-test
       - processing-unit-test
       - wmg-processing-unit-test
@@ -483,7 +483,7 @@ jobs:
   publish-test-report:
     needs:
       - backend-unit-test
-      - backend-unit-wmg-test
+      - backend-wmg-unit-test
       - e2e-test
     runs-on: ubuntu-20.04
     steps:
@@ -528,7 +528,7 @@ jobs:
   add-image-tags:
     needs:
       - backend-unit-test
-      - backend-unit-wmg-test
+      - backend-wmg-unit-test
       - backend-integration-test
       - processing-unit-test
       - wmg-processing-unit-test

--- a/Dockerfile.data_cube_creation
+++ b/Dockerfile.data_cube_creation
@@ -20,6 +20,7 @@ ADD backend/wmg/__init__.py backend/wmg/__init__.py
 ADD backend/wmg/config.py backend/wmg/config.py
 ADD backend/wmg/data backend/wmg/data
 ADD backend/wmg/pipeline backend/wmg/pipeline
+ADD backend/layers backend/layers
 ADD backend/common backend/common
 
 ARG HAPPY_BRANCH="unknown"

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,10 @@ local-unit-test: local-unit-test-backend local-unit-test-wmg-processing# Run all
 local-unit-test-backend: 
 	docker-compose run --rm -T backend bash -c "cd /single-cell-data-portal && python3 -m pytest tests/unit/backend/layers/";
 
+.PHONY: local-unit-test-wmg-backend
+local-unit-test-wmg-backend: 
+	docker-compose run --rm -T backend bash -c "cd /single-cell-data-portal && python3 -m pytest tests/unit/backend/wmg/";
+
 .PHONY: local-integration-test-backend
 local-integration-test-backend:
 	docker-compose run --rm -e INTEGRATION_TEST=true -e DB_URI=postgresql://corpora:test_pw@database -T backend bash -c "cd /single-cell-data-portal && python3 -m pytest tests/unit/backend/layers/";

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -9,8 +9,6 @@ import connexion
 from flask import jsonify
 from pandas import DataFrame
 
-from backend.common.entities import Dataset
-from backend.common.utils.db_session import db_session_manager
 from backend.wmg.data.ontology_labels import ontology_term_label, gene_term_label
 from backend.wmg.data.query import (
     WmgQuery,
@@ -88,6 +86,8 @@ def markers():
 
 
 _business_logic = None
+
+
 def get_business_logic():
     """
     Returns an instance of the business logic handler. Use this to interrogate the database
@@ -96,6 +96,7 @@ def get_business_logic():
     if not _business_logic:
         _business_logic = BusinessLogic(DatabaseProvider(), None, None, None, None)
     return _business_logic
+
 
 # TODO: Read this from generated data artifact instead of DB.
 #  https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data

--- a/backend/wmg/pipeline/integrated_corpus/extract.py
+++ b/backend/wmg/pipeline/integrated_corpus/extract.py
@@ -7,9 +7,6 @@ import numpy as np
 from anndata._core.views import ArrayView
 from scipy import sparse
 
-from backend.common.corpora_orm import DatasetArtifactFileType
-from backend.common.entities import Dataset, Collection, DatasetAsset
-from backend.common.utils.db_session import db_session_manager
 from backend.layers.business.business import BusinessLogic
 from backend.layers.persistence.persistence import DatabaseProvider
 from backend.wmg.data.constants import INCLUDED_ASSAYS
@@ -51,7 +48,7 @@ def get_dataset_s3_uris() -> Dict[str, str]:
         ):
             if any(assay.ontology_term_id in INCLUDED_ASSAYS for assay in dataset.metadata.assay):
                 if len(dataset.metadata.organism) < 2:
-                    s3_uri = next(a for a in dataset.artifacts if a.type == DatasetArtifactType.H5AD)
+                    s3_uri = next(a.uri for a in dataset.artifacts if a.type == DatasetArtifactType.H5AD)
                     s3_uris[dataset.dataset_id.id] = s3_uri
     return s3_uris
 

--- a/backend/wmg/pipeline/integrated_corpus/extract.py
+++ b/backend/wmg/pipeline/integrated_corpus/extract.py
@@ -13,7 +13,7 @@ from backend.common.utils.db_session import db_session_manager
 from backend.layers.business.business import BusinessLogic
 from backend.layers.persistence.persistence import DatabaseProvider
 from backend.wmg.data.constants import INCLUDED_ASSAYS
-from entities import DatasetArtifactType
+from backend.layers.common.entities import DatasetArtifactType
 
 logger = logging.getLogger(__name__)
 

--- a/backend/wmg/pipeline/integrated_corpus/extract.py
+++ b/backend/wmg/pipeline/integrated_corpus/extract.py
@@ -10,10 +10,22 @@ from scipy import sparse
 from backend.common.corpora_orm import DatasetArtifactFileType
 from backend.common.entities import Dataset, Collection, DatasetAsset
 from backend.common.utils.db_session import db_session_manager
+from backend.layers.business.business import BusinessLogic
+from backend.layers.persistence.persistence import DatabaseProvider
 from backend.wmg.data.constants import INCLUDED_ASSAYS
+from entities import DatasetArtifactType
 
 logger = logging.getLogger(__name__)
 
+_business_logic = None
+def get_business_logic():
+    """
+    Returns an instance of the business logic handler. Use this to interrogate the database
+    """
+    global _business_logic
+    if not _business_logic:
+        _business_logic = BusinessLogic(DatabaseProvider(), None, None, None, None)
+    return _business_logic
 
 def get_X_raw(anndata_object: anndata.AnnData) -> Union[np.ndarray, sparse.spmatrix, ArrayView]:
     """
@@ -25,35 +37,23 @@ def get_X_raw(anndata_object: anndata.AnnData) -> Union[np.ndarray, sparse.spmat
     return raw_expression_matrix if raw_expression_matrix is not None else anndata_object.X
 
 
-def get_dataset_s3_uris() -> Dict:
+def get_dataset_s3_uris() -> Dict[str, str]:
     """
     Retrieve list of s3 uris for datasets included in the wmg cube
     """
-    with db_session_manager() as session:
-
-        dataset_ids = []
-        published_dataset_non_null_assays = (
-            session.query(Dataset.table.id, Dataset.table.assay, Dataset.table.organism)
-            .join(Dataset.table.collection)
-            .filter(
-                Dataset.table.assay != "null",
-                Dataset.table.published == "TRUE",
-                Dataset.table.is_primary_data == "PRIMARY",
-                Collection.table.visibility == "PUBLIC",
-                Dataset.table.tombstone == "FALSE",
-                Dataset.table.organism != "null",
-            )
-            .all()
-        )
-
-        for dataset_id, assays, organisms in published_dataset_non_null_assays:
-            if any(assay["ontology_term_id"] in INCLUDED_ASSAYS for assay in assays):
-                if len(organisms) < 2:
-                    dataset_ids.append(dataset_id)
-
-        s3_uris = DatasetAsset.s3_uris_for_datasets(session, dataset_ids, DatasetArtifactFileType.H5AD, "local.h5ad")
+    s3_uris = dict()
+    for dataset in get_business_logic().get_all_published_datasets():
+        if (
+            (dataset.metadata is not None) and
+            (dataset.metadata.assay is not None) and 
+            (dataset.metadata.is_primary_data == "PRIMARY") and
+            (dataset.metadata.organism is not None)
+        ):
+            if any(assay.ontology_term_id in INCLUDED_ASSAYS for assay in dataset.metadata.assay):
+                if len(dataset.metadata.organism) < 2:
+                    s3_uri = next(a for a in dataset.artifacts if a.type == DatasetArtifactType.H5AD)
+                    s3_uris[dataset.dataset_id.id] = s3_uri
     return s3_uris
-
 
 def copy_datasets_to_instance(s3_uris: Dict, dataset_directory: str):
     """Copy given list of s3 uris to the provided path"""

--- a/backend/wmg/pipeline/integrated_corpus/extract.py
+++ b/backend/wmg/pipeline/integrated_corpus/extract.py
@@ -15,6 +15,8 @@ from backend.layers.common.entities import DatasetArtifactType
 logger = logging.getLogger(__name__)
 
 _business_logic = None
+
+
 def get_business_logic():
     """
     Returns an instance of the business logic handler. Use this to interrogate the database
@@ -23,6 +25,7 @@ def get_business_logic():
     if not _business_logic:
         _business_logic = BusinessLogic(DatabaseProvider(), None, None, None, None)
     return _business_logic
+
 
 def get_X_raw(anndata_object: anndata.AnnData) -> Union[np.ndarray, sparse.spmatrix, ArrayView]:
     """
@@ -41,16 +44,17 @@ def get_dataset_s3_uris() -> Dict[str, str]:
     s3_uris = dict()
     for dataset in get_business_logic().get_all_published_datasets():
         if (
-            (dataset.metadata is not None) and
-            (dataset.metadata.assay is not None) and 
-            (dataset.metadata.is_primary_data == "PRIMARY") and
-            (dataset.metadata.organism is not None)
+            (dataset.metadata is not None)
+            and (dataset.metadata.assay is not None)
+            and (dataset.metadata.is_primary_data == "PRIMARY")
+            and (dataset.metadata.organism is not None)
         ):
             if any(assay.ontology_term_id in INCLUDED_ASSAYS for assay in dataset.metadata.assay):
                 if len(dataset.metadata.organism) < 2:
                     s3_uri = next(a.uri for a in dataset.artifacts if a.type == DatasetArtifactType.H5AD)
                     s3_uris[dataset.dataset_id.id] = s3_uri
     return s3_uris
+
 
 def copy_datasets_to_instance(s3_uris: Dict, dataset_directory: str):
     """Copy given list of s3 uris to the provided path"""

--- a/backend/wmg/pipeline/requirements.txt
+++ b/backend/wmg/pipeline/requirements.txt
@@ -8,6 +8,7 @@ charset-normalizer==2.0.12
 clickclick==20.10.2
 connexion==2.12.0
 cycler==0.11.0
+dataclasses-json
 decorator==5.1.1
 executing==0.8.2
 fastobo==0.11.1

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -229,7 +229,6 @@ class BaseTest(unittest.TestCase):
         if not artifacts:
             artifacts = [
                 DatasetArtifactUpdate(DatasetArtifactType.H5AD, f"s3://fake.bucket/{dataset_version_id}/local.h5ad"),
-                DatasetArtifactUpdate(DatasetArtifactType.RAW_H5AD, f"s3://fake.bucket/{dataset_version_id}/raw.h5ad"),
                 DatasetArtifactUpdate(DatasetArtifactType.CXG, f"s3://fake.bucket/{dataset_version_id}/local.cxg"),
                 DatasetArtifactUpdate(DatasetArtifactType.RDS, f"s3://fake.bucket/{dataset_version_id}/local.rds"),
             ]

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -201,7 +201,7 @@ class BaseTest(unittest.TestCase):
         name: Optional[str] = None,
         statuses: List[DatasetStatusUpdate] = [],
         validation_message: str = None,
-        artifacts: List[DatasetArtifactUpdate] = [],
+        artifacts: List[DatasetArtifactUpdate] = None,
         publish: bool = False,
     ) -> DatasetData:
         """
@@ -226,7 +226,7 @@ class BaseTest(unittest.TestCase):
                 DatasetValidationStatus.INVALID,
                 validation_message=validation_message,
             )
-        if not artifacts:
+        if artifacts is None:
             artifacts = [
                 DatasetArtifactUpdate(DatasetArtifactType.H5AD, f"s3://fake.bucket/{dataset_version_id}/local.h5ad"),
                 DatasetArtifactUpdate(DatasetArtifactType.CXG, f"s3://fake.bucket/{dataset_version_id}/local.cxg"),

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -11,6 +11,7 @@ from backend.layers.common.entities import (
     CollectionMetadata,
     CollectionVersion,
     CollectionVersionWithDatasets,
+    DatasetArtifactType,
     DatasetMetadata,
     DatasetStatusGeneric,
     DatasetStatusKey,
@@ -225,6 +226,13 @@ class BaseTest(unittest.TestCase):
                 DatasetValidationStatus.INVALID,
                 validation_message=validation_message,
             )
+        if not artifacts:
+            artifacts = [
+                DatasetArtifactUpdate(DatasetArtifactType.H5AD, f"s3://fake.bucket/{dataset_version_id}/local.h5ad"),
+                DatasetArtifactUpdate(DatasetArtifactType.RAW_H5AD, f"s3://fake.bucket/{dataset_version_id}/raw.h5ad"),
+                DatasetArtifactUpdate(DatasetArtifactType.CXG, f"s3://fake.bucket/{dataset_version_id}/local.cxg"),
+                DatasetArtifactUpdate(DatasetArtifactType.RDS, f"s3://fake.bucket/{dataset_version_id}/local.rds"),
+            ]
         artifact_ids = []
         for artifact in artifacts:
             artifact_ids.append(

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -140,6 +140,13 @@ class BaseTest(unittest.TestCase):
         if cls.run_as_integration:
             cls.database_provider._engine.dispose()
 
+    def get_sample_dataset_metadata(self):
+        """
+        Returns a copy of the sample metadata. This can be freely modified and passed
+        to one of the generate methods below.
+        """
+        return copy.deepcopy(self.sample_dataset_metadata)
+
     def generate_unpublished_collection(
         self,
         owner="test_user_id",

--- a/tests/unit/backend/wmg/pipelines/test_extract.py
+++ b/tests/unit/backend/wmg/pipelines/test_extract.py
@@ -1,130 +1,79 @@
 import backend.wmg.pipeline.integrated_corpus.extract
 from backend.common.corpora_orm import DatasetArtifactFileType
 from backend.wmg.data.constants import INCLUDED_ASSAYS
+from backend.layers.common.entities import CollectionId, OntologyTermId
 from tests.unit.backend.fixtures.generate_data_mixin import GenerateDataMixin
 from tests.unit.backend.fixtures.mock_aws_test_case import CorporaTestCaseUsingMockAWS
+from tests.unit.backend.layers.common.base_test import BaseTest
 
 
-class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
+class TestExtract(BaseTest):
     """
     Test case for extracting data to load into corpus to compute gene exression summary statistic cube
     """
 
+    def generate_base_metadata(self):
+        """
+        Generate a set of dataset metadata that verifies the criteria for inclusion in the 
+        extraction pipeline
+        """
+        assay_ontologies = list(INCLUDED_ASSAYS.keys())
+        metadata = self.get_sample_dataset_metadata()
+        metadata.is_primary_data = "PRIMARY"
+        metadata.assay = [OntologyTermId(ontology_term_id=assay_ontologies[0], label="test_assay")]
+        metadata.organism = [OntologyTermId(ontology_term_id="NCBITaxon:9606", label="Homo Sapiens")]
+        return metadata
+
     def setUp(self):
         super().setUp()
-        pub_collection = self.generate_collection(self.session, visibility="PUBLIC")
-        # INCLUDE
+        pub_collection = self.generate_collection(visibility="PUBLIC")
         assay_ontologies = list(INCLUDED_ASSAYS.keys())
-        self.dataset_0 = self.generate_dataset_with_s3_resources(
-            self.session,
-            artifacts=True,
-            explorer_s3_object=False,
-            collection_id=pub_collection.id,
-            published=True,
-            is_primary_data="PRIMARY",
-            tombstone=False,
-            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
-            assay=[{"ontology_term_id": assay_ontologies[0], "label": "test_assay"}],
-        )
-        self.dataset_1 = self.generate_dataset_with_s3_resources(
-            self.session,
-            artifacts=True,
-            explorer_s3_object=False,
-            collection_id=pub_collection.id,
-            published=True,
-            is_primary_data="PRIMARY",
-            tombstone=False,
-            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
-            # Only one assay needs to be included in the list of allowed assays
-            assay=[
-                {"ontology_term_id": assay_ontologies[1], "label": "test_assay"},
-                {"ontology_term_id": "any_other_obo_id", "label": "test_assay"},
-            ],
-        )
 
-        # DONT INCLUDE
-        self.dataset__multiple_organisms = self.generate_dataset_with_s3_resources(
-            self.session,
-            artifacts=True,
-            explorer_s3_object=False,
-            collection_id=pub_collection.id,
-            published=True,
-            is_primary_data="PRIMARY",
-            tombstone=False,
-            organism=[
-                {"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"},
-                {"label": "Mus musculus", "ontology_term_id": "NCBITaxon:10090"},
-            ],
-            assay=[{"ontology_term_id": assay_ontologies[0], "label": "test_assay"}],
-        )
-        self.dataset__wrong_assay = self.generate_dataset_with_s3_resources(
-            self.session,
-            artifacts=True,
-            explorer_s3_object=False,
-            collection_id=pub_collection.id,
-            published=True,
-            is_primary_data="PRIMARY",
-            tombstone=False,
-            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
-            assay=[{"ontology_term_id": "any_other_obo_id", "label": "test_assay"}],
-        )
-        self.dataset__not_primary = self.generate_dataset_with_s3_resources(
-            self.session,
-            artifacts=True,
-            explorer_s3_object=False,
-            collection_id=pub_collection.id,
-            published=True,
-            is_primary_data="SECONDARY",
-            tombstone=True,
-            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
-            assay=[{"ontology_term_id": assay_ontologies[1], "label": "test_assay"}],
-        )
+        # Dataset 1: should be included in the extraction pipeline
+        metadata = self.generate_base_metadata()
+        self.dataset_0 = self.generate_dataset(metadata=metadata, publish=True)
 
-        self.dataset__not_published = self.generate_dataset_with_s3_resources(
-            self.session,
-            artifacts=True,
-            explorer_s3_object=False,
-            collection_id=pub_collection.id,
-            published=False,
-            is_primary_data="PRIMARY",
-            tombstone=False,
-            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
-            assay=[{"ontology_term_id": assay_ontologies[1], "label": "test_assay"}],
-        )
-        self.dataset__tombstoned = self.generate_dataset_with_s3_resources(
-            self.session,
-            artifacts=True,
-            explorer_s3_object=False,
-            collection_id=pub_collection.id,
-            published=True,
-            is_primary_data="PRIMARY",
-            tombstone=True,
-            organism=[{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}],
-            assay=[{"ontology_term_id": assay_ontologies[1], "label": "test_assay"}],
-        )
-        self.dataset__null_organism = self.generate_dataset_with_s3_resources(
-            self.session,
-            artifacts=True,
-            explorer_s3_object=False,
-            collection_id=pub_collection.id,
-            published=True,
-            is_primary_data="PRIMARY",
-            tombstone=False,
-            organism=None,
-            assay=[{"ontology_term_id": assay_ontologies[1], "label": "test_assay"}],
-        )
-        private_collection = self.generate_collection(self.session, visibility="PRIVATE")
-        self.dataset__private_collection = self.generate_dataset_with_s3_resources(
-            self.session,
-            artifacts=True,
-            explorer_s3_object=False,
-            collection_id=private_collection.id,
-            published=True,
-            is_primary_data="PRIMARY",
-            tombstone=False,
-            organism=[{"label": "Mus musculus", "ontology_term_id": "NCBITaxon:10090"}],
-            assay=[{"ontology_term_id": assay_ontologies[0], "label": "test_assay"}],
-        )
+        # Dataset 2: should be included in the extraction pipeline
+        metadata = self.generate_base_metadata()
+        # Only one assay needs to be included in the list of allowed assays
+        metadata.assay = [
+            OntologyTermId(ontology_term_id="any_other_obo_id", label="test_assay"),
+            OntologyTermId(ontology_term_id=assay_ontologies[0], label="test_assay")
+        ]
+        self.dataset_1 = self.generate_dataset(metadata=metadata, publish=True)
+
+
+        # Dataset 3: should NOT be included in the pipeline, since it has multiple organisms
+        metadata = self.generate_base_metadata()
+        metadata.organism = [
+            OntologyTermId(ontology_term_id="NCBITaxon:9606", label="Homo Sapiens"),
+            OntologyTermId(ontology_term_id="NCBITaxon:10090", label="Mus musculus"),
+
+        ]
+        self.dataset__multiple_organisms = self.generate_dataset(metadata=metadata, publish=True)
+
+        # Dataset 4: should NOT be included in the pipeline, since the assay isn't included in the whitelist
+        metadata = self.generate_base_metadata()
+        metadata.assay = [OntologyTermId(ontology_term_id="any_other_obo_id", label="test_assay")]
+        self.dataset__wrong_assay = self.generate_dataset(metadata=metadata, publish=True)
+
+
+        # Dataset 5: should NOT be included in the pipeline because is_primary_data is SECONDARY
+        metadata = self.generate_base_metadata()
+        metadata.is_primary_data = "SECONDARY"
+        self.dataset__not_primary = self.generate_dataset(metadata=metadata, publish=True)
+
+        # Dataset 6: should NOT be included in the pipeline because it doesn't belong to a published collection
+        self.dataset__not_published = self.generate_dataset(publish=False)
+
+        # Dataset 7: should NOT be included in the pipeline because it belongs to a tombstoned collection
+        self.dataset__tombstoned = self.generate_dataset(publish=True)
+        self.business_logic.tombstone_collection(CollectionId(self.dataset__tombstoned.collection_id))
+        
+        # Dataset 8: should NOT be included in the pipeline because it has no organism
+        metadata = self.generate_base_metadata()
+        self.dataset__null_organism = self.generate_dataset(metadata=metadata, publish=True)
+
 
     def tearDown(self):
         super().tearDown()
@@ -147,7 +96,6 @@ class TestExtract(CorporaTestCaseUsingMockAWS, GenerateDataMixin):
             self.dataset__tombstoned,
             self.dataset__not_primary,
             self.dataset__not_published,
-            self.dataset__private_collection,
             self.dataset__wrong_assay,
             self.dataset__multiple_organisms,
             self.dataset__null_organism,

--- a/tests/unit/backend/wmg/pipelines/test_extract.py
+++ b/tests/unit/backend/wmg/pipelines/test_extract.py
@@ -1,10 +1,7 @@
 from unittest.mock import patch
 import backend.wmg.pipeline.integrated_corpus.extract
-from backend.common.corpora_orm import DatasetArtifactFileType
 from backend.wmg.data.constants import INCLUDED_ASSAYS
 from backend.layers.common.entities import CollectionId, DatasetArtifactType, DatasetVersionId, OntologyTermId
-from tests.unit.backend.fixtures.generate_data_mixin import GenerateDataMixin
-from tests.unit.backend.fixtures.mock_aws_test_case import CorporaTestCaseUsingMockAWS
 from tests.unit.backend.layers.common.base_test import BaseTest
 
 
@@ -15,7 +12,7 @@ class TestExtract(BaseTest):
 
     def generate_base_metadata(self):
         """
-        Generate a set of dataset metadata that verifies the criteria for inclusion in the 
+        Generate a set of dataset metadata that verifies the criteria for inclusion in the
         extraction pipeline
         """
         assay_ontologies = list(INCLUDED_ASSAYS.keys())
@@ -29,7 +26,9 @@ class TestExtract(BaseTest):
         super().setUp()
 
         # enable mocking of business logic
-        self.mock_business_logic = patch("backend.wmg.pipeline.integrated_corpus.extract._business_logic", new=self.business_logic)
+        self.mock_business_logic = patch(
+            "backend.wmg.pipeline.integrated_corpus.extract._business_logic", new=self.business_logic
+        )
         self.mock_business_logic.start()
 
         assay_ontologies = list(INCLUDED_ASSAYS.keys())
@@ -43,7 +42,7 @@ class TestExtract(BaseTest):
         # Only one assay needs to be included in the list of allowed assays
         metadata.assay = [
             OntologyTermId(ontology_term_id="any_other_obo_id", label="test_assay"),
-            OntologyTermId(ontology_term_id=assay_ontologies[0], label="test_assay")
+            OntologyTermId(ontology_term_id=assay_ontologies[0], label="test_assay"),
         ]
         self.dataset_1 = self.generate_dataset(metadata=metadata, publish=True)
 
@@ -52,7 +51,6 @@ class TestExtract(BaseTest):
         metadata.organism = [
             OntologyTermId(ontology_term_id="NCBITaxon:9606", label="Homo Sapiens"),
             OntologyTermId(ontology_term_id="NCBITaxon:10090", label="Mus musculus"),
-
         ]
         self.dataset__multiple_organisms = self.generate_dataset(metadata=metadata, publish=True)
 
@@ -60,7 +58,6 @@ class TestExtract(BaseTest):
         metadata = self.generate_base_metadata()
         metadata.assay = [OntologyTermId(ontology_term_id="any_other_obo_id", label="test_assay")]
         self.dataset__wrong_assay = self.generate_dataset(metadata=metadata, publish=True)
-
 
         # Dataset 5: should NOT be included in the pipeline because is_primary_data is SECONDARY
         metadata = self.generate_base_metadata()
@@ -73,12 +70,11 @@ class TestExtract(BaseTest):
         # Dataset 7: should NOT be included in the pipeline because it belongs to a tombstoned collection
         self.dataset__tombstoned = self.generate_dataset(publish=True)
         self.business_logic.tombstone_collection(CollectionId(self.dataset__tombstoned.collection_id))
-        
+
         # Dataset 8: should NOT be included in the pipeline because it has no organism
         metadata = self.generate_base_metadata()
         metadata.organism = None
         self.dataset__null_organism = self.generate_dataset(metadata=metadata, publish=True)
-
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
1. Migrate the WMG functions to the redesign
2. Reintroduce WMG API tests (accidentally dropped)
3. Create a new `backend-wmg-unit-test` GHA action for it