### PR TITLE
chore(FMG): change the effect size label in the marker gene panel to "marker score"

### DIFF
--- a/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
@@ -103,7 +103,7 @@ function CellInfoSideBar({
             </GeneHeaderWrapper>
           </GeneCellHeader>
           <CellHeader hideSortIcon horizontalAlign="right">
-            Effect Size
+            Marker Score
           </CellHeader>
         </TableHeader>
         <tbody>


### PR DESCRIPTION
- #3853

This changes the effect size label in the marker gene panel to "Marker Score" which is a more accurate description of the numbers being shown.

A separate PR will add the tooltip next week.