### PR TITLE
fix(portal redesign): handle raw h5ads at api layer in portal and curation API

### DIFF
--- a/backend/portal/api/app/portal-api.yml
+++ b/backend/portal/api/app/portal-api.yml
@@ -1140,7 +1140,7 @@ components:
           type: string
         filetype:
           type: string
-          enum: [H5AD, RDS, CXG]
+          enum: [RAW_H5AD, H5AD, RDS, CXG]
         filename:
           type: string
         s3_uri:

--- a/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/assets.py
+++ b/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/assets.py
@@ -7,7 +7,6 @@ from backend.portal.api.curation.v1.curation.collections.common import (
     get_infered_collection_version_else_forbidden,
     get_infered_dataset_version,
 )
-from backend.layers.common.entities import DatasetArtifactType
 
 
 def get(collection_id: str, dataset_id=None):

--- a/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/assets.py
+++ b/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/assets.py
@@ -3,6 +3,7 @@ from flask import make_response, jsonify
 from backend.common.utils.http_exceptions import NotFoundHTTPException
 from backend.layers.api.router import get_business_logic
 from backend.portal.api.curation.v1.curation.collections.common import (
+    allowed_dataset_asset_types,
     get_infered_collection_version_else_forbidden,
     get_infered_dataset_version,
 )
@@ -25,7 +26,7 @@ def get(collection_id: str, dataset_id=None):
     asset_list = []
     error_flag = False
     for asset in assets:
-        if asset.type == DatasetArtifactType.CXG:
+        if asset.type not in allowed_dataset_asset_types:
             continue
         download_data = business_logic.get_dataset_artifact_download_data(dataset.version_id, asset.id)
         if download_data.file_size is None:

--- a/backend/portal/api/curation/v1/curation/collections/common.py
+++ b/backend/portal/api/curation/v1/curation/collections/common.py
@@ -65,7 +65,7 @@ def reshape_for_curation_api(
     """
     business_logic = get_business_logic()
     is_published = collection_version.published_at is not None
-    # get collectoin attributes based on published status
+    # get collection attributes based on published status
     if is_published:
         # Published
         collection_id = collection_version.collection_id

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -37,6 +37,7 @@ class TestAsset(BaseAPIPortalTest):
             artifacts=[
                 DatasetArtifactUpdate(DatasetArtifactType.H5AD, "http://mock.uri/asset.h5ad"),
                 DatasetArtifactUpdate(DatasetArtifactType.CXG, "http://mock.uri/asset.cxg"),
+                DatasetArtifactUpdate(DatasetArtifactType.RAW_H5AD, "http://mock.uri/raw.h5ad"),
             ],
             publish=True,
         )
@@ -61,6 +62,7 @@ class TestAsset(BaseAPIPortalTest):
             artifacts=[
                 DatasetArtifactUpdate(DatasetArtifactType.H5AD, "http://mock.uri/asset.h5ad"),
                 DatasetArtifactUpdate(DatasetArtifactType.CXG, "http://mock.uri/asset.cxg"),
+                DatasetArtifactUpdate(DatasetArtifactType.RAW_H5AD, "http://mock.uri/raw.h5ad"),
             ],
             publish=True,
         )


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- In Portal API layer, accept RAW_H5AD (original, unlabeled H5AD we store) as an acceptable filetype
- In Curation API layer, filter out RAW_H5AD from API responses by using a whitelist of allowed API response filetypes (since CXG is already filtered out, whitelist already existed in common class)
- Added to curation API tests

## QA steps (optional)

## Notes for Reviewer
