### PR TITLE
feat(fmg): shift marker genes to front if already selected when adding

### DIFF
--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -363,16 +363,13 @@ function addSelectedGenes(
   action: PayloadAction<State["selectedGenes"]>
 ): State {
   const { payload } = action;
+  let newSelectedGenes = state.selectedGenes;
 
-  // only add unique genes
-  const genesToAdd = payload.filter(
-    (gene) => !state.selectedGenes.includes(gene)
-  );
-  if (genesToAdd.length === 0) return state;
+  newSelectedGenes = newSelectedGenes.filter((gene) => !payload.includes(gene));
 
   return {
     ...state,
-    selectedGenes: [...genesToAdd, ...state.selectedGenes],
+    selectedGenes: [...payload, ...newSelectedGenes],
   };
 }
 


### PR DESCRIPTION
https://github.com/chanzuckerberg/single-cell-data-portal/issues/3802

Changed reducer logic to filter out existing genes and then insert all at front when adding marker genes to the heatmap


https://user-images.githubusercontent.com/8716829/210895827-63e94b90-f113-4e7b-88f4-3df2c988f694.mov

