### PR TITLE
fix(wmg): y axis is now properly sticky

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
@@ -1,7 +1,6 @@
 import cloneDeep from "lodash/cloneDeep";
 import { memo, useContext, useMemo, useRef, useState } from "react";
 import { EMPTY_ARRAY } from "src/common/constants/utils";
-import { useResizeObserver } from "src/common/hooks/useResizeObserver";
 import {
   generateTermsByKey,
   OntologyTerm,
@@ -28,7 +27,7 @@ import {
 } from "./hooks/useSortedGeneNames";
 import { useTrackHeatMapLoaded } from "./hooks/useTrackHeatMapLoaded";
 import {
-  FlexRow,
+  InlineRow,
   ChartWrapper,
   Container,
   ContainerWrapper,
@@ -37,7 +36,6 @@ import {
   XAxisMask,
   XAxisWrapper,
 } from "./style";
-import { X_AXIS_CHART_HEIGHT_PX } from "./utils";
 
 interface Props {
   className?: string;
@@ -79,7 +77,6 @@ export default memo(function HeatMap({
   // Loading state per tissue
   const [isLoading, setIsLoading] = useState(setInitialIsLoading(cellTypes));
   const chartWrapperRef = useRef<HTMLDivElement>(null);
-  const chartWrapperRect = useResizeObserver(chartWrapperRef);
 
   const dispatch = useContext(DispatchContext);
 
@@ -161,10 +158,8 @@ export default memo(function HeatMap({
           <XAxisMask />
           <XAxisChart geneNames={sortedGeneNames} />
         </XAxisWrapper>
-        <FlexRow>
-          <YAxisWrapper
-            height={(chartWrapperRect?.height || 0) - X_AXIS_CHART_HEIGHT_PX}
-          >
+        <InlineRow>
+          <YAxisWrapper>
             {selectedTissues.map((tissue) => {
               const tissueCellTypes = getTissueCellTypes({
                 cellTypeSortBy,
@@ -214,7 +209,7 @@ export default memo(function HeatMap({
               );
             })}
           </ChartWrapper>
-        </FlexRow>
+        </InlineRow>
       </Container>
     </ContainerWrapper>
   );

--- a/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
@@ -27,7 +27,6 @@ import {
 } from "./hooks/useSortedGeneNames";
 import { useTrackHeatMapLoaded } from "./hooks/useTrackHeatMapLoaded";
 import {
-  InlineRow,
   ChartWrapper,
   Container,
   ContainerWrapper,
@@ -158,58 +157,56 @@ export default memo(function HeatMap({
           <XAxisMask />
           <XAxisChart geneNames={sortedGeneNames} />
         </XAxisWrapper>
-        <InlineRow>
-          <YAxisWrapper>
-            {selectedTissues.map((tissue) => {
-              const tissueCellTypes = getTissueCellTypes({
-                cellTypeSortBy,
-                cellTypes,
-                sortedCellTypesByTissueName,
-                tissue,
-              });
+        <YAxisWrapper>
+          {selectedTissues.map((tissue) => {
+            const tissueCellTypes = getTissueCellTypes({
+              cellTypeSortBy,
+              cellTypes,
+              sortedCellTypesByTissueName,
+              tissue,
+            });
 
-              return (
-                <YAxisChart
-                  key={tissue}
-                  tissue={tissue}
-                  tissueID={tissuesByName[tissue].id}
-                  cellTypes={tissueCellTypes}
-                  hasDeletedCellTypes={tissuesWithDeletedCellTypes.includes(
-                    tissue
-                  )}
-                  availableCellTypes={allTissueCellTypes[tissue]}
-                  generateMarkerGenes={generateMarkerGenes}
-                  selectedOrganismId={selectedOrganismId}
-                />
-              );
-            })}
-          </YAxisWrapper>
-          <ChartWrapper ref={chartWrapperRef}>
-            {selectedTissues.map((tissue) => {
-              const tissueCellTypes = getTissueCellTypes({
-                cellTypeSortBy,
-                cellTypes,
-                sortedCellTypesByTissueName,
-                tissue,
-              });
+            return (
+              <YAxisChart
+                key={tissue}
+                tissue={tissue}
+                tissueID={tissuesByName[tissue].id}
+                cellTypes={tissueCellTypes}
+                hasDeletedCellTypes={tissuesWithDeletedCellTypes.includes(
+                  tissue
+                )}
+                availableCellTypes={allTissueCellTypes[tissue]}
+                generateMarkerGenes={generateMarkerGenes}
+                selectedOrganismId={selectedOrganismId}
+              />
+            );
+          })}
+        </YAxisWrapper>
+        <ChartWrapper ref={chartWrapperRef}>
+          {selectedTissues.map((tissue) => {
+            const tissueCellTypes = getTissueCellTypes({
+              cellTypeSortBy,
+              cellTypes,
+              sortedCellTypesByTissueName,
+              tissue,
+            });
 
-              return (
-                <Chart
-                  isScaled={isScaled}
-                  key={tissue}
-                  tissue={tissue}
-                  cellTypes={tissueCellTypes}
-                  selectedGeneData={
-                    orderedSelectedGeneExpressionSummariesByTissueName[tissue]
-                  }
-                  setIsLoading={setIsLoading}
-                  scaledMeanExpressionMax={scaledMeanExpressionMax}
-                  scaledMeanExpressionMin={scaledMeanExpressionMin}
-                />
-              );
-            })}
-          </ChartWrapper>
-        </InlineRow>
+            return (
+              <Chart
+                isScaled={isScaled}
+                key={tissue}
+                tissue={tissue}
+                cellTypes={tissueCellTypes}
+                selectedGeneData={
+                  orderedSelectedGeneExpressionSummariesByTissueName[tissue]
+                }
+                setIsLoading={setIsLoading}
+                scaledMeanExpressionMax={scaledMeanExpressionMax}
+                scaledMeanExpressionMin={scaledMeanExpressionMin}
+              />
+            );
+          })}
+        </ChartWrapper>
       </Container>
     </ContainerWrapper>
   );

--- a/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
@@ -40,6 +40,7 @@ export const XAxisMask = styled.div`
   height: ${X_AXIS_CHART_HEIGHT_PX}px;
 `;
 
+// (atarashansky): inline display needed to make y axis properly sticky
 export const InlineRow = styled.div`
   display: inline;
 `;

--- a/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
@@ -33,12 +33,6 @@ export const YAxisWrapper = styled.div`
   padding-top: 5px;
   /* Somehow Firefox requires this to scroll */
   overflow: hidden;
-
-  ${({ height }: { height: number }) => {
-    return `
-      height: ${height}px
-    `;
-  }}
 `;
 
 export const XAxisMask = styled.div`
@@ -46,9 +40,8 @@ export const XAxisMask = styled.div`
   height: ${X_AXIS_CHART_HEIGHT_PX}px;
 `;
 
-export const FlexRow = styled.div`
-  display: flex;
-  flex-direction: row;
+export const InlineRow = styled.div`
+  display: inline;
 `;
 
 export const XAxisWrapper = styled.div`

--- a/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
@@ -40,11 +40,6 @@ export const XAxisMask = styled.div`
   height: ${X_AXIS_CHART_HEIGHT_PX}px;
 `;
 
-// (atarashansky): inline display needed to make y axis properly sticky
-export const InlineRow = styled.div`
-  display: inline;
-`;
-
 export const XAxisWrapper = styled.div`
   display: flex;
   background-color: white;


### PR DESCRIPTION
Y axis stopped being sticky when scrolling horizontally on a very large heatmap. The fix involved (a) changing the y axis/chart container to be inline instead of flex and (b) ensuring that both y axis and chart had the same height.