### PR TITLE
fix(wmg): image download

### DIFF
--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveImage/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveImage/index.tsx
@@ -32,6 +32,7 @@ const screenshotFilter =
       EXCLUDE_IN_SCREENSHOT_CLASS_NAME
     );
     const isNoScript = domNode.tagName === "NOSCRIPT";
+
     const isNonTissueChart =
       domNode.id &&
       domNode.id.includes("chart") &&
@@ -80,7 +81,7 @@ export default function SaveImage({
     try {
       const heatmapNode = document.getElementById("view") as HTMLCanvasElement;
       //(ashin): #3569 Get scrollTop to go back to place after downloading image
-      let heatmapContainer = document.getElementById(
+      const heatmapContainer = document.getElementById(
         HEATMAP_CONTAINER_ID
       ) as HTMLCanvasElement;
       heatmapContainerScrollTop = heatmapContainer?.scrollTop;

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
@@ -307,7 +307,12 @@ export default memo(function Chart({
         ],
       }}
     >
-      <ChartContainer height={heatmapHeight} width={heatmapWidth} ref={ref} />
+      <ChartContainer
+        height={heatmapHeight}
+        width={heatmapWidth}
+        ref={ref}
+        id={`${tissue}-chart`}
+      />
     </Tooltip>
   );
 });


### PR DESCRIPTION
The image download was including tissue charts from other tissues because the tissue id was accidentally deleted from [this PR](https://github.com/chanzuckerberg/single-cell-data-portal/pull/3811/files). Thus adding it back!

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
