### PR TITLE
fix(wmg): Select Tissues/Genes dropdown not triggering onClick event

### DIFF
--- a/frontend/src/views/WheresMyGene/components/Filters/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/index.tsx
@@ -6,7 +6,6 @@ import {
 } from "czifui";
 import isEqual from "lodash/isEqual";
 import {
-  Fragment,
   memo,
   ReactElement,
   useCallback,
@@ -241,13 +240,15 @@ export default memo(function Filters({ isLoading }: Props): JSX.Element {
   );
 
   function TooltipWrapper({ children }: { children: ReactElement }) {
-    const Wrapper = areFiltersDisabled ? Tooltip : Fragment;
+    if (areFiltersDisabled) {
+      return (
+        <Tooltip title="Please select an organism, tissue and at least one gene to use these filters.">
+          {children}
+        </Tooltip>
+      );
+    }
 
-    return (
-      <Wrapper title="Please select an organism, tissue and at least one gene to use these filters.">
-        {children}
-      </Wrapper>
-    );
+    return <>{children}</>;
   }
 });
 

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
@@ -20,6 +20,7 @@ import { pull, uniq } from "lodash";
 import React, {
   createContext,
   HTMLAttributes,
+  MouseEvent,
   ReactChild,
   SyntheticEvent,
   useRef,
@@ -322,6 +323,11 @@ export default function QuickSelect<
   );
 
   function renderOption(
+    /**
+     * (thuang): MUI passes their own event handlers via `optionProps`, so if we
+     * need our own event handlers, we need to make sure to call their handlers
+     * too
+     */
     optionProps: HTMLAttributes<HTMLLIElement>,
     option: T,
     { selected }: AutocompleteRenderOptionState
@@ -329,16 +335,18 @@ export default function QuickSelect<
     return (
       <StyledMenuItem
         {...{ component: "li" }}
+        {...optionProps}
         isMultiSelect={multiple}
         selected={selected}
         onClick={onClick}
-        {...optionProps}
       >
         {option.name}
       </StyledMenuItem>
     );
 
-    function onClick() {
+    function onClick(event: MouseEvent<HTMLLIElement>): void {
+      optionProps.onClick && optionProps.onClick(event);
+
       // (thuang): Only track select, not deselect
       if (selected) return;
 

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
@@ -66,7 +66,7 @@ export default memo(function Chart({
   const [isChartInitialized, setIsChartInitialized] = useState(false);
 
   const [chart, setChart] = useState<echarts.ECharts | null>(null);
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement | null>(null);
 
   const [heatmapWidth, setHeatmapWidth] = useState(
     getHeatmapWidth(selectedGeneData)
@@ -100,7 +100,13 @@ export default memo(function Chart({
   useEffect(() => {
     const { current } = ref;
 
-    if (!current || isChartInitialized) {
+    if (
+      !current ||
+      isChartInitialized ||
+      // (thuang): echart's `init()` will throw error if the container has 0 width or height
+      current?.getAttribute("height") === "0" ||
+      current?.getAttribute("width") === "0"
+    ) {
       return;
     }
 
@@ -121,7 +127,13 @@ export default memo(function Chart({
     setHeatmapHeight(getHeatmapHeight(cellTypes));
   }, [cellTypes, selectedGeneData]);
 
-  useUpdateChart({ chart, chartProps, isScaled, heatmapWidth, heatmapHeight });
+  useUpdateChart({
+    chart,
+    chartProps,
+    heatmapHeight,
+    heatmapWidth,
+    isScaled,
+  });
 
   // Calculate cellTypeSummaries
   /**


### PR DESCRIPTION
- #TICKET_NUMBER

### Reviewers
**Functional:** 
@atarashansky 

**Readability:** 
@ainfeld 
---


## Changes
This triggers the onClick analytics event when selecting a previously unselected option again

How it broke:
After migrating to MUIv5, MUI adds their own `onClick()` handler now, which overrides our custom one, thus the need to merge the two now

## QA steps
1. Select a tissue option, you should see a Plausible response
2. In the GIF below, you can see that the warning message count is incrementing, which is a warning that Plausible received the event but is not reporting it to the server because this is a local dev environment

![demo](https://user-images.githubusercontent.com/6309723/211122839-e1406504-3e07-4fe3-8a2b-d07c4ebacf00.gif)


## Notes for Reviewer
