### PR TITLE
fix(wmg): fix echarts initialization

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
@@ -119,7 +119,7 @@ export default memo(function Chart({
     });
 
     setChart(chart);
-  }, [ref, isChartInitialized, throttledSetCurrentIndices]);
+  }, [ref, isChartInitialized, throttledSetCurrentIndices, heatmapWidth, heatmapHeight]);
 
   // Update heatmap size
   useEffect(() => {


### PR DESCRIPTION
Currently, echarts initialization is broken for the chart introduced by [this PR](https://github.com/chanzuckerberg/single-cell-data-portal/pull/3881). The fix is to add heatmapWidth and height to the dependencies in the useEffect so that when they update, the initialization triggers. For some reason, the update to the reference is not enough to trigger useEffect to run again.
