### PR TITLE
feat: unpublished collections can be looked up by canonical id

### DIFF
--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -238,17 +238,15 @@ def get_collection_details(collection_id: str, token_info: dict):
     only if the previous returns None.
     Returns None only if no lookup was successful.
     1. A published collection that has `collection_id` as the canonical id
-    2. A collection version with `collection_id` as the version_id (published or not)
-    3. An unpublished collection that has `collection_id` as the canonical id. This matches the case
+    2. An unpublished collection that has `collection_id` as the canonical id. This matches the case
        where a collection doesn't have any published version yet, but we want to access it
        via its permalink
+    3. A collection version with `collection_id` as the version_id (published or not)
     """
     # TODO: this logic might belong to the business layer?
-    version = get_business_logic().get_published_collection_version(CollectionId(collection_id))
+    version = get_business_logic().get_collection_version_from_canonical(CollectionId(collection_id))
     if version is None:
         version = get_business_logic().get_collection_version(CollectionVersionId(collection_id))
-    if version is None:
-        version = get_business_logic().get_collection_version_from_canonical(CollectionId(collection_id))
     if version is None:
         raise ForbiddenHTTPException()
 

--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -240,7 +240,8 @@ def get_collection_details(collection_id: str, token_info: dict):
     1. A published collection that has `collection_id` as the canonical id
     2. A collection version with `collection_id` as the version_id (published or not)
     3. An unpublished collection that has `collection_id` as the canonical id. This matches the case
-       where a
+       where a collection doesn't have any published version yet, but we want to access it
+       via its permalink
     """
     # TODO: this logic might belong to the business layer?
     version = get_business_logic().get_published_collection_version(CollectionId(collection_id))

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -307,7 +307,7 @@ class TestCollection(BaseAPIPortalTest):
 
     def test__get_collection_id__403_not_found(self):
         """
-        GET /collections/:collection_id returns 403 if a valid is specified
+        GET /collections/:collection_id returns 403 if an invalid is specified
         """
         fake_id = CollectionId()
         test_url = furl(path=f"/dp/v1/collections/{fake_id}", query_params=dict(visibility="PUBLIC"))


### PR DESCRIPTION
### Reviewers
**Functional:** 
@nayib-jose-gloria 

**Readability:** 

---


Allows lookup by canonical `collection_id` for unpublished collections.
