### PR TITLE
fix: curation API differentiates unpublished collections for revisions

### DIFF
--- a/backend/portal/api/curation/curation-api.yml
+++ b/backend/portal/api/curation/curation-api.yml
@@ -582,7 +582,9 @@ components:
       description: Collection metadata
       properties:
         collection_url:
-          description: The CELLxGENE Discover URL for the Collection.
+          description: |
+            The CELLxGENE Discover URL for the Collection. This points to the canonical link unless it's a revision, 
+            in which case it points to the unpublished revision version.
           type: string
         contact_email:
           $ref: "#/components/schemas/contact_email"

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -353,7 +353,7 @@ class TestGetCollections(BaseAPIPortalTest):
         resp = self._test_response(visibility="PRIVATE", auth=True)
         self.assertEqual(1, len(resp))
         resp_collection = resp[0]
-        self.assertEqual(unpublished_collection_id.collection_id.id, resp_collection["revision_of"])
+        self.assertIsNone(resp_collection["revision_of"])
 
     def test__get_collections_no_auth_visibility_private__403(self):
         self._test_response(visibility="PRIVATE", status_code=403)


### PR DESCRIPTION
For an unpublished collection that is not a revision, Curation API should return the `collection_url` pointing to the permalink instead of the private version. This is a requirement for the curation workflow.