### PR TITLE
feat: newly unpublished collections return canonical collection_id in API

### DIFF
--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -195,12 +195,24 @@ def _dataset_to_response(dataset: DatasetVersion, is_tombstoned: bool, is_in_pub
 
 
 def _collection_to_response(collection: CollectionVersionWithDatasets, access_type: str):
-    collection_id = collection.collection_id.id if collection.published_at is not None else collection.version_id.id
-
+    """
+    Converts a CollectionVersion to a format that can be used as an API response. The returned id
+    """
     if collection.canonical_collection.originally_published_at is not None and collection.published_at is None:
+        # In this case, the collection version is a revision of an already published collection.
+        # We should expose version_id as the collection_id
         revision_of = collection.collection_id.id
-    else:
+        collection_id = collection.version_id.id
+    elif collection.canonical_collection.originally_published_at is None and collection.published_at is None:
+        # In this case, we're dealing with a freshly created collection - we should expose the canonical id here,
+        # since the curators will circulate the permalink immediately. `revision_of` is also null.
+        # Note that this case is effectively equivalent to a published collection
         revision_of = None
+        collection_id = collection.collection_id.id
+    else:
+        # The last case is a published collection. We just return the canonical id and set revision_of to None
+        revision_of = None
+        collection_id = collection.collection_id.id
 
     is_tombstoned = collection.canonical_collection.tombstoned
     is_in_published_collection = collection.published_at is not None
@@ -324,7 +336,7 @@ def create_collection(body: dict, user: str):
     except CollectionCreationException as ex:
         raise InvalidParametersHTTPException(detail=ex.errors)
 
-    return make_response(jsonify({"collection_id": version.version_id.id}), 201)
+    return make_response(jsonify({"collection_id": version.collection_id.id}), 201)
 
 
 # TODO: we should use a dataclass here
@@ -391,6 +403,8 @@ def update_collection(collection_id: str, body: dict, token_info: dict):
     # Ensure that the version exists and the user is authorized to update it
     # TODO: this should be extracted to a method, I think
     version = get_business_logic().get_collection_version(CollectionVersionId(collection_id))
+    if version is None:
+        version = get_business_logic().get_collection_version_from_canonical(CollectionId(collection_id))
     if version is None or not UserInfo(token_info).is_user_owner_or_allowed(version.owner):
         raise ForbiddenHTTPException()
 
@@ -407,11 +421,11 @@ def update_collection(collection_id: str, body: dict, token_info: dict):
         update_links,
     )
 
-    get_business_logic().update_collection_version(CollectionVersionId(collection_id), payload)
+    get_business_logic().update_collection_version(version.version_id, payload)
 
     # Requires strong consistency w.r.t. the operation above - if not available, the update needs
     # to be done in memory
-    version = get_business_logic().get_collection_version(CollectionVersionId(collection_id))
+    version = get_business_logic().get_collection_version(version.version_id)
 
     response = _collection_to_response(version, "WRITE")
     return make_response(jsonify(response), 200)
@@ -423,11 +437,13 @@ def publish_post(collection_id: str, body: object, token_info: dict):
     """
 
     version = get_business_logic().get_collection_version(CollectionVersionId(collection_id))
+    if version is None:
+        version = get_business_logic().get_collection_version_from_canonical(CollectionId(collection_id))
     if version is None or not UserInfo(token_info).is_user_owner_or_allowed(version.owner):
         raise ForbiddenHTTPException()
 
     try:
-        get_business_logic().publish_collection_version(CollectionVersionId(collection_id))
+        get_business_logic().publish_collection_version(version.version_id)
     except CollectionPublishException:
         raise ConflictException(detail="The collection must have a least one dataset.")
 
@@ -439,12 +455,14 @@ def publish_post(collection_id: str, body: object, token_info: dict):
 def upload_from_link(collection_id: str, token_info: dict, url: str, dataset_id: str = None):
 
     version = get_business_logic().get_collection_version(CollectionVersionId(collection_id))
+    if version is None:
+        version = get_business_logic().get_collection_version_from_canonical(CollectionId(collection_id))
     if version is None or not UserInfo(token_info).is_user_owner_or_allowed(version.owner):
         raise ForbiddenHTTPException()
 
     try:
         dataset_version_id, _ = get_business_logic().ingest_dataset(
-            CollectionVersionId(collection_id),
+            version.version_id,
             url,
             None,
             None if dataset_id is None else DatasetVersionId(dataset_id),

--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 
 from flask import Response, jsonify, make_response
@@ -242,6 +242,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
             "visibility": "PUBLIC" if collection.published_at is not None else "PRIVATE",
         }
     )
+
 
 def lookup_collection(collection_id: str):
     """

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -12,7 +12,6 @@ from backend.layers.common.entities import (
 from backend.layers.common.entities import (
     CollectionId,
     CollectionLinkType,
-    CollectionVersionId,
     DatasetArtifactType,
     DatasetProcessingStatus,
     DatasetUploadStatus,
@@ -364,10 +363,11 @@ class TestCollection(BaseAPIPortalTest):
         )
         self.assertEqual(201, response.status_code)
         collection_id = json.loads(response.data)["collection_id"]
-        collection = self.business_logic.get_collection_version(CollectionVersionId(collection_id))
-        print(collection)
-        doi = next(link.uri for link in collection.metadata.links if link.type == "DOI")  # TODO: careful
-        self.assertEquals(doi, "https://doi.org/10.1016/foo")
+        # TODO: this endpoint should also return `version_id`
+        collection = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
+        if collection is not None:
+            doi = next(link.uri for link in collection.metadata.links if link.type == "DOI")  # TODO: careful
+            self.assertEquals(doi, "https://doi.org/10.1016/foo")
 
     # ✅
     def test__post_collection_rejects_two_dois(self):
@@ -458,8 +458,10 @@ class TestCollection(BaseAPIPortalTest):
         )
         self.assertEqual(201, response.status_code)
         collection_id = json.loads(response.data)["collection_id"]
-        collection = self.business_logic.get_collection_version(CollectionVersionId(collection_id))
-        self.assertIsNone(collection.publisher_metadata)
+        # TODO: this endpoint should also return `version_id`
+        collection = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
+        if collection is not None:
+            self.assertIsNone(collection.publisher_metadata)
 
     # ✅
     def test__post_collection_ignores_metadata_if_no_doi(self):
@@ -479,8 +481,10 @@ class TestCollection(BaseAPIPortalTest):
         )
         self.assertEqual(201, response.status_code)
         collection_id = json.loads(response.data)["collection_id"]
-        collection = self.business_logic.get_collection_version(CollectionVersionId(collection_id))
-        self.assertIsNone(collection.publisher_metadata)
+        # TODO: this endpoint should also return `version_id`
+        collection = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
+        if collection is not None:
+            self.assertIsNone(collection.publisher_metadata)
 
     # ✅
     def test__post_collection_adds_publisher_metadata(self):
@@ -504,9 +508,11 @@ class TestCollection(BaseAPIPortalTest):
         )
         self.assertEqual(201, response.status_code)
         collection_id = json.loads(response.data)["collection_id"]
-        collection = self.business_logic.get_collection_version(CollectionVersionId(collection_id))
-        self.assertIsNotNone(collection.publisher_metadata)
-        self.assertEqual(collection.publisher_metadata, generate_mock_publisher_metadata())
+        # TODO: this endpoint should also return `version_id`
+        collection = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
+        if collection is not None:
+            self.assertIsNotNone(collection.publisher_metadata)
+            self.assertEqual(collection.publisher_metadata, generate_mock_publisher_metadata())
 
     # ✅
     def test__post_collection_fails_with_extra_fields(self):

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -332,6 +332,11 @@ class TestCollection(BaseAPIPortalTest):
         )
         self.assertEqual(201, response.status_code)
 
+        # Check that the collection_id is the canonical collection ID
+        collection_id = response.json["collection_id"]
+        version = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
+        self.assertEqual(version.collection_id.id, collection_id)
+
         # Add curator_name
         data["curator_name"] = "john smith"
         json_data = json.dumps(data)
@@ -365,9 +370,8 @@ class TestCollection(BaseAPIPortalTest):
         collection_id = json.loads(response.data)["collection_id"]
         # TODO: this endpoint should also return `version_id`
         collection = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
-        if collection is not None:
-            doi = next(link.uri for link in collection.metadata.links if link.type == "DOI")  # TODO: careful
-            self.assertEquals(doi, "https://doi.org/10.1016/foo")
+        doi = next(link.uri for link in collection.metadata.links if link.type == "DOI")  # TODO: careful
+        self.assertEquals(doi, "https://doi.org/10.1016/foo")
 
     # ✅
     def test__post_collection_rejects_two_dois(self):
@@ -460,8 +464,7 @@ class TestCollection(BaseAPIPortalTest):
         collection_id = json.loads(response.data)["collection_id"]
         # TODO: this endpoint should also return `version_id`
         collection = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
-        if collection is not None:
-            self.assertIsNone(collection.publisher_metadata)
+        self.assertIsNone(collection.publisher_metadata)
 
     # ✅
     def test__post_collection_ignores_metadata_if_no_doi(self):
@@ -483,8 +486,7 @@ class TestCollection(BaseAPIPortalTest):
         collection_id = json.loads(response.data)["collection_id"]
         # TODO: this endpoint should also return `version_id`
         collection = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
-        if collection is not None:
-            self.assertIsNone(collection.publisher_metadata)
+        self.assertIsNone(collection.publisher_metadata)
 
     # ✅
     def test__post_collection_adds_publisher_metadata(self):
@@ -510,9 +512,8 @@ class TestCollection(BaseAPIPortalTest):
         collection_id = json.loads(response.data)["collection_id"]
         # TODO: this endpoint should also return `version_id`
         collection = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
-        if collection is not None:
-            self.assertIsNotNone(collection.publisher_metadata)
-            self.assertEqual(collection.publisher_metadata, generate_mock_publisher_metadata())
+        self.assertIsNotNone(collection.publisher_metadata)
+        self.assertEqual(collection.publisher_metadata, generate_mock_publisher_metadata())
 
     # ✅
     def test__post_collection_fails_with_extra_fields(self):


### PR DESCRIPTION

### Reviewers
**Functional:** 
@nayib-jose-gloria @Bento007 

**Readability:** 

---
With this change, newly unpublished collections will work with canonical ids rather than version ids. Also introduces double lookups for all update operations, since they will need to work with collection_ids as well.
