### PR TITLE
chore: cxg links are permalinks for new unpublished collections

### DIFF
--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -203,19 +203,22 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
         # We should expose version_id as the collection_id
         revision_of = collection.collection_id.id
         collection_id = collection.version_id.id
+        is_in_published_collection = False
     elif collection.canonical_collection.originally_published_at is None and collection.published_at is None:
         # In this case, we're dealing with a freshly created collection - we should expose the canonical id here,
         # since the curators will circulate the permalink immediately. `revision_of` is also null.
-        # Note that this case is effectively equivalent to a published collection
+        # We should also expose the canonical CXG link for each dataset
+        # Note that this case is effectively equivalent to a published collection.
         revision_of = None
         collection_id = collection.collection_id.id
+        is_in_published_collection = True
     else:
         # The last case is a published collection. We just return the canonical id and set revision_of to None
         revision_of = None
         collection_id = collection.collection_id.id
+        is_in_published_collection = True
 
     is_tombstoned = collection.canonical_collection.tombstoned
-    is_in_published_collection = collection.published_at is not None
 
     return remove_none(
         {

--- a/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
+++ b/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
@@ -51,13 +51,13 @@ def get(collection_id: str, dataset_id: str = None):
     # A canonical url should be only used in two cases:
     # 1. the collection version is unpublished but it's not a revision
     # 2. the collection version is published
-    should_use_canonical_url = (
+    use_canonical_url = (
         collection_version.canonical_collection.originally_published_at is None
         or collection_version.published_at is not None
     )
 
     response_body = reshape_dataset_for_curation_api(
-        version, collection_version.published_at is not None, should_use_canonical_url
+        version, collection_version.published_at is not None, use_canonical_url
     )
     return make_response(jsonify(response_body), 200)
 

--- a/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
+++ b/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
@@ -48,7 +48,17 @@ def get(collection_id: str, dataset_id: str = None):
     if version is None:
         raise NotFoundHTTPException("Dataset not found")
 
-    response_body = reshape_dataset_for_curation_api(version, collection_version.published_at is not None)
+    # A canonical url should be only used in two cases:
+    # 1. the collection version is unpublished but it's not a revision
+    # 2. the collection version is published
+    should_use_canonical_url = (
+        collection_version.canonical_collection.originally_published_at is None
+        or collection_version.published_at is not None
+    )
+
+    response_body = reshape_dataset_for_curation_api(
+        version, collection_version.published_at is not None, should_use_canonical_url
+    )
     return make_response(jsonify(response_body), 200)
 
 

--- a/backend/portal/api/curation/v1/curation/collections/common.py
+++ b/backend/portal/api/curation/v1/curation/collections/common.py
@@ -144,7 +144,9 @@ def reshape_datasets_for_curation_api(
     active_datasets = []
     for dv in datasets:
         dataset_version = get_business_logic().get_dataset_version(dv) if isinstance(dv, DatasetVersionId) else dv
-        active_datasets.append(reshape_dataset_for_curation_api(dataset_version, is_published, use_canonical_url, preview))
+        active_datasets.append(
+            reshape_dataset_for_curation_api(dataset_version, is_published, use_canonical_url, preview)
+        )
     return active_datasets
 
 

--- a/backend/portal/api/curation/v1/curation/collections/common.py
+++ b/backend/portal/api/curation/v1/curation/collections/common.py
@@ -78,7 +78,7 @@ def reshape_for_curation_api(
                 collection_version.collection_id
             )
         revising_in = _revising_in.version_id.id if _revising_in else None
-        should_use_canonical_url = True
+        use_canonical_url = True
     else:
         # Unpublished - need to determine if it's a revision or first time collection
         # For that, we look at whether the canonical collection is published
@@ -89,7 +89,7 @@ def reshape_for_curation_api(
             collection_id = collection_version.version_id
             collection_url = f"{get_collections_base_url()}/collections/{collection_id.id}"
             revision_of = collection_version.collection_id.id
-            should_use_canonical_url = False
+            use_canonical_url = False
         else:
             # If it's an unpublished, unrevised collection, then collection_url will point to the permalink
             # (aka the link to the canonical_id) and the collection_id will point to version_id.
@@ -97,12 +97,12 @@ def reshape_for_curation_api(
             collection_id = collection_version.version_id
             collection_url = f"{get_collections_base_url()}/collections/{collection_version.collection_id}"
             revision_of = None
-            should_use_canonical_url = True
+            use_canonical_url = True
         revising_in = None
 
     # get collection dataset attributes
     response_datasets = reshape_datasets_for_curation_api(
-        collection_version.datasets, is_published, should_use_canonical_url, preview
+        collection_version.datasets, is_published, use_canonical_url, preview
     )
 
     # build response
@@ -138,18 +138,18 @@ def reshape_for_curation_api(
 def reshape_datasets_for_curation_api(
     datasets: List[Union[DatasetVersionId, DatasetVersion]],
     is_published: bool,
-    should_use_canonical_url: bool,
+    use_canonical_url: bool,
     preview: bool = False,
 ) -> List[dict]:
     active_datasets = []
     for dv in datasets:
         dataset_version = get_business_logic().get_dataset_version(dv) if isinstance(dv, DatasetVersionId) else dv
-        active_datasets.append(reshape_dataset_for_curation_api(dataset_version, is_published, should_use_canonical_url, preview))
+        active_datasets.append(reshape_dataset_for_curation_api(dataset_version, is_published, use_canonical_url, preview))
     return active_datasets
 
 
 def reshape_dataset_for_curation_api(
-    dataset_version: DatasetVersion, is_published: bool, should_use_canonical_url: bool, preview=False
+    dataset_version: DatasetVersion, is_published: bool, use_canonical_url: bool, preview=False
 ) -> dict:
     ds = dict()
 
@@ -183,7 +183,7 @@ def reshape_dataset_for_curation_api(
         ds["revision"] = 0  # TODO this should be the number of times this dataset has been revised and published
         ds["title"] = ds.pop("name", None)
         ds["is_primary_data"] = is_primary_data_mapping.get(ds.pop("is_primary_data"), [])
-        ds["explorer_url"] = generate_explorer_url(dataset_version, should_use_canonical_url)
+        ds["explorer_url"] = generate_explorer_url(dataset_version, use_canonical_url)
         ds["tombstone"] = False  # TODO this will always be false. Remove in the future
         if ds["x_approximate_distribution"]:
             ds["x_approximate_distribution"] = ds["x_approximate_distribution"].upper()

--- a/backend/portal/api/curation/v1/curation/collections/common.py
+++ b/backend/portal/api/curation/v1/curation/collections/common.py
@@ -78,26 +78,32 @@ def reshape_for_curation_api(
                 collection_version.collection_id
             )
         revising_in = _revising_in.version_id.id if _revising_in else None
+        should_use_canonical_url = True
     else:
         # Unpublished - need to determine if it's a revision or first time collection
         # For that, we look at whether the canonical collection is published
         is_revision = collection_version.canonical_collection.originally_published_at is not None
         if is_revision:
-            # If it's a revision, both collection_id and collection_url need to point to the version_id
+            # If it's a revision, both collection_id and collection_url need to point to the version_id,
+            # and datasets should expose the private url (based on version_id)
             collection_id = collection_version.version_id
             collection_url = f"{get_collections_base_url()}/collections/{collection_id.id}"
             revision_of = collection_version.collection_id.id
+            should_use_canonical_url = False
         else:
             # If it's an unpublished, unrevised collection, then collection_url will point to the permalink
             # (aka the link to the canonical_id) and the collection_id will point to version_id.
-            # Also, revision_of should be None
+            # Also, revision_of should be None, and the datasets should expose the canonical url
             collection_id = collection_version.version_id
             collection_url = f"{get_collections_base_url()}/collections/{collection_version.collection_id}"
             revision_of = None
+            should_use_canonical_url = True
         revising_in = None
 
     # get collection dataset attributes
-    response_datasets = reshape_datasets_for_curation_api(collection_version.datasets, is_published, preview)
+    response_datasets = reshape_datasets_for_curation_api(
+        collection_version.datasets, is_published, should_use_canonical_url, preview
+    )
 
     # build response
     doi, links = extract_doi_from_links(collection_version.metadata.links)
@@ -130,16 +136,21 @@ def reshape_for_curation_api(
 
 
 def reshape_datasets_for_curation_api(
-    datasets: List[Union[DatasetVersionId, DatasetVersion]], is_published: bool, preview: bool = False
+    datasets: List[Union[DatasetVersionId, DatasetVersion]],
+    is_published: bool,
+    should_use_canonical_url: bool,
+    preview: bool = False,
 ) -> List[dict]:
     active_datasets = []
     for dv in datasets:
         dataset_version = get_business_logic().get_dataset_version(dv) if isinstance(dv, DatasetVersionId) else dv
-        active_datasets.append(reshape_dataset_for_curation_api(dataset_version, is_published, preview))
+        active_datasets.append(reshape_dataset_for_curation_api(dataset_version, is_published, should_use_canonical_url, preview))
     return active_datasets
 
 
-def reshape_dataset_for_curation_api(dataset_version: DatasetVersion, is_published: bool, preview=False) -> dict:
+def reshape_dataset_for_curation_api(
+    dataset_version: DatasetVersion, is_published: bool, should_use_canonical_url: bool, preview=False
+) -> dict:
     ds = dict()
 
     # Determine what columns to include from the dataset
@@ -172,7 +183,7 @@ def reshape_dataset_for_curation_api(dataset_version: DatasetVersion, is_publish
         ds["revision"] = 0  # TODO this should be the number of times this dataset has been revised and published
         ds["title"] = ds.pop("name", None)
         ds["is_primary_data"] = is_primary_data_mapping.get(ds.pop("is_primary_data"), [])
-        ds["explorer_url"] = generate_explorer_url(dataset_version)
+        ds["explorer_url"] = generate_explorer_url(dataset_version, should_use_canonical_url)
         ds["tombstone"] = False  # TODO this will always be false. Remove in the future
         if ds["x_approximate_distribution"]:
             ds["x_approximate_distribution"] = ds["x_approximate_distribution"].upper()

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -569,7 +569,7 @@ class TestGetCollectionID(BaseAPIPortalTest):
         expect_dataset["title"] = expect_dataset.pop("name")
         expect_dataset.update(
             **{
-                "explorer_url": f"/e/{dataset.version_id}.cxg/",
+                "explorer_url": f"/e/{dataset.dataset_id}.cxg/",
                 "id": dataset.dataset_id.id,
                 "processing_status": "INITIALIZED",
                 "revision": 0,


### PR DESCRIPTION
CXG links are using canonical dataset ids for collections that are unpublished but not revisions.

### Reviewers
**Functional:** 
@Bento007 

**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
