### PR TITLE
chore: use canonical collection_id in curation API responses

### DIFF
--- a/backend/portal/api/curation/v1/curation/collections/common.py
+++ b/backend/portal/api/curation/v1/curation/collections/common.py
@@ -94,7 +94,7 @@ def reshape_for_curation_api(
             # If it's an unpublished, unrevised collection, then collection_url will point to the permalink
             # (aka the link to the canonical_id) and the collection_id will point to version_id.
             # Also, revision_of should be None, and the datasets should expose the canonical url
-            collection_id = collection_version.version_id
+            collection_id = collection_version.collection_id
             collection_url = f"{get_collections_base_url()}/collections/{collection_version.collection_id}"
             revision_of = None
             use_canonical_url = True

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -710,12 +710,12 @@ class TestGetCollectionID(BaseAPIPortalTest):
         res = self.app.get(f"/curation/v1/collections/{version_id}", headers=self.make_owner_header())
         self.assertEqual(status_code, res.status_code)
         if status_code == 200:
-            self.assertEqual(collection_version.version_id.id, res.json["id"])
+            self.assertEqual(collection_version.collection_id.id, res.json["id"])
 
         res = self.app.get(f"/curation/v1/collections/{collection_id}", headers=self.make_owner_header())
         self.assertEqual(status_code, res.status_code)
         if status_code == 200:
-            self.assertEqual(collection_version.version_id.id, res.json["id"])
+            self.assertEqual(collection_version.collection_id.id, res.json["id"])
 
     def test__get_collection_with_x_approximate_distribution_none__OK(self):
         metadata = copy.deepcopy(self.sample_dataset_metadata)


### PR DESCRIPTION
Curation API only returns version_id for collections that are revisions.

### Reviewers
**Functional:** 
@Bento007 

**Readability:** 

---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
