### PR TITLE
fix: improve dataset identifiers

### DIFF
--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -679,7 +679,7 @@ def get_dataset_identifiers(url: str):
     for version in reversed(list(all_versions)):
         if dataset.version_id in [v.version_id for v in version.datasets]:
             collection_id, dataset_id = version.version_id.id, dataset.version_id.id
-            
+
     if not collection_id or not dataset_id:
         raise NotFoundHTTPException()
 

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1846,14 +1846,12 @@ class TestDataset(BaseAPIPortalTest):
             datasets = response_data["datasets"]
             self.assertIn(returned_dataset_id, [dataset["id"] for dataset in datasets])
 
-        
         with self.subTest("Dataset belonging to a published collection"):
 
             test_uri = "some_uri_1"
 
             dataset = self.generate_dataset(
-                artifacts=[DatasetArtifactUpdate(DatasetArtifactType.CXG, test_uri)],
-                publish=True
+                artifacts=[DatasetArtifactUpdate(DatasetArtifactType.CXG, test_uri)], publish=True
             )
             # In this case, explorer_url points to the canonical link
             explorer_url = f"http://base.url/{dataset.dataset_id}.cxg/"
@@ -1872,14 +1870,12 @@ class TestDataset(BaseAPIPortalTest):
             datasets = response_data["datasets"]
             self.assertIn(returned_dataset_id, [dataset["id"] for dataset in datasets])
 
-        
         with self.subTest("Dataset belonging to a revision of a published collection, not replaced"):
 
             test_uri = "some_uri_2"
 
             dataset = self.generate_dataset(
-                artifacts=[DatasetArtifactUpdate(DatasetArtifactType.CXG, test_uri)],
-                publish=True
+                artifacts=[DatasetArtifactUpdate(DatasetArtifactType.CXG, test_uri)], publish=True
             )
             self.business_logic.create_collection_version(CollectionId(dataset.collection_id))
 
@@ -1905,8 +1901,7 @@ class TestDataset(BaseAPIPortalTest):
             test_uri = "some_uri_1"
 
             dataset = self.generate_dataset(
-                artifacts=[DatasetArtifactUpdate(DatasetArtifactType.CXG, test_uri)],
-                publish=True
+                artifacts=[DatasetArtifactUpdate(DatasetArtifactType.CXG, test_uri)], publish=True
             )
             revision = self.business_logic.create_collection_version(CollectionId(dataset.collection_id))
             revised_dataset = self.generate_dataset(
@@ -1925,8 +1920,10 @@ class TestDataset(BaseAPIPortalTest):
             response_data = json.loads(response.data)
             datasets = response_data["datasets"]
             self.assertIn(revised_dataset.dataset_version_id, [dataset["id"] for dataset in datasets])
-            replaced_dataset = next(dataset for dataset in datasets if dataset["id"] == revised_dataset.dataset_version_id)
-            
+            replaced_dataset = next(
+                dataset for dataset in datasets if dataset["id"] == revised_dataset.dataset_version_id
+            )
+
             explorer_url = replaced_dataset["dataset_deployments"][0]["url"]
 
             test_url = f"/dp/v1/datasets/meta?url={explorer_url}"
@@ -1943,7 +1940,7 @@ class TestDataset(BaseAPIPortalTest):
 
             datasets = response_data["datasets"]
             self.assertIn(returned_dataset_id, [dataset["id"] for dataset in datasets])
-        
+
 
 class TestDatasetCurators(BaseAPIPortalTest):
     def setUp(self):

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -16,6 +16,7 @@ from backend.layers.common.entities import (
     DatasetStatusGeneric,
     DatasetStatusKey,
     DatasetValidationStatus,
+    DatasetVersionId,
     Link,
     OntologyTermId,
 )
@@ -226,6 +227,7 @@ class BaseTest(unittest.TestCase):
         validation_message: str = None,
         artifacts: List[DatasetArtifactUpdate] = None,
         publish: bool = False,
+        replace_dataset_version_id: Optional[DatasetVersionId] = None,
     ) -> DatasetData:
         """
         Convenience method for generating a dataset. Also generates an unpublished collection if needed.
@@ -233,7 +235,7 @@ class BaseTest(unittest.TestCase):
         if not collection_version:
             collection_version = self.generate_unpublished_collection(owner)
         dataset_version_id, dataset_id = self.business_logic.ingest_dataset(
-            collection_version.version_id, "http://fake.url", None, None
+            collection_version.version_id, "http://fake.url", None, replace_dataset_version_id
         )
         if not metadata:
             metadata = copy.deepcopy(self.sample_dataset_metadata)


### PR DESCRIPTION
Improves the `dataset_identifiers` endpoint (aka the meta endpoint). This was previously failing when viewing a replaced dataset in a revision. Also add unit tests to explicitly test the hard-to-test portal <-> explorer integration workflow.