### PR TITLE
fix: support null metadata and double lookup for write datasets

### DIFF
--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -10,6 +10,7 @@ from backend.layers.common.entities import (
     CollectionMetadata,
     CollectionVersion,
     CollectionVersionId,
+    CollectionVersionWithDatasets,
     DatasetArtifact,
     DatasetArtifactId,
     DatasetId,
@@ -29,13 +30,15 @@ class BusinessLogicInterface:
     def get_published_collection_version(self, collection_id: CollectionId) -> CollectionVersion:
         pass
 
-    def get_collection_version(self, version_id: CollectionVersionId) -> CollectionVersion:
+    def get_collection_version(self, version_id: CollectionVersionId) -> CollectionVersionWithDatasets:
         pass
 
     def get_collection_versions_from_canonical(self, collection_id: CollectionId) -> Iterable[CollectionVersion]:
         pass
 
-    def get_collection_version_from_canonical(self, collection_id: CollectionId) -> Optional[CollectionVersion]:
+    def get_collection_version_from_canonical(
+        self, collection_id: CollectionId
+    ) -> Optional[CollectionVersionWithDatasets]:
         pass
 
     def create_collection(

--- a/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
+++ b/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
@@ -79,13 +79,13 @@ def _get_collection_and_dataset(
         dataset_version = next(
             d for d in collection_version.datasets if d.version_id.id == dataset_id or d.dataset_id.id == dataset_id
         )
-    except Exception:
+    except StopIteration:
         raise ForbiddenHTTPException()
 
     return collection_version, dataset_version
 
 
-def delete(token_info: dict, collection_id: str, dataset_id: str = None):
+def delete(token_info: dict, collection_id: str, dataset_id: str):
     business_logic = get_business_logic()
     user_info = UserInfo(token_info)
 

--- a/backend/portal/api/curation/v1/curation/collections/common.py
+++ b/backend/portal/api/curation/v1/curation/collections/common.py
@@ -162,14 +162,16 @@ def reshape_dataset_for_curation_api(
     else:
         columns = EntityColumns.dataset_metadata_cols
 
-    # Get dataset metadata fields
-    for column in columns:
-        col = getattr(dataset_version.metadata, column)
-        if isinstance(col, OntologyTermId):
-            col = [asdict(col)]
-        elif isinstance(col, list) and len(col) != 0 and isinstance(col[0], OntologyTermId):
-            col = [asdict(i) for i in col]
-        ds[column] = col
+    # Get dataset metadata fields.
+    # Metadata can be None if the dataset isn't still fully processed, so we account for that
+    if dataset_version.metadata is not None:
+        for column in columns:
+            col = getattr(dataset_version.metadata, column)
+            if isinstance(col, OntologyTermId):
+                col = [asdict(col)]
+            elif isinstance(col, list) and len(col) != 0 and isinstance(col[0], OntologyTermId):
+                col = [asdict(i) for i in col]
+            ds[column] = col
 
     # Get none preview specific dataset fields
     if not preview:

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -961,18 +961,29 @@ class TestDeleteDataset(BaseAPIPortalTest):
         ]
         for auth, auth_description, expected_status_code in auth_credentials:
             with self.subTest(f"{auth_description} {expected_status_code}"):
-                dataset = self.generate_dataset(
-                    statuses=[DatasetStatusUpdate(DatasetStatusKey.UPLOAD, DatasetUploadStatus.UPLOADING)],
-                    publish=False,
-                )
+                with self.subTest("with version_ids"):
+                    dataset = self.generate_dataset(
+                        statuses=[DatasetStatusUpdate(DatasetStatusKey.UPLOAD, DatasetUploadStatus.UPLOADING)],
+                        publish=False,
+                    )
 
-                test_url = (
-                    f"/curation/v1/collections/{dataset.collection_version_id}/datasets/"
-                    f"{dataset.dataset_version_id}"
-                )
-                headers = auth() if callable(auth) else auth
-                response = self.app.delete(test_url, headers=headers)
-                self.assertEqual(expected_status_code, response.status_code)
+                    test_url = (
+                        f"/curation/v1/collections/{dataset.collection_version_id}/datasets/"
+                        f"{dataset.dataset_version_id}"
+                    )
+                    headers = auth() if callable(auth) else auth
+                    response = self.app.delete(test_url, headers=headers)
+                    self.assertEqual(expected_status_code, response.status_code)
+                with self.subTest("with version_ids"):
+                    dataset = self.generate_dataset(
+                        statuses=[DatasetStatusUpdate(DatasetStatusKey.UPLOAD, DatasetUploadStatus.UPLOADING)],
+                        publish=False,
+                    )
+
+                    test_url = f"/curation/v1/collections/{dataset.collection_id}/datasets/" f"{dataset.dataset_id}"
+                    headers = auth() if callable(auth) else auth
+                    response = self.app.delete(test_url, headers=headers)
+                    self.assertEqual(expected_status_code, response.status_code)
 
 
 class TestGetDatasets(BaseAPIPortalTest):
@@ -1191,17 +1202,31 @@ class TestPutLink(BaseAPIPortalTest):
         Calling PUT /datasets/:dataset_id should succeed if a valid link is uploaded by the owner of the collection
         """
 
-        dataset = self.generate_dataset(
-            statuses=[DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)],
-        )
-        body = {"link": self.good_link}
-        headers = self.make_owner_header()
-        response = self.app.put(
-            f"/curation/v1/collections/{dataset.collection_version_id}/datasets/{dataset.dataset_version_id}",
-            json=body,
-            headers=headers,
-        )
-        self.assertEqual(202, response.status_code)
+        with self.subTest("with version_ids"):
+            dataset = self.generate_dataset(
+                statuses=[DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)],
+            )
+            body = {"link": self.good_link}
+            headers = self.make_owner_header()
+            response = self.app.put(
+                f"/curation/v1/collections/{dataset.collection_version_id}/datasets/{dataset.dataset_version_id}",
+                json=body,
+                headers=headers,
+            )
+            self.assertEqual(202, response.status_code)
+
+        with self.subTest("with collection_ids"):
+            dataset = self.generate_dataset(
+                statuses=[DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)],
+            )
+            body = {"link": self.good_link}
+            headers = self.make_owner_header()
+            response = self.app.put(
+                f"/curation/v1/collections/{dataset.collection_id}/datasets/{dataset.dataset_id}",
+                json=body,
+                headers=headers,
+            )
+            self.assertEqual(202, response.status_code)
 
     def test__new_from_link__Super_Curator(self, *mocks):
         """

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -952,35 +952,50 @@ class TestPatchCollectionID(BaseAPIPortalTest):
 
 
 class TestDeleteDataset(BaseAPIPortalTest):
-    def test__delete_dataset(self):
-        auth_credentials = [
+    def setUp(self):
+        super().setUp()
+        self.auth_credentials = [
             (self.make_super_curator_header, "super", 202),
             (self.make_owner_header, "owner", 202),
             (None, "none", 401),
             (self.make_not_owner_header, "not_owner", 403),
         ]
 
-        def _delete(collection_id, dataset_id):
-            test_url = f"/curation/v1/collections/{collection_id}/datasets/{dataset_id}"
-            headers = auth() if callable(auth) else auth
-            return self.app.delete(test_url, headers=headers)
+    def _delete(self, auth, collection_id, dataset_id):
+        """
+        Helper method to call the delete endpoint
+        """
+        test_url = f"/curation/v1/collections/{collection_id}/datasets/{dataset_id}"
+        headers = auth() if callable(auth) else auth
+        return self.app.delete(test_url, headers=headers)
 
-        for auth, auth_description, expected_status_code in auth_credentials:
+    def test__delete_dataset_by_version_id(self):
+        """
+        Calling DELETE /collections/:collection_id/datasets/:dataset_id should work according to the
+        auth token passed and when using versioned ids
+        """
+        for auth, auth_description, expected_status_code in self.auth_credentials:
             with self.subTest(f"{auth_description} {expected_status_code}"):
-                # with version ids
                 dataset = self.generate_dataset(
                     statuses=[DatasetStatusUpdate(DatasetStatusKey.UPLOAD, DatasetUploadStatus.UPLOADING)],
                     publish=False,
                 )
-                response = _delete(dataset.collection_version_id, dataset.dataset_version_id)
+                response = self._delete(auth, dataset.collection_version_id, dataset.dataset_version_id)
                 self.assertEqual(expected_status_code, response.status_code)
 
-                # with canonical ids
+    def test__delete_dataset_by_canonical_id(self):
+        """
+        Calling DELETE /collections/:collection_id/datasets/:dataset_id should work according to the
+        auth token passed and when using canonical ids. In this case, the unpublished collection
+        version will be looked up and used for deletion.
+        """
+        for auth, auth_description, expected_status_code in self.auth_credentials:
+            with self.subTest(f"{auth_description} {expected_status_code}"):
                 dataset = self.generate_dataset(
                     statuses=[DatasetStatusUpdate(DatasetStatusKey.UPLOAD, DatasetUploadStatus.UPLOADING)],
                     publish=False,
                 )
-                response = _delete(dataset.collection_id, dataset.dataset_id)
+                response = self._delete(auth, dataset.collection_id, dataset.dataset_id)
                 self.assertEqual(expected_status_code, response.status_code)
 
 


### PR DESCRIPTION
### Reviewers
**Functional:** 
@Bento007 

**Readability:** 

---

1. In Curation API's `GET collection`, support the case where `metadata = None`. This is necessary if the endpoint is queried before the dataset is fully ingested
2. Add support for double lookup in operations that involve updating datasets: PUT and DELETE. Previously this wasn't required as they were only accessed via the version_id. The double lookup here isn't ideal but it will work since the only change is for unpublished, not revised collection, for which only a version exists.