### PR TITLE
fix: Portal Get /collections

### DIFF
--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -73,18 +73,18 @@ def get_collections_list(from_date: int = None, to_date: int = None, token_info:
         )
 
     collections = []
-    for c in itertools.chain(all_published_collections, all_owned_collections):
+    for version in itertools.chain(all_published_collections, all_owned_collections):
         collection = {
-            "visibility": "PRIVATE" if c.published_at is None else "PUBLIC",
-            "owner": c.owner,
-            "created_at": c.created_at,
+            "visibility": "PRIVATE" if version.published_at is None else "PUBLIC",
+            "owner": version.owner,
+            "created_at": version.created_at,
         }
-        if c.is_unpublished_version():
-            collection["id"] = c.version_id.id
+        if version.is_unpublished_version():
+            collection["id"] = version.version_id.id
         else:
-            collection["id"] = c.collection_id.id
-        if not c.is_published():
-            collection["revision_of"] = c.collection_id.id
+            collection["id"] = version.collection_id.id
+        if not version.is_published():
+            collection["revision_of"] = version.collection_id.id
         collections.append(collection)
 
     result = {"collections": collections}

--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -75,12 +75,15 @@ def get_collections_list(from_date: int = None, to_date: int = None, token_info:
     collections = []
     for c in itertools.chain(all_published_collections, all_owned_collections):
         collection = {
-            "id": c.version_id.id if c.published_at is None else c.collection_id.id,
             "visibility": "PRIVATE" if c.published_at is None else "PUBLIC",
             "owner": c.owner,
             "created_at": c.created_at,
         }
-        if c.published_at is None:
+        if c.published_at is not None or c.canonical_collection.originally_published_at is None:
+            collection["id"] = c.collection_id.id
+        else:
+            collection["id"] = c.version_id.id
+        if c.published_at is None and c.canonical_collection.originally_published_at is not None:
             collection["revision_of"] = c.collection_id.id
         collections.append(collection)
 

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -247,6 +247,7 @@ class CollectionVersionBase:
     def is_published(self) -> bool:
         """
         This collection version has been published.
+        TODO: After old API code is removed consider moving closer to API layer
         """
         if self.published_at is not None:
             return True
@@ -254,15 +255,21 @@ class CollectionVersionBase:
             return False
 
     def is_unpublished_version(self) -> bool:
-        """The collection has been published, and this is a unpublished version of the collection."""
+        """
+        The collection has been published, and this is a unpublished version of the collection.
+        TODO: After old API code is removed consider moving closer to API layer
+        """
         if self.canonical_collection.originally_published_at is not None and not self.is_published():
             return True
         else:
             return False
 
     def is_initial_unpublished_version(self) -> bool:
-        """The collection is unpublished, this version is unpublished, and no previous versions have been
-        published."""
+        """
+        The collection is unpublished, this version is unpublished, and no previous versions have been
+        published.
+        TODO: After old API code is removed consider moving closer to API layer
+        """
         if not self.is_published() and self.canonical_collection.originally_published_at is None:
             return True
         else:

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -244,6 +244,30 @@ class CollectionVersionBase:
     created_at: datetime
     canonical_collection: CanonicalCollection
 
+    def is_published(self) -> bool:
+        """
+        This collection version has been published.
+        """
+        if self.published_at is not None:
+            return True
+        else:
+            return False
+
+    def is_unpublished_version(self) -> bool:
+        """The collection has been published, and this is a unpublished version of the collection."""
+        if self.canonical_collection.originally_published_at is not None and not self.is_published():
+            return True
+        else:
+            return False
+
+    def is_initial_unpublished_version(self) -> bool:
+        """The collection is unpublished, this version is unpublished, and no previous versions have been
+        published."""
+        if not self.is_published() and self.canonical_collection.originally_published_at is None:
+            return True
+        else:
+            return False
+
 
 @dataclass
 class CollectionVersion(CollectionVersionBase):

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -680,13 +680,13 @@ class TestCollection(BaseAPIPortalTest):
     def test__list_collection__check_owner(self):
 
         # Generate test collection
-        public_owned = self.generate_published_collection(owner="test_user_id").collection_id
-        private_owned = self.generate_unpublished_collection(owner="test_user_id").version_id
-        public_not_owned = self.generate_published_collection(owner="someone else").collection_id
-        private_not_owned = self.generate_unpublished_collection(owner="someone else").version_id
+        public_owned = self.generate_published_collection(owner="test_user_id")
+        private_owned = self.generate_unpublished_collection(owner="test_user_id")
+        public_not_owned = self.generate_published_collection(owner="someone else")
+        private_not_owned = self.generate_unpublished_collection(owner="someone else")
 
-        revision_not_owned = self.business_logic.create_collection_version(public_not_owned).version_id
-        revision_owned = self.business_logic.create_collection_version(public_owned).version_id
+        revision_not_owned = self.business_logic.create_collection_version(public_not_owned.collection_id)
+        revision_owned = self.business_logic.create_collection_version(public_owned.collection_id)
 
         path = "/dp/v1/collections"
         with self.subTest("no auth"):
@@ -697,11 +697,18 @@ class TestCollection(BaseAPIPortalTest):
             collections = result.get("collections")
             self.assertIsNotNone(collections)
             ids = [collection.get("id") for collection in collections]
-            self.assertIn(public_owned.id, ids)
-            self.assertIn(public_not_owned.id, ids)
-            self.assertNotIn(private_owned.id, ids)
-            self.assertNotIn(private_not_owned.id, ids)
-            self.assertNotIn(revision_owned.id, ids)
+            self.assertIn(public_owned.collection_id.id, ids)
+            self.assertNotIn(public_owned.version_id.id, ids)
+            self.assertIn(public_not_owned.collection_id.id, ids)
+            self.assertIn(public_not_owned.version_id.id, ids)
+            self.assertNotIn(private_owned.collection_id.id, ids)
+            self.assertNotIn(private_owned.version_id.id, ids)
+            self.assertNotIn(private_not_owned.collection_id.id, ids)
+            self.assertNotIn(private_not_owned.version_id.id, ids)
+            self.assertNotIn(revision_owned.collection_id.id, ids)
+            self.assertNotIn(revision_owned.version_id.id, ids)
+            self.assertNotIn(revision_not_owned.collection_id.id, ids)
+            self.assertNotIn(revision_not_owned.version_id.id, ids)
 
         with self.subTest("auth"):
             headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
@@ -711,12 +718,18 @@ class TestCollection(BaseAPIPortalTest):
             collections = result.get("collections")
             self.assertIsNotNone(collections)
             ids = [collection.get("id") for collection in collections]
-            self.assertIn(public_owned.id, ids)
-            self.assertIn(public_not_owned.id, ids)
-            self.assertIn(private_owned.id, ids)
-            self.assertNotIn(private_not_owned.id, ids)
-            self.assertNotIn(revision_not_owned.id, ids)
-            self.assertIn(revision_owned.id, ids)
+            self.assertIn(public_owned.collection_id.id, ids)
+            self.assertNotIn(public_owned.version_id.id, ids)
+            self.assertIn(public_not_owned.collection_id.id, ids)
+            self.assertNotIn(public_not_owned.version_id.id, ids)
+            self.assertIn(private_owned.collection_id.id, ids)
+            self.assertNotIn(private_owned.version_id.id, ids)
+            self.assertNotIn(private_not_owned.collection_id.id, ids)
+            self.assertNotIn(private_not_owned.version_id.id, ids)
+            self.assertNotIn(revision_owned.collection_id.id, ids)
+            self.assertIn(revision_owned.version_id.id, ids)
+            self.assertNotIn(revision_not_owned.collection_id.id, ids)
+            self.assertNotIn(revision_not_owned.version_id.id, ids)
             self.assertTrue(
                 [collection for collection in collections if collection.get("revision_of") == public_owned.id][0]
             )
@@ -931,9 +944,9 @@ class TestCollectionDeletion(BaseAPIPortalTest):
         response = self.app.get("/dp/v1/collections", headers=headers)
 
         collection_ids = [collection["id"] for collection in json.loads(response.data)["collections"]]
-        self.assertIn(private_collection.version_id.id, collection_ids)
+        self.assertIn(private_collection.collection_id.id, collection_ids)
         self.assertIn(public_collection.collection_id.id, collection_ids)
-        self.assertIn(collection_to_delete.version_id.id, collection_ids)
+        self.assertIn(collection_to_delete.collection_id.id, collection_ids)
 
         test_url = furl(
             path=f"/dp/v1/collections/{collection_to_delete.version_id.id}", query_params=dict(visibility="PRIVATE")
@@ -944,18 +957,19 @@ class TestCollectionDeletion(BaseAPIPortalTest):
         # check not returned privately
         response = self.app.get("/dp/v1/collections", headers=headers)
         collection_ids = [collection["id"] for collection in json.loads(response.data)["collections"]]
-        self.assertIn(private_collection.version_id.id, collection_ids)
+        self.assertIn(private_collection.collection_id.id, collection_ids)
         self.assertIn(public_collection.collection_id.id, collection_ids)
-
         self.assertNotIn(collection_to_delete.version_id.id, collection_ids)
+        self.assertNotIn(collection_to_delete.collection_id.id, collection_ids)
 
         # check not returned publicly
         headers = {"host": "localhost", "Content-Type": "application/json"}
         response = self.app.get("/dp/v1/collections", headers=headers)
         collection_ids = [collection["id"] for collection in json.loads(response.data)["collections"]]
         self.assertIn(public_collection.collection_id.id, collection_ids)
-        self.assertNotIn(private_collection.version_id.id, collection_ids)
+        self.assertNotIn(private_collection.collection_id.id, collection_ids)
         self.assertNotIn(collection_to_delete.version_id.id, collection_ids)
+        self.assertNotIn(collection_to_delete.collection_id.id, collection_ids)
 
 
 class TestUpdateCollection(BaseAPIPortalTest):

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -726,9 +726,7 @@ class TestCollection(BaseAPIPortalTest):
         collections = result.get("collections")
         self.assertIsNotNone(collections)
         ids = [collection.get("id") for collection in collections]
-        revision_ids = [
-            collection for collection in collections if collection.get("revision_of") == public_owned.collection_id.id
-        ]
+        revision_ids = [collection.get("revision_of") for collection in collections if collection.get("revision_of")]
         self.assertIn(public_owned.collection_id.id, ids)
         self.assertNotIn(public_owned.version_id.id, ids)
         self.assertIn(public_not_owned.collection_id.id, ids)
@@ -739,7 +737,7 @@ class TestCollection(BaseAPIPortalTest):
         self.assertNotIn(private_not_owned.version_id.id, ids)
         self.assertIn(revision_owned.version_id.id, ids)
         self.assertNotIn(revision_not_owned.version_id.id, ids)
-        self.assertTrue(revision_ids[0])
+        self.assertIn(public_owned.collection_id.id, revision_ids)
 
     # ✅
     def test__get_all_collections_for_index(self):

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -697,17 +697,16 @@ class TestCollection(BaseAPIPortalTest):
             collections = result.get("collections")
             self.assertIsNotNone(collections)
             ids = [collection.get("id") for collection in collections]
+
             self.assertIn(public_owned.collection_id.id, ids)
             self.assertNotIn(public_owned.version_id.id, ids)
             self.assertIn(public_not_owned.collection_id.id, ids)
-            self.assertIn(public_not_owned.version_id.id, ids)
+            self.assertNotIn(public_not_owned.version_id.id, ids)
             self.assertNotIn(private_owned.collection_id.id, ids)
             self.assertNotIn(private_owned.version_id.id, ids)
             self.assertNotIn(private_not_owned.collection_id.id, ids)
             self.assertNotIn(private_not_owned.version_id.id, ids)
-            self.assertNotIn(revision_owned.collection_id.id, ids)
             self.assertNotIn(revision_owned.version_id.id, ids)
-            self.assertNotIn(revision_not_owned.collection_id.id, ids)
             self.assertNotIn(revision_not_owned.version_id.id, ids)
 
         with self.subTest("auth"):
@@ -726,12 +725,14 @@ class TestCollection(BaseAPIPortalTest):
             self.assertNotIn(private_owned.version_id.id, ids)
             self.assertNotIn(private_not_owned.collection_id.id, ids)
             self.assertNotIn(private_not_owned.version_id.id, ids)
-            self.assertNotIn(revision_owned.collection_id.id, ids)
             self.assertIn(revision_owned.version_id.id, ids)
-            self.assertNotIn(revision_not_owned.collection_id.id, ids)
             self.assertNotIn(revision_not_owned.version_id.id, ids)
             self.assertTrue(
-                [collection for collection in collections if collection.get("revision_of") == public_owned.id][0]
+                [
+                    collection
+                    for collection in collections
+                    if collection.get("revision_of") == public_owned.collection_id.id
+                ][0]
             )
 
     # ✅


### PR DESCRIPTION
- #TICKET_NUMBER

### Reviewers
**Functional:** @ebezzi 

**Readability:** 

---


## Changes
- We need to return the canonical collection_id for a new unpublished collections when list all the collections. This technically isn't user facing problem but it would mean we no longer have working functional test if we don't fix this way. Since we do not openly disclose the version ID we wont be able to determine if a collection was successfully listed by get collection since creating a collection only return the canonical collection ID.


## QA steps (optional)
Updated the unit test to reflect the ID that should be returned when listing collections.
## Notes for Reviewer
