### PR TITLE
fix: local dev database config / secret name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ local-status: ## Show the status of the containers in the dev environment.
 
 .PHONY: local-rebuild
 local-rebuild: .env.ecr local-ecr-login ## Rebuild local dev without re-importing data
-	docker-compose $(COMPOSE_OPTS) build frontend backend processing wmg_processing
+	docker-compose $(COMPOSE_OPTS) build frontend backend processing wmg_processing database oidc localstack
 	docker-compose $(COMPOSE_OPTS) up -d frontend backend processing database oidc localstack
 
 local-rebuild-backend: .env.ecr local-ecr-login

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Environment variables are set using the command `export <name>=<value>`. For exa
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
 | `DEPLOYMENT_STAGE`  | Specifies an app deployment stage for tasks such as deployments and functional tests. The `test` value implies local Docker development environment (and should probably be renamed `local`). | `test`, `dev`, `staging`, `prod`      |
 | `AWS_PROFILE`       | Specifies the profile used to interact with AWS resources via the awscli.                                                                                                                     | `single-cell-dev`, `single-cell-prod` |
-| `CORPORA_LOCAL_DEV` | Flag: If this variable is set to any value, the app will look for the database on **localhost:5432** and will use the aws secret `corpora/backend/\${DEPLOYMENT_STAGE}/database_local`.       | Any                                   |
+| `CORPORA_LOCAL_DEV` | Flag: If this variable is set to any value, the app will look for the database on **localhost:5432** and will use the aws secret `corpora/backend/\${DEPLOYMENT_STAGE}/database`.       | Any                                   |
 
 ### Database Procedures
 

--- a/backend/common/corpora_config.py
+++ b/backend/common/corpora_config.py
@@ -41,7 +41,7 @@ class CorporaDbConfig(SecretConfig):
     def __init__(self, *args, **kwargs):
         super().__init__(
             component_name="backend",
-            secret_name=f"database{'_local' if 'CORPORA_LOCAL_DEV' in os.environ else ''}",
+            secret_name=f"database",
             **kwargs,
         )
 

--- a/backend/common/corpora_config.py
+++ b/backend/common/corpora_config.py
@@ -41,7 +41,7 @@ class CorporaDbConfig(SecretConfig):
     def __init__(self, *args, **kwargs):
         super().__init__(
             component_name="backend",
-            secret_name=f"database",
+            secret_name="database",
             **kwargs,
         )
 

--- a/backend/database/README.md
+++ b/backend/database/README.md
@@ -115,4 +115,4 @@ AWS_PROFILE=single-cell-{dev,prod} DEPLOYMENT_STAGE={dev,staging,prod} make db/t
 This command opens an SSH tunnel from `localhost:5432` to the RDS connection endpoint via the _bastion_ server.
 The local port `5432` is fixed and encoded in the DB connection string stored in
 [AWS Secrets Manager](https://us-west-2.console.aws.amazon.com/secretsmanager/home?region=us-west-2#!/listSecrets/)
-in the secret named `corpora/backend/${DEPLOYMENT_STAGE}/database_local`.
+in the secret named `corpora/backend/${DEPLOYMENT_STAGE}/database`.


### PR DESCRIPTION
Recent commit 4e6c4e2876 simplified the '../database_local' secret name to '../database'. However, local dev case exceptions still caused the database config to look for a '../database_local' secret.

- #3984 

### Reviewers
**Functional:** 
@Bento007 
**Readability:** 
@ebezzi 
---


## Changes
- add
- remove
- modify

## QA steps (optional)

## Notes for Reviewer
