### PR TITLE
fix: handle null metadata in curation API GET collection (take 2)

### DIFF
--- a/backend/portal/api/curation/v1/curation/collections/common.py
+++ b/backend/portal/api/curation/v1/curation/collections/common.py
@@ -187,11 +187,12 @@ def reshape_dataset_for_curation_api(
         ds["revision_of"] = None if is_published else dataset_version.canonical_dataset.dataset_version_id.id
         ds["revision"] = 0  # TODO this should be the number of times this dataset has been revised and published
         ds["title"] = ds.pop("name", None)
-        ds["is_primary_data"] = is_primary_data_mapping.get(ds.pop("is_primary_data"), [])
         ds["explorer_url"] = generate_explorer_url(dataset_version, use_canonical_url)
         ds["tombstone"] = False  # TODO this will always be false. Remove in the future
-        if ds["x_approximate_distribution"]:
-            ds["x_approximate_distribution"] = ds["x_approximate_distribution"].upper()
+        if dataset_version.metadata is not None:
+            ds["is_primary_data"] = is_primary_data_mapping.get(ds.pop("is_primary_data"), [])
+            if ds["x_approximate_distribution"]:
+                ds["x_approximate_distribution"] = ds["x_approximate_distribution"].upper()
         if status := dataset_version.status:
             if status.processing_status == DatasetProcessingStatus.FAILURE:
                 if status.validation_status == DatasetValidationStatus.INVALID:

--- a/scripts/setup_dev_data.sh
+++ b/scripts/setup_dev_data.sh
@@ -103,7 +103,7 @@ snapshot_identifier='dummy-snapshot'
 wmg_bucket="wmg-test"
 wmg_config_secret_name="corpora/backend/test/wmg_config"
 python3 -m tests.unit.backend.wmg.fixtures.test_snapshot ${tmp_snapshot_dir}
-${local_aws} s3api create-bucket --bucket ${wmg_bucket} &>/dev/null || true
+${local_aws} s3api create-bsucket --bucket ${wmg_bucket} &>/dev/null || true
 ${local_aws} s3 sync --delete --quiet ${tmp_snapshot_dir} s3://${wmg_bucket}/$snapshot_identifier/
 echo $snapshot_identifier | ${local_aws} s3 cp --quiet - s3://${wmg_bucket}/latest_snapshot_identifier
 ${local_aws} secretsmanager create-secret --name ${wmg_config_secret_name} &>/dev/null || true

--- a/scripts/setup_dev_data.sh
+++ b/scripts/setup_dev_data.sh
@@ -103,7 +103,7 @@ snapshot_identifier='dummy-snapshot'
 wmg_bucket="wmg-test"
 wmg_config_secret_name="corpora/backend/test/wmg_config"
 python3 -m tests.unit.backend.wmg.fixtures.test_snapshot ${tmp_snapshot_dir}
-${local_aws} s3api create-bsucket --bucket ${wmg_bucket} &>/dev/null || true
+${local_aws} s3api create-bucket --bucket ${wmg_bucket} &>/dev/null || true
 ${local_aws} s3 sync --delete --quiet ${tmp_snapshot_dir} s3://${wmg_bucket}/$snapshot_identifier/
 echo $snapshot_identifier | ${local_aws} s3 cp --quiet - s3://${wmg_bucket}/latest_snapshot_identifier
 ${local_aws} secretsmanager create-secret --name ${wmg_config_secret_name} &>/dev/null || true

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -682,7 +682,6 @@ class TestGetCollectionID(BaseAPIPortalTest):
         self.business_logic.create_empty_dataset(collection_version.version_id)
         self._test_response(collection_version)
 
-
     def test__get_public_collection_with_auth_access_type_write__OK(self):
         """The Canonical Collection id should be returned"""
         collection_version = self.generate_published_collection()

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -673,6 +673,16 @@ class TestGetCollectionID(BaseAPIPortalTest):
         collection_version = self.generate_unpublished_collection(add_datasets=0)
         self._test_response(collection_version)
 
+    def test_get_colletion_with_dataset_no_metadata(self):
+        """
+        GET collection should work when the collection has datasets with no metadata.
+        This happens when the dataset did not complete ingestion yet.
+        """
+        collection_version = self.generate_unpublished_collection(add_datasets=0)
+        self.business_logic.create_empty_dataset(collection_version.version_id)
+        self._test_response(collection_version)
+
+
     def test__get_public_collection_with_auth_access_type_write__OK(self):
         """The Canonical Collection id should be returned"""
         collection_version = self.generate_published_collection()


### PR DESCRIPTION
### Reviewers
**Functional:** 
@Bento007 

**Readability:** 

---


## Changes
- In the `GET /collections/:collection_id` endpoint, handle additional cases where the endpoint breaks when the metadata is null
- Add a unit test for this case 
