### PR TITLE
fix: add double lookup in dataset submissions lambda

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -520,3 +520,26 @@ class BusinessLogic(BusinessLogicInterface):
 
     def get_dataset_version_from_canonical(self, dataset_id: DatasetId) -> Optional[DatasetVersion]:
         return self.database_provider.get_dataset_mapped_version(dataset_id)
+
+    def _get_collection_and_dataset(
+        self, collection_id: str, dataset_id: str
+    ) -> Tuple[CollectionVersionWithDatasets, DatasetVersion]:
+        """
+        Get collection and dataset by their ids. Will look up by both version and canonical id for both.
+        """
+
+        collection_version = self.get_collection_version_from_canonical(CollectionId(collection_id))
+        if collection_version is None:
+            collection_version = self.get_collection_version(CollectionVersionId(collection_id))
+        if collection_version is None:
+            raise CollectionNotFoundException()
+
+        # Extract the dataset from the dataset list.
+        try:
+            dataset_version = next(
+                d for d in collection_version.datasets if d.version_id.id == dataset_id or d.dataset_id.id == dataset_id
+            )
+        except StopIteration:
+            raise DatasetNotFoundException()
+
+        return collection_version, dataset_version

--- a/tests/unit/processing/test_dataset_submissions.py
+++ b/tests/unit/processing/test_dataset_submissions.py
@@ -75,6 +75,20 @@ class TestDatasetSubmissions(BaseTest):
         dataset_submissions_handler(s3_event, None)
         mock_ingest.assert_called()
 
+    def test__upload_update_by_dataset_canonical_id__OK(self):
+        """
+        Processing starts when an update of a dataset is uploaded using canonical ids
+
+        """
+        version = self.generate_unpublished_collection()
+        _, dataset_id = self.business_logic.create_empty_dataset(version.version_id)
+
+        mock_ingest = self.business_logic.ingest_dataset = Mock()
+
+        s3_event = create_s3_event(key=f"{self.user_name}/{version.collection_id}/{dataset_id}")
+        dataset_submissions_handler(s3_event, None)
+        mock_ingest.assert_called()
+
 
 def create_s3_event(bucket_name: str = "some_bucket", key: str = "", size: int = 0) -> dict:
     """


### PR DESCRIPTION
### Reviewers
**Functional:** 
@Bento007 

**Readability:** 

---


## Changes
- Add double lookup for both collection and version id in the dataset submissions lambda. This is required since for non-revisions, the curation API will use the canonical ids now.

## QA steps (optional)
Cannot be easily be tested in rdev. The unit test should suffice, but this should be retested using the local upload notebook once in dev.