### PR TITLE
fix(curation api): GET /collections/{collection_id}/datasets/{dataset_id}

### DIFF
--- a/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/actions.py
+++ b/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/actions.py
@@ -19,6 +19,6 @@ def post(token_info: dict, collection_id: str):
     if collection_version.published_at is not None:
         raise MethodNotAllowedException("Collection must be PRIVATE Collection, or a revision of a PUBLIC Collection.")
 
-    dataset_id, _ = business_logic.create_empty_dataset(collection_version.version_id)
+    _, dataset_id = business_logic.create_empty_dataset(collection_version.version_id)
 
     return make_response(jsonify({"id": dataset_id.id}), 201)

--- a/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
+++ b/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
@@ -50,14 +50,9 @@ def get(collection_id: str, dataset_id: str = None):
     # A canonical url should be only used in two cases:
     # 1. the collection version is unpublished but it's not a revision
     # 2. the collection version is published
-    use_canonical_url = (
-        collection_version.canonical_collection.originally_published_at is None
-        or collection_version.published_at is not None
-    )
+    use_canonical_url = collection_version.is_initial_unpublished_version() or collection_version.is_published()
 
-    response_body = reshape_dataset_for_curation_api(
-        version, collection_version.published_at is not None, use_canonical_url
-    )
+    response_body = reshape_dataset_for_curation_api(version, collection_version.is_published(), use_canonical_url)
     return make_response(jsonify(response_body), 200)
 
 

--- a/backend/portal/api/curation/v1/curation/collections/common.py
+++ b/backend/portal/api/curation/v1/curation/collections/common.py
@@ -184,7 +184,11 @@ def reshape_dataset_for_curation_api(
         ds["dataset_assets"] = assets
         ds["processing_status_detail"] = dataset_version.status.validation_message
         ds["revised_at"] = dataset_version.canonical_dataset.revised_at
-        ds["revision_of"] = None if is_published else dataset_version.canonical_dataset.dataset_version_id.id
+        ds["revision_of"] = (
+            None
+            if dataset_version.canonical_dataset.dataset_version_id == dataset_version.version_id
+            else dataset_version.dataset_id.id
+        )
         ds["revision"] = 0  # TODO this should be the number of times this dataset has been revised and published
         ds["title"] = ds.pop("name", None)
         ds["explorer_url"] = generate_explorer_url(dataset_version, use_canonical_url)

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 
 from backend.layers.business.business import BusinessLogic
 from backend.layers.common.entities import (
+    CollectionId,
     CollectionMetadata,
     CollectionVersion,
     CollectionVersionWithDatasets,
@@ -213,7 +214,7 @@ class BaseTest(unittest.TestCase):
         self.business_logic.publish_collection_version(unpublished_collection.version_id)
         return self.business_logic.get_collection_version(unpublished_collection.version_id)
 
-    def generate_revision(self, collection_id: str) -> CollectionVersionWithDatasets:
+    def generate_revision(self, collection_id: CollectionId) -> CollectionVersionWithDatasets:
         revision = self.business_logic.create_collection_version(collection_id)
         return self.business_logic.get_collection_version(revision.version_id)
 


### PR DESCRIPTION

- #TICKET_NUMBER

### Reviewers
**Functional:** @ebezzi 

**Readability:** @nayib-jose-gloria 

---


## Changes
- added tests for revision_of in GET /collections/{collection_id}/datasets/{dataset_id}
- revision_of only refers to the published dataset when revising a dataset. Otherwise it is NULL.
- fix typing in test code


## QA steps (optional)

## Notes for Reviewer
