### PR TITLE
chore: POST /datasets returns the canonical dataset_id

### DIFF
--- a/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/actions.py
+++ b/backend/portal/api/curation/v1/curation/collections/collection_id/datasets/actions.py
@@ -19,6 +19,6 @@ def post(token_info: dict, collection_id: str):
     if collection_version.published_at is not None:
         raise MethodNotAllowedException("Collection must be PRIVATE Collection, or a revision of a PUBLIC Collection.")
 
-    dataset_id, _ = business_logic.create_empty_dataset(collection_version.version_id)
+    _, dataset_id = business_logic.create_empty_dataset(collection_version.version_id)
 
     return make_response(jsonify({"id": dataset_id.id}), 201)


### PR DESCRIPTION
### Reviewers
**Functional:**
@Bento007 @nayib-jose-gloria  

**Readability:** 

---


## Changes
- `POST /datasets` returns the canonical dataset id instead of the dataset version_id
