### PR TITLE
fix: check whether revision's consortia list has changed when determining whether collection has updates

### DIFF
--- a/frontend/src/common/utils/checkForRevisionChange.ts
+++ b/frontend/src/common/utils/checkForRevisionChange.ts
@@ -16,6 +16,7 @@ const IGNORED_COLLECTION_FIELDS = [
   "datasets",
   "genesets",
   "links",
+  "consortia",
 ] as Array<keyof Collection>;
 const IGNORED_DATASET_FIELDS = [
   "created_at",
@@ -113,6 +114,10 @@ export default function checkForRevisionChange(
   if (publishedCollection.links.length !== revision.links.length) return true;
   //Check links for differences
   if (checkListForChanges(revision.links, publishedCollection.links))
+    return true;
+  //Check consortia for differences
+  if (publishedCollection.consortia.length !== revision.consortia.length) return true;
+  if (checkListForChanges(revision.consortia, publishedCollection.consortia))
     return true;
 
   if (


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

## Changes
- update checkRevisionForChanges function that runs when fetching a revision. 'consortia' field check was triggering 'updated' messages on all revisions because the comparison between revision vs. published collection was treating it as a scalar (rather than a list). Now, it checks it as a list and returns an accurate check on whether the revision has changes, which is used by the frontend to notify the end users. 

## QA steps (optional)
- Ran failing e2e test locally with the fix

## Notes for Reviewer
- Implementation follows established pattern for checking list fields (put on ignore list for scalar check, then check separately)