### PR TITLE
chore: GET /collections/:collection_id should return the correct dataset_id

### DIFF
--- a/backend/portal/api/curation/v1/curation/collections/common.py
+++ b/backend/portal/api/curation/v1/curation/collections/common.py
@@ -78,7 +78,7 @@ def reshape_for_curation_api(
                 collection_version.collection_id
             )
         revising_in = _revising_in.version_id.id if _revising_in else None
-        use_canonical_url = True
+        use_canonical_id = True
     else:
         # Unpublished - need to determine if it's a revision or first time collection
         # For that, we look at whether the canonical collection is published
@@ -89,7 +89,7 @@ def reshape_for_curation_api(
             collection_id = collection_version.version_id
             collection_url = f"{get_collections_base_url()}/collections/{collection_id.id}"
             revision_of = collection_version.collection_id.id
-            use_canonical_url = False
+            use_canonical_id = False
         else:
             # If it's an unpublished, unrevised collection, then collection_url will point to the permalink
             # (aka the link to the canonical_id) and the collection_id will point to version_id.
@@ -97,12 +97,12 @@ def reshape_for_curation_api(
             collection_id = collection_version.collection_id
             collection_url = f"{get_collections_base_url()}/collections/{collection_version.collection_id}"
             revision_of = None
-            use_canonical_url = True
+            use_canonical_id = True
         revising_in = None
 
     # get collection dataset attributes
     response_datasets = reshape_datasets_for_curation_api(
-        collection_version.datasets, is_published, use_canonical_url, preview
+        collection_version.datasets, is_published, use_canonical_id, preview
     )
 
     # build response
@@ -139,20 +139,20 @@ def reshape_for_curation_api(
 def reshape_datasets_for_curation_api(
     datasets: List[Union[DatasetVersionId, DatasetVersion]],
     is_published: bool,
-    use_canonical_url: bool,
+    use_canonical_id: bool,
     preview: bool = False,
 ) -> List[dict]:
     active_datasets = []
     for dv in datasets:
         dataset_version = get_business_logic().get_dataset_version(dv) if isinstance(dv, DatasetVersionId) else dv
         active_datasets.append(
-            reshape_dataset_for_curation_api(dataset_version, is_published, use_canonical_url, preview)
+            reshape_dataset_for_curation_api(dataset_version, is_published, use_canonical_id, preview)
         )
     return active_datasets
 
 
 def reshape_dataset_for_curation_api(
-    dataset_version: DatasetVersion, is_published: bool, use_canonical_url: bool, preview=False
+    dataset_version: DatasetVersion, is_published: bool, use_canonical_id: bool, preview=False
 ) -> dict:
     ds = dict()
 
@@ -191,7 +191,7 @@ def reshape_dataset_for_curation_api(
         )
         ds["revision"] = 0  # TODO this should be the number of times this dataset has been revised and published
         ds["title"] = ds.pop("name", None)
-        ds["explorer_url"] = generate_explorer_url(dataset_version, use_canonical_url)
+        ds["explorer_url"] = generate_explorer_url(dataset_version, use_canonical_id)
         ds["tombstone"] = False  # TODO this will always be false. Remove in the future
         if dataset_version.metadata is not None:
             ds["is_primary_data"] = is_primary_data_mapping.get(ds.pop("is_primary_data"), [])
@@ -206,7 +206,10 @@ def reshape_dataset_for_curation_api(
                     ds["processing_status"] = "PIPELINE_FAILURE"
             else:
                 ds["processing_status"] = status.processing_status
-    ds["id"] = dataset_version.dataset_id.id
+    if use_canonical_id:
+        ds["id"] = dataset_version.dataset_id.id
+    else:
+        ds["id"] = dataset_version.version_id.id
     return ds
 
 


### PR DESCRIPTION
### Reviewers
**Functional:** 
@Bento007 @nayib-jose-gloria 

**Readability:** 

---


## Changes
- When calling `GET /collections/:collection_id`, the dataset id should only be a version_id if the collection is a revision. This is consistent with the `explorer_url` and the general behavior of the curation API
- Rename `use_canonical_url` to `use_canonical_id` for additional clarity
