### PR TITLE
fix: Adapt RevisionStatusTag to use redesigned data model

### DIFF
--- a/backend/layers/api/explorer_url.py
+++ b/backend/layers/api/explorer_url.py
@@ -2,12 +2,12 @@ import os
 from backend.layers.common.entities import DatasetVersion
 
 
-def generate(dataset: DatasetVersion, is_published=False):
+def generate(dataset: DatasetVersion, use_canonical=True):
     """
     Generates an explorer_url for the present dataset.
-    If the dataset is published, or if it's referenced in the context of a published collection,
-    the dataset_id should be used. Otherwise, version_id should be used.
+    By default, set to use canonical dataset ID to build URL but
+    will use dataset version ID if use_canonical is set to False.
     """
     frontend_url = os.getenv("FRONTEND_URL", "")
-    id = dataset.dataset_id if is_published else dataset.version_id
-    return f"{frontend_url}/e/{id}.cxg/"
+    dataset_id = dataset.dataset_id if use_canonical else dataset.version_id
+    return f"{frontend_url}/e/{dataset_id}.cxg/"

--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -201,7 +201,9 @@ def _dataset_to_response(
             "suspension_type": None if dataset.metadata is None else dataset.metadata.suspension_type,
             "tissue": None if dataset.metadata is None else _ontology_term_ids_to_response(dataset.metadata.tissue),
             "tombstone": is_tombstoned,
-            "updated": True if is_in_revision and published is False else None,
+            "updated": True
+            if is_in_revision and dataset.canonical_dataset.published_at and published is False
+            else None,
             "updated_at": dataset.created_at,
             "x_approximate_distribution": None
             if dataset.metadata is None

--- a/backend/layers/api/portal_api.py
+++ b/backend/layers/api/portal_api.py
@@ -1,4 +1,5 @@
 import itertools
+from datetime import datetime
 from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -147,14 +148,24 @@ def remove_none(body: dict):
 
 
 # Note: `metadata` can be none while the dataset is uploading
-def _dataset_to_response(dataset: DatasetVersion, is_tombstoned: bool, is_in_published_collection: bool = False):
+def _dataset_to_response(
+    dataset: DatasetVersion, is_tombstoned: bool, is_in_revision: bool = False, revision_created_at: datetime = None
+):
     dataset_id = dataset.version_id.id
     # Only return `dataset_deployments` if a CXG artifact is available. This is to prevent the "Explore"
     # button to show up while a dataset upload is in progress
     if any(a for a in dataset.artifacts if a.type == DatasetArtifactType.CXG):
-        dataset_deployments = [{"url": explorer_url.generate(dataset, is_in_published_collection)}]
+        use_canonical = False if is_in_revision else True
+        dataset_deployments = [{"url": explorer_url.generate(dataset, use_canonical=use_canonical)}]
     else:
         dataset_deployments = []
+
+    published = False
+    if dataset.canonical_dataset.published_at:
+        published = True
+        # If dataset is an update of a published dataset and in an unpublished revision, it isn't published
+        if is_in_revision and revision_created_at and dataset.created_at > revision_created_at:
+            published = False
     return remove_none(
         {
             "assay": None if dataset.metadata is None else _ontology_term_ids_to_response(dataset.metadata.assay),
@@ -179,7 +190,7 @@ def _dataset_to_response(dataset: DatasetVersion, is_tombstoned: bool, is_in_pub
             "name": "" if dataset.metadata is None else dataset.metadata.name,
             "organism": None if dataset.metadata is None else _ontology_term_ids_to_response(dataset.metadata.organism),
             "processing_status": _dataset_processing_status_to_response(dataset.status, dataset.version_id.id),
-            "published": True,  # TODO
+            "published": published,
             "published_at": dataset.canonical_dataset.published_at,
             "revision": 0,  # TODO this is the progressive revision number. I don't think we'll need this
             "schema_version": None if dataset.metadata is None else dataset.metadata.schema_version,
@@ -190,7 +201,8 @@ def _dataset_to_response(dataset: DatasetVersion, is_tombstoned: bool, is_in_pub
             "suspension_type": None if dataset.metadata is None else dataset.metadata.suspension_type,
             "tissue": None if dataset.metadata is None else _ontology_term_ids_to_response(dataset.metadata.tissue),
             "tombstone": is_tombstoned,
-            "updated_at": dataset.created_at,  # Legacy: datasets can't be updated anymore
+            "updated": True if is_in_revision and published is False else None,
+            "updated_at": dataset.created_at,
             "x_approximate_distribution": None
             if dataset.metadata is None
             else dataset.metadata.x_approximate_distribution,
@@ -207,7 +219,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
         # We should expose version_id as the collection_id
         revision_of = collection.collection_id.id
         collection_id = collection.version_id.id
-        is_in_published_collection = False
+        is_in_revision = True
     elif collection.is_initial_unpublished_version():
         # In this case, we're dealing with a freshly created collection - we should expose the canonical id here,
         # since the curators will circulate the permalink immediately. `revision_of` is also null.
@@ -215,12 +227,12 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
         # Note that this case is effectively equivalent to a published collection.
         revision_of = None
         collection_id = collection.collection_id.id
-        is_in_published_collection = True
+        is_in_revision = False
     else:
         # The last case is a published collection. We just return the canonical id and set revision_of to None
         revision_of = None
         collection_id = collection.collection_id.id
-        is_in_published_collection = True
+        is_in_revision = False
 
     is_tombstoned = collection.canonical_collection.tombstoned
 
@@ -234,7 +246,10 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
             "data_submission_policy_version": "1.0",  # TODO
             "datasets": [
                 _dataset_to_response(
-                    ds, is_tombstoned=is_tombstoned, is_in_published_collection=is_in_published_collection
+                    ds,
+                    is_tombstoned=is_tombstoned,
+                    is_in_revision=is_in_revision,
+                    revision_created_at=collection.created_at,
                 )
                 for ds in collection.datasets
             ],
@@ -627,8 +642,7 @@ def get_datasets_index():
         )
         enrich_dataset_with_ancestors(payload, "tissue", ontology_mappings.tissue_ontology_mapping)
         enrich_dataset_with_ancestors(payload, "cell_type", ontology_mappings.cell_type_ontology_mapping)
-        # In this context, datasets always belong to published collections
-        payload["explorer_url"] = explorer_url.generate(dataset, is_published=True)
+        payload["explorer_url"] = explorer_url.generate(dataset)
         response.append(payload)
 
     return make_response(jsonify(response), 200)

--- a/backend/portal/api/curation/v1/curation/collections/common.py
+++ b/backend/portal/api/curation/v1/curation/collections/common.py
@@ -78,7 +78,7 @@ def reshape_for_curation_api(
                 collection_version.collection_id
             )
         revising_in = _revising_in.version_id.id if _revising_in else None
-        use_canonical_url = True
+        use_canonical_id = True
     else:
         # Unpublished - need to determine if it's a revision or first time collection
         # For that, we look at whether the canonical collection is published
@@ -89,7 +89,7 @@ def reshape_for_curation_api(
             collection_id = collection_version.version_id
             collection_url = f"{get_collections_base_url()}/collections/{collection_id.id}"
             revision_of = collection_version.collection_id.id
-            use_canonical_url = False
+            use_canonical_id = False
         else:
             # If it's an unpublished, unrevised collection, then collection_url will point to the permalink
             # (aka the link to the canonical_id) and the collection_id will point to version_id.
@@ -97,12 +97,12 @@ def reshape_for_curation_api(
             collection_id = collection_version.collection_id
             collection_url = f"{get_collections_base_url()}/collections/{collection_version.collection_id}"
             revision_of = None
-            use_canonical_url = True
+            use_canonical_id = True
         revising_in = None
 
     # get collection dataset attributes
     response_datasets = reshape_datasets_for_curation_api(
-        collection_version.datasets, is_published, use_canonical_url, preview
+        collection_version.datasets, is_published, use_canonical_id, preview
     )
 
     # build response
@@ -139,20 +139,20 @@ def reshape_for_curation_api(
 def reshape_datasets_for_curation_api(
     datasets: List[Union[DatasetVersionId, DatasetVersion]],
     is_published: bool,
-    use_canonical_url: bool,
+    use_canonical_id: bool,
     preview: bool = False,
 ) -> List[dict]:
     active_datasets = []
     for dv in datasets:
         dataset_version = get_business_logic().get_dataset_version(dv) if isinstance(dv, DatasetVersionId) else dv
         active_datasets.append(
-            reshape_dataset_for_curation_api(dataset_version, is_published, use_canonical_url, preview)
+            reshape_dataset_for_curation_api(dataset_version, is_published, use_canonical_id, preview)
         )
     return active_datasets
 
 
 def reshape_dataset_for_curation_api(
-    dataset_version: DatasetVersion, is_published: bool, use_canonical_url: bool, preview=False
+    dataset_version: DatasetVersion, is_published: bool, use_canonical_id: bool, preview=False
 ) -> dict:
     ds = dict()
 
@@ -191,7 +191,7 @@ def reshape_dataset_for_curation_api(
         )
         ds["revision"] = 0  # TODO this should be the number of times this dataset has been revised and published
         ds["title"] = ds.pop("name", None)
-        ds["explorer_url"] = generate_explorer_url(dataset_version, use_canonical_url)
+        ds["explorer_url"] = generate_explorer_url(dataset_version, use_canonical_id)
         ds["tombstone"] = False  # TODO this will always be false. Remove in the future
         if dataset_version.metadata is not None:
             ds["is_primary_data"] = is_primary_data_mapping.get(ds.pop("is_primary_data"), [])
@@ -206,7 +206,10 @@ def reshape_dataset_for_curation_api(
                     ds["processing_status"] = "PIPELINE_FAILURE"
             else:
                 ds["processing_status"] = status.processing_status
-    ds["id"] = dataset_version.dataset_id.id
+    if use_canonical_id:
+        ds["id"] = dataset_version.dataset_id.id
+    else:
+        ds["id"] = dataset_version.version_id.id
     return ds
 
 

--- a/frontend/src/common/entities.ts
+++ b/frontend/src/common/entities.ts
@@ -139,6 +139,7 @@ export interface Dataset {
   original_id?: string;
   published?: boolean;
   tombstone?: boolean;
+  updated?: boolean;
   collection_visibility: Collection["visibility"];
 }
 

--- a/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/components/RevisionStatusTag/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/components/RevisionStatusTag/index.tsx
@@ -25,9 +25,9 @@ const RevisionStatusTag = ({ dataset }: Props): ReactElement | null => {
   if (!isPublished) {
     if (dataset.tombstone) {
       revisionStatus = REVISION_STATUS.DELETED;
-    } else if (dataset.original_id) {
+    } else if (dataset.updated) {
       revisionStatus = REVISION_STATUS.UPDATED;
-    } else if (!dataset.original_id) {
+    } else if (!dataset.updated) {
       revisionStatus = REVISION_STATUS.NEW;
     }
   } else {


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

- #4007

### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
-  implement logic to determine 'published' field in portal API response  
-  update dataset portal API response translator method to optionally accept arg for collection revision created timestamp (logic: if dataset is in an unpublished revision and its created time is after the revision created time, it is also unpublished even if the canonical dataset has been published before). 
- add optional 'updated' boolean in portal API dataset response, to share with frontend whether a dataset in a revision is updated from its published counterpart or not 
- update Frontend to use new data model to interpret whether revised datasets need a NEW, UPDATED, or DELETED RevisionStatusTag (this feature was previously depending on fields that were deprecated or unimplemented in redesign)
- refactor explorer URL generate method name + is_in_published arg, since the flag was no longer about whether a dataset was in a published collection (we were setting to True for unpublished, non-revision collections)

## QA steps (optional)
- tests + rdev

## Notes for Reviewer
