### PR TITLE
fix: sort consortia on collection create or edit (#3996)

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -101,9 +101,10 @@ class BusinessLogic(BusinessLogicInterface):
         retrieve publisher metadata from Crossref and add it to the collection.
         """
 
-        errors = []
+        collection_metadata.sanitize()
+
         # Check metadata is valid
-        collection_metadata.strip_fields()
+        errors = []
         validation.verify_collection_metadata(collection_metadata, errors)
 
         # TODO: Maybe switch link.type to be an enum

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -223,6 +223,14 @@ class CollectionMetadata:
         if self.consortia is not None:
             self.consortia = [consortium.strip() for consortium in self.consortia]
 
+    def sortConsortia(self):
+        if self.consortia is not None:
+            self.consortia = sorted(self.consortia)
+
+    def sanitize(self):
+        self.strip_fields()
+        self.sortConsortia()
+
 
 @dataclass
 class CanonicalCollection:

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -223,13 +223,13 @@ class CollectionMetadata:
         if self.consortia is not None:
             self.consortia = [consortium.strip() for consortium in self.consortia]
 
-    def sortConsortia(self):
+    def sort_consortia(self):
         if self.consortia is not None:
-            self.consortia = sorted(self.consortia)
+            self.consortia.sort()
 
     def sanitize(self):
         self.strip_fields()
-        self.sortConsortia()
+        self.sort_consortia()
 
 
 @dataclass

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -620,6 +620,20 @@ class TestGetCollectionID(BaseAPIPortalTest):
         self.assertDictEqual(expected_body, res_body)  # Confirm dict has been packaged in list
         self.assertEqual(json.dumps(expected_body, sort_keys=True), json.dumps(res_body))
 
+    def test__get_public_collection_verify_consortia_sorted__OK_1(self):
+        collection_metadata = copy.deepcopy(self.sample_collection_metadata)
+        collection_metadata.consortia = ["Consortia 3", "Consortia 1", "Consortia 2"]
+        collection_version = self.generate_unpublished_collection(metadata=collection_metadata)
+        self.assertEqual(collection_version.metadata.consortia, sorted(collection_metadata.consortia))
+
+    def test__get_public_collection_verify_consortia_sorted__OK_2(self):
+        collection_metadata = copy.deepcopy(self.sample_collection_metadata)
+        collection_metadata.consortia = ["Consortia 3", "Consortia 1", "Consortia 2"]
+        collection_version = self.generate_unpublished_collection(metadata=collection_metadata)
+
+        res = self.app.get(f"/curation/v1/collections/{collection_version.collection_id}")
+        self.assertEqual(res.json["consortia"], sorted(collection_metadata.consortia))
+
     def test__get_private_collection__OK(self):
         collection_version = self.generate_unpublished_collection()
         self._test_response(collection_version)

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -374,6 +374,30 @@ class TestCollection(BaseAPIPortalTest):
 
         self.assertEqual(400, response.status_code)
 
+    def test__post_collection_sorts_consortia(self):
+        test_url = furl(path="/dp/v1/collections")
+        data = {
+            "name": "collection name",
+            "description": "This is a test collection",
+            "contact_name": "person human",
+            "contact_email": "person@human.com",
+            "curator_name": "Curator Name",
+            "links": [
+                {"link_name": "DOI Link", "link_url": "10.1016/foo", "link_type": "DOI"},
+            ],
+            "consortia": ["Consortia 3", "Consortia 1"],
+        }
+        json_data = json.dumps(data)
+        response = self.app.post(
+            test_url.url,
+            headers={"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()},
+            data=json_data,
+        )
+        self.assertEqual(201, response.status_code)
+        collection_id = json.loads(response.data)["collection_id"]
+        collection = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
+        self.assertEqual(collection.metadata.consortia, sorted(data["consortia"]))
+
     # ✅
     def test__post_collection_normalizes_doi(self):
         test_url = furl(path="/dp/v1/collections")


### PR DESCRIPTION
- #TICKET_NUMBER
#3996 

### Reviewers
**Functional:** 
@ebezzi 

---


## Changes
- sorted collection during creation and edit of consortia
- added tests for portal and curation APIs

## QA steps (optional)

## Notes for Reviewer
