### PR TITLE
fix: check for Revision Changes accounts for deleted datasets in new data model + refactor Collection checks

### DIFF
--- a/frontend/src/common/utils/checkForRevisionChange.ts
+++ b/frontend/src/common/utils/checkForRevisionChange.ts
@@ -47,7 +47,6 @@ function checkCollectionKeyForDifference(
         revisedCollection[collectionKey] as Array<unknown>
       )
     ) {
-      console.log(collectionKey);
       return true;
     }
   } else if (
@@ -55,14 +54,12 @@ function checkCollectionKeyForDifference(
     publishedCollection[collectionKey] instanceof Object
   ) {
     if (!isEqual(publishedCollection[collectionKey], revisedCollection[collectionKey])) {
-      console.log(collectionKey);
       return true;
     }
   } else if (
     // scalar value
     publishedCollection[collectionKey] !== revisedCollection[collectionKey]
   ) {
-     console.log(collectionKey)
     return true;
   }
   return false;
@@ -81,7 +78,6 @@ function checkDatasetKeyForDifference(
         revisedDataset[datasetKey] as Array<unknown>
       )
     ) {
-      console.log(datasetKey);
       return true;
     }
   } else if (
@@ -89,14 +85,12 @@ function checkDatasetKeyForDifference(
     publishedDataset[datasetKey] instanceof Object
   ) {
     if (!isEqual(publishedDataset[datasetKey], revisedDataset[datasetKey])) {
-      console.log(datasetKey);
       return true;
     }
   } else if (
     // scalar value
     publishedDataset[datasetKey] !== revisedDataset[datasetKey]
   ) {
-    console.log(datasetKey)
     return true;
   }
   return false;
@@ -110,7 +104,7 @@ function checkDatasetsForChanges(
   // Check dataset fields for differences
   return Array.from(publishedDatasets.values()).some((publishedDataset) => {
     const revisedDataset = revisedDatasets.get(publishedDataset.id) as Dataset;
-    if (revisedDataset == undefined) return true;
+    if (revisedDataset === undefined) return true;
     let datasetKey = "" as keyof Dataset;
     for (datasetKey in publishedDataset) {
       if (IGNORED_DATASET_FIELDS.includes(datasetKey)) {


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

Bug: Certain revisions were not rendering in the UI even though backend updates went through and curation API worked for equivalent endpoints

## Changes
- check for revision changes at Collection-level in same way as Datasets (dependent on data field type) to avoid edge case bugs when adding new fields 
- update dataset-level changes check to return True when revision datasets are missing a published dataset (i.e. mark collection as changed if dataset from published is deleted in revision).

## QA steps (optional)
- checked revisions failing to render in dev in local frontend (pointed at dev backend). Renders correctly locally w/ changes

## Notes for Reviewer
- The discovered issue was that, before the redesign, deleted datasets in revisions were simply marked as tombstoned but still existed in the collection dataset map. Revision changes check assumed all datasets from published collection would be in revision dataset map, which was no longer the case with the new data model in which deleted datasets in revisions are removed. Issue caused a null pointer 
