### PR TITLE
fix: update collection handles DOI correctly

### DIFF
--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1228,7 +1228,7 @@ class TestUpdateCollection(BaseAPIPortalTest):
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
         response = self.app.put(
             f"/dp/v1/collections/{collection.version_id}",
-            data=json.dumps({"links": [{"link_name": "Link 1", "link_url": "http://doi.org/456", "link_type": "DOI"}]}),
+            data=json.dumps({"links": [{"link_name": "Link 1", "link_url": "10.1234/5678", "link_type": "DOI"}]}),
             headers=headers,
         )
         self.assertEqual(200, response.status_code)


### PR DESCRIPTION
### Reviewers
**Functional:** 
@nayib-jose-gloria @Bento007 

**Readability:** 

---


## Changes
- Fixes an issue where update collection in the portal API doesn't handle DOIs correctly

## Notes
- Current Portal tests (both pre and post redesign) assume that the payload will contain DOIs that start with https://doi.org, and are not necessarily valid (e.g. http://doi.org/123). This isn't the case as the FE sends Curie DOIs (i.e. with only the trailing part). We should change them to reflect this behavior
