### PR TITLE
fix(apis): sanitize collection metadata on update (#4032)

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -25,6 +25,7 @@ from backend.layers.business.exceptions import (
     MaxFileSizeExceededException,
 )
 from backend.layers.common import validation
+from backend.layers.common.cleanup import sanitize
 from backend.layers.common.entities import (
     CollectionId,
     CollectionLinkType,
@@ -101,7 +102,7 @@ class BusinessLogic(BusinessLogicInterface):
         retrieve publisher metadata from Crossref and add it to the collection.
         """
 
-        collection_metadata.sanitize()
+        sanitize(collection_metadata)
 
         # Check metadata is valid
         errors = []
@@ -213,7 +214,7 @@ class BusinessLogic(BusinessLogicInterface):
 
         # TODO: CollectionMetadataUpdate should probably be used for collection creation as well
         # TODO: link.type should DEFINITELY move to an enum. pylance will help with the refactor
-
+        sanitize(body)
         errors = []
 
         # Check metadata

--- a/backend/layers/common/cleanup.py
+++ b/backend/layers/common/cleanup.py
@@ -1,0 +1,29 @@
+from backend.layers.business.entities import CollectionMetadataUpdate
+from backend.layers.common.entities import CollectionMetadata, Link
+from typing import Union
+
+
+def strip_fields(metadata: Union[CollectionMetadata, CollectionMetadataUpdate]):
+    if metadata.name is not None:
+        metadata.name = metadata.name.strip()
+    if metadata.description is not None:
+        metadata.description = metadata.description.strip()
+    if metadata.contact_name is not None:
+        metadata.contact_name = metadata.contact_name.strip()
+    if metadata.contact_email is not None:
+        metadata.contact_email = metadata.contact_email.strip()
+    if metadata.links is not None:
+        for link in metadata.links:
+            link.strip_fields()
+    if metadata.consortia is not None:
+        metadata.consortia = [consortium.strip() for consortium in metadata.consortia]
+
+
+def sort_consortia(metadata: Union[CollectionMetadata, CollectionMetadataUpdate]):
+    if metadata.consortia is not None:
+        metadata.consortia.sort()
+
+
+def sanitize(metadata: Union[CollectionMetadata, CollectionMetadataUpdate]):
+    strip_fields(metadata)
+    sort_consortia(metadata)

--- a/backend/layers/common/cleanup.py
+++ b/backend/layers/common/cleanup.py
@@ -1,5 +1,5 @@
 from backend.layers.business.entities import CollectionMetadataUpdate
-from backend.layers.common.entities import CollectionMetadata, Link
+from backend.layers.common.entities import CollectionMetadata
 from typing import Union
 
 

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -213,24 +213,6 @@ class CollectionMetadata:
     links: List[Link]
     consortia: List[str] = field(default_factory=list)
 
-    def strip_fields(self):
-        self.name = self.name.strip()
-        self.description = self.description.strip()
-        self.contact_name = self.contact_name.strip()
-        self.contact_email = self.contact_email.strip()
-        for link in self.links:
-            link.strip_fields()
-        if self.consortia is not None:
-            self.consortia = [consortium.strip() for consortium in self.consortia]
-
-    def sort_consortia(self):
-        if self.consortia is not None:
-            self.consortia.sort()
-
-    def sanitize(self):
-        self.strip_fields()
-        self.sort_consortia()
-
 
 @dataclass
 class CanonicalCollection:

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -824,7 +824,7 @@ class TestPatchCollectionID(BaseAPIPortalTest):
         self.assertEqual(collection.publisher_metadata, response.json["publisher_metadata"])
 
     def test__update_collection_strip_string_fields(self):
-        links = [Link("name", "RAW_DATA", "http://test_link.place")]
+        links = [Link("   name ", "RAW_DATA", "http://test_link.place")]
         self.crossref_provider.fetch_metadata = Mock(return_value=generate_mock_publisher_metadata())
         collection = self.generate_unpublished_collection(links=links)
         collection_id = collection.collection_id
@@ -848,9 +848,19 @@ class TestPatchCollectionID(BaseAPIPortalTest):
         )
 
         self.assertEqual(200, response.status_code)
+        self.assertEqual(new_name.strip(), response.json["name"])
+        self.assertEqual(new_description.strip(), response.json["description"])
+        self.assertEqual(new_contact_name.strip(), response.json["contact_name"])
+        self.assertEqual(new_contact_email.strip(), response.json["contact_email"])
+        self.assertEqual(
+            [{"link_name": "name", "link_type": "RAW_DATA", "link_url": "http://test_link.place"}],
+            response.json["links"],
+        )
+        self.assertEqual(collection.publisher_metadata, response.json["publisher_metadata"])
 
         response = self.app.get(f"curation/v1/collections/{collection_id}")
 
+        self.assertEqual(200, response.status_code)
         self.assertEqual(new_name.strip(), response.json["name"])
         self.assertEqual(new_description.strip(), response.json["description"])
         self.assertEqual(new_contact_name.strip(), response.json["contact_name"])

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1018,6 +1018,41 @@ class TestUpdateCollection(BaseAPIPortalTest):
         for field in test_fields:
             self.assertEqual(expected_body[field], actual_body[field])
 
+    def test__update_collection_strip_string_fields__OK(self):
+        collection = self.generate_unpublished_collection()
+        test_fields = [
+            "name",
+            "description",
+            "contact_name",
+            "contact_email",
+            "links",
+            "consortia",
+        ]
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
+
+        # Update the collection
+        new_body = {
+            "name": "collection name    ",
+            "description": "    This is a test collection",
+            "contact_name": "   person human",
+            "contact_email": "  person@human.com  ",
+            "links": [{"link_name": " DOI Link ", "link_url": "http://doi.org/10.1016", "link_type": "DOI"}],
+            "consortia": ["  Consortia 1   "],
+        }
+        data = json.dumps(new_body)
+        response = self.app.put(f"/dp/v1/collections/{collection.version_id.id}", data=data, headers=headers)
+
+        self.assertEqual(200, response.status_code)
+        actual_body = json.loads(response.data)
+        self.assertEqual(new_body["name"].strip(), actual_body["name"])
+        self.assertEqual(new_body["description"].strip(), actual_body["description"])
+        self.assertEqual(new_body["contact_name"].strip(), actual_body["contact_name"])
+        self.assertEqual(new_body["contact_email"].strip(), actual_body["contact_email"])
+        self.assertEqual(["Consortia 1"], actual_body["consortia"])
+        self.assertEqual(
+            [{"link_name": "DOI Link", "link_url": "http://doi.org/10.1016", "link_type": "DOI"}], actual_body["links"]
+        )
+
     def test__update_collection_partial__OK(self):
         collection = self.generate_unpublished_collection(links=[Link("Link 1", "DOI", "http://doi.org/123")])
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1020,14 +1020,6 @@ class TestUpdateCollection(BaseAPIPortalTest):
 
     def test__update_collection_strip_string_fields__OK(self):
         collection = self.generate_unpublished_collection()
-        test_fields = [
-            "name",
-            "description",
-            "contact_name",
-            "contact_email",
-            "links",
-            "consortia",
-        ]
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
 
         # Update the collection


### PR DESCRIPTION
- #TICKET_NUMBER
#4032
### Reviewers
**Functional:** 

**Readability:** 

---


## Changes
- Added tests to validate that collection metadata is sanitized on update for both the Discover and Portal APIs and that in the put response:
    - consortia are sorted
    - leading/trailing whitespace is removed
- Modified the collection metadata "sanitize" to be a function in its own file rather than be on the CollectionMetadata class so that the same code can be used to sanitize the "CollectionMetadataUpdate" class. 

