### PR TITLE
hotfix(fmg): update api schema effect size

### DIFF
--- a/backend/wmg/api/wmg-api.yml
+++ b/backend/wmg/api/wmg-api.yml
@@ -395,7 +395,6 @@ paths:
                           type: number
                           format: float
                           maxLength: 4
-                          minimum: 0.0
 
 components:
   schemas:


### PR DESCRIPTION
- #4035

Previously, negative effect size was not allowed, but in the latest version we decided to not zero out negative values. The api spec wasn't updated, so any response that yields negative effect size was treated as malformed. This PR removes the api spec requirement for effectsize >0