### PR TITLE
chore(fmg): update index of cell labels after filtering out healthy cells

### DIFF
--- a/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/transform.py
+++ b/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/transform.py
@@ -117,6 +117,7 @@ def make_cube_index(tdb_group: str, cube_dims: list) -> (pd.DataFrame, pd.DataFr
     healthy_filter = cell_labels["disease_ontology_term_id"].astype("str") == NORMAL_CELL_DISEASE_ONTOLOGY_TERM_ID
     if np.any(healthy_filter):
         cell_labels = cell_labels[healthy_filter]
+        cell_labels.index = pd.Index(range(len(cell_labels)))
 
     # number of cells with specific tuple of dims
     cube_index = pd.DataFrame(cell_labels.value_counts(), columns=["n"])


### PR DESCRIPTION
After filtering out healthy cells, the cell labels index was missing values so its maximum value no longer equaled its length. This PR resets the cell labels index after filtering out healthy cells.