### PR TITLE
fix: add validation_message back to the pipeline

### DIFF
--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -99,6 +99,7 @@ class BusinessLogicInterface:
         dataset_version_id: DatasetVersionId,
         status_key: DatasetStatusKey,
         new_dataset_status: DatasetStatusGeneric,
+        validation_message: Optional[str] = None,
     ) -> None:
         pass
 

--- a/backend/layers/processing/process.py
+++ b/backend/layers/processing/process.py
@@ -112,7 +112,9 @@ class ProcessMain(ProcessingLogic):
         except ProcessingCanceled:
             pass  # TODO: what's the effect of canceling a dataset now?
         except ValidationFailed as e:
-            self.update_processing_status(dataset_id, DatasetStatusKey.VALIDATION, DatasetValidationStatus.INVALID, e.errors)
+            self.update_processing_status(
+                dataset_id, DatasetStatusKey.VALIDATION, DatasetValidationStatus.INVALID, e.errors
+            )
             return False
         except ProcessingFailed:
             self.update_processing_status(dataset_id, DatasetStatusKey.PROCESSING, DatasetProcessingStatus.FAILURE)

--- a/backend/layers/processing/process.py
+++ b/backend/layers/processing/process.py
@@ -111,8 +111,8 @@ class ProcessMain(ProcessingLogic):
         # TODO: this could be better - maybe collapse all these exceptions and pass in the status key and value
         except ProcessingCanceled:
             pass  # TODO: what's the effect of canceling a dataset now?
-        except ValidationFailed:
-            self.update_processing_status(dataset_id, DatasetStatusKey.VALIDATION, DatasetValidationStatus.INVALID)
+        except ValidationFailed as e:
+            self.update_processing_status(dataset_id, DatasetStatusKey.VALIDATION, DatasetValidationStatus.INVALID, e.errors)
             return False
         except ProcessingFailed:
             self.update_processing_status(dataset_id, DatasetStatusKey.PROCESSING, DatasetProcessingStatus.FAILURE)

--- a/backend/layers/processing/process_logic.py
+++ b/backend/layers/processing/process_logic.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from logging import Logger
 from os.path import basename, join
-from typing import Callable
+from typing import Callable, List, Optional
 
 from backend.layers.business.business_interface import BusinessLogicInterface
 from backend.layers.common.entities import (
@@ -31,9 +31,17 @@ class ProcessingLogic:  # TODO: ProcessingLogicBase
         self.logger = Logger("processing")
 
     def update_processing_status(
-        self, dataset_id: DatasetVersionId, status_key: DatasetStatusKey, status_value: DatasetStatusGeneric
+        self,
+        dataset_id: DatasetVersionId,
+        status_key: DatasetStatusKey,
+        status_value: DatasetStatusGeneric,
+        validation_errors: Optional[List[str]] = None,
     ):
-        self.business_logic.update_dataset_version_status(dataset_id, status_key, status_value)
+        if validation_errors is not None:
+            validation_message = "\n".join(validation_errors)
+        else:
+            validation_message = None
+        self.business_logic.update_dataset_version_status(dataset_id, status_key, status_value, validation_message)
 
     def download_from_s3(self, bucket_name: str, object_key: str, local_filename: str):
         self.s3_provider.download_file(bucket_name, object_key, local_filename)

--- a/backend/layers/thirdparty/schema_validator_provider.py
+++ b/backend/layers/thirdparty/schema_validator_provider.py
@@ -10,7 +10,11 @@ class SchemaValidatorProvider(SchemaValidatorProviderInterface):
     def validate_and_save_labels(self, input_file: str, output_file: str) -> Tuple[bool, list, bool]:
         """
         Runs `cellxgene-schema validate` on the provided `input_file`. This also saves a labeled copy
-        of the artifact to `output_file`
+        of the artifact to `output_file`.
+        Returns a tuple that contains, in order:
+        1. A boolean that indicates whether the artifact is valid
+        2. A List[str] with the validation errors. This is only defined if the first boolean is false
+        3. A boolean that indicates whether the artifact is Seurat convertible
         """
         from cellxgene_schema import validate
 

--- a/tests/unit/processing/test_processing.py
+++ b/tests/unit/processing/test_processing.py
@@ -196,7 +196,9 @@ class ProcessingTest(BaseTest):
         )
 
         # Set a mock failure for the schema validator
-        self.schema_validator.validate_and_save_labels = Mock(return_value=(False, ["Validation error 1", "Validation error 2"], True))
+        self.schema_validator.validate_and_save_labels = Mock(
+            return_value=(False, ["Validation error 1", "Validation error 2"], True)
+        )
 
         collection = self.generate_unpublished_collection()
         dataset_version_id, dataset_id = self.business_logic.ingest_dataset(

--- a/tests/unit/processing/test_processing.py
+++ b/tests/unit/processing/test_processing.py
@@ -183,5 +183,33 @@ class ProcessingTest(BaseTest):
         artifacts = list(self.business_logic.get_dataset_artifacts(dataset_version_id))
         self.assertEqual(4, len(artifacts))
 
-    def test_process_download_validate_fail(self):
-        pass
+    def test_process_all_download_validate_fail(self):
+        """
+        If the validation is not successful, the processing pipeline should:
+        1. Set the processing status to INVALID
+        2. Set a validation message accordingly
+        """
+        dropbox_uri = "https://www.dropbox.com/s/ow84zm4h0wkl409/test.h5ad?dl=0"
+        collection = self.generate_unpublished_collection()
+        dataset_version_id, dataset_id = self.business_logic.ingest_dataset(
+            collection.version_id, dropbox_uri, None, None
+        )
+
+        # Set a mock failure for the schema validator
+        self.schema_validator.validate_and_save_labels = Mock(return_value=(False, ["Validation error 1", "Validation error 2"], True))
+
+        collection = self.generate_unpublished_collection()
+        dataset_version_id, dataset_id = self.business_logic.ingest_dataset(
+            collection.version_id, dropbox_uri, None, None
+        )
+
+        pm = ProcessMain(
+            self.business_logic, self.uri_provider, self.s3_provider, self.downloader, self.schema_validator
+        )
+
+        for step_name in ["download-validate"]:
+            pm.process(dataset_version_id, step_name, dropbox_uri, "fake_bucket_name", "fake_cxg_bucket")
+
+        status = self.business_logic.get_dataset_status(dataset_version_id)
+        self.assertEqual(status.validation_status, DatasetValidationStatus.INVALID)
+        self.assertEqual(status.validation_message, "Validation error 1\nValidation error 2")


### PR DESCRIPTION
### Reviewers
**Functional:**
@nayib-jose-gloria  

**Readability:** 

---


## Changes
- Restores `validation_message` for uploaded artifacts that fail validation

## QA steps
- Unit tests
- [rdev stack pointed to a collection with failed upload](https://ebezzi-redesign-frontend.rdev.single-cell.czi.technology/collections/2514cd5a-e87e-42a3-bab8-c77303c9a801). Note that the `validation_message` can only be viewed in the database.
