### PR TITLE
fix: reintroduce original_id to curation API for revisions

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -825,6 +825,9 @@ components:
           type: string
         organism:
           $ref: "#/components/schemas/dataset_organism"
+        original_id:
+          $ref: "#/components/schemas/original_id"
+          nullable: true
         processing_status:
           $ref: "#/components/schemas/processing_status_dataset"
         processing_status_detail:
@@ -987,6 +990,13 @@ components:
         ontology_term_id:
           type: string
       type: object
+    original_id:
+      description: |
+        For Datasets in private revisions of published Datasets, a unique identifier of the published Dataset 
+        counterpart if applicable. Null if the published Collection does not contain the revision Dataset.
+      example: 01234567-89ab-cdef-0123-456789abcdef
+      type: string
+      nullable: true
     problem:
       description: Error message container for HTTP APIs.
       properties:

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -210,6 +210,7 @@ def reshape_dataset_for_curation_api(
         ds["id"] = dataset_version.dataset_id.id
     else:
         ds["id"] = dataset_version.version_id.id
+        ds["original_id"] = dataset_version.dataset_id.id if dataset_version.canonical_dataset.published_at else None
     return ds
 
 


### PR DESCRIPTION
Signed-off-by: nayib-jose-gloria <ngloria@chanzuckerberg.com>

## Changes
- re-add original_id to curation API--it points to the canonical dataset ID for datasets in private revisions that have counterparts in the published Collection. Otherwise, it is None for newly added datasets in a revision Collection and not returned at all for non-revision collections. 

## QA steps (optional)
- tests

## Notes for Reviewer
- Will unblock "replace second dataset" step in [curator example workflow notebook](https://github.com/chanzuckerberg/single-cell-curation/blob/main/notebooks/curation_api/python/example_workflow.ipynb)
- Achieves parity with existing curator use
