### PR TITLE
chore(dag): revert update to expression summary fmg and put it in a different PR

### DIFF
--- a/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/transform.py
+++ b/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/transform.py
@@ -12,7 +12,6 @@ from backend.wmg.pipeline.summary_cubes.extract import extract_obs_data
 from backend.wmg.data.schemas.corpus_schema import INTEGRATED_ARRAY_NAME
 from backend.wmg.data.tiledb import create_ctx
 from backend.wmg.data.utils import log_func_runtime
-from backend.wmg.pipeline.summary_cubes.rollup import rollup_across_cell_type_descendants
 from backend.wmg.data.constants import NORMAL_CELL_DISEASE_ONTOLOGY_TERM_ID
 
 logger = logging.getLogger(__name__)
@@ -42,9 +41,6 @@ def transform(
     reduce_X(corpus_path, cell_labels.cube_idx.values, cube_sum, cube_sqsum, cube_nnz, cube_nnz_thr)
 
     cell_types = list(cube_index.index.get_level_values("cell_type_ontology_term_id").astype("str"))
-    cube_sum, cube_sqsum, cube_nnz, cube_nnz_thr = rollup_across_cell_type_descendants(
-        cell_types, [cube_sum, cube_sqsum, cube_nnz, cube_nnz_thr]
-    )
 
     return cube_index, cube_sum, cube_sqsum, cube_nnz, cube_nnz_thr
 

--- a/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/transform.py
+++ b/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/transform.py
@@ -39,9 +39,6 @@ def transform(
     cube_nnz_thr = np.zeros((n_groups, n_genes), dtype=np.uint64)
 
     reduce_X(corpus_path, cell_labels.cube_idx.values, cube_sum, cube_sqsum, cube_nnz, cube_nnz_thr)
-
-    cell_types = list(cube_index.index.get_level_values("cell_type_ontology_term_id").astype("str"))
-
     return cube_index, cube_sum, cube_sqsum, cube_nnz, cube_nnz_thr
 
 


### PR DESCRIPTION
I updated the expression summary fmg data artifact in a PR that was meant to only update the gene expression heatmap, _not_ the calculated marker genes. This reverts this change. This change will be re-applied in this PR: #3955 
