### PR TITLE
fix: used numba to achieve 20x speedup for expression roll-up and fix seg-fault due to healthy cell filter

### DIFF
--- a/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/load.py
+++ b/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/load.py
@@ -22,7 +22,10 @@ def build_in_mem_cube(
     logger.info("Building in-mem cube")
 
     # filter out groups with unhealthy cells
-    healthy_filter = cube_index.index.get_level_values("disease_ontology_term_id").astype("str") == NORMAL_CELL_DISEASE_ONTOLOGY_TERM_ID
+    healthy_filter = (
+        cube_index.index.get_level_values("disease_ontology_term_id").astype("str")
+        == NORMAL_CELL_DISEASE_ONTOLOGY_TERM_ID
+    )
     cube_index = cube_index[healthy_filter]
 
     # Count total values so we can allocate buffers once

--- a/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/load.py
+++ b/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/load.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 import pandas as pd
+from backend.wmg.data.constants import NORMAL_CELL_DISEASE_ONTOLOGY_TERM_ID
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,10 @@ def build_in_mem_cube(
     Build the cube in memory, calculating the gene expression value for each combination of attributes
     """
     logger.info("Building in-mem cube")
+
+    # filter out groups with unhealthy cells
+    healthy_filter = cube_index.index.get_level_values("disease_ontology_term_id").astype("str") == NORMAL_CELL_DISEASE_ONTOLOGY_TERM_ID
+    cube_index = cube_index[healthy_filter]
 
     # Count total values so we can allocate buffers once
     total_vals = 0

--- a/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/load.py
+++ b/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/load.py
@@ -26,7 +26,8 @@ def build_in_mem_cube(
         cube_index.index.get_level_values("disease_ontology_term_id").astype("str")
         == NORMAL_CELL_DISEASE_ONTOLOGY_TERM_ID
     )
-    cube_index = cube_index[healthy_filter]
+    if np.any(healthy_filter):
+        cube_index = cube_index[healthy_filter]
 
     # Count total values so we can allocate buffers once
     total_vals = 0

--- a/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/transform.py
+++ b/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/transform.py
@@ -12,7 +12,6 @@ from backend.wmg.pipeline.summary_cubes.extract import extract_obs_data
 from backend.wmg.data.schemas.corpus_schema import INTEGRATED_ARRAY_NAME
 from backend.wmg.data.tiledb import create_ctx
 from backend.wmg.data.utils import log_func_runtime
-from backend.wmg.data.constants import NORMAL_CELL_DISEASE_ONTOLOGY_TERM_ID
 
 logger = logging.getLogger(__name__)
 
@@ -107,10 +106,6 @@ def make_cube_index(tdb_group: str, cube_dims: list) -> (pd.DataFrame, pd.DataFr
     Create index for queryable dimensions
     """
     cell_labels = extract_obs_data(tdb_group, cube_dims)
-    healthy_filter = cell_labels["disease_ontology_term_id"].astype("str") == NORMAL_CELL_DISEASE_ONTOLOGY_TERM_ID
-    if np.any(healthy_filter):
-        cell_labels = cell_labels[healthy_filter]
-        cell_labels.index = pd.Index(range(len(cell_labels)))
 
     # number of cells with specific tuple of dims
     cube_index = pd.DataFrame(cell_labels.value_counts(), columns=["n"])

--- a/backend/wmg/pipeline/summary_cubes/rollup.py
+++ b/backend/wmg/pipeline/summary_cubes/rollup.py
@@ -33,6 +33,7 @@ def find_descendants_per_cell_type(cell_types):
         descendants_per_cell_type.append(descendants)
     return descendants_per_cell_type
 
+
 def rollup_across_cell_type_descendants(cell_types, arrays_to_sum):
     """
     Aggregate values for each cell type across its descendants in the input arrays.
@@ -79,9 +80,10 @@ def rollup_across_cell_type_descendants(cell_types, arrays_to_sum):
         summed_arrays.append(summed)
     return summed_arrays
 
-@nb.njit(parallel=True,fastmath=True,nogil=True)
+
+@nb.njit(parallel=True, fastmath=True, nogil=True)
 def _array_summer(array, summed, descendants_indexes, linear_indices):
-    for i in nb.prange(len(linear_indices)-1):
-        index = descendants_indexes[linear_indices[i] : linear_indices[i+1]]
+    for i in nb.prange(len(linear_indices) - 1):
+        index = descendants_indexes[linear_indices[i] : linear_indices[i + 1]]
         for j in index:
             summed[i] += array[j]

--- a/backend/wmg/pipeline/summary_cubes/rollup.py
+++ b/backend/wmg/pipeline/summary_cubes/rollup.py
@@ -65,6 +65,10 @@ def rollup_across_cell_type_descendants(cell_types, arrays_to_sum):
     # a pandas series to map cell types to their index in the input arrays
     indexer = pd.Series(index=cell_types, data=range(len(cell_types)))
     descendants_indexes = [indexer[children].to_numpy() for children in descendants]
+
+    # flatten the descendant indices into a single array and create a linear
+    # index array for slicing out the descendants per cell type. The array
+    # must be flattened to satisfy numba type requirements.
     z = 0
     linear_indices = [z]
     for ix in descendants_indexes:


### PR DESCRIPTION
 - #4057

This PR fixes two bugs:
 - Expression roll-up was unexpectedly computationally intensive. It added 4 hours to the processing pipeline. Here, I re-implemented the rollup function in parallelized numba to get a 20x speedup.
 - The way the healthy cell filter was implemented resulted in the `reduce_X` operation seg-faulting. It probably has something to do with misaligned cube indices, but I'm not exactly sure what the problem was. I fixed this issue by moving the filter to _after_ the reduction in `build_in_mem_cube`.

# QA
 - The expression rollup tests pass using the numba implementation.
 - Healthy cells are properly filtered out from the expression summary cube and no segfault occurs (tested locally)