### PR TITLE
[WIP] chore: reintroduce dataset revision number (approach 2)

### DIFF
--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -176,6 +176,7 @@ class CanonicalDataset:
     dataset_version_id: Optional[DatasetVersionId]
     published_at: Optional[datetime] = None
     revised_at: Optional[datetime] = None  # The last time this Dataset Version was Published
+    revision_count: int = 0
 
 
 @dataclass

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -316,6 +316,10 @@ class DatabaseProviderMock(DatabaseProviderInterface):
         dataset_version = self.datasets_versions[version_id.id]
         dataset_version.status.validation_message = validation_message
 
+    def increment_dataset_revision_counter(self, dataset_id: DatasetId) -> None:
+        self.datasets[dataset_id.id].revision_count = 1 + self.datasets[dataset_id.id].revision_count
+
+
     def add_dataset_to_collection_version(self, version_id: CollectionVersionId, dataset_id: DatasetId) -> None:
         # Not needed for now - create_dataset does this
         # As an alternative, this could either be called by create_dataset


### PR DESCRIPTION
Similar to https://github.com/chanzuckerberg/single-cell-data-portal/pull/4062, but uses a different approach (stores the counter in the canonical dataset table)