### PR TITLE
fix: supply default for typed fields

### DIFF
--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -163,11 +163,11 @@ class DatasetMetadata:
     cell_count: int
     schema_version: str
     mean_genes_per_cell: float
-    batch_condition: List[str]
-    suspension_type: List[str]
-    donor_id: List[str]
     is_primary_data: str
     x_approximate_distribution: Optional[str]
+    batch_condition: List[str] = field(default_factory=list)
+    suspension_type: List[str] = field(default_factory=list)
+    donor_id: List[str] = field(default_factory=list)
 
 
 @dataclass


### PR DESCRIPTION
## Reason for Change
- #4097 

## Changes
- add usage of `field` with `default_factory` to a few fields that were missing it

## Testing steps
- in process of rdev testing
- see discussion of solution in the issue itself
- no other instances of a non-Optional type that needs a default appear to exist.

## Notes for Reviewer
