### PR TITLE
fix(fmg): update analytics on tooltips to fire properly

### DIFF
--- a/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
@@ -57,17 +57,23 @@ function CellInfoSideBar({
   }, [data, dispatch]);
 
   const [hoverStartTime, setHoverStartTime] = useState(0);
-  
-  const useHandleHoverEnd = (event: EVENTS, payload = {}) => {
-      return useCallback(() => {
-        if (Date.now() - hoverStartTime > 2 * 1000) {
-          track(event, payload);
-        }
-      }, [hoverStartTime])
-  }
 
-  const handleFmgHoverEnd = useHandleHoverEnd(EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER, {label: "marker genes"});
-  const handleMarkerScoreHoverEnd = useHandleHoverEnd(EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER, {label: "marker score"});
+  const useHandleHoverEnd = (event: EVENTS, payload = {}) => {
+    return useCallback(() => {
+      if (Date.now() - hoverStartTime > 2 * 1000) {
+        track(event, payload);
+      }
+    }, [hoverStartTime]);
+  };
+
+  const handleFmgHoverEnd = useHandleHoverEnd(
+    EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER,
+    { label: "marker genes" }
+  );
+  const handleMarkerScoreHoverEnd = useHandleHoverEnd(
+    EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER,
+    { label: "marker score" }
+  );
 
   if (isLoading || !data) return null;
 
@@ -84,11 +90,10 @@ function CellInfoSideBar({
             width="default"
             className="fmg-tooltip-icon"
             arrow={true}
-            onOpen={() => setHoverStartTime(Date.now())}   
+            onOpen={() => setHoverStartTime(Date.now())}
             onClose={handleFmgHoverEnd}
             title={
-              <StyledTooltip             
-              >
+              <StyledTooltip>
                 <div>
                   Marker genes are highly and uniquely expressed in the cell
                   type relative to all other cell types.
@@ -100,8 +105,12 @@ function CellInfoSideBar({
                     rel="noopener"
                     target="_blank"
                     onClick={() => {
-                      track(EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER, {label: "marker genes"});
-                      track(EVENTS.WMG_FMG_DOCUMENTATION_CLICKED, {label: "marker genes"});
+                      track(EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER, {
+                        label: "marker genes",
+                      });
+                      track(EVENTS.WMG_FMG_DOCUMENTATION_CLICKED, {
+                        label: "marker genes",
+                      });
                     }}
                   >
                     Click to read more about the identification method.
@@ -156,13 +165,14 @@ function CellInfoSideBar({
                 className="fmg-tooltip-icon"
                 arrow={true}
                 onOpen={() => setHoverStartTime(Date.now())}
-                onClose={handleMarkerScoreHoverEnd}                
+                onClose={handleMarkerScoreHoverEnd}
                 title={
                   <StyledTooltip>
                     <div>
-                    Marker Score indicates the strength and specificity of a gene as a marker.
-                    It is the 5th percentile of the effect sizes when comparing the expressions
-                    in a cell type of interest to each other cell type in the tissue.
+                      Marker Score indicates the strength and specificity of a
+                      gene as a marker. It is the 5th percentile of the effect
+                      sizes when comparing the expressions in a cell type of
+                      interest to each other cell type in the tissue.
                     </div>
                     <br />
                     <div>
@@ -171,13 +181,17 @@ function CellInfoSideBar({
                         rel="noopener"
                         target="_blank"
                         onClick={() => {
-                          track(EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER, {label: "marker score"});
-                          track(EVENTS.WMG_FMG_DOCUMENTATION_CLICKED, {label: "marker score"});
+                          track(EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER, {
+                            label: "marker score",
+                          });
+                          track(EVENTS.WMG_FMG_DOCUMENTATION_CLICKED, {
+                            label: "marker score",
+                          });
                         }}
                       >
                         Click to read more about the identification method.
                       </a>
-                    </div>                    
+                    </div>
                   </StyledTooltip>
                 }
               >

--- a/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
@@ -57,15 +57,17 @@ function CellInfoSideBar({
   }, [data, dispatch]);
 
   const [hoverStartTime, setHoverStartTime] = useState(0);
+  
+  const useHandleHoverEnd = (event: EVENTS, payload = {}) => {
+      return useCallback(() => {
+        if (Date.now() - hoverStartTime > 2 * 1000) {
+          track(event, payload);
+        }
+      }, [hoverStartTime])
+  }
 
-  const useHandleHoverEnd = useCallback((event: EVENTS, payload = {}) => {
-    if (Date.now() - hoverStartTime > 2 * 1000) {
-      track(event, payload);
-    }
-  }, [hoverStartTime])
-
-  const handleFmgHoverEnd = useHandleHoverEnd(EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER, {label: "marker score"});
-  const handleMarkerScoreHoverEnd = useHandleHoverEnd(EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER, {label: "marker genes"});
+  const handleFmgHoverEnd = useHandleHoverEnd(EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER, {label: "marker genes"});
+  const handleMarkerScoreHoverEnd = useHandleHoverEnd(EVENTS.WMG_FMG_QUESTION_BUTTON_HOVER, {label: "marker score"});
 
   if (isLoading || !data) return null;
 
@@ -82,8 +84,11 @@ function CellInfoSideBar({
             width="default"
             className="fmg-tooltip-icon"
             arrow={true}
+            onOpen={() => setHoverStartTime(Date.now())}   
+            onClose={handleFmgHoverEnd}
             title={
-              <StyledTooltip>
+              <StyledTooltip             
+              >
                 <div>
                   Marker genes are highly and uniquely expressed in the cell
                   type relative to all other cell types.
@@ -110,8 +115,6 @@ function CellInfoSideBar({
               sdsType="secondary"
               isAllCaps={false}
               style={{ fontWeight: "500" }}
-              onMouseEnter={() => setHoverStartTime(Date.now())}
-              onMouseLeave={handleFmgHoverEnd}
             >
               <StyledIconImage src={questionMarkIcon} />
             </TooltipButton>
@@ -152,6 +155,8 @@ function CellInfoSideBar({
                 width="default"
                 className="fmg-tooltip-icon"
                 arrow={true}
+                onOpen={() => setHoverStartTime(Date.now())}
+                onClose={handleMarkerScoreHoverEnd}                
                 title={
                   <StyledTooltip>
                     <div>
@@ -181,8 +186,6 @@ function CellInfoSideBar({
                   sdsType="secondary"
                   isAllCaps={false}
                   style={{ fontWeight: "500" }}
-                  onMouseEnter={() => setHoverStartTime(Date.now())}
-                  onMouseLeave={handleMarkerScoreHoverEnd}
                 >
                   <StyledIconImage src={questionMarkIcon} />
                 </TooltipButton>


### PR DESCRIPTION
## Reason for Change
- Analytics were broken after CR in #4090 (oops!)
## Changes
- wrap useCallback in a function so it properly behaves as an event
- replace onMouseEnter/Leave logic with onOpen/Close of the tooltip itself. That way mouse doesn't need to hover over the question mark button specifically.

## Testing steps
- Tested locally and console.log'd the events firing with the appropriate payloads.

