### PR TITLE
fix: removed na from suspension type filter. #2622

### DIFF
--- a/frontend/src/common/queries/filter.ts
+++ b/frontend/src/common/queries/filter.ts
@@ -18,6 +18,7 @@ import {
   COLLATOR_CASE_INSENSITIVE,
   SELF_REPORTED_ETHNICITY_DENY_LIST,
   PUBLICATION_DATE_VALUES,
+  SUSPENSION_TYPES_DENY_LIST,
 } from "src/components/common/Filter/common/constants";
 import {
   Categories,
@@ -780,6 +781,12 @@ function sanitizeDatasetResponse(
   ).filter(
     (self_reported_ethnicity) =>
       !SELF_REPORTED_ETHNICITY_DENY_LIST.includes(self_reported_ethnicity.label)
+  );
+
+  sanitizedDatasetResponse.suspension_type = (
+    datasetResponse.suspension_type ?? []
+  ).filter(
+    (suspensionType) => !SUSPENSION_TYPES_DENY_LIST.includes(suspensionType)
   );
 
   sanitizedDatasetResponse.assay = datasetResponse.assay ?? [];

--- a/frontend/src/common/queries/filter.ts
+++ b/frontend/src/common/queries/filter.ts
@@ -18,7 +18,7 @@ import {
   COLLATOR_CASE_INSENSITIVE,
   SELF_REPORTED_ETHNICITY_DENY_LIST,
   PUBLICATION_DATE_VALUES,
-  SUSPENSION_TYPES_DENY_LIST,
+  SUSPENSION_TYPE_DENY_LIST,
 } from "src/components/common/Filter/common/constants";
 import {
   Categories,
@@ -786,7 +786,7 @@ function sanitizeDatasetResponse(
   sanitizedDatasetResponse.suspension_type = (
     datasetResponse.suspension_type ?? []
   ).filter(
-    (suspensionType) => !SUSPENSION_TYPES_DENY_LIST.includes(suspensionType)
+    (suspensionType) => !SUSPENSION_TYPE_DENY_LIST.includes(suspensionType)
   );
 
   sanitizedDatasetResponse.assay = datasetResponse.assay ?? [];

--- a/frontend/src/components/common/Filter/common/constants.ts
+++ b/frontend/src/components/common/Filter/common/constants.ts
@@ -255,7 +255,7 @@ export const SELF_REPORTED_ETHNICITY_DENY_LIST = ["na"];
 /**
  * List of suspension types to exclude from filter functionality.
  */
-export const SUSPENSION_TYPES_DENY_LIST = ["na"];
+export const SUSPENSION_TYPE_DENY_LIST = ["na"];
 
 /**
  * String value to append to labels in multi-panel categories if the value appears in more than one panel.

--- a/frontend/src/components/common/Filter/common/constants.ts
+++ b/frontend/src/components/common/Filter/common/constants.ts
@@ -253,6 +253,11 @@ export const DEVELOPMENT_STAGE_ONTOLOGY_TERM_SET: OntologyTermSet = {
 export const SELF_REPORTED_ETHNICITY_DENY_LIST = ["na"];
 
 /**
+ * List of suspension types to exclude from filter functionality.
+ */
+export const SUSPENSION_TYPES_DENY_LIST = ["na"];
+
+/**
  * String value to append to labels in multi-panel categories if the value appears in more than one panel.
  */
 export const LABEL_SUFFIX_NON_SPECIFIC = ", non-specific";


### PR DESCRIPTION
## Reason for Change
- #2622
- Remove "na" option from suspension type filter as per [Slack](https://clevercanary.slack.com/archives/C02CF7MQPGV/p1675267437217269).

## Changes
- Removed "na" option from suspension type filter values.

## Testing steps
- For both collections and datasets, verify there is no "na" option in the suspension type filter.
