### PR TITLE
chore: enable happy shell into the backend container

### DIFF
--- a/.happy/terraform/modules/service/main.tf
+++ b/.happy/terraform/modules/service/main.tf
@@ -19,7 +19,7 @@ resource aws_ecs_service service {
     subnets          = var.subnets
     assign_public_ip = false
   }
-
+  enable_execute_command = true
   wait_for_steady_state = var.wait_for_steady_state
 }
 


### PR DESCRIPTION
Currently we are unable to use `happy shell` to get inside the backend containers. This would be very helpful for debugging certain issues.