### PR TITLE
fix(wmg): rewrite the dataset metadata logic to eliminate performance bottleneck for tissues with many datasets

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -81,7 +81,7 @@ def markers():
 
 
 def fetch_datasets_metadata(snapshot: WmgSnapshot, dataset_ids: Iterable[str]) -> List[Dict]:
-    return [snapshot.dataset_dict[dataset_id] for dataset_id in dataset_ids]
+    return [snapshot.dataset_dict.get(dataset_id, {}) for dataset_id in dataset_ids]
 
 
 def find_dim_option_values(criteria: Dict, snapshot: WmgSnapshot, dimension: str) -> set:

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -6,9 +6,6 @@ import connexion
 from flask import jsonify
 from pandas import DataFrame
 
-from backend.layers.business.business import BusinessLogic
-from backend.layers.common.entities import DatasetId
-from backend.layers.persistence.persistence import DatabaseProvider
 from backend.wmg.data.ontology_labels import gene_term_label, ontology_term_label
 from backend.wmg.data.query import MarkerGeneQueryCriteria, WmgQuery, WmgQueryCriteria, retrieve_top_n_markers
 from backend.wmg.data.rollup import rollup_across_cell_type_descendants
@@ -81,19 +78,6 @@ def markers():
             marker_genes=marker_genes,
         )
     )
-
-
-_business_logic = None
-
-
-def get_business_logic():
-    """
-    Returns an instance of the business logic handler. Use this to interrogate the database
-    """
-    global _business_logic
-    if not _business_logic:
-        _business_logic = BusinessLogic(DatabaseProvider(), None, None, None, None)
-    return _business_logic
 
 
 def fetch_datasets_metadata(snapshot: WmgSnapshot, dataset_ids: Iterable[str]) -> List[Dict]:

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -68,7 +68,13 @@ class WmgSnapshot:
         return hash(None)  # hash is not used for WmgSnapshot
 
     def build_dataset_metadata_dict(self):
-        API_URL = os.getenv("API_URL")
+        # hardcode to dev backend if deployment is rdev
+        API_URL = (
+            "https://api.cellxgene.dev.single-cell.czi.technology"
+            if os.environ.get("REMOTE_DEV_PREFIX")
+            else os.getenv("API_URL")
+        )
+
         # this should always be true for deployed environments.
         # otherwise, skip so tests pass.
         if API_URL:

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -69,27 +69,30 @@ class WmgSnapshot:
 
     def __init__(self, **kwargs):
         API_URL = os.getenv("API_URL")
-        dataset_metadata_url = f"{API_URL}/dp/v1/datasets/index"
-        datasets = requests.get(dataset_metadata_url).json()
+        # this should always be true for deployed environments.
+        # otherwise, skip so tests pass.
+        if API_URL:
+            dataset_metadata_url = f"{API_URL}/dp/v1/datasets/index"
+            datasets = requests.get(dataset_metadata_url).json()
 
-        collection_metadata_url = f"{API_URL}/dp/v1/collections/index"
-        collections = requests.get(collection_metadata_url).json()
+            collection_metadata_url = f"{API_URL}/dp/v1/collections/index"
+            collections = requests.get(collection_metadata_url).json()
 
-        collections_dict = {collection["id"]: collection for collection in collections}
+            collections_dict = {collection["id"]: collection for collection in collections}
 
-        dataset_dict = {}
-        for dataset in datasets:
-            for asset in dataset["dataset_assets"]:
-                if asset["filename"] == "local.h5ad":
-                    dataset_id = asset["s3_uri"].split("/")[-2]
-                    dataset_dict[dataset_id] = dict(
-                        id=dataset_id,
-                        label=dataset["name"],
-                        collection_id=dataset["collection_id"],
-                        collection_label=collections_dict[dataset["collection_id"]]["name"],
-                    )
+            dataset_dict = {}
+            for dataset in datasets:
+                for asset in dataset["dataset_assets"]:
+                    if asset["filename"] == "local.h5ad":
+                        dataset_id = asset["s3_uri"].split("/")[-2]
+                        dataset_dict[dataset_id] = dict(
+                            id=dataset_id,
+                            label=dataset["name"],
+                            collection_id=dataset["collection_id"],
+                            collection_label=collections_dict[dataset["collection_id"]]["name"],
+                        )
 
-        self.dataset_dict = dataset_dict
+            self.dataset_dict = dataset_dict
 
 
 # Cached data

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -27,7 +27,7 @@ DATASET_TO_GENE_IDS_FILENAME = f"{DATASET_TO_GENE_IDS_NAME}.json"
 logger = logging.getLogger("wmg")
 
 
-@dataclass(init=True)
+@dataclass
 class WmgSnapshot:
     """
     All of the data artifacts the WMG API depends upon to perform its functions, versioned by "snapshot_identifier".
@@ -67,7 +67,7 @@ class WmgSnapshot:
     def __hash__(self):
         return hash(None)  # hash is not used for WmgSnapshot
 
-    def __init__(self, **kwargs):
+    def build_dataset_metadata_dict(self):
         API_URL = os.getenv("API_URL")
         # this should always be true for deployed environments.
         # otherwise, skip so tests pass.
@@ -108,6 +108,7 @@ def load_snapshot() -> WmgSnapshot:
     global cached_snapshot
     if new_snapshot_identifier := _update_latest_snapshot_identifier():
         cached_snapshot = _load_snapshot(new_snapshot_identifier)
+        cached_snapshot.build_dataset_metadata_dict()
     return cached_snapshot
 
 

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -67,7 +67,7 @@ class WmgSnapshot:
     def __hash__(self):
         return hash(None)  # hash is not used for WmgSnapshot
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         API_URL = os.getenv("API_URL")
         dataset_metadata_url = f"{API_URL}/dp/v1/datasets/index"
         datasets = requests.get(dataset_metadata_url).json()

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -88,7 +88,7 @@ class WmgSnapshot:
 
             dataset_dict = {}
             for dataset in datasets:
-                dataset_id = dataset["dataset_deployments"][0]["url"].split("/")[-2].split(".cxg")[0]
+                dataset_id = dataset["explorer_url"].split("/")[-2].split(".cxg")[0]
                 dataset_dict[dataset_id] = dict(
                     id=dataset_id,
                     label=dataset["name"],

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -88,15 +88,13 @@ class WmgSnapshot:
 
             dataset_dict = {}
             for dataset in datasets:
-                for asset in dataset["dataset_assets"]:
-                    if asset["filename"] == "local.h5ad":
-                        dataset_id = asset["s3_uri"].split("/")[-2]
-                        dataset_dict[dataset_id] = dict(
-                            id=dataset_id,
-                            label=dataset["name"],
-                            collection_id=dataset["collection_id"],
-                            collection_label=collections_dict[dataset["collection_id"]]["name"],
-                        )
+                dataset_id = dataset["dataset_deployments"][0]["url"].split("/")[-2].split(".cxg")[0]
+                dataset_dict[dataset_id] = dict(
+                    id=dataset_id,
+                    label=dataset["name"],
+                    collection_id=dataset["collection_id"],
+                    collection_label=collections_dict[dataset["collection_id"]]["name"],
+                )
 
             self.dataset_dict = dataset_dict
 

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from typing import Dict, Optional
 
 import pandas as pd
-import tiledb
 import requests
+import tiledb
 from pandas import DataFrame
 from tiledb import Array
 

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -27,7 +27,7 @@ DATASET_TO_GENE_IDS_FILENAME = f"{DATASET_TO_GENE_IDS_NAME}.json"
 logger = logging.getLogger("wmg")
 
 
-@dataclass
+@dataclass(init=True)
 class WmgSnapshot:
     """
     All of the data artifacts the WMG API depends upon to perform its functions, versioned by "snapshot_identifier".


### PR DESCRIPTION
## Reason for Change

- #4119 

There are now 145 datasets for brain tissue in the WMG snapshot. The `fetch_dataset_metadata` logic was getting dataset metadata one at a time from the RDS database. This makes any query for brain tissue take >2 minutes which times out the query and eventually crashes the server forcing a restart of the ECS task.

The proposed solution is to fetch the dataset and collection metadata from the data portal endpoints and parse them to get all the metadata we'd need. This would happen every time a snapshot loads for the first time. 

This will also greatly improve the query response times for pretty much all tissues.

## Changes

- added dataset metadata builder to WmgSnapshot
- remove previous logic for `fetch_dataset_metadata`

## Testing steps
RDEV STACK