### PR TITLE
chore: update default dataset metadata response when dataset ID is not found

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -81,7 +81,10 @@ def markers():
 
 
 def fetch_datasets_metadata(snapshot: WmgSnapshot, dataset_ids: Iterable[str]) -> List[Dict]:
-    return [snapshot.dataset_dict.get(dataset_id, {}) for dataset_id in dataset_ids]
+    return [
+        snapshot.dataset_dict.get(dataset_id, dict(id=dataset_id, label="", collection_id="", collection_label=""))
+        for dataset_id in dataset_ids
+    ]
 
 
 def find_dim_option_values(criteria: Dict, snapshot: WmgSnapshot, dimension: str) -> set:


### PR DESCRIPTION
This ensures that the behavior of `fetch_dataset_metadata` perfectly matches what it was before #4133 