### PR TITLE
fix(wmg): fix transient tissue clearing due to default hierarchical sorting 

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
@@ -245,10 +245,12 @@ function getTissueCellTypes({
   const tissueCellTypes = cellTypes[tissue];
   const sortedTissueCellTypes = sortedCellTypesByTissueName[tissue];
   const isRollup = get(FEATURES.IS_ROLLUP) === BOOLEAN.TRUE;
+  const sortedTissueCellTypesIfDefined =
+    sortedTissueCellTypes ?? tissueCellTypes;
   return (
     (cellTypeSortBy === SORT_BY.CELL_ONTOLOGY && !isRollup
       ? tissueCellTypes
-      : sortedTissueCellTypes) || EMPTY_ARRAY
+      : sortedTissueCellTypesIfDefined) || EMPTY_ARRAY
   );
 }
 


### PR DESCRIPTION
## Reason for Change

This is a small bug-fix. For the rollup work, we set cell types to be sorted hierarchically by default. If no genes are selected, the original ordering is used instead. When genes are first selected, there is a transient period where genes are selected but no data is present, which clears the cell type information transiently. This PR fixes that issue.

- #4138 

## Changes

- add nullish coalescence to set sorted cell types = to default sorting if sorted cell types are still null during data loading

## Testing steps

- Tested locally