### PR TITLE
chore: update published_at in the collection details endpoint

### DIFF
--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -282,7 +282,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
             "id": collection_id,
             "links": [_link_to_response(link) for link in collection.metadata.links],
             "name": collection.metadata.name,
-            "published_at": collection.published_at,
+            "published_at": collection.canonical_collection.originally_published_at,
             "publisher_metadata": collection.publisher_metadata,  # TODO: convert
             "revision_of": revision_of,
             "updated_at": collection.published_at or collection.created_at,


### PR DESCRIPTION
## Reason for Change
This endpoint is currently used by Amanda for analytics. Even if she should probably migrate to a different approach, this fix is still valuable.
Note that the field isn't currently used by the website so this is not a regression outside of analytics.

No ticket.

## Changes

- `published_at` in the collections detail endpoint should point to the original publishing date, not to the collection version's publication date.