### PR TITLE
feat(wmg): 3991 SVG download with MutationObserver

### DIFF
--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveImage/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveImage/index.tsx
@@ -2,6 +2,7 @@ import { Classes, Intent } from "@blueprintjs/core";
 import { FormControlLabel } from "@mui/material";
 import { InputRadio } from "czifui";
 import { toPng, toSvg } from "html-to-image";
+import { debounce } from "lodash";
 import { Dispatch, useCallback, useState } from "react";
 import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
@@ -12,23 +13,27 @@ import {
 import Modal from "src/components/common/Modal";
 import { HEATMAP_CONTAINER_ID } from "src/views/WheresMyGene/common/constants";
 import { CellType, Tissue } from "src/views/WheresMyGene/common/types";
-import {
-  ECHART_AXIS_LABEL_COLOR_HEX,
-  ECHART_AXIS_LABEL_FONT_SIZE_PX,
-} from "../../../HeatMap/components/XAxisChart/style";
+
 import {
   getHeatmapHeight,
   getHeatmapWidth,
-  HEAT_MAP_BASE_CELL_PX,
   X_AXIS_CHART_HEIGHT_PX,
   Y_AXIS_CHART_WIDTH_PX,
 } from "../../../HeatMap/utils";
-import { plasmaSvgString } from "../../../InfoPanel/components/ColorScale";
+
 import { Label } from "../../style";
 import { StyledButtonIcon } from "../QuickSelect/style";
 import { ButtonWrapper, DownloadButton, StyledDiv } from "./style";
+import {
+  NAME_SPACE_URI,
+  renderLegend,
+  renderXAxis,
+  renderYAxis,
+} from "./utils";
 
 let heatmapContainerScrollTop: number | undefined;
+
+const MUTATION_OBSERVER_TIMEOUT = 3 * 1000;
 
 export const EXCLUDE_IN_SCREENSHOT_CLASS_NAME = "screenshot-exclude";
 const screenshotFilter =
@@ -89,100 +94,41 @@ export default function SaveImage({
   const handleDownload = useCallback(async () => {
     setIsOpen(false);
     setIsDownloading(true);
+
+    const heatmapNode = document.getElementById("view") as HTMLDivElement;
+
+    // Options for the observer (which mutations to observe)
+    const config = { childList: true, subtree: true };
+
+    // Callback function to execute when mutations are observed
+    const callback = debounce(() => {
+      download();
+    }, MUTATION_OBSERVER_TIMEOUT);
+
+    const observer = new MutationObserver(callback);
+
+    /**
+     * (thuang): We only want to call download() once, AFTER the heatmap is fully rendered.
+     * We assume the heatmap is fully rendered after no more changes to the DOM tree
+     * after `MUTATION_OBSERVER_TIMEOUT` milliseconds
+     */
+    const download = debounce(
+      download_({
+        fileType,
+        heatmapNode,
+        observer,
+        selectedCellTypes,
+        selectedGenes,
+        selectedTissues,
+        setEchartsRendererMode,
+        setIsDownloading,
+      }),
+      MUTATION_OBSERVER_TIMEOUT
+    );
+
+    observer.observe(heatmapNode, config);
+
     setEchartsRendererMode("svg");
-
-    await new Promise((resolve) => setTimeout(resolve, 5 * 1000));
-
-    try {
-      const heatmapNode = document.getElementById("view") as HTMLCanvasElement;
-      //(ashin): #3569 Get scrollTop to go back to place after downloading image
-      const heatmapContainer = document.getElementById(
-        HEATMAP_CONTAINER_ID
-      ) as HTMLCanvasElement;
-      heatmapContainerScrollTop = heatmapContainer?.scrollTop;
-
-      // Adding this class causes the y-axis scrolling to jump but is required for image download
-      heatmapNode.classList.add("CLONED");
-      const initialWidth = heatmapNode.style.width;
-      heatmapNode.style.width = `${
-        getHeatmapWidth(selectedGenes) + Y_AXIS_CHART_WIDTH_PX + 100
-      }px`;
-      const isPNG = fileType === "png";
-      const convertHTMLtoImage = isPNG ? toPng : toSvg;
-      const images = await Promise.all(
-        selectedTissues.map(async (tissueName) => {
-          const height = getHeatmapHeight(selectedCellTypes[tissueName]);
-
-          // Handles if whitespace is in the tissue name for the element ID
-          tissueName = tissueName.replace(/\s+/g, "-");
-
-          const imageURL = await convertHTMLtoImage(heatmapNode, {
-            backgroundColor: "white",
-            filter: screenshotFilter(tissueName),
-            height: height + X_AXIS_CHART_HEIGHT_PX + 120,
-            pixelRatio: 4,
-            width: heatmapNode.width,
-          });
-          // raw URI if only one tissue is selected
-
-          const input = isPNG
-            ? selectedTissues.length === 1
-              ? imageURL
-              : base64URLToArrayBuffer(imageURL)
-            : processSvg({
-                height,
-                svg: decodeURIComponent(imageURL.split(",")[1]),
-                tissueName,
-              });
-
-          return {
-            input,
-            name: `${tissueName}.${fileType}`,
-          };
-        })
-      );
-
-      //(thuang): #3569 Restore scrollTop position
-      heatmapNode.classList.remove("CLONED");
-      heatmapNode.style.width = initialWidth;
-      if (heatmapContainer) {
-        heatmapContainer.scrollTop = heatmapContainerScrollTop || 0;
-      }
-
-      const link = document.createElement("a");
-
-      if (images.length > 1) {
-        const { downloadZip } = await import("client-zip");
-        const blob = await downloadZip(images).blob();
-        link.href = URL.createObjectURL(blob);
-        link.download = `CELLxGENE_gene_expression.zip`;
-      } else {
-        if (isPNG) {
-          // PNG download link
-          link.href = images[0].input as string;
-          link.download = images[0].name;
-        } else {
-          // SVG download link
-          // (ashin-czi): Fixes SVG string breaking when encountering a "#" character
-          link.href =
-            "data:image/svg+xml," +
-            (images[0].input as string).replace(/#/g, "%23");
-          link.download = images[0].name;
-        }
-      }
-      link.click();
-      link.remove();
-      track(EVENTS.WMG_DOWNLOAD_COMPLETE, {
-        file_type: fileType,
-        genes: selectedGenes.toString(),
-        tissues: selectedTissues.toString(),
-      });
-    } catch (error) {
-      console.error(error);
-    }
-
-    setIsDownloading(false);
-    setEchartsRendererMode("canvas");
   }, [
     fileType,
     selectedCellTypes,
@@ -198,7 +144,6 @@ export default function SaveImage({
         <Label>Download</Label>
         <StyledButtonIcon
           data-test-id="download-button"
-          // TODO: put handleButtonClick when svgs are fixed
           onClick={handleButtonClick}
           disabled={selectedTissues.length === 0 || selectedGenes.length === 0}
           sdsSize="medium"
@@ -291,10 +236,10 @@ function processSvg({
   finalSvg.setAttribute("width", `${svgWidth}`);
 
   // Append elements to final SVG
-  finalSvg.append(legendSvg!);
-  finalSvg.append(xAxisSvg!);
-  finalSvg.append(yAxisSvg!);
-  finalSvg.append(dotsSvg!);
+  finalSvg.append(legendSvg || "");
+  finalSvg.append(xAxisSvg || "");
+  finalSvg.append(yAxisSvg || "");
+  finalSvg.append(dotsSvg || "");
 
   return finalSvg.outerHTML;
 }
@@ -328,375 +273,115 @@ function renderDots({
   return chart;
 }
 
-const NAME_SPACE_URI = "http://www.w3.org/2000/svg";
-
-function renderLegend({
-  heatmapContainer,
+function download_({
+  heatmapNode,
+  selectedTissues,
+  selectedGenes,
+  selectedCellTypes,
+  fileType,
+  observer,
+  setIsDownloading,
+  setEchartsRendererMode,
 }: {
-  heatmapContainer?: HTMLElement | null;
+  heatmapNode: HTMLDivElement;
+  selectedTissues: Props["selectedTissues"];
+  selectedGenes: Props["selectedGenes"];
+  selectedCellTypes: Props["selectedCellTypes"];
+  fileType: "png" | "svg";
+  observer: MutationObserver;
+  setIsDownloading: (isDownloading: boolean) => void;
+  setEchartsRendererMode: (mode: "canvas" | "svg") => void;
 }) {
-  if (!heatmapContainer) return;
+  return async () => {
+    try {
+      //(ashin): #3569 Get scrollTop to go back to place after downloading image
+      const heatmapContainer = document.getElementById(
+        HEATMAP_CONTAINER_ID
+      ) as HTMLCanvasElement;
+      heatmapContainerScrollTop = heatmapContainer?.scrollTop;
 
-  const width = 120;
+      // Adding this class causes the y-axis scrolling to jump but is required for image download
+      heatmapNode.classList.add("CLONED");
+      const initialWidth = heatmapNode.style.width;
+      heatmapNode.style.width = `${
+        getHeatmapWidth(selectedGenes) + Y_AXIS_CHART_WIDTH_PX + 100
+      }px`;
+      const isPNG = fileType === "png";
+      const convertHTMLtoImage = isPNG ? toPng : toSvg;
+      const images = await Promise.all(
+        selectedTissues.map(async (tissueName) => {
+          const height = getHeatmapHeight(selectedCellTypes[tissueName]);
 
-  const relativeGeneExpressionElement = heatmapContainer.querySelector(
-    `#relative-gene-expression`
-  );
-  const expressedInCellsElement =
-    heatmapContainer.querySelector(`#expressed-in-cells`);
+          // Handles if whitespace is in the tissue name for the element ID
+          tissueName = tissueName.replace(/\s+/g, "-");
 
-  const colorScale = renderColorScale({
-    element: relativeGeneExpressionElement,
-    width,
-  });
-  const expressedInCells = renderExpressedInCells({
-    element: expressedInCellsElement,
-    width,
-  });
+          const imageURL = await convertHTMLtoImage(heatmapNode, {
+            backgroundColor: "white",
+            filter: screenshotFilter(tissueName),
+            height: height + X_AXIS_CHART_HEIGHT_PX + 120,
+            pixelRatio: 4,
+            width: heatmapNode.offsetWidth,
+          });
+          // raw URI if only one tissue is selected
 
-  const FONT_FAMILY = "sans-serif";
+          const input = isPNG
+            ? selectedTissues.length === 1
+              ? imageURL
+              : base64URLToArrayBuffer(imageURL)
+            : processSvg({
+                height,
+                svg: decodeURIComponent(imageURL.split(",")[1]),
+                tissueName,
+              });
 
-  // Create root SVG elemnt
-  const svg = document.createElementNS(NAME_SPACE_URI, "svg");
+          return {
+            input,
+            name: `${tissueName}.${fileType}`,
+          };
+        })
+      );
 
-  const svgAttributes = {
-    x: `0`,
-    y: `0`,
-    fill: ECHART_AXIS_LABEL_COLOR_HEX,
-    "font-family": FONT_FAMILY,
-    "font-size": ECHART_AXIS_LABEL_FONT_SIZE_PX,
+      //(thuang): #3569 Restore scrollTop position
+      heatmapNode.classList.remove("CLONED");
+      heatmapNode.style.width = initialWidth;
+      if (heatmapContainer) {
+        heatmapContainer.scrollTop = heatmapContainerScrollTop || 0;
+      }
+
+      const link = document.createElement("a");
+
+      if (images.length > 1) {
+        const { downloadZip } = await import("client-zip");
+        const blob = await downloadZip(images).blob();
+        link.href = URL.createObjectURL(blob);
+        link.download = `CELLxGENE_gene_expression.zip`;
+      } else {
+        if (isPNG) {
+          // PNG download link
+          link.href = images[0].input as string;
+          link.download = images[0].name;
+        } else {
+          // SVG download link
+          // (ashin-czi): Fixes SVG string breaking when encountering a "#" character
+          link.href =
+            "data:image/svg+xml," +
+            (images[0].input as string).replace(/#/g, "%23");
+          link.download = images[0].name;
+        }
+      }
+      link.click();
+      link.remove();
+      track(EVENTS.WMG_DOWNLOAD_COMPLETE, {
+        file_type: fileType,
+        genes: selectedGenes.toString(),
+        tissues: selectedTissues.toString(),
+      });
+    } catch (error) {
+      console.error(error);
+    }
+
+    observer.disconnect();
+    setIsDownloading(false);
+    setEchartsRendererMode("canvas");
   };
-
-  applyAttributes(svg, svgAttributes);
-
-  svg.append(colorScale!);
-  svg.append(expressedInCells!);
-
-  return svg;
-}
-
-function renderExpressedInCells({
-  element,
-  width = 0,
-}: {
-  element?: Element | null;
-  width?: number;
-}) {
-  if (!element) return;
-
-  const expressedCellsGroup = document.createElementNS(NAME_SPACE_URI, "g");
-  expressedCellsGroup.id = "expressed-in-cells";
-
-  const xPosition = width + 60;
-
-  // Expressed in cells label
-  const expressedCellsLabel = document.createElementNS(NAME_SPACE_URI, "text");
-  expressedCellsLabel.textContent = element.querySelector(
-    `#expressed-in-cells-label`
-  )?.innerHTML!;
-  expressedCellsLabel.setAttribute("transform", `translate(${xPosition}, 45)`);
-
-  // Expressed in cells dots
-  const expressedCellsDots = document.createElementNS(NAME_SPACE_URI, "g");
-  expressedCellsDots.setAttribute("fill", "#CCCCCC");
-
-  const dots = element?.querySelectorAll(`#expressed-in-cells-dots span`);
-  Array.from(dots || []).forEach((dot, index) => {
-    const circle = document.createElementNS(NAME_SPACE_URI, "circle");
-
-    const circleAttributes = {
-      r: `${Number(dot.getAttribute("size")) / 2}`,
-      transform: `translate(${xPosition + 2 + 28 * index}, 60)`,
-    };
-
-    applyAttributes(circle, circleAttributes);
-
-    expressedCellsDots.append(circle);
-  });
-
-  // Expressed in cells values
-  const expressedCellsValuesGroup = document.createElementNS(
-    NAME_SPACE_URI,
-    "g"
-  );
-  expressedCellsValuesGroup.setAttribute(
-    "transform",
-    `translate(${xPosition}, 80)`
-  );
-  const expressedCellsValues = element.querySelectorAll(`.low-high span`);
-
-  const expressedCellsValueLow = document.createElementNS(
-    NAME_SPACE_URI,
-    "text"
-  );
-  expressedCellsValueLow.setAttribute("x", "0");
-  expressedCellsValueLow.textContent = expressedCellsValues[0].innerHTML!;
-
-  const expressedCellsValueHigh = document.createElementNS(
-    NAME_SPACE_URI,
-    "text"
-  );
-  expressedCellsValueHigh.setAttribute("x", `${width}`);
-  expressedCellsValueHigh.setAttribute("text-anchor", "end");
-  expressedCellsValueHigh.textContent = expressedCellsValues[1].innerHTML!;
-
-  expressedCellsValuesGroup.append(expressedCellsValueLow);
-  expressedCellsValuesGroup.append(expressedCellsValueHigh);
-
-  // Append color scale legend
-  expressedCellsGroup.append(expressedCellsLabel);
-  expressedCellsGroup.append(expressedCellsDots);
-  expressedCellsGroup.append(expressedCellsValuesGroup);
-
-  return expressedCellsGroup;
-}
-
-function renderColorScale({
-  element,
-  width = 0,
-}: {
-  element?: Element | null;
-  width?: number;
-}) {
-  if (!element) return;
-
-  const xPosition = "40";
-
-  const colorScaleGroup = document.createElementNS(NAME_SPACE_URI, "g");
-  colorScaleGroup.id = "color-scale";
-
-  // Color scale label
-  const colorScaleLabel = document.createElementNS(NAME_SPACE_URI, "text");
-  colorScaleLabel.textContent = element.querySelector(
-    `#relative-gene-expression-label`
-  )?.innerHTML!;
-  colorScaleLabel.setAttribute("transform", `translate(${xPosition}, 45)`);
-
-  // Color scale image
-  const colorScaleImage = document.createElementNS(NAME_SPACE_URI, "g");
-  colorScaleImage.innerHTML = plasmaSvgString;
-  colorScaleImage.setAttribute("transform", `translate(${xPosition}, 50)`);
-  colorScaleImage.setAttribute("width", `${width}px`);
-
-  // Color scale values
-  const colorScaleValuesGroup = document.createElementNS(NAME_SPACE_URI, "g");
-  colorScaleValuesGroup.setAttribute(
-    "transform",
-    `translate(${xPosition}, 80)`
-  );
-  const colorScaleValues = element.querySelectorAll(`.low-high span`);
-
-  const colorScaleValueLow = document.createElementNS(NAME_SPACE_URI, "text");
-  colorScaleValueLow.setAttribute("x", "0");
-  colorScaleValueLow.textContent = colorScaleValues[0].innerHTML!;
-
-  const colorScaleValueHigh = document.createElementNS(NAME_SPACE_URI, "text");
-  colorScaleValueHigh.setAttribute("x", `120`);
-  colorScaleValueHigh.setAttribute("text-anchor", "end");
-  colorScaleValueHigh.textContent = colorScaleValues[1].innerHTML!;
-
-  colorScaleValuesGroup.append(colorScaleValueLow);
-  colorScaleValuesGroup.append(colorScaleValueHigh);
-
-  // Append color scale legend
-  colorScaleGroup.append(colorScaleLabel);
-  colorScaleGroup.append(colorScaleImage);
-  colorScaleGroup.append(colorScaleValuesGroup);
-
-  return colorScaleGroup;
-}
-
-function renderXAxis({
-  heatmapContainer,
-}: {
-  heatmapContainer?: HTMLElement | null;
-}) {
-  if (!heatmapContainer) return;
-
-  const xAxis = heatmapContainer.querySelector(`#x-axis-wrapper`);
-
-  const FONT_FAMILY = "sans-serif";
-
-  // Create root SVG elemnt
-  const svg = document.createElementNS(NAME_SPACE_URI, "svg");
-
-  const svgAttributes = {
-    height: `${200}px`,
-    x: `${Y_AXIS_CHART_WIDTH_PX}`,
-    y: `10`,
-    fill: ECHART_AXIS_LABEL_COLOR_HEX,
-    "font-family": FONT_FAMILY,
-    "font-size": ECHART_AXIS_LABEL_FONT_SIZE_PX,
-  };
-
-  applyAttributes(svg, svgAttributes);
-
-  // Create cell type count label
-  const cellTypeCount = document.createElementNS(NAME_SPACE_URI, "text");
-
-  const cellTypeCountAttributes = {
-    x: 0,
-    width: `100px`,
-    transform: `translate(40, ${X_AXIS_CHART_HEIGHT_PX}) rotate(90)`,
-    "text-anchor": "end",
-  };
-
-  applyAttributes(cellTypeCount, cellTypeCountAttributes);
-  cellTypeCount.textContent = "Cell Count";
-
-  svg.append(cellTypeCount);
-
-  // Create gene labels
-  const geneLabelContainer = document.createElementNS(NAME_SPACE_URI, "g");
-
-  Array.from(
-    xAxis?.querySelectorAll(`[data-test-id*='gene-label-'] div`) || []
-  ).forEach((label, index) => {
-    const geneLabelText = document.createElementNS(NAME_SPACE_URI, "text");
-
-    const labelAttributes = {
-      x: 0,
-      transform: `translate(${
-        65 + 20 * index
-      }, ${X_AXIS_CHART_HEIGHT_PX}) rotate(90)`,
-      "text-anchor": "end",
-    };
-
-    applyAttributes(geneLabelText, labelAttributes);
-    geneLabelText.textContent = label.innerHTML;
-
-    geneLabelContainer.append(geneLabelText);
-  });
-
-  svg.append(geneLabelContainer);
-
-  return svg;
-}
-
-function renderYAxis({
-  heatmapContainer,
-  tissueName,
-  height,
-}: {
-  heatmapContainer?: HTMLElement | null;
-  tissueName: Tissue;
-  height: number;
-}) {
-  if (!heatmapContainer) return;
-
-  const yAxis = heatmapContainer.querySelector(`#${tissueName}-y-axis`);
-
-  const FONT_FAMILY = "sans-serif";
-
-  const svg = document.createElementNS(NAME_SPACE_URI, "svg");
-
-  const svgAttributes = {
-    y: `${X_AXIS_CHART_HEIGHT_PX + 25}`,
-    height: `${height}px`,
-    width: `${Y_AXIS_CHART_WIDTH_PX + 60}px`, // Adds padding for current tissue label
-  };
-
-  applyAttributes(svg, svgAttributes);
-
-  // Container for tissue label
-  const tissueLabelContainer = document.createElementNS(NAME_SPACE_URI, "g");
-
-  const tissueLabelText = document.createElementNS(NAME_SPACE_URI, "text");
-  tissueLabelText.textContent = tissueName;
-  tissueLabelText.setAttribute("transform", "translate(35, 100) rotate(270)");
-  tissueLabelText.setAttribute("font-family", "Inter, sans-serif");
-  tissueLabelText.setAttribute("font-size", "14px");
-  tissueLabelText.setAttribute("font-weight", "bold");
-
-  const tissueLabelRect = document.createElementNS(NAME_SPACE_URI, "rect");
-  tissueLabelRect.setAttribute("x", "40");
-  tissueLabelRect.setAttribute("width", "5");
-  tissueLabelRect.setAttribute("height", height + "");
-
-  tissueLabelContainer.append(tissueLabelText);
-  tissueLabelContainer.append(tissueLabelRect);
-
-  // cell type names container group
-  const cellTypeNamesContainer = document.createElementNS(NAME_SPACE_URI, "g");
-
-  Array.from(
-    yAxis?.querySelectorAll("[data-test-id='cell-type-label-count']") || []
-  ).forEach((labelCount, index) => {
-    const label = labelCount.querySelector(
-      "[data-test-id='cell-type-label']"
-    )?.textContent;
-
-    const count = labelCount.querySelector(
-      "[data-test-id='cell-count']"
-    )?.textContent;
-
-    // group
-    const group = document.createElementNS(NAME_SPACE_URI, "g");
-
-    const groupAttributes = {
-      fill: ECHART_AXIS_LABEL_COLOR_HEX,
-      "font-family": FONT_FAMILY,
-      "font-size": ECHART_AXIS_LABEL_FONT_SIZE_PX,
-      /**
-       * (thuang): Add `HEAT_MAP_BASE_CELL_PX / 2` top margin, so we render the
-       * first label in the middle of the first cell
-       */
-      transform: `translate(50, ${
-        HEAT_MAP_BASE_CELL_PX / 2 + index * HEAT_MAP_BASE_CELL_PX
-      })`,
-    };
-
-    applyAttributes(group, groupAttributes);
-
-    // cellTypeLabel
-    const cellTypeLabel = document.createElementNS(NAME_SPACE_URI, "text");
-
-    // Preserves whitespace
-    cellTypeLabel.setAttributeNS(
-      "http://www.w3.org/XML/1998/namespace",
-      "xml:space",
-      "preserve"
-    );
-
-    const labelAttributes = {
-      x: 0,
-      y: 0,
-    };
-
-    applyAttributes(cellTypeLabel, labelAttributes);
-    cellTypeLabel.textContent = String(label);
-
-    // cellCount
-    const cellCount = document.createElementNS(NAME_SPACE_URI, "text");
-
-    const countAttributes = {
-      "text-anchor": "end",
-      x: Y_AXIS_CHART_WIDTH_PX,
-      y: 0,
-    };
-
-    applyAttributes(cellCount, countAttributes);
-
-    cellCount.textContent = String(count);
-
-    // append children
-    group.appendChild(cellTypeLabel);
-    group.appendChild(cellCount);
-
-    cellTypeNamesContainer.appendChild(group);
-  });
-
-  svg.append(tissueLabelContainer);
-  svg.append(cellTypeNamesContainer);
-
-  return svg;
-}
-
-function applyAttributes(
-  node: SVGElement,
-  attributes: Record<string, string | number>
-) {
-  for (const [key, value] of Object.entries(attributes)) {
-    node.setAttribute(key, String(value));
-  }
 }

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveImage/utils.ts
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveImage/utils.ts
@@ -1,0 +1,380 @@
+import { Tissue } from "src/views/WheresMyGene/common/types";
+import {
+  ECHART_AXIS_LABEL_COLOR_HEX,
+  ECHART_AXIS_LABEL_FONT_SIZE_PX,
+} from "../../../HeatMap/components/XAxisChart/style";
+import {
+  HEAT_MAP_BASE_CELL_PX,
+  X_AXIS_CHART_HEIGHT_PX,
+  Y_AXIS_CHART_WIDTH_PX,
+} from "../../../HeatMap/utils";
+import { plasmaSvgString } from "../../../InfoPanel/components/ColorScale";
+
+export const NAME_SPACE_URI = "http://www.w3.org/2000/svg";
+const FONT_FAMILY = "sans-serif";
+
+export function renderLegend({
+  heatmapContainer,
+}: {
+  heatmapContainer?: HTMLElement | null;
+}) {
+  if (!heatmapContainer) return;
+
+  const width = 120;
+
+  const relativeGeneExpressionElement = heatmapContainer.querySelector(
+    `#relative-gene-expression`
+  );
+  const expressedInCellsElement =
+    heatmapContainer.querySelector(`#expressed-in-cells`);
+
+  const colorScale = renderColorScale({
+    element: relativeGeneExpressionElement,
+    width,
+  });
+
+  const expressedInCells = renderExpressedInCells({
+    element: expressedInCellsElement,
+    width,
+  });
+
+  // Create root SVG element
+  const svg = document.createElementNS(NAME_SPACE_URI, "svg");
+
+  const svgAttributes = {
+    fill: ECHART_AXIS_LABEL_COLOR_HEX,
+    "font-family": FONT_FAMILY,
+    "font-size": ECHART_AXIS_LABEL_FONT_SIZE_PX,
+    x: `0`,
+    y: `0`,
+  };
+
+  applyAttributes(svg, svgAttributes);
+
+  svg.append(colorScale || "");
+  svg.append(expressedInCells || "");
+
+  return svg;
+}
+
+export function renderExpressedInCells({
+  element,
+  width = 0,
+}: {
+  element?: Element | null;
+  width?: number;
+}) {
+  if (!element) return;
+
+  const expressedCellsGroup = document.createElementNS(NAME_SPACE_URI, "g");
+  expressedCellsGroup.id = "expressed-in-cells";
+
+  const xPosition = width + 60;
+
+  // Expressed in cells label
+  const expressedCellsLabel = document.createElementNS(NAME_SPACE_URI, "text");
+  expressedCellsLabel.textContent =
+    element.querySelector(`#expressed-in-cells-label`)?.innerHTML || null;
+  expressedCellsLabel.setAttribute("transform", `translate(${xPosition}, 45)`);
+
+  // Expressed in cells dots
+  const expressedCellsDots = document.createElementNS(NAME_SPACE_URI, "g");
+  expressedCellsDots.setAttribute("fill", "#CCCCCC");
+
+  const dots = element?.querySelectorAll(`#expressed-in-cells-dots span`);
+  Array.from(dots || []).forEach((dot, index) => {
+    const circle = document.createElementNS(NAME_SPACE_URI, "circle");
+
+    const circleAttributes = {
+      r: `${Number(dot.getAttribute("size")) / 2}`,
+      transform: `translate(${xPosition + 2 + 28 * index}, 60)`,
+    };
+
+    applyAttributes(circle, circleAttributes);
+
+    expressedCellsDots.append(circle);
+  });
+
+  // Expressed in cells values
+  const expressedCellsValuesGroup = document.createElementNS(
+    NAME_SPACE_URI,
+    "g"
+  );
+  expressedCellsValuesGroup.setAttribute(
+    "transform",
+    `translate(${xPosition}, 80)`
+  );
+  const expressedCellsValues = element.querySelectorAll(`.low-high span`);
+
+  const expressedCellsValueLow = document.createElementNS(
+    NAME_SPACE_URI,
+    "text"
+  );
+  expressedCellsValueLow.setAttribute("x", "0");
+  expressedCellsValueLow.textContent =
+    expressedCellsValues[0].innerHTML || null;
+
+  const expressedCellsValueHigh = document.createElementNS(
+    NAME_SPACE_URI,
+    "text"
+  );
+  expressedCellsValueHigh.setAttribute("x", `${width}`);
+  expressedCellsValueHigh.setAttribute("text-anchor", "end");
+  expressedCellsValueHigh.textContent =
+    expressedCellsValues[1].innerHTML || null;
+
+  expressedCellsValuesGroup.append(expressedCellsValueLow);
+  expressedCellsValuesGroup.append(expressedCellsValueHigh);
+
+  // Append color scale legend
+  expressedCellsGroup.append(expressedCellsLabel);
+  expressedCellsGroup.append(expressedCellsDots);
+  expressedCellsGroup.append(expressedCellsValuesGroup);
+
+  return expressedCellsGroup;
+}
+
+export function renderColorScale({
+  element,
+  width = 0,
+}: {
+  element?: Element | null;
+  width?: number;
+}) {
+  if (!element) return;
+
+  const xPosition = "40";
+
+  const colorScaleGroup = document.createElementNS(NAME_SPACE_URI, "g");
+  colorScaleGroup.id = "color-scale";
+
+  // Color scale label
+  const colorScaleLabel = document.createElementNS(NAME_SPACE_URI, "text");
+  colorScaleLabel.textContent =
+    element.querySelector(`#relative-gene-expression-label`)?.innerHTML || null;
+  colorScaleLabel.setAttribute("transform", `translate(${xPosition}, 45)`);
+
+  // Color scale image
+  const colorScaleImage = document.createElementNS(NAME_SPACE_URI, "g");
+  colorScaleImage.innerHTML = plasmaSvgString;
+  colorScaleImage.setAttribute("transform", `translate(${xPosition}, 50)`);
+  colorScaleImage.setAttribute("width", `${width}px`);
+
+  // Color scale values
+  const colorScaleValuesGroup = document.createElementNS(NAME_SPACE_URI, "g");
+  colorScaleValuesGroup.setAttribute(
+    "transform",
+    `translate(${xPosition}, 80)`
+  );
+  const colorScaleValues = element.querySelectorAll(`.low-high span`);
+
+  const colorScaleValueLow = document.createElementNS(NAME_SPACE_URI, "text");
+  colorScaleValueLow.setAttribute("x", "0");
+  colorScaleValueLow.textContent = colorScaleValues[0].innerHTML || null;
+
+  const colorScaleValueHigh = document.createElementNS(NAME_SPACE_URI, "text");
+  colorScaleValueHigh.setAttribute("x", `120`);
+  colorScaleValueHigh.setAttribute("text-anchor", "end");
+  colorScaleValueHigh.textContent = colorScaleValues[1].innerHTML || null;
+
+  colorScaleValuesGroup.append(colorScaleValueLow);
+  colorScaleValuesGroup.append(colorScaleValueHigh);
+
+  // Append color scale legend
+  colorScaleGroup.append(colorScaleLabel);
+  colorScaleGroup.append(colorScaleImage);
+  colorScaleGroup.append(colorScaleValuesGroup);
+
+  return colorScaleGroup;
+}
+
+export function renderXAxis({
+  heatmapContainer,
+}: {
+  heatmapContainer?: HTMLElement | null;
+}) {
+  if (!heatmapContainer) return;
+
+  const xAxis = heatmapContainer.querySelector(`#x-axis-wrapper`);
+
+  // Create root SVG elemnt
+  const svg = document.createElementNS(NAME_SPACE_URI, "svg");
+
+  const svgAttributes = {
+    fill: ECHART_AXIS_LABEL_COLOR_HEX,
+    "font-family": FONT_FAMILY,
+    "font-size": ECHART_AXIS_LABEL_FONT_SIZE_PX,
+    height: `${200}px`,
+    x: `${Y_AXIS_CHART_WIDTH_PX}`,
+    y: `10`,
+  };
+
+  applyAttributes(svg, svgAttributes);
+
+  // Create cell type count label
+  const cellTypeCount = document.createElementNS(NAME_SPACE_URI, "text");
+
+  const cellTypeCountAttributes = {
+    "text-anchor": "end",
+    transform: `translate(40, ${X_AXIS_CHART_HEIGHT_PX}) rotate(90)`,
+    width: `100px`,
+    x: 0,
+  };
+
+  applyAttributes(cellTypeCount, cellTypeCountAttributes);
+  cellTypeCount.textContent = "Cell Count";
+
+  svg.append(cellTypeCount);
+
+  // Create gene labels
+  const geneLabelContainer = document.createElementNS(NAME_SPACE_URI, "g");
+
+  Array.from(
+    xAxis?.querySelectorAll(`[data-test-id*='gene-label-'] div`) || []
+  ).forEach((label, index) => {
+    const geneLabelText = document.createElementNS(NAME_SPACE_URI, "text");
+
+    const labelAttributes = {
+      "text-anchor": "end",
+      transform: `translate(${
+        65 + 20 * index
+      }, ${X_AXIS_CHART_HEIGHT_PX}) rotate(90)`,
+      x: 0,
+    };
+
+    applyAttributes(geneLabelText, labelAttributes);
+    geneLabelText.textContent = label.innerHTML;
+
+    geneLabelContainer.append(geneLabelText);
+  });
+
+  svg.append(geneLabelContainer);
+
+  return svg;
+}
+
+export function renderYAxis({
+  heatmapContainer,
+  tissueName,
+  height,
+}: {
+  heatmapContainer?: HTMLElement | null;
+  tissueName: Tissue;
+  height: number;
+}) {
+  if (!heatmapContainer) return;
+
+  const yAxis = heatmapContainer.querySelector(`#${tissueName}-y-axis`);
+
+  const svg = document.createElementNS(NAME_SPACE_URI, "svg");
+
+  const svgAttributes = {
+    height: `${height}px`,
+    width: `${Y_AXIS_CHART_WIDTH_PX + 60}px`, // Adds padding for current tissue label
+    y: `${X_AXIS_CHART_HEIGHT_PX + 25}`,
+  };
+
+  applyAttributes(svg, svgAttributes);
+
+  // Container for tissue label
+  const tissueLabelContainer = document.createElementNS(NAME_SPACE_URI, "g");
+
+  const tissueLabelText = document.createElementNS(NAME_SPACE_URI, "text");
+  tissueLabelText.textContent = tissueName;
+  tissueLabelText.setAttribute("transform", "translate(35, 100) rotate(270)");
+  tissueLabelText.setAttribute("font-family", "Inter, sans-serif");
+  tissueLabelText.setAttribute("font-size", "14px");
+  tissueLabelText.setAttribute("font-weight", "bold");
+
+  const tissueLabelRect = document.createElementNS(NAME_SPACE_URI, "rect");
+  tissueLabelRect.setAttribute("x", "40");
+  tissueLabelRect.setAttribute("width", "5");
+  tissueLabelRect.setAttribute("height", height + "");
+
+  tissueLabelContainer.append(tissueLabelText);
+  tissueLabelContainer.append(tissueLabelRect);
+
+  // cell type names container group
+  const cellTypeNamesContainer = document.createElementNS(NAME_SPACE_URI, "g");
+
+  Array.from(
+    yAxis?.querySelectorAll("[data-test-id='cell-type-label-count']") || []
+  ).forEach((labelCount, index) => {
+    const label = labelCount.querySelector(
+      "[data-test-id='cell-type-label']"
+    )?.textContent;
+
+    const count = labelCount.querySelector(
+      "[data-test-id='cell-count']"
+    )?.textContent;
+
+    // group
+    const group = document.createElementNS(NAME_SPACE_URI, "g");
+
+    const groupAttributes = {
+      fill: ECHART_AXIS_LABEL_COLOR_HEX,
+      "font-family": FONT_FAMILY,
+      "font-size": ECHART_AXIS_LABEL_FONT_SIZE_PX,
+      /**
+       * (thuang): Add `HEAT_MAP_BASE_CELL_PX / 2` top margin, so we render the
+       * first label in the middle of the first cell
+       */
+      transform: `translate(50, ${
+        HEAT_MAP_BASE_CELL_PX / 2 + index * HEAT_MAP_BASE_CELL_PX
+      })`,
+    };
+
+    applyAttributes(group, groupAttributes);
+
+    // cellTypeLabel
+    const cellTypeLabel = document.createElementNS(NAME_SPACE_URI, "text");
+
+    // Preserves whitespace
+    cellTypeLabel.setAttributeNS(
+      "http://www.w3.org/XML/1998/namespace",
+      "xml:space",
+      "preserve"
+    );
+
+    const labelAttributes = {
+      x: 0,
+      y: 0,
+    };
+
+    applyAttributes(cellTypeLabel, labelAttributes);
+    cellTypeLabel.textContent = String(label);
+
+    // cellCount
+    const cellCount = document.createElementNS(NAME_SPACE_URI, "text");
+
+    const countAttributes = {
+      "text-anchor": "end",
+      x: Y_AXIS_CHART_WIDTH_PX,
+      y: 0,
+    };
+
+    applyAttributes(cellCount, countAttributes);
+
+    cellCount.textContent = String(count);
+
+    // append children
+    group.appendChild(cellTypeLabel);
+    group.appendChild(cellCount);
+
+    cellTypeNamesContainer.appendChild(group);
+  });
+
+  svg.append(tissueLabelContainer);
+  svg.append(cellTypeNamesContainer);
+
+  return svg;
+}
+
+function applyAttributes(
+  node: SVGElement,
+  attributes: Record<string, string | number>
+) {
+  for (const [key, value] of Object.entries(attributes)) {
+    node.setAttribute(key, String(value));
+  }
+}

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from "czifui";
-import { init } from "echarts";
+import { ECharts, init } from "echarts";
 import cloneDeep from "lodash/cloneDeep";
 import debounce from "lodash/debounce";
 import throttle from "lodash/throttle";
@@ -71,7 +71,7 @@ export default memo(function Chart({
 
   const [isChartInitialized, setIsChartInitialized] = useState(false);
 
-  const [chart, setChart] = useState<echarts.ECharts | null>(null);
+  const [chart, setChart] = useState<ECharts | null>(null);
   const ref = useRef<HTMLDivElement | null>(null);
 
   const [heatmapWidth, setHeatmapWidth] = useState(
@@ -89,7 +89,7 @@ export default memo(function Chart({
   }, [cellTypes, selectedGeneData, setIsLoading, tissue]);
 
   const throttledSetCurrentIndices = useMemo(() => {
-    return throttle((params, chart) => {
+    return throttle((params, chart: ECharts) => {
       const { offsetX, offsetY, event } = params;
       const { pageX, pageY } = event;
 
@@ -98,7 +98,7 @@ export default memo(function Chart({
       const pointInGrid = chart.convertFromPixel("grid", [offsetX, offsetY]);
 
       setCursorOffset([pageX, pageY]);
-      setCurrentIndices(pointInGrid);
+      if (pointInGrid) setCurrentIndices(pointInGrid);
     }, TOOLTIP_THROTTLE_MS);
   }, []);
 
@@ -119,8 +119,7 @@ export default memo(function Chart({
     setIsChartInitialized(true);
 
     const chart = init(current, EMPTY_OBJECT, {
-      renderer: "svg",
-      // renderer: echartsRendererMode,
+      renderer: echartsRendererMode,
       useDirtyRect: true,
     });
 


### PR DESCRIPTION
## Reason for Change

- #3991 
- If the reason for this PR's code changes are not clear in the issue, state value/impact

1. Interactive heatmap is in canvas mode, which is NOT suitable for downloads, so we need to re-render heatmap in SVG before triggering the download. However, if we trigger download before the heatmap is done rendering, we'll miss elements in the downloaded files, thus the need to add MutationObserver to ensure the heatmap is done rendering before triggering download

## Changes

1. Add MutationObserver to check if the heatmap is done rendering SVG elements before downloading images
2. Move SVG render functions into `util.ts`
3. Re-enable canvas mode for interactive heatmap
4. Minor TS fixes to avoid using `!`

## Testing steps

1. Go to GE
2. In Genes selector, paste and enter the following to populate many genes:
```
MALAT1,TSPAN6,TNMD,DPM1,SCYL3,C1orf112,FGR,CFH,FUCA2,GCLC,NFYA,STPG1,NIPAL3,LAS1L,ENPP4,SEMA3F,CFTR,ANKIB1,CYP51A1,KRIT1,RAD52,MYH16,BAD,LAP3,CD99,HS3ST1,AOC1,MALAT1,WNT16,HECW1,MAD1L1,LASP1,SNX11,TMEM176A,M6PR,KLHL13,CYP26B1,ICA1,DBNDD1,ALS2,CASP10,CFLAR,TFPI,NDUFAF7,RBM5,MTMR7,SLC7A2,ARF5,SARM1,POLDIP2,PLXND1,AK2,CD38,FKBP4,RBM6,KDM1A,CAMKK1,RECQL,VPS50,HSPB6,ARHGAP33,NDUFAB1,PDK4,SLC22A16,ZMYND10
```
3. Add a few tissues
4. Once rendering is done, trigger download
5. Check the downloaded files and make sure they match the fully rendered heatmap in the browser

## Notes for Reviewer

Thank you!