### PR TITLE
fix: corrected filter payload field. #4176.

### DIFF
--- a/frontend/src/common/hooks/useCategoryFilter/common/selectUtils.ts
+++ b/frontend/src/common/hooks/useCategoryFilter/common/selectUtils.ts
@@ -295,12 +295,27 @@ function trackSelectCategoryValueSelected<T extends Categories>(
     getCategoryFilter(categoryFilterId, filters)?.value as CategoryValueId
   );
   if (!categoryFilters.has(categoryValueKey)) {
-    // Build up payload for tracking event and send. Newer filters such as suspension type track events in the format
-    // {payloadKey: payloadValue} whereas older filters such as author track events in the format
-    // {"payload": payloadValue}.
-    const payload = analyticsPayloadKey
-      ? { [analyticsPayloadKey]: categoryValueKey }
-      : { categoryValueKey };
+    const payload = buildAnalyticsPayload(
+      categoryValueKey,
+      analyticsPayloadKey
+    );
     track(analyticsEvent, payload);
   }
+}
+
+/**
+ * Build up payload for tracking event and send. Newer filters such as suspension type track events in the format
+ * {payloadKey: payloadValue} whereas older filters such as author track events in the format
+ * {"payload": payloadValue}.
+ * @param payloadKey Payload field, if any. Defaults to "payload" if not specified.
+ * @param payloadValue Value to send as payload.
+ * @returns
+ */
+export function buildAnalyticsPayload(
+  payloadValue: string,
+  payloadKey?: string
+): Record<string, unknown> {
+  return payloadKey
+    ? { [payloadKey]: payloadValue }
+    : { payload: payloadValue };
 }

--- a/frontend/tests/features/filter/selectUtils.test.ts
+++ b/frontend/tests/features/filter/selectUtils.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Test suite for select filter-related utils.
+ */
+
+import { expect, test } from "@playwright/test";
+import { buildAnalyticsPayload } from "src/common/hooks/useCategoryFilter/common/selectUtils";
+
+const { describe } = test;
+
+describe("filter", () => {
+  const KEY_PAYLOAD = "payload";
+  const KEY_TISSUE = "tissue";
+  const VALUE_TISSUE = "brain";
+  describe("Analytics", () => {
+    test("builds analytics payload with no payload key", () => {
+      const payload = buildAnalyticsPayload(VALUE_TISSUE);
+      expect(payload[KEY_PAYLOAD]).toBeTruthy();
+      expect(payload[KEY_PAYLOAD]).toEqual(VALUE_TISSUE);
+    });
+    test("builds analytics payload with payload key", () => {
+      const payload = buildAnalyticsPayload(VALUE_TISSUE, KEY_TISSUE);
+      expect(payload[KEY_TISSUE]).toBeTruthy();
+      expect(payload[KEY_TISSUE]).toEqual(VALUE_TISSUE);
+    });
+  });
+});


### PR DESCRIPTION
## Reason for Change

- #4176

## Changes

- Corrected payload key for select filters to use the text "payload" if a payload key is not specified.
- Added tests to check generating the analytics event payload with and without a payload key.

## Testing steps

- "Existing" filters such as assay and author should send a payload in the format `{payload: ${value}}`.
- New filters such as suspension type should send a payload in the format `{suspension_type: ${value}}`.

