### PR TITLE
fix(fmg): 4161 Different tissues with the same cellType should displa…

### DIFF
--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -826,13 +826,18 @@ export function useMarkerGenes({
   }, [data]);
 
   return useQuery(
-    [USE_MARKER_GENES, cellTypeID, test],
+    /**
+     * (thuang): Add all arguments to `fetchMarkerGenes()` as dependencies,
+     * so React Query can cache responses correctly without running into
+     * issues like #4161
+     */
+    [USE_MARKER_GENES, cellTypeID, organismID, test, tissueID],
     async () => {
       const output = await fetchMarkerGenes({
         cellTypeID,
         organismID,
-        tissueID,
         test,
+        tissueID,
       });
       const markerGenesIndexedByGeneName = Object.fromEntries(
         output.marker_genes.reduce(

--- a/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
@@ -35,9 +35,9 @@ function CellInfoSideBar({
   }
   const { isLoading, data } = useMarkerGenes({
     cellTypeID: cellInfoCellType.cellType.id,
-    tissueID: cellInfoCellType.tissueID,
     organismID: cellInfoCellType.organismID,
     test: testType,
+    tissueID: cellInfoCellType.tissueID,
   });
 
   const dispatch = useContext(DispatchContext);


### PR DESCRIPTION
…y different values

## Reason for Change

- #4161 

We need to add `tissueId` to the cache key, so React Query will fetch the response accordingly and not use the wrongly cached value

## Changes

## Testing steps

1. Select lung + B cell
2. Observe marker genes
3. Select Speen + B cell
4. The marker genes should be different from the values at step 2

![demo](https://user-images.githubusercontent.com/6309723/218592069-a9c309f9-4a2f-4181-83c4-b04c6433cba0.gif)


## Notes for Reviewer
