### PR TITLE
chore: pin scanpy and matplotlib dependencies

### DIFF
--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -12,7 +12,7 @@ ENV PIP_NO_CACHE_DIR=1
 
 # Install python dependencies
 # Remove packaging dependency once pyparser>3 is supported.
-RUN pip3 install scanpy==1.6.0 python-igraph==0.8.3 louvain==0.7.0 packaging==21.0 awscli
+RUN pip3 install python-igraph==0.8.3 louvain==0.7.0 packaging==21.0 awscli
 
 
 ADD requirements.txt requirements-base.txt

--- a/backend/layers/processing/requirements.txt
+++ b/backend/layers/processing/requirements.txt
@@ -1,5 +1,6 @@
 cellxgene-schema==3.0.0
 dataclasses-json
+matplotlib==3.6.3 # 3.7.0 isn't compatible with scanpy: https://github.com/scverse/scanpy/issues/2411
 numba==0.56.2
 numpy==1.23.2
 pandas==1.4.4
@@ -8,5 +9,6 @@ psycopg2-binary>=2.8.5
 pyarrow>=1.0
 pydantic>=1.9.0
 python-json-logger
+scanpy==1.6.0
 SQLAlchemy-Utils>=0.36.8
 SQLAlchemy>=1.4.0,<1.5

--- a/frontend/src/views/Landing/index.tsx
+++ b/frontend/src/views/Landing/index.tsx
@@ -665,10 +665,9 @@ const LandingPage = (): JSX.Element => {
           <div className={styles.freethinkVideoSection}>
             <h2>Behind-the-scenes of Chan Zuckerberg CELLxGENE</h2>
             <p>
-              Watch a behind-the-scenes look at Chan Zuckerberg CELLxGENE (CZ
-              CELLxGENE) and explore how the platform can help scientists
-              quickly surface important information that could lead to
-              discoveries in treating disease.
+              Watch a behind-the-scenes look at CZ CELLxGENE and explore how the
+              platform can help scientists quickly surface important information
+              that could lead to discoveries in treating disease.
             </p>
             <iframe
               title="Wistia video player"


### PR DESCRIPTION
Required due to https://github.com/scverse/scanpy/issues/2411

Also pins scapy to 1.6.0 (the version currently used) since this is likely a library that will introduce potential breaking updates.


## Testing steps

- See if unit tests pass
- Do an upload in dev
