### PR TITLE
chore: restore js env files

### DIFF
--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -1,0 +1,9 @@
+const { PLAUSIBLE_DATA_DOMAIN_STAGING } = require("./common");
+
+const configs = {
+  API_URL: "https://api.cellxgene.dev.single-cell.czi.technology",
+  PLAUSIBLE_DATA_DOMAIN: PLAUSIBLE_DATA_DOMAIN_STAGING,
+  SENTRY_DEPLOYMENT_ENVIRONMENT: "staging",
+};
+
+if (typeof module !== "undefined") module.exports = configs;

--- a/frontend/src/configs/prod.js
+++ b/frontend/src/configs/prod.js
@@ -1,0 +1,7 @@
+const configs = {
+  API_URL: "https://api.cellxgene.cziscience.com",
+  PLAUSIBLE_DATA_DOMAIN: "cellxgene.cziscience.com",
+  SENTRY_DEPLOYMENT_ENVIRONMENT: "production",
+};
+
+if (typeof module !== "undefined") module.exports = configs;

--- a/frontend/src/configs/staging.js
+++ b/frontend/src/configs/staging.js
@@ -1,0 +1,9 @@
+const { PLAUSIBLE_DATA_DOMAIN_STAGING } = require("./common");
+
+const configs = {
+  API_URL: "https://api.cellxgene.staging.single-cell.czi.technology",
+  PLAUSIBLE_DATA_DOMAIN: PLAUSIBLE_DATA_DOMAIN_STAGING,
+  SENTRY_DEPLOYMENT_ENVIRONMENT: "staging",
+};
+
+if (typeof module !== "undefined") module.exports = configs;


### PR DESCRIPTION
https://github.com/chanzuckerberg/single-cell-data-portal/issues/3830

## Changes

- Reintroduce the configuration js files. This is necessary in order for the e2e tests to work. This introduces some config duplication, but I think it's acceptable. As an alternative, the file would have to be written at line 144 in deploy-happy-stack.yml based on the .env files, but that will require a new script since the tests are run outside Docker.