### PR TITLE
fix: handle_failures lambda import error

### DIFF
--- a/Dockerfile.upload_failures
+++ b/Dockerfile.upload_failures
@@ -2,6 +2,7 @@ FROM public.ecr.aws/lambda/python:3.8
 
 COPY backend/layers/processing/upload_failures .
 COPY backend/layers ./backend/layers
+COPY backend/portal ./backend/portal
 
 RUN pip3 install -r requirements.txt
 


### PR DESCRIPTION
## Reason for Change
Due to a rename, the handle failures lambda was broken because of a missing import. This fixes it.

## Changes
- Adds a missing directory in the handle_failures Dockerfile

## Testing steps

1. Deploy
2. Upload a failing h5ad (e.g. a 2.0.0 schema)
3. Go to our step functions page (devstack)
4. Find the failed pipeline
5. Ensure that the HandleFailures lambda is being called and it's green.
