### PR TITLE
chore: add exception details for Dropbox failures

### DIFF
--- a/backend/layers/thirdparty/uri_provider.py
+++ b/backend/layers/thirdparty/uri_provider.py
@@ -56,7 +56,7 @@ class UriProvider(UriProviderInterface):
                 file_info["name"],
             )
 
-        except requests.HTTPError:
-            raise FileInfoException("The URL provided causes an error with Dropbox.") from None
+        except requests.HTTPError as ex:
+            raise FileInfoException("The URL provided causes an error with Dropbox.") from ex
         except MissingHeaderException as ex:
             raise FileInfoException from ex


### PR DESCRIPTION
[#4244](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/4244)

## Changes

- Add exception details for Dropbox failures
