### PR TITLE
fix(wmg): Filters selected options not showing active state

### DIFF
--- a/frontend/src/views/WheresMyGene/components/Filters/components/Sort/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/components/Sort/index.tsx
@@ -40,17 +40,17 @@ export default function Sort({ areFiltersDisabled }: Props): JSX.Element {
     [areFiltersDisabled]
   );
 
-  const cellTypeSelectedOptionLabel = useMemo(() => {
+  const cellTypeSelectedOption = useMemo(() => {
     return (
-      CELL_TYPE_OPTIONS.find((option) => option.id === sortBy.cellTypes)
-        ?.name || CELL_TYPE_OPTIONS[0].name
+      CELL_TYPE_OPTIONS.find((option) => option.id === sortBy.cellTypes) ||
+      CELL_TYPE_OPTIONS[0]
     );
   }, [sortBy]);
 
-  const geneSelectedOptionLabel = useMemo(() => {
+  const geneSelectedOption = useMemo(() => {
     return (
-      GENE_OPTIONS.find((option) => option.id === sortBy.genes)?.name ||
-      GENE_OPTIONS[0].name
+      GENE_OPTIONS.find((option) => option.id === sortBy.genes) ||
+      GENE_OPTIONS[0]
     );
   }, [sortBy]);
 
@@ -62,9 +62,10 @@ export default function Sort({ areFiltersDisabled }: Props): JSX.Element {
         <StyledDropdown
           data-test-id="cell-type-sort-dropdown"
           onChange={cellTypesOnChange}
-          label={cellTypeSelectedOptionLabel}
+          label={cellTypeSelectedOption.name}
           options={CELL_TYPE_OPTIONS}
           InputDropdownProps={InputDropdownProps}
+          value={cellTypeSelectedOption}
         />
       </FilterWrapper>
       <FilterWrapper>
@@ -72,9 +73,10 @@ export default function Sort({ areFiltersDisabled }: Props): JSX.Element {
         <StyledDropdown
           data-test-id="gene-sort-dropdown"
           onChange={genesOnChange}
-          label={geneSelectedOptionLabel}
+          label={geneSelectedOption.name}
           options={GENE_OPTIONS}
           InputDropdownProps={InputDropdownProps}
+          value={geneSelectedOption}
         />
       </FilterWrapper>
     </div>

--- a/frontend/src/views/WheresMyGene/components/Filters/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/index.tsx
@@ -282,11 +282,6 @@ export default memo(function Filters({ isLoading }: Props): JSX.Element {
 
         <Organism isLoading={isLoading} />
 
-        {/* DEBUG */}
-        {/* DEBUG */}
-        {/* DEBUG */}
-        <Foo />
-
         <Sort areFiltersDisabled={areFiltersDisabled} />
       </Wrapper>
     </Tooltip>
@@ -308,15 +303,4 @@ function sortOptions(a: DefaultMenuSelectOption, b: DefaultMenuSelectOption) {
     return 1;
   }
   return 0;
-}
-
-// DEBUG
-// DEBUG
-// DEBUG
-function Foo() {
-  useMemo(() => {
-    console.log("----------Foo calculating...");
-  }, []);
-
-  return null;
 }

--- a/frontend/src/views/WheresMyGene/components/Filters/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/index.tsx
@@ -8,7 +8,6 @@ import {
 import isEqual from "lodash/isEqual";
 import {
   memo,
-  ReactElement,
   useCallback,
   useContext,
   useEffect,

--- a/frontend/src/views/WheresMyGene/components/Filters/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/index.tsx
@@ -219,7 +219,14 @@ export default memo(function Filters({ isLoading }: Props): JSX.Element {
   );
 
   return (
-    <TooltipWrapper areFiltersDisabled={areFiltersDisabled}>
+    <Tooltip
+      title={
+        "Please select an organism, tissue and at least one gene to use these filters."
+      }
+      // (thuang): We need to disable the tooltip when filters are enabled
+      disableHoverListener={!areFiltersDisabled}
+      disableFocusListener={!areFiltersDisabled}
+    >
       <Wrapper>
         <div>
           <StyledComplexFilter
@@ -275,25 +282,16 @@ export default memo(function Filters({ isLoading }: Props): JSX.Element {
 
         <Organism isLoading={isLoading} />
 
+        {/* DEBUG */}
+        {/* DEBUG */}
+        {/* DEBUG */}
+        <Foo />
+
         <Sort areFiltersDisabled={areFiltersDisabled} />
       </Wrapper>
-    </TooltipWrapper>
+    </Tooltip>
   );
 });
-
-function TooltipWrapper({
-  areFiltersDisabled,
-  children,
-}: {
-  areFiltersDisabled: boolean;
-  children: ReactElement;
-}) {
-  const title = areFiltersDisabled
-    ? "Please select an organism, tissue and at least one gene to use these filters."
-    : null;
-
-  return <Tooltip title={title}>{children}</Tooltip>;
-}
 
 function getOptionSelected(
   option: { id: string },
@@ -310,4 +308,15 @@ function sortOptions(a: DefaultMenuSelectOption, b: DefaultMenuSelectOption) {
     return 1;
   }
   return 0;
+}
+
+// DEBUG
+// DEBUG
+// DEBUG
+function Foo() {
+  useMemo(() => {
+    console.log("----------Foo calculating...");
+  }, []);
+
+  return null;
 }

--- a/frontend/src/views/WheresMyGene/components/Filters/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/index.tsx
@@ -44,6 +44,27 @@ const DropdownMenuProps = {
   getOptionSelected,
 };
 
+const ANALYTIC_MAPPING: {
+  [key in keyof IFilters]: { eventName: EVENTS; label: string };
+} = {
+  datasets: {
+    eventName: EVENTS.FILTER_SELECT_DATASET,
+    label: "dataset_name",
+  },
+  diseases: {
+    eventName: EVENTS.FILTER_SELECT_DISEASE,
+    label: "disease",
+  },
+  ethnicities: {
+    eventName: EVENTS.FILTER_SELECT_SELF_REPORTED_ETHNICITY,
+    label: "ethnicity",
+  },
+  sexes: {
+    eventName: EVENTS.FILTER_SELECT_SEX,
+    label: "gender",
+  },
+};
+
 export interface Props {
   isLoading: boolean;
 }
@@ -131,27 +152,6 @@ export default memo(function Filters({ isLoading }: Props): JSX.Element {
     return sex_terms.filter((sex) => sexes?.includes(sex.id));
   }, [sex_terms, sexes]);
 
-  const analyticMapping: {
-    [key in keyof IFilters]: { eventName: EVENTS; label: string };
-  } = {
-    datasets: {
-      eventName: EVENTS.FILTER_SELECT_DATASET,
-      label: "dataset_name",
-    },
-    diseases: {
-      eventName: EVENTS.FILTER_SELECT_DISEASE,
-      label: "disease",
-    },
-    ethnicities: {
-      eventName: EVENTS.FILTER_SELECT_SELF_REPORTED_ETHNICITY,
-      label: "ethnicity",
-    },
-    sexes: {
-      eventName: EVENTS.FILTER_SELECT_SEX,
-      label: "gender",
-    },
-  };
-
   const handleFilterChange = useCallback(
     function handleFilterChange_(
       key: keyof IFilters
@@ -178,7 +178,7 @@ export default memo(function Filters({ isLoading }: Props): JSX.Element {
         // If there are newly selected filters, send an analytic event for each of them
         if (newlySelected.length) {
           newlySelected.forEach((selected) => {
-            const { eventName, label } = analyticMapping[key]!;
+            const { eventName, label } = ANALYTIC_MAPPING[key]!;
             track(eventName, {
               [label]: selected.name,
             });
@@ -219,7 +219,7 @@ export default memo(function Filters({ isLoading }: Props): JSX.Element {
   );
 
   return (
-    <TooltipWrapper>
+    <TooltipWrapper areFiltersDisabled={areFiltersDisabled}>
       <Wrapper>
         <div>
           <StyledComplexFilter
@@ -279,19 +279,25 @@ export default memo(function Filters({ isLoading }: Props): JSX.Element {
       </Wrapper>
     </TooltipWrapper>
   );
-
-  function TooltipWrapper({ children }: { children: ReactElement }) {
-    if (areFiltersDisabled) {
-      return (
-        <Tooltip title="Please select an organism, tissue and at least one gene to use these filters.">
-          {children}
-        </Tooltip>
-      );
-    }
-
-    return <>{children}</>;
-  }
 });
+
+function TooltipWrapper({
+  areFiltersDisabled,
+  children,
+}: {
+  areFiltersDisabled: boolean;
+  children: ReactElement;
+}) {
+  if (areFiltersDisabled) {
+    return (
+      <Tooltip title="Please select an organism, tissue and at least one gene to use these filters.">
+        {children}
+      </Tooltip>
+    );
+  }
+
+  return <>{children}</>;
+}
 
 function getOptionSelected(
   option: { id: string },

--- a/frontend/src/views/WheresMyGene/components/Filters/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/index.tsx
@@ -288,15 +288,11 @@ function TooltipWrapper({
   areFiltersDisabled: boolean;
   children: ReactElement;
 }) {
-  if (areFiltersDisabled) {
-    return (
-      <Tooltip title="Please select an organism, tissue and at least one gene to use these filters.">
-        {children}
-      </Tooltip>
-    );
-  }
+  const title = areFiltersDisabled
+    ? "Please select an organism, tissue and at least one gene to use these filters."
+    : null;
 
-  return <>{children}</>;
+  return <Tooltip title={title}>{children}</Tooltip>;
 }
 
 function getOptionSelected(

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/Organism/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/Organism/index.tsx
@@ -18,13 +18,6 @@ import { StyledDropdown, Wrapper } from "./style";
 
 const TEMP_ALLOW_NAME_LIST = ["Homo sapiens", "Mus musculus"];
 
-const DropdownMenuProps = {
-  isOptionEqualToValue: (
-    option: DefaultMenuSelectOption,
-    value: DefaultMenuSelectOption
-  ) => option.name === value.name,
-};
-
 const InputDropdownProps: Partial<RawInputDropdownProps> = {
   sdsStyle: "square",
 };
@@ -84,7 +77,7 @@ export default function Organism({ isLoading }: Props): JSX.Element {
         onChange={handleOnChange as tempOnChange}
         InputDropdownProps={{ ...InputDropdownProps, disabled: isLoading }}
         data-test-id="add-organism"
-        DropdownMenuProps={DropdownMenuProps}
+        value={organism}
       />
     </Wrapper>
   );

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/Organism/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/Organism/index.tsx
@@ -18,6 +18,13 @@ import { StyledDropdown, Wrapper } from "./style";
 
 const TEMP_ALLOW_NAME_LIST = ["Homo sapiens", "Mus musculus"];
 
+const DropdownMenuProps = {
+  isOptionEqualToValue: (
+    option: DefaultMenuSelectOption,
+    value: DefaultMenuSelectOption
+  ) => option.name === value.name,
+};
+
 const InputDropdownProps: Partial<RawInputDropdownProps> = {
   sdsStyle: "square",
 };
@@ -77,6 +84,7 @@ export default function Organism({ isLoading }: Props): JSX.Element {
         onChange={handleOnChange as tempOnChange}
         InputDropdownProps={{ ...InputDropdownProps, disabled: isLoading }}
         data-test-id="add-organism"
+        DropdownMenuProps={DropdownMenuProps}
       />
     </Wrapper>
   );

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/ColorScale/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/ColorScale/index.tsx
@@ -51,10 +51,10 @@ export default function ColorScale({ setIsScaled }: Props): JSX.Element {
   const dispatch = useContext(DispatchContext);
   const { sortBy } = useContext(StateContext);
 
-  const colorScaledOptionLabel = useMemo(() => {
+  const colorScaledOption = useMemo(() => {
     return (
-      COLOR_SCALE_OPTIONS.find((option) => option.id === sortBy.scaled)?.name ||
-      COLOR_SCALE_OPTIONS[0].name
+      COLOR_SCALE_OPTIONS.find((option) => option.id === sortBy.scaled) ||
+      COLOR_SCALE_OPTIONS[0]
     );
   }, [sortBy]);
 
@@ -73,9 +73,10 @@ export default function ColorScale({ setIsScaled }: Props): JSX.Element {
       <StyledDropdown
         data-test-id="color-scale-dropdown"
         onChange={colorScaleOnChange}
-        label={colorScaledOptionLabel}
+        label={colorScaledOption.name}
         options={COLOR_SCALE_OPTIONS}
         InputDropdownProps={DEFAULT_INPUT_DROPDOWN_PROPS}
+        value={colorScaledOption}
       />
     </Wrapper>
   );


### PR DESCRIPTION
## Reason for Change

- #4211 @ashin-czi please help add the ticket number thank you!

1. The filters are not showing the selected item as active state, because every time we change an option, React destroys all the children of `<TooltipWrapper />` and re-create new instances of them. This results in calculating memoized values for the first time, thus breaking active select state

## Changes

1. The root cause is because we're re-generating `TooltipWrapper` component in each render, thus all its children are considered first time showing up in the DOM tree, thus triggering useMemo() every time `TooltipWrapper`'s parent re-renders. The solution is simply removing the `TooltipWrapper` component and use the hidden API `disableHoverListener` and `disableFocusListener` to decide whether to show tooltip or not instead of relying on Fragment.

I also tried just passing `null` as `title` to the Tooltip component, which does suppress tooltip, but it still re-instantiates all children, which we don't want. So the hidden API is the best solution!

## Testing steps

1. Pull the PR and start up locally
3. Check all filters, the selected option should now show the active state for all filters

![demo](https://user-images.githubusercontent.com/6309723/221057810-1e15cbbf-8ab4-4714-902b-55128b110b8b.gif)


## Notes for Reviewer
