### PR TITLE
fix: wrap try/except around dropbox download link HEAD request

### DIFF
--- a/backend/common/utils/dl_sources/url.py
+++ b/backend/common/utils/dl_sources/url.py
@@ -92,8 +92,11 @@ class DropBoxURL(URL):
         :param url: a DropBox URL leading to a file.
         :return: The file name and size of the file.
         """
-        resp = requests.head(self.url, allow_redirects=True)
-        resp.raise_for_status()
+        try:
+            resp = requests.head(self.url, allow_redirects=True)
+            resp.raise_for_status()
+        except Exception:
+            return {"size": None, "name": None}
 
         try:
             size = int(self._get_key_with_fallback(resp.headers, "content-length", "x-dropbox-content-length"))


### PR DESCRIPTION
## Reason for Change
- #4245 and #4244
- dropbox HEAD request on download links are not officially supported/maintained by dropbox API, and transient errors are causing flakiness in our functional tests
- trade-off: links to files larger than our max supported filesize will fail slower, more downstream in the process than currently. However, failing on transient errors is also causing issues and that occurs more often than overly large uploads. Further, those will still fail gracefully. 

## Changes

- add try/except block around HEAD request

## Testing steps

- processing unit tests

## Notes for Reviewer
