### PR TITLE
fix(wmg): fixing selectNthOption from 1 to 2

### DIFF
--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -260,13 +260,13 @@ describe("Where's My Gene", () => {
       getTestID("cell-type-sort-dropdown")
     );
     await cellTypeSortDropdown.click();
-    await selectNthOption(1, page);
+    await selectNthOption(2, page);
 
     const geneSortDropdown = await page.locator(
       getTestID("gene-sort-dropdown")
     );
     await geneSortDropdown.click();
-    await selectNthOption(1, page);
+    await selectNthOption(2, page);
 
     const afterGeneNames = await getNames(
       `${getTestID(GENE_LABELS_ID)} span`,


### PR DESCRIPTION
## Reason for Change

Fixes playwright test

## Changes

selectNthOption from 1 to 2 because of new offset logic

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Notes for Reviewer
