### PR TITLE
fix: Clicking Download resets the Datasets view to the top (#4300)

### DIFF
--- a/frontend/src/components/Layout/style.ts
+++ b/frontend/src/components/Layout/style.ts
@@ -9,6 +9,7 @@ export const Wrapper = styled.div`
   min-height: 100vh; /* required for full height flex on child */
   /* TODO(seve): #2755 */
   overflow-x: clip; /* responsive requirement; facilitates hiding of content when viewport is resized and layout min width is applied */
+  overflow-y: auto;
 `;
 
 export const contentWrapper = css`
@@ -37,6 +38,7 @@ export const SidebarMainWrapper = styled(MainWrapper)`
 
 export const StyledDocsLayout = styled(MainWrapper)`
   justify-content: center; /* Allows for center resizing based on viewport width */
+
   main {
     display: grid;
     grid-template-areas: "leftsidebar content rightsidebar";

--- a/frontend/src/views/globalStyle.ts
+++ b/frontend/src/views/globalStyle.ts
@@ -21,14 +21,13 @@ export const View = styled.div`
   ${contentWrapper}
   grid-area: content;
   overflow: ${(props: ViewProps) =>
-    props.overflow
-      ? props.overflow
-      : "auto"}; /* facilitates independent content scrolling for sidebar layout */
+    props.overflow ? props.overflow : undefined};
 
   &.CLONED {
     overflow: hidden;
     height: fit-content;
     width: fit-content;
+
     & ${Wrapper}, ${Container} {
       height: fit-content;
       overflow: hidden;


### PR DESCRIPTION
## Reason for Change
The dataset download button, when actioned, causes the datasets table to scroll back to the top of the table. It is desirable to maintain the scroll position when downloading any dataset.

- #4300

## Changes

- Overflow styles on the datasets/collections table are relocated to an ancestor element.

## Testing steps

- Navigate to the Datasets view.
- Scroll down the page.
- Download any dataset.
- The table view should remain at the current scroll position.
