### PR TITLE
fix(wmg): fixing compare and crossfiltering test

### DIFF
--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -807,7 +807,11 @@ function addCellTypeRowToResult({
      * (thuang): We manually indent 4 spaces instead of using CSS, so we don't
      * have to update SVG render function to mimic CSS padding
      */
-    const name = isAggregated ? rawName : `    ${rawName || "unknown"}`;
+    const name = isAggregated 
+      ? rawName 
+      : compareOptionId === COMPARE_OPTION_ID_FOR_UNKNOWN
+        ? `    ${rawName || COMPARE_OPTION_ID_FOR_UNKNOWN}`
+        : `    ${rawName || compareOptionId}`;
 
     if (isAggregated) {
       cellTypeName = rawName;

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -162,20 +162,21 @@ describe("Where's My Gene", () => {
     await clickUntilOptionsShowUp(getDiseaseSelectorButton, page);
     const diseaseOptionsBefore = await page.$$("[role=option]");
     const numberOfDiseasesBefore = diseaseOptionsBefore.length;
+    await page.keyboard.press("Escape");
 
     await clickUntilOptionsShowUp(getDatasetSelectorButton, page);
     const datasetOptions = await page.$$("[role=option]");
     await datasetOptions[0].click();
     await page.keyboard.press("Escape");
 
-    await clickUntilOptionsShowUp(getDiseaseSelectorButton, page);
-    const diseaseOptionsAfter = await page.$$("[role=option]");
-    const numberOfDiseasesAfter = diseaseOptionsAfter.length;
-    await page.keyboard.press("Escape");
-
     await clickUntilOptionsShowUp(getTissueSelectorButton, page);
     const tissueOptionsAfter = await page.$$("[role=option]");
     const numberOfTissuesAfter = tissueOptionsAfter.length;
+    await page.keyboard.press("Escape");
+
+    await clickUntilOptionsShowUp(getDiseaseSelectorButton, page);
+    const diseaseOptionsAfter = await page.$$("[role=option]");
+    const numberOfDiseasesAfter = diseaseOptionsAfter.length;
     await page.keyboard.press("Escape");
 
     expect(numberOfDiseasesBefore).toBeGreaterThan(numberOfDiseasesAfter);


### PR DESCRIPTION
## Reason for Change

- Compare e2e test was failing for "multiethnic" compare option value
- Crossfiltering test was failing because disease wasn't done loading after selecting a dataset and retained same disease count after selecting a dataset

## Changes

- add
- remove
- modify
    - Handling multiethnic and similar cases from not showing up as "unknown" in the UI
    - After selecting a dataset, getting after tissue count before getting after disease count

## Testing steps

`npm run e2e -- tests/features/wheresMyGene.test.ts`

## Notes for Reviewer
