### PR TITLE
chore(wmg): selected items in quick select pin after reopen

### DIFF
--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
@@ -134,6 +134,7 @@ export default function QuickSelect<
   const [open, setOpen] = useState(false);
   const [input, setInput] = useState("");
   const [hasComma, setHasComma] = useState(false);
+  const [itemOptions, setItemOptions] = useState<T[]>(items);
 
   const useStyles = makeStyles((theme: SDSTheme) => {
     const colors = getColors({ theme });
@@ -163,6 +164,14 @@ export default function QuickSelect<
 
   const classes = useStyles();
 
+  const toggleDropdownAndUpdateItemOptions = () => {
+    setOpen(!open);
+    const itemOptionsWithSelectedOnTop = [
+      ...new Set([...selectedAsArray, ...items]),
+    ];
+    setItemOptions(itemOptionsWithSelectedOnTop);
+  };
+
   // `HandleEnter()` handles the enter key press when we detect comma(",") in the search bar
   // Since this functionality is currently only used in the gene search bar, we'll be assuming that `itemsByName` is a Map<string, Gene>.
   // NOTE that `itemsByName` the key is lowercase!
@@ -183,7 +192,7 @@ export default function QuickSelect<
                 newSelected.push(newItem);
             });
 
-            setOpen(false);
+            toggleDropdownAndUpdateItemOptions();
 
             return setSelected(
               newSelected as AutocompleteValue<
@@ -213,7 +222,7 @@ export default function QuickSelect<
         !(nativeEvent.relatedTarget instanceof Element)) ||
       !(nativeEvent instanceof FocusEvent)
     ) {
-      setOpen(false);
+      toggleDropdownAndUpdateItemOptions();
     }
 
     setInput("");
@@ -228,7 +237,7 @@ export default function QuickSelect<
   };
 
   const handleClick = () => {
-    setOpen(!open);
+    toggleDropdownAndUpdateItemOptions();
   };
 
   const ref = useRef(null);
@@ -253,9 +262,7 @@ export default function QuickSelect<
     }
   };
   const selectedAsArray = Array.isArray(selected) ? selected : [selected];
-  const itemOptionsWithSelectedOnTop = useMemo(() => {
-    return [...new Set([...selectedAsArray, ...items])];
-  }, [open]);
+
   return (
     <>
       <ButtonWrapper>
@@ -301,7 +308,7 @@ export default function QuickSelect<
           disableCloseOnSelect
           disableListWrap
           onKeyDownCapture={multiple ? handleEnter : undefined}
-          options={itemOptionsWithSelectedOnTop}
+          options={itemOptions}
           ListboxComponent={
             ListboxComponent as React.ComponentType<
               React.HTMLAttributes<HTMLElement>

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
@@ -26,6 +26,7 @@ import React, {
   SyntheticEvent,
   useRef,
   useState,
+  useMemo,
 } from "react";
 import { FixedSizeList, ListChildComponentProps } from "react-window";
 import { track } from "src/common/analytics";
@@ -252,10 +253,9 @@ export default function QuickSelect<
     }
   };
   const selectedAsArray = Array.isArray(selected) ? selected : [selected];
-
-  const itemOptionsWithSelectedOnTop = [
-    ...new Set([...selectedAsArray, ...items]),
-  ];
+  const itemOptionsWithSelectedOnTop = useMemo(() => {
+    return [...new Set([...selectedAsArray, ...items])];
+  }, [open]);
   return (
     <>
       <ButtonWrapper>

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
@@ -164,7 +164,7 @@ export default function QuickSelect<
   const classes = useStyles();
 
   const toggleDropdownAndUpdateItemOptions = () => {
-    setOpen(!open);
+    setOpen((open) => !open);
     const itemOptionsWithSelectedOnTop = [
       ...new Set([...selectedAsArray, ...items]),
     ];

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
@@ -26,7 +26,6 @@ import React, {
   SyntheticEvent,
   useRef,
   useState,
-  useMemo,
 } from "react";
 import { FixedSizeList, ListChildComponentProps } from "react-window";
 import { track } from "src/common/analytics";


### PR DESCRIPTION
## Reason for Change

- #4209

## Changes

- added a useMemo hook to make it so item options update only when the dropdown closes and opens.

## Testing steps

- tested locally