### PR TITLE
chore(wmg+compare): return name as ID when no label is found in ontology

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -370,7 +370,7 @@ def build_ordered_cell_types_by_tissue(
             id_to_label = build_ontology_term_id_label_mapping([row[compare]])[0]
             structured_result[row.tissue_ontology_term_id][row.cell_type_ontology_term_id][row[compare]] = {
                 "cell_type_ontology_term_id": row.cell_type_ontology_term_id,
-                "name": id_to_label.pop(row[compare]),
+                "name": id_to_label.pop(row[compare], row[compare]),
                 "total_count": int(
                     cell_counts_cell_type_agg_T[row.tissue_ontology_term_id][row.cell_type_ontology_term_id][
                         row[compare]

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -368,9 +368,10 @@ def build_ordered_cell_types_by_tissue(
         for i in range(joined.shape[0]):
             row = joined.iloc[i]
             id_to_label = build_ontology_term_id_label_mapping([row[compare]])[0]
+            name = id_to_label.pop(row[compare])
             structured_result[row.tissue_ontology_term_id][row.cell_type_ontology_term_id][row[compare]] = {
                 "cell_type_ontology_term_id": row.cell_type_ontology_term_id,
-                "name": id_to_label.pop(row[compare], row[compare]),
+                "name": name if name else row[compare],
                 "total_count": int(
                     cell_counts_cell_type_agg_T[row.tissue_ontology_term_id][row.cell_type_ontology_term_id][
                         row[compare]


### PR DESCRIPTION
# Reason for change
 - We want invalid IDs to not be `null` and just return the ID instead 