### PR TITLE
fix: make the integration secret nonsensitive

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -6,7 +6,7 @@ data aws_secretsmanager_secret_version config {
 }
 
 locals {
-  secret = jsondecode(data.aws_secretsmanager_secret_version.config.secret_string)
+  secret = jsondecode(nonsensitive(data.aws_secretsmanager_secret_version.config.secret_string))
   alb_key = var.require_okta ? "private_albs" : "public_albs"
 
   custom_stack_name            = var.stack_name


### PR DESCRIPTION
This allows us to output the stack URLs in the latest version of Terraform.

## Reason for Change

-  The TFE workspaces Terraform version has been updated to 1.3.0. This version checks for the senitivity of values and disallows certain actions based on them. We want to be able to display information about the integration secret, so this change marks it nonsensitive.

## Changes

- modify sensitivity of integration secret
