### PR TITLE
chore: update happy actions to latest

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -34,9 +34,7 @@ jobs:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
       - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
-        with:
-          happy_version: "0.23.0"
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
       - name: Push images
         run: |
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
@@ -68,9 +66,7 @@ jobs:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
       - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
-        with:
-          happy_version: "0.23.0"
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
       - name: Docker build, push, and tag
         shell: bash
         run: |
@@ -104,9 +100,7 @@ jobs:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
       - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
-        with:
-          happy_version: "0.42.1"
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
       - name: Docker re-tag
         shell: bash
         run: |

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -51,11 +51,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update deployment
-        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@89b77fd9a74df0e29ed3cc2057c23b9d73011574
+        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@deploy-happy-stack-v1.7.2
         with:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           stack-name: ${{ github.event.deployment.environment }}stack
-          happy_version: "0.28.0"
           operation: update
           tag: ${{ github.event.deployment.payload.tag }}
           env: ${{ github.event.deployment.environment }}

--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -36,9 +36,7 @@ jobs:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
       - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
-        with:
-          happy_version: "0.23.0"
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
       - name: Build component
         shell: bash
         run: |

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -98,9 +98,7 @@ jobs:
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/allure-results
           retention-days: 20
       - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
-        with:
-          happy_version: "0.23.0"
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
## Reason for Change

Updates github actions for installing happy and deploying stacks to the latest available versions. This causes the actions to use the latest version of happy CLI which fixes some recent stacklist issues.