### PR TITLE
chore: re-pin happy version

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -34,7 +34,7 @@ jobs:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
       - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2\
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
         with:
           happy_version: "0.59.0"
       - name: Push images

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -34,7 +34,9 @@ jobs:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
       - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2\
+        with:
+          happy_version: "0.59.0"
       - name: Push images
         run: |
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
@@ -67,6 +69,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+        with:
+          happy_version: "0.59.0"
       - name: Docker build, push, and tag
         shell: bash
         run: |
@@ -101,6 +105,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+        with:
+          happy_version: "0.59.0"
       - name: Docker re-tag
         shell: bash
         run: |

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -58,6 +58,7 @@ jobs:
           operation: update
           tag: ${{ github.event.deployment.payload.tag }}
           env: ${{ github.event.deployment.environment }}
+          happy_version: "0.59.0"
       - name: Invalidate CloudFront
         env:
           DEPLOYMENT_STAGE: ${{ github.event.deployment.environment }}

--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -37,6 +37,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+        with:
+          happy_version: "0.59.0"
       - name: Build component
         shell: bash
         run: |

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -99,6 +99,8 @@ jobs:
           retention-days: 20
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+        with:
+          happy_version: "0.59.0"
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
Follow-up to https://github.com/chanzuckerberg/single-cell-data-portal/pull/4376

Bumping past happy version 0.59.0 introduces a breaking change (autocreation of ECR, which we don't want to do here)