### PR TITLE
fix: update instructions to create local dev stack

### DIFF
--- a/DEV_ENV.md
+++ b/DEV_ENV.md
@@ -3,10 +3,13 @@
 ## Development quickstart
 
 1. [install docker](https://docs.docker.com/get-docker/). If brew is installed run `brew install docker`. If you have a Mac, [install Docker Desktop](https://www.docker.com/products/docker-desktop) and open it so it's running on your machine. Note: If you have a Mac M1 (arm64 CPU), follow instructions in [`docker-compose.yml`](docker-compose.yml) under `oidc` service, for manually building the oidc-server-mock images for the M1 architecture.
-1. If you have a Mac with an M1 chip, please add `export DOCKER_DEFAULT_PLATFORM="linux/amd64"` to your `.zshrc` or `.bashrc` file (don't forget to `source ~/.zshrc` or restart the terminal). Otherwise, Docker will fail to build your images.
+1. [install jq](https://stedolan.github.io/jq/download/). If brew is installed run `brew install jq`.
+1. [install postgres](https://formulae.brew.sh/formula/postgresql@14). If brew is installed run ` brew install postgresql@14` (or whatever is the latest stable release at the time you are reading this). For the purposes of local development, the main reason install `postgres` is to have
+   access to the `psql` commandline tool.
 1. [install chamber](https://github.com/segmentio/chamber). If brew is installed run `brew install chamber`. (This is needed for running functional tests.)
 1. From the root of this repository, run `make local-init` to build and run the dev environment. The first build takes awhile, but subsequent runs will use cached artifacts. Note: If Docker reports a conflict for port 5000, and you are on a Mac, you should turn off Control Center's "Airplay Receiver" in the "Sharing" System Preferences ([details](https://developer.apple.com/forums/thread/682332)).
-1. Visit [https://backend.corporanet.local:5000](https://backend.corporanet.local:5000) to view the backend, and [https://frontend.corporanet.local:3000](https://frontend.corporanet.local:3000) for the frontend.
+1. Visit [https://backend.corporanet.local:5000](https://backend.corporanet.local:5000) to view the backend, and [https://frontend.corporanet.local:3000](https://frontend.corporanet.local:3000) for the frontend. If your browser can't resolve the url, try [https://localhost:5000](https://localhost:5000) for the backend and
+   [https://localhost:3000](https://localhost:3000) for the frontend.
 1. `make local-dbconsole` starts a connection with the local postgresql db.
 1. **Open the source code and start editing!**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.8"
 services:
   database:
     image: postgres:13.0
+    platform: linux/amd64
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
## Reason for Change

Local dev environment setup was broken and needed a fix.

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- add
- remove
- modify

## Testing steps

Please follow these steps on your local machine to check that it works for your machine platform

### Clean up current local dev environment state
1. `make local-clean`
2. `docker images -a` # lists the images you have
3. If you are ok deleting all the images then run: `docker rmi $(docker images -a -q)`. If not, at least delete all images generated by this repo
4. `unset DOCKER_DEFAULT_PLATFORM`
5. `rm .env.ecr`

### Set up local dev environment
1. Follow instructions in the **Development quickstart** heading of `DEV_ENV.md` file to setup a local dev

### Run Tests
1. `AWS_PROFILE=single-cell-dev make unit-test`

### Run Functional tests
1. Please run functional test per [these instructions in the README](https://github.com/chanzuckerberg/single-cell-data-portal#running-functional-tests)


## Notes for Reviewer

Please see **Testing Steps** above
