### PR TITLE
fix(wmg): fix failing functional test by updating invalid request fixture

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -53,31 +53,33 @@ def query():
         expression_summary = q.expression_summary_default(criteria) if default else q.expression_summary(criteria)
 
         cell_counts = q.cell_counts(criteria)
+        if expression_summary.shape[0] > 0 and cell_counts.shape[0] > 0:
+            group_by_terms = ["tissue_ontology_term_id", "cell_type_ontology_term_id", compare] if compare else None
 
-        group_by_terms = ["tissue_ontology_term_id", "cell_type_ontology_term_id", compare] if compare else None
-
-        dot_plot_matrix_df, cell_counts_cell_type_agg = get_dot_plot_data(
-            expression_summary, cell_counts, group_by_terms
-        )
-        if is_rollup:
-            dot_plot_matrix_df, cell_counts_cell_type_agg = rollup(dot_plot_matrix_df, cell_counts_cell_type_agg)
-
-        response = jsonify(
-            dict(
-                snapshot_id=snapshot.snapshot_identifier,
-                expression_summary=build_expression_summary(dot_plot_matrix_df, compare),
-                term_id_labels=dict(
-                    genes=build_gene_id_label_mapping(criteria.gene_ontology_term_ids),
-                    cell_types=build_ordered_cell_types_by_tissue(
-                        cell_counts,
-                        cell_counts_cell_type_agg.T,
-                        snapshot.cell_type_orderings,
-                        compare,
-                        group_by_terms,
-                    ),
-                ),
+            dot_plot_matrix_df, cell_counts_cell_type_agg = get_dot_plot_data(
+                expression_summary, cell_counts, group_by_terms
             )
-        )
+            if is_rollup:
+                dot_plot_matrix_df, cell_counts_cell_type_agg = rollup(dot_plot_matrix_df, cell_counts_cell_type_agg)
+
+            response = jsonify(
+                dict(
+                    snapshot_id=snapshot.snapshot_identifier,
+                    expression_summary=build_expression_summary(dot_plot_matrix_df, compare),
+                    term_id_labels=dict(
+                        genes=build_gene_id_label_mapping(criteria.gene_ontology_term_ids),
+                        cell_types=build_ordered_cell_types_by_tissue(
+                            cell_counts,
+                            cell_counts_cell_type_agg.T,
+                            snapshot.cell_type_orderings,
+                            compare,
+                            group_by_terms,
+                        ),
+                    ),
+                )
+            )
+        else:  # no data, return empty json
+            response = jsonify(dict(snapshot_id=snapshot.snapshot_identifier, expression_summary={}, term_id_labels={}))
     return response
 
 

--- a/tests/functional/backend/wmg/fixtures.py
+++ b/tests/functional/backend/wmg/fixtures.py
@@ -436,13 +436,13 @@ secondary_filter_common_case_request_data = {
     "filter": {
         "dataset_ids": [],
         "disease_ontology_term_ids": ["MONDO:0005812", "MONDO:0100096", "PATO:0000461"],
-        "self_reported_ethnicity_ontology_term_ids": ["HANCESTRO:0010", "HANCESTRO:0014"],
         "gene_ontology_term_ids": list(genes_20_count.keys()),
         "organism_ontology_term_id": "NCBITaxon:9606",
         "sex_ontology_term_ids": ["PATO:0000383"],
         "tissue_ontology_term_ids": ["UBERON:0000178"],
     },  # blood (more than 50 cell types)
 }
+
 secondary_filter_extreme_case_request_data = {
     "filter": {
         "dataset_ids": [],


### PR DESCRIPTION
## Reason for Change

- #4396

## Changes

- update `/query` to return empty response if tiledb query returns empty dataframes
- remove `self_reported_ethnicity_ids` from the secondary filter common case request fixture

## Testing steps

- tests pass