### PR TITLE
fix(WMG): no genes selected should not return empty response

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -53,7 +53,7 @@ def query():
         expression_summary = q.expression_summary_default(criteria) if default else q.expression_summary(criteria)
 
         cell_counts = q.cell_counts(criteria)
-        if expression_summary.shape[0] > 0 and cell_counts.shape[0] > 0:
+        if expression_summary.shape[0] > 0 or cell_counts.shape[0] > 0:
             group_by_terms = ["tissue_ontology_term_id", "cell_type_ontology_term_id", compare] if compare else None
 
             dot_plot_matrix_df, cell_counts_cell_type_agg = get_dot_plot_data(


### PR DESCRIPTION
## Reason for Change

- [This PR](https://github.com/chanzuckerberg/single-cell-data-portal/pull/4397) was merged into main to fix a failing functional test. It was hotfixed into staging, but the PR failed to take into account the edge case where no genes are selected. In that particular case, `expression_summary` is an empty dataframe which defaults the endpoint to returning an empty response.


## Changes

- modify `and` to `or`

## Testing steps

- test will be added https://github.com/chanzuckerberg/single-cell-data-portal/issues/4406
## Notes for Reviewer
