### PR TITLE
feat: return dataset versions as array

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -601,12 +601,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  datasets:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/dataset_version"
+                type: array
+                items:
+                  $ref: "#/components/schemas/dataset_version"
         "403":
           $ref: "#/components/responses/403"
         "404":

--- a/backend/curation/api/v1/curation/datasets/dataset_id/versions/actions.py
+++ b/backend/curation/api/v1/curation/datasets/dataset_id/versions/actions.py
@@ -22,7 +22,5 @@ def get(dataset_id: str):
 
     # business function returns in chronological order; must return in reverse chronological
     dataset_versions.reverse()
-    response_body = {
-        "datasets": reshape_datasets_for_curation_api(dataset_versions, use_canonical_url=False),
-    }
-    return make_response(jsonify(response_body), 200)
+
+    return make_response(jsonify(reshape_datasets_for_curation_api(dataset_versions, use_canonical_url=False)), 200)

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1582,7 +1582,7 @@ class TestGetDatasetIdVersions(BaseAPIPortalTest):
         response = self.app.get(test_url, headers=headers)
         self.assertEqual(200, response.status_code)
         expected = defaultdict(list)
-        for dataset in response.json["datasets"]:
+        for dataset in response.json:
             expected["dataset_version_ids"].append(dataset["dataset_version_id"])
             expected["collection_ids"].append(dataset["collection_id"])
             expected["collection_version_ids"].append(dataset["collection_version_id"])


### PR DESCRIPTION
## See discussion on issue

- #4329 

## Changes

- modify endpoint response to return an array of dataset versions rather than an object with a nested array

## Testing steps

- unit tested

## Notes for Reviewer

- notebooks do NOT need updates for this change