### PR TITLE
chore(wmg): add unit test for no gene query edge case

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -53,7 +53,7 @@ def query():
         expression_summary = q.expression_summary_default(criteria) if default else q.expression_summary(criteria)
 
         cell_counts = q.cell_counts(criteria)
-        if expression_summary.shape[0] > 0 and cell_counts.shape[0] > 0:
+        if expression_summary.shape[0] > 0 or cell_counts.shape[0] > 0:
             group_by_terms = ["tissue_ontology_term_id", "cell_type_ontology_term_id", compare] if compare else None
 
             dot_plot_matrix_df, cell_counts_cell_type_agg = get_dot_plot_data(

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -239,6 +239,20 @@ describe("Where's My Gene", () => {
     }
   });
 
+  test("Selected tissue and no genes displays cell types", async ({ page }) => {
+    await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
+
+    async function getTissueSelectorButton() {
+      return page.$(getTestID(ADD_TISSUE_ID));
+    }
+
+    await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+    await selectFirstOption(page);
+
+    const cellTypes = await page.$$(getTestID("cell-type-name"));
+    expect(cellTypes.length).toBeGreaterThan(0);
+  });
+
   test("Source Data", async ({ page }) => {
     await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -249,6 +249,7 @@ describe("Where's My Gene", () => {
     await clickUntilOptionsShowUp(getTissueSelectorButton, page);
     await selectFirstOption(page);
 
+    await waitForElement(page, getTestID("cell-type-name"));
     const cellTypes = await page.$$(getTestID("cell-type-name"));
     expect(cellTypes.length).toBeGreaterThan(0);
   });
@@ -1004,6 +1005,16 @@ async function waitForHeatmapToRender(page: Page) {
     async () => {
       const canvases = await page.$$("canvas");
       await expect(canvases.length).not.toBe(0);
+    },
+    { page }
+  );
+}
+
+async function waitForElement(page: Page, selector: string) {
+  await tryUntil(
+    async () => {
+      const element = await page.$(selector);
+      await expect(element).not.toBeNull();
     },
     { page }
   );

--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -60,31 +60,33 @@ def generate_expected_term_id_labels_dictionary(genes, tissues, cell_types, tota
     result["genes"] = []
     for gene in genes:
         result["genes"].append({gene: f"{gene}_label"})
+
     return result
 
 
 def generate_expected_expression_summary_dictionary(genes, tissues, cell_types, n, me, pc, tpc, compare_terms=None):
     result = {}
     for gene in genes:
-        result[gene] = {}
-        for tissue in tissues:
-            result[gene][tissue] = {}
-            for cell_type in cell_types:
-                result[gene][tissue][cell_type] = {}
-                result[gene][tissue][cell_type]["aggregated"] = {
-                    "n": n,
-                    "me": me,
-                    "pc": pc,
-                    "tpc": tpc,
-                }
-                if compare_terms:
-                    for term in compare_terms:
-                        result[gene][tissue][cell_type][term] = {
-                            "n": n // len(compare_terms),
-                            "me": me,
-                            "pc": pc,
-                            "tpc": tpc / len(compare_terms),
-                        }
+        if gene != ".":
+            result[gene] = {}
+            for tissue in tissues:
+                result[gene][tissue] = {}
+                for cell_type in cell_types:
+                    result[gene][tissue][cell_type] = {}
+                    result[gene][tissue][cell_type]["aggregated"] = {
+                        "n": n,
+                        "me": me,
+                        "pc": pc,
+                        "tpc": tpc,
+                    }
+                    if compare_terms:
+                        for term in compare_terms:
+                            result[gene][tissue][cell_type][term] = {
+                                "n": n // len(compare_terms),
+                                "me": me,
+                                "pc": pc,
+                                "tpc": tpc / len(compare_terms),
+                            }
 
     return result
 

--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -254,6 +254,94 @@ class WmgApiV1Tests(unittest.TestCase):
     @patch("backend.wmg.api.v1.gene_term_label")
     @patch("backend.wmg.api.v1.ontology_term_label")
     @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_single_tissue_no_genes__returns_200_and_correct_response(
+        self, load_snapshot, ontology_term_label, gene_term_label
+    ):
+        dim_size = 3
+        with create_temp_wmg_snapshot(
+            dim_size=dim_size,
+            expression_summary_vals_fn=all_ones_expression_summary_values,
+            cell_counts_generator_fn=all_tens_cell_counts_values,
+        ) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            # this is the convention used by the FE to indicate no genes are selected
+            # see https://github.com/chanzuckerberg/single-cell-data-portal/pull/2729
+            genes = ["."]
+
+            tissues = ["tissue_ontology_term_id_0"]
+            organism = "organism_ontology_term_id_0"
+
+            (request, expected_expression_summary, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
+                genes, tissues, organism, dim_size, 1.0, 10
+            )
+
+            response = self.app.post("/wmg/v1/query", json=request)
+
+            self.assertEqual(200, response.status_code)
+
+            expected_response = {
+                "snapshot_id": "dummy-snapshot",
+                "expression_summary": expected_expression_summary,
+                "term_id_labels": expected_term_id_labels,
+            }
+            self.assertEqual(expected_response, json.loads(response.data))
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_multiple_tissues_no_genes__returns_200_and_correct_response(
+        self, load_snapshot, ontology_term_label, gene_term_label
+    ):
+        dim_size = 3
+        with create_temp_wmg_snapshot(
+            dim_size=dim_size,
+            expression_summary_vals_fn=all_ones_expression_summary_values,
+            cell_counts_generator_fn=all_tens_cell_counts_values,
+        ) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            # this is the convention used by the FE to indicate no genes are selected
+            # see https://github.com/chanzuckerberg/single-cell-data-portal/pull/2729
+            genes = ["."]
+
+            tissues = ["tissue_ontology_term_id_0", "tissue_ontology_term_id_1", "tissue_ontology_term_id_2"]
+            organism = "organism_ontology_term_id_0"
+
+            (request, expected_expression_summary, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
+                genes, tissues, organism, dim_size, 1.0, 10
+            )
+
+            response = self.app.post("/wmg/v1/query", json=request)
+
+            self.assertEqual(200, response.status_code)
+
+            expected_response = {
+                "snapshot_id": "dummy-snapshot",
+                "expression_summary": expected_expression_summary,
+                "term_id_labels": expected_term_id_labels,
+            }
+            self.assertEqual(expected_response, json.loads(response.data))
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
     def test__query_request_multi_primary_dims_only__returns_200_and_correct_response(
         self, load_snapshot, ontology_term_label, gene_term_label
     ):


### PR DESCRIPTION
## Reason for Change

- #4406

## Changes

- added api tests to cover the edge case where no genes are selected.
  - one for 1 tissue
  - one for multiple tissues
- added an e2e test to cover the same edge case from the FE perspective

## Testing steps

- Tests pass

## Notes for reviewer
I confirmed that these tests fail as expected when the bug fixed by #4405 is introduced.