### PR TITLE
fix(WMG): no genes selected should not return empty response (#4405)

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -53,7 +53,7 @@ def query():
         expression_summary = q.expression_summary_default(criteria) if default else q.expression_summary(criteria)
 
         cell_counts = q.cell_counts(criteria)
-        if expression_summary.shape[0] > 0 and cell_counts.shape[0] > 0:
+        if expression_summary.shape[0] > 0 or cell_counts.shape[0] > 0:
             group_by_terms = ["tissue_ontology_term_id", "cell_type_ontology_term_id", compare] if compare else None
 
             dot_plot_matrix_df, cell_counts_cell_type_agg = get_dot_plot_data(

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -239,6 +239,21 @@ describe("Where's My Gene", () => {
     }
   });
 
+  test("Selected tissue and no genes displays cell types", async ({ page }) => {
+    await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
+
+    async function getTissueSelectorButton() {
+      return page.$(getTestID(ADD_TISSUE_ID));
+    }
+
+    await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+    await selectFirstOption(page);
+
+    await waitForElement(page, getTestID("cell-type-name"));
+    const cellTypes = await page.$$(getTestID("cell-type-name"));
+    expect(cellTypes.length).toBeGreaterThan(0);
+  });
+
   test("Source Data", async ({ page }) => {
     await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
@@ -990,6 +1005,16 @@ async function waitForHeatmapToRender(page: Page) {
     async () => {
       const canvases = await page.$$("canvas");
       await expect(canvases.length).not.toBe(0);
+    },
+    { page }
+  );
+}
+
+async function waitForElement(page: Page, selector: string) {
+  await tryUntil(
+    async () => {
+      const element = await page.$(selector);
+      await expect(element).not.toBeNull();
     },
     { page }
   );


### PR DESCRIPTION
## Reason for Change

- This cherry picks fix #4405 into staging

## Notes for reviewer
 - This fix was tested in dev and confirmed by newly added unit tests in #4414 