### PR TITLE
chore(wmg): add fmg e2e tests and refactor to use locators

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -53,8 +53,6 @@ const config: PlaywrightTestConfig = {
          * https://github.com/matomo-org/device-detector/blob/master/regexes/bots.yml#L2762
          */
         userAgent: devices["Desktop Chrome"].userAgent + " czi-checker",
-        // sets testIdAttribute to "data-test-id" for all tests
-        testIdAttribute: "data-test-id",
       },
     },
   ],

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -53,6 +53,8 @@ const config: PlaywrightTestConfig = {
          * https://github.com/matomo-org/device-detector/blob/master/regexes/bots.yml#L2762
          */
         userAgent: devices["Desktop Chrome"].userAgent + " czi-checker",
+        // sets testIdAttribute to "data-test-id" for all tests
+        testIdAttribute: "data-test-id",
       },
     },
   ],

--- a/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/index.tsx
@@ -238,7 +238,7 @@ const DatasetRow: FC<Props> = ({
               intent={Intent.DANGER}
             >
               <StyledPrimaryAnchorButton
-                data-test-id="view-dataset-link"
+                data-testid="view-dataset-link"
                 disabled={dataset.tombstone || isOverMaxCellCount}
                 href={dataset?.dataset_deployments[0]?.url}
                 intent={Intent.PRIMARY}

--- a/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DownloadDataset/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DownloadDataset/index.tsx
@@ -46,7 +46,7 @@ const DownloadDataset: FC<Props> = ({
         datasetName={name}
         disabled={isDisabled}
         onClick={toggleOpen}
-        data-test-id="dataset-download-button"
+        data-testid="dataset-download-button"
       />
       <Modal
         title="Download Dataset"

--- a/frontend/src/components/Collection/components/CollectionDescription/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDescription/index.tsx
@@ -52,7 +52,7 @@ export default function CollectionDescription({
   }, [descriptionScrollHeight]);
 
   return (
-    <Description data-test-id="collection-description">
+    <Description data-testid="collection-description">
       <DescriptionText isEllipsis={isEllipsis} ref={descriptionRef}>
         {description}
       </DescriptionText>

--- a/frontend/src/components/Collection/components/CollectionMetadata/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionMetadata/index.tsx
@@ -27,7 +27,7 @@ export default function CollectionMetadata({
           <MetadataLabel>{label}</MetadataLabel>
           <Link href={url} passHref>
             <MetadataValue
-              data-test-id={testId}
+              data-testid={testId}
               href="passHref"
               rel="noopener"
               target="_blank"

--- a/frontend/src/components/Collection/components/CollectionRevisionStatusCallout/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionRevisionStatusCallout/index.tsx
@@ -11,7 +11,7 @@ export default function CollectionRevisionStatusCallout({
 }: Props): JSX.Element {
   return (
     <CollectionRevisionCallout intent={Intent.PRIMARY} icon={null}>
-      <span data-test-id="revision-status">
+      <span data-testid="revision-status">
         {isRevisionDifferent
           ? "This collection has changed since you last published it."
           : "This is a private revision of a public collection."}

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Name/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Name/index.tsx
@@ -8,7 +8,7 @@ interface Props {
 const Name: FC<Props> = ({ name }) => (
   <Section>
     <Title>NAME</Title>
-    <Text data-test-id="download-asset-name">{name}</Text>
+    <Text data-testid="download-asset-name">{name}</Text>
   </Section>
 );
 

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
@@ -110,7 +110,7 @@ const Content: FC<Props> = ({ onClose, name, dataAssets }) => {
     return (
       <DownloadButton
         disabled={!downloadLink || isLoading}
-        data-test-id="download-asset-download-button"
+        data-testid="download-asset-download-button"
         href={downloadLink}
         intent={Intent.PRIMARY}
         onClick={() => handleAnalytics(EVENTS.DOWNLOAD_DATA_COMPLETE)}

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/index.tsx
@@ -35,7 +35,7 @@ const DownloadDataset: FC<Props> = ({
         datasetName={name}
         disabled={isDisabled || !dataAssets.length}
         onClick={toggleOpen}
-        data-test-id="dataset-download-button"
+        data-testid="dataset-download-button"
       />
       <Modal title="Download Dataset" isOpen={isOpen} onClose={toggleOpen}>
         <Content name={name} dataAssets={dataAssets} onClose={toggleOpen} />

--- a/frontend/src/components/Collections/components/Grid/components/Row/CollectionRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/CollectionRow/index.tsx
@@ -105,10 +105,10 @@ const CollectionRow: FC<Props> = (props) => {
     aggregateDatasetsMetadata(datasets);
 
   return (
-    <StyledRow data-test-id="collection-row">
+    <StyledRow data-testid="collection-row">
       <StyledCell>
         <Link href={`/collections/${id}`} passHref>
-          <CollectionTitleText data-test-id="collection-link" href="passHref">
+          <CollectionTitleText data-testid="collection-link" href="passHref">
             {name}
           </CollectionTitleText>
         </Link>
@@ -118,12 +118,12 @@ const CollectionRow: FC<Props> = (props) => {
             <Tag
               minimal
               intent={isPrivate ? Intent.PRIMARY : Intent.SUCCESS}
-              data-test-id="visibility-tag"
+              data-testid="visibility-tag"
             >
               {isPrivate ? "Private" : "Published"}
             </Tag>
             {props.revisionsEnabled && collection.revisioning_in && (
-              <Tag minimal intent={Intent.PRIMARY} data-test-id="revision-tag">
+              <Tag minimal intent={Intent.PRIMARY} data-testid="revision-tag">
                 Revision Pending
               </Tag>
             )}
@@ -164,7 +164,7 @@ const RevisionCell = ({
         intent={Intent.PRIMARY}
         minimal
         onClick={handleRevisionClick}
-        data-test-id="revision-action-button"
+        data-testid="revision-action-button"
       >
         {revisionId ? "Continue" : "Start Revision"}
       </Button>

--- a/frontend/src/components/Collections/components/PublishCollection/index.tsx
+++ b/frontend/src/components/Collections/components/PublishCollection/index.tsx
@@ -80,7 +80,7 @@ const PublishCollection: FC<Props> = ({
         intent={Intent.PRIMARY}
         text="Publish"
         disabled={!isPublishable}
-        data-test-id="publish-collection-button"
+        data-testid="publish-collection-button"
       />
       {isOpen && (
         <AsyncAlert

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -172,7 +172,7 @@ const Content: FC<Props> = (props) => {
   const { onClose } = props;
   return (
     <>
-      <div data-test-id="collection-form-content">
+      <div data-testid="collection-form-content">
         {/* (thuang): turn off autocomplete seems to be the safest bet for now
          * https://github.com/facebook/react/issues/1159
          */}
@@ -293,7 +293,7 @@ const Content: FC<Props> = (props) => {
             text="Cancel"
           />
           <StyledPrimaryButton
-            data-test-id="create-button"
+            data-testid="create-button"
             disabled={!isValid}
             intent={Intent.PRIMARY}
             loading={isLoading}

--- a/frontend/src/components/Datasets/components/Grid/components/DatasetActionsCell/index.tsx
+++ b/frontend/src/components/Datasets/components/Grid/components/DatasetActionsCell/index.tsx
@@ -41,7 +41,7 @@ export default function DatasetsActionsCell({
         position={Position.TOP}
       >
         <StyledPrimaryAnchorButton
-          data-test-id="view-dataset-link"
+          data-testid="view-dataset-link"
           disabled={explorerDisabled || isOverMaxCellCount} // TODO(cc) isOverMaxCellCount needed to be a boolean...
           href={explorerUrl}
           intent={Intent.PRIMARY}

--- a/frontend/src/components/Datasets/components/Grid/components/DatasetNameCell/index.tsx
+++ b/frontend/src/components/Datasets/components/Grid/components/DatasetNameCell/index.tsx
@@ -25,7 +25,7 @@ export default function DatasetNameCell({
         (collectionId ? (
           <SubTitle>
             <LinkCell
-              data-test-id="collection-link"
+              data-testid="collection-link"
               url={url}
               value={collectionName}
             />

--- a/frontend/src/components/LandingHeader/index.tsx
+++ b/frontend/src/components/LandingHeader/index.tsx
@@ -70,7 +70,7 @@ const LandingHeader: FC = () => {
                 <LinkWrapper>
                   <Link href={ROUTES.COLLECTIONS} passHref>
                     <AnchorButton
-                      data-test-id="collection-link"
+                      data-testid="collection-link"
                       onClick={() => {
                         track(EVENTS.COLLECTIONS_CLICK_NAV);
                       }}

--- a/frontend/src/components/UploadCSV/index.tsx
+++ b/frontend/src/components/UploadCSV/index.tsx
@@ -39,13 +39,13 @@ const UploadCSV: FC = () => {
   return (
     <>
       <input
-        data-test-id="upload-csv"
+        data-testid="upload-csv"
         type="file"
         accept=".csv"
         onChange={handleCSV}
       />
       {csvResult && (
-        <div data-test-id="csv-result">{JSON.stringify(csvResult)}</div>
+        <div data-testid="csv-result">{JSON.stringify(csvResult)}</div>
       )}
     </>
   );

--- a/frontend/src/components/common/Grid/components/DownloadButton/index.tsx
+++ b/frontend/src/components/common/Grid/components/DownloadButton/index.tsx
@@ -12,7 +12,7 @@ interface Props {
 export default function DownloadButton({
   datasetName,
   onClick,
-  ...props /* Spread props to allow for data-test-id and other ButtonProps e.g. "disabled". */
+  ...props /* Spread props to allow for data-testid and other ButtonProps e.g. "disabled". */
 }: Props): JSX.Element {
   return (
     <StyledOutlineButton

--- a/frontend/src/components/common/Grid/components/LinkCell/index.tsx
+++ b/frontend/src/components/common/Grid/components/LinkCell/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 export default function LinkCell({
   url,
   value,
-  ...props /* Spread props to allow for data-test-id. */
+  ...props /* Spread props to allow for data-testid. */
 }: Props): JSX.Element {
   return (
     <Link href={url} passHref>

--- a/frontend/src/components/common/Logo/index.tsx
+++ b/frontend/src/components/common/Logo/index.tsx
@@ -6,7 +6,7 @@ export const Logo: FC = () => {
   return (
     <Image
       alt="CELLxGENE logo"
-      data-test-id="logo"
+      data-testid="logo"
       height={23}
       src={logo}
       width={23}

--- a/frontend/src/components/common/MoreDropdown/index.tsx
+++ b/frontend/src/components/common/MoreDropdown/index.tsx
@@ -17,7 +17,7 @@ const MoreDropdown = ({
         {...buttonProps}
         minimal
         icon={IconNames.MORE}
-        data-test-id="collection-more-button"
+        data-testid="collection-more-button"
       />
     </Popover>
   );

--- a/frontend/src/components/common/SideBar/index.tsx
+++ b/frontend/src/components/common/SideBar/index.tsx
@@ -78,7 +78,7 @@ export default function SideBar({
     <SideBarWrapperComponent
       sideBarWidth={sideBarWidth}
       position={position}
-      data-test-id={testId}
+      data-testid={testId}
     >
       <SideBarPositionerComponent isExpanded={isExpanded}>
         <SideBarToggleButtonWrapper>

--- a/frontend/src/pages/privacy.tsx
+++ b/frontend/src/pages/privacy.tsx
@@ -18,7 +18,7 @@ const Privacy = (): JSX.Element => {
           </Head>
           <header>
             <Image
-              data-test-id="cellxgene-logo"
+              data-testid="cellxgene-logo"
               src={rawCellxgeneLogo}
               alt="CELLxGENE logo"
               width="119"

--- a/frontend/src/pages/tos.tsx
+++ b/frontend/src/pages/tos.tsx
@@ -18,7 +18,7 @@ const ToS = (): JSX.Element => {
           </Head>
           <header>
             <Image
-              data-test-id="cellxgene-logo"
+              data-testid="cellxgene-logo"
               src={rawCellxgeneLogo}
               alt="CELLxGENE logo"
               width="119"

--- a/frontend/src/views/Collection/components/ActionButtons/components/DeleteButton/index.tsx
+++ b/frontend/src/views/Collection/components/ActionButtons/components/DeleteButton/index.tsx
@@ -35,7 +35,7 @@ const DeleteCollectionButton = ({
         onClick={handleClick}
         text="Delete Collection"
         intent={Intent.DANGER}
-        data-test-id="delete-collection-button"
+        data-testid="delete-collection-button"
         minimal
         outlined
         onMouseEnter={handleHover}

--- a/frontend/src/views/Collection/components/ActionButtons/components/MoreDropdown/components/Menu/index.tsx
+++ b/frontend/src/views/Collection/components/ActionButtons/components/MoreDropdown/components/Menu/index.tsx
@@ -21,7 +21,7 @@ const DeleteButton = ({
       icon={IconNames.TRASH}
       intent={Intent.DANGER}
       text={isRevision ? "Cancel Revision" : "Delete Collection"}
-      data-test-id={
+      data-testid={
         isRevision ? "dropdown-cancel-revision" : "dropdown-delete-collection"
       }
     />
@@ -36,7 +36,7 @@ const EditButton = (props: Partial<IMenuItemProps>) => {
       icon={IconNames.EDIT}
       intent={Intent.NONE}
       text="Edit Details"
-      data-test-id="dropdown-edit-details"
+      data-testid="dropdown-edit-details"
     />
   );
 };

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -189,7 +189,7 @@ const Collection: FC = () => {
         )}
         {/* Collection title and actions */}
         <CollectionHero>
-          <H3 data-test-id="collection-name">{collection.name}</H3>
+          <H3 data-testid="collection-name">{collection.name}</H3>
           {shouldShowPrivateWriteAction && (
             <ActionButtons
               id={id}

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -77,7 +77,7 @@ export default function Collections(): JSX.Element {
           return (
             <Title>
               <LinkCell
-                data-test-id="collection-link"
+                data-testid="collection-link"
                 url={ROUTES.COLLECTION.replace(":id", row.values.id)}
                 value={row.values.name}
               />

--- a/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
@@ -147,6 +147,7 @@ function CellInfoSideBar({
           <BetaChip label="Beta" size="small" />
         </div>
         <Button
+          data-test-id="add-to-dotplot-fmg-button"
           startIcon={<Icon sdsIcon="plus" sdsSize="s" sdsType="button" />}
           onClick={handleDisplayGenes}
           sdsStyle="minimal"
@@ -164,7 +165,7 @@ function CellInfoSideBar({
           combination: `${cellInfoCellType.cellType.id}, ${tissueInfo.id}`,
         }),
         (
-          <NoMarkerGenesContainer>
+          <NoMarkerGenesContainer data-test-id="no-marker-genes-warning">
             <NoMarkerGenesHeader>No Marker Genes</NoMarkerGenesHeader>
             <NoMarkerGenesDescription>
               No reliable marker genes for this cell type.
@@ -272,7 +273,9 @@ function CellInfoSideBar({
                     />
                   </InfoButtonWrapper>
                 </td>
-                <td>{metadata.effect_size.toPrecision(4)}</td>
+                <td data-test-id="marker-scores-fmg">
+                  {metadata.effect_size.toPrecision(4)}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
@@ -147,7 +147,7 @@ function CellInfoSideBar({
           <BetaChip label="Beta" size="small" />
         </div>
         <Button
-          data-test-id="add-to-dotplot-fmg-button"
+          data-testid="add-to-dotplot-fmg-button"
           startIcon={<Icon sdsIcon="plus" sdsSize="s" sdsType="button" />}
           onClick={handleDisplayGenes}
           sdsStyle="minimal"
@@ -165,7 +165,7 @@ function CellInfoSideBar({
           combination: `${cellInfoCellType.cellType.id}, ${tissueInfo.id}`,
         }),
         (
-          <NoMarkerGenesContainer data-test-id="no-marker-genes-warning">
+          <NoMarkerGenesContainer data-testid="no-marker-genes-warning">
             <NoMarkerGenesHeader>No Marker Genes</NoMarkerGenesHeader>
             <NoMarkerGenesDescription>
               No reliable marker genes for this cell type.
@@ -255,7 +255,7 @@ function CellInfoSideBar({
                 <td>
                   {symbol}
                   <InfoButtonWrapper
-                    data-test-id="gene-info-button-cell-info"
+                    data-testid="gene-info-button-cell-info"
                     onClick={() => {
                       generateGeneInfo(symbol);
 
@@ -273,7 +273,7 @@ function CellInfoSideBar({
                     />
                   </InfoButtonWrapper>
                 </td>
-                <td data-test-id="marker-scores-fmg">
+                <td data-testid="marker-scores-fmg">
                   {metadata.effect_size.toPrecision(4)}
                 </td>
               </tr>

--- a/frontend/src/views/WheresMyGene/components/Filters/components/ColorScale/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/components/ColorScale/index.tsx
@@ -92,7 +92,7 @@ export default function ColorScale({ setIsScaled }: Props): JSX.Element {
       </LabelWrapper>
 
       <StyledDropdown
-        data-test-id="color-scale-dropdown"
+        data-testid="color-scale-dropdown"
         onChange={colorScaleOnChange}
         label={colorScaledOption.name}
         options={COLOR_SCALE_OPTIONS}

--- a/frontend/src/views/WheresMyGene/components/Filters/components/Compare/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/components/Compare/index.tsx
@@ -47,7 +47,7 @@ export default function Compare({ areFiltersDisabled }: Props): JSX.Element {
       </LabelWrapper>
       <Wrapper>
         <StyledDropdown
-          data-test-id="compare-dropdown"
+          data-testid="compare-dropdown"
           onChange={handleChange}
           label={optionLabel?.name || "None"}
           options={COMPARE_OPTIONS}

--- a/frontend/src/views/WheresMyGene/components/Filters/components/Organism/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/components/Organism/index.tsx
@@ -62,7 +62,7 @@ export default function Organism({ isLoading }: Props): JSX.Element {
         options={organisms || EMPTY_ARRAY}
         onChange={handleOnChange as tempOnChange}
         InputDropdownProps={{ ...InputDropdownProps, disabled: isLoading }}
-        data-test-id="add-organism"
+        data-testid="add-organism"
         value={organism}
       />
     </Wrapper>

--- a/frontend/src/views/WheresMyGene/components/Filters/components/Sort/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/components/Sort/index.tsx
@@ -60,7 +60,7 @@ export default function Sort({ areFiltersDisabled }: Props): JSX.Element {
       <Wrapper>
         <FilterLabel>Sort Cell Types</FilterLabel>
         <StyledDropdown
-          data-test-id="cell-type-sort-dropdown"
+          data-testid="cell-type-sort-dropdown"
           onChange={cellTypesOnChange}
           label={cellTypeSelectedOption.name}
           options={CELL_TYPE_OPTIONS}
@@ -71,7 +71,7 @@ export default function Sort({ areFiltersDisabled }: Props): JSX.Element {
       <Wrapper>
         <FilterLabel>Sort Genes</FilterLabel>
         <StyledDropdown
-          data-test-id="gene-sort-dropdown"
+          data-testid="gene-sort-dropdown"
           onChange={genesOnChange}
           label={geneSelectedOption.name}
           options={GENE_OPTIONS}

--- a/frontend/src/views/WheresMyGene/components/Filters/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Filters/index.tsx
@@ -278,7 +278,7 @@ export default memo(function Filters({
       <div>
         <StyledComplexFilter
           multiple
-          data-test-id="dataset-filter"
+          data-testid="dataset-filter"
           search
           label="Dataset"
           options={datasets as unknown as DefaultMenuSelectOption[]}
@@ -292,7 +292,7 @@ export default memo(function Filters({
         />
         <StyledComplexFilter
           multiple
-          data-test-id="disease-filter"
+          data-testid="disease-filter"
           search
           label="Disease"
           options={disease_terms as unknown as DefaultMenuSelectOption[]}
@@ -306,7 +306,7 @@ export default memo(function Filters({
         />
         <StyledComplexFilter
           multiple
-          data-test-id="self-reported-ethnicity-filter"
+          data-testid="self-reported-ethnicity-filter"
           search
           label="Self-Reported Ethnicity"
           options={
@@ -322,7 +322,7 @@ export default memo(function Filters({
         />
         <StyledComplexFilter
           multiple
-          data-test-id="sex-filter"
+          data-testid="sex-filter"
           search
           label="Sex"
           options={sex_terms as unknown as DefaultMenuSelectOption[]}

--- a/frontend/src/views/WheresMyGene/components/GeneInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneInfoSideBar/index.tsx
@@ -41,7 +41,7 @@ function GeneInfoSideBar({
   );
 
   return (
-    <div id="gene-info-wrapper" data-test-id={`${geneInfoGene}-gene-info`}>
+    <div id="gene-info-wrapper" data-testid={`${geneInfoGene}-gene-info`}>
       {data ? <GeneInfoResult data={data} /> : GeneInfoNoData}
     </div>
   );
@@ -51,7 +51,7 @@ function GeneInfoResult({ data }: { data: GeneInfo }) {
   return (
     <div id="gene-info-wrapper">
       <>
-        <GeneName data-test-id="gene-info-header">{data.name}</GeneName>
+        <GeneName data-testid="gene-info-header">{data.name}</GeneName>
 
         {data.show_warning_banner && (
           <>
@@ -61,11 +61,11 @@ function GeneInfoResult({ data }: { data: GeneInfo }) {
           </>
         )}
 
-        <GeneSummary data-test-id="gene-info-gene-summary">
+        <GeneSummary data-testid="gene-info-gene-summary">
           {data.summary}
         </GeneSummary>
 
-        <GeneSynonymsWrapper data-test-id="gene-info-gene-synonyms">
+        <GeneSynonymsWrapper data-testid="gene-info-gene-synonyms">
           <GeneSynonymsLabel>Synonyms</GeneSynonymsLabel>
           <GeneSynonyms>{data.synonyms.join(", ")}</GeneSynonyms>
         </GeneSynonymsWrapper>
@@ -74,7 +74,7 @@ function GeneInfoResult({ data }: { data: GeneInfo }) {
           href={data.ncbi_url}
           target="_blank"
           rel="noreferrer noopener"
-          data-test-id="gene-info-ncbi-link"
+          data-testid="gene-info-ncbi-link"
         >
           View on NCBI
         </GeneUrl>

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/QuickSelect/index.tsx
@@ -269,7 +269,7 @@ export default function QuickSelect<
         <StyledSelectButton
           disabled={isLoading}
           id={`${dataTestId}-id`}
-          data-test-id={dataTestId}
+          data-testid={dataTestId}
           ref={ref}
           onClick={handleClick}
           sdsType="primary"

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveExport/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveExport/index.tsx
@@ -213,7 +213,7 @@ export default function SaveExport({
       <ButtonWrapper className={EXCLUDE_IN_SCREENSHOT_CLASS_NAME}>
         <Label>Download</Label>
         <StyledButtonIcon
-          data-test-id="download-button"
+          data-testid="download-button"
           onClick={handleButtonClick}
           disabled={selectedTissues.length === 0 || selectedGenes.length === 0}
           sdsSize="medium"
@@ -239,7 +239,7 @@ export default function SaveExport({
                 }
                 label="PNG"
                 onChange={() => selectFileType("png")}
-                data-test-id="png-checkbox"
+                data-testid="png-checkbox"
               />
 
               <StyledFormControlLabel
@@ -250,7 +250,7 @@ export default function SaveExport({
                 }
                 label="SVG"
                 onChange={() => selectFileType("svg")}
-                data-test-id="svg-checkbox"
+                data-testid="svg-checkbox"
               />
             </StyledDiv>
           </StyledSection>
@@ -265,7 +265,7 @@ export default function SaveExport({
                 }
                 label="CSV"
                 onChange={() => selectFileType("csv")}
-                data-test-id="csv-checkbox"
+                data-testid="csv-checkbox"
               />
             </StyledDiv>
           </StyledSection>
@@ -285,7 +285,7 @@ export default function SaveExport({
             sdsSize="large"
             onClick={handleDownload}
             disabled={!selectedFileTypes.length}
-            data-test-id="dialog-download-button"
+            data-testid="dialog-download-button"
           >
             Download
           </DownloadButton>

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveExport/utils.ts
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveExport/utils.ts
@@ -231,7 +231,7 @@ export function renderXAxis({
   const geneLabelContainer = document.createElementNS(NAME_SPACE_URI, "g");
 
   Array.from(
-    xAxis?.querySelectorAll(`[data-test-id*='gene-label-'] span`) || []
+    xAxis?.querySelectorAll(`[data-testid*='gene-label-'] span`) || []
   ).forEach((label, index) => {
     const geneLabelText = document.createElementNS(NAME_SPACE_URI, "text");
 
@@ -300,14 +300,14 @@ export function renderYAxis({
   const cellTypeNamesContainer = document.createElementNS(NAME_SPACE_URI, "g");
 
   Array.from(
-    yAxis?.querySelectorAll("[data-test-id='cell-type-label-count']") || []
+    yAxis?.querySelectorAll("[data-testid='cell-type-label-count']") || []
   ).forEach((labelCount, index) => {
     const label = labelCount.querySelector(
-      "[data-test-id='cell-type-name']"
+      "[data-testid='cell-type-name']"
     )?.textContent;
 
     const count = labelCount.querySelector(
-      "[data-test-id='cell-count']"
+      "[data-testid='cell-count']"
     )?.textContent;
 
     // group

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/ShareButton/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/ShareButton/index.tsx
@@ -113,7 +113,7 @@ export default function ShareButton(): JSX.Element {
         <StyledLabel>Share</StyledLabel>
 
         <StyledButtonIcon
-          data-test-id={"share-button"}
+          data-testid={"share-button"}
           onClick={copyShareUrl}
           sdsSize="medium"
           sdsType="primary"

--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SourceDataButton/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SourceDataButton/index.tsx
@@ -13,7 +13,7 @@ export default function SourceDataButton({
       <StyledLabel>Source Data</StyledLabel>
 
       <StyledButtonIcon
-        data-test-id={"source-data-button"}
+        data-testid={"source-data-button"}
         onClick={handleRightSidebarButtonClick}
         sdsSize="medium"
         sdsType="primary"

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/XAxisChart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/XAxisChart/index.tsx
@@ -53,10 +53,10 @@ function GeneButton({
   );
 
   return (
-    <GeneButtonStyle data-test-id={`gene-label-${geneName}`}>
+    <GeneButtonStyle data-testid={`gene-label-${geneName}`}>
       <XAxisLabel className={"gene-label-container"}>
         <div
-          data-test-id={"gene-delete-button"}
+          data-testid={"gene-delete-button"}
           className="gene-delete-icon"
           onClick={() => {
             track(EVENTS.WMG_DELETE_GENE, { gene: geneName });
@@ -73,7 +73,7 @@ function GeneButton({
           font={currentFont}
         >
           <InfoButtonWrapper
-            data-test-id="gene-info-button-x-axis"
+            data-testid="gene-info-button-x-axis"
             className={EXCLUDE_IN_SCREENSHOT_CLASS_NAME}
             onClick={() => {
               if (!dispatch) return;
@@ -115,7 +115,7 @@ export default function XAxisChart({ geneNames }: Props): JSX.Element {
       width={heatmapWidth}
       left={Y_AXIS_CHART_WIDTH_PX + CHART_LEFT_PADDING}
     >
-      <XAxisContainer data-test-id="gene-labels" width={heatmapWidth}>
+      <XAxisContainer data-testid="gene-labels" width={heatmapWidth}>
         {geneNames.map((geneName) => (
           <GeneButton
             key={geneName}

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/YAxisChart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/YAxisChart/index.tsx
@@ -65,7 +65,7 @@ export default memo(function YAxisChart({
         <TissueName>{capitalize(tissue)}</TissueName>
       </TissueWrapper>
       <Container
-        data-test-id={`cell-type-labels-${tissueKey}`}
+        data-testid={`cell-type-labels-${tissueKey}`}
         height={heatmapHeight}
       >
         {cellTypeMetadata
@@ -91,7 +91,7 @@ export default memo(function YAxisChart({
                 tissueID={tissueID}
                 tissue={tissue}
                 generateMarkerGenes={generateMarkerGenes}
-                date-test-id="cell-type-label"
+                data-testid="cell-type-label"
               />
             );
           })}
@@ -123,9 +123,9 @@ const CellTypeButton = ({
   const cellType = deserializeCellTypeMetadata(metadata);
 
   return (
-    <FlexRowJustified data-test-id="cell-type-label-count">
+    <FlexRowJustified data-testid="cell-type-label-count">
       <FlexRow>
-        <CellTypeLabelStyle data-test-id="cell-type-name">
+        <CellTypeLabelStyle data-testid="cell-type-name">
           {name}
         </CellTypeLabelStyle>
 
@@ -149,7 +149,7 @@ const CellTypeButton = ({
               }}
             >
               <StyledImage
-                data-test-id="marker-gene-button"
+                data-testid="marker-gene-button"
                 src={InfoSVG.src}
                 width="10"
                 height="10"
@@ -158,7 +158,7 @@ const CellTypeButton = ({
             </InfoButtonWrapper>
           )}
       </FlexRow>
-      <CellCountLabelStyle data-test-id="cell-count">
+      <CellCountLabelStyle data-testid="cell-count">
         {countString}
       </CellCountLabelStyle>
     </FlexRowJustified>

--- a/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
@@ -171,7 +171,7 @@ export default memo(function HeatMap({
       <Container {...{ className }} id={HEATMAP_CONTAINER_ID}>
         {isLoadingAPI || isAnyTissueLoading(isLoading) ? <Loader /> : null}
         <XAxisWrapper id="x-axis-wrapper">
-          <XAxisMask data-test-id="x-axis-mask" />
+          <XAxisMask data-testid="x-axis-mask" />
           <XAxisChart geneNames={sortedGeneNames} />
         </XAxisWrapper>
         <YAxisWrapper>

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/Legend/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/Legend/index.tsx
@@ -37,7 +37,7 @@ export default memo(function Legend({
   availableFilters,
 }: Props): JSX.Element {
   return (
-    <LegendWrapper data-test-id="legend-wrapper">
+    <LegendWrapper data-testid="legend-wrapper">
       <SaveExport
         selectedTissues={selectedTissues}
         selectedGenes={selectedGenes}

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/Legend/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/Legend/index.tsx
@@ -37,7 +37,7 @@ export default memo(function Legend({
   availableFilters,
 }: Props): JSX.Element {
   return (
-    <LegendWrapper>
+    <LegendWrapper data-test-id="legend-wrapper">
       <SaveExport
         selectedTissues={selectedTissues}
         selectedGenes={selectedGenes}

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/SourceData/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/SourceData/index.tsx
@@ -32,7 +32,7 @@ export default function SourceData(): JSX.Element {
   return (
     <Wrapper>
       <Content>
-        <List ordered data-test-id="source-data-list">
+        <List ordered data-testid="source-data-list">
           {Object.values(collections).map(({ name, url, datasets }) => {
             return (
               <ListItem ordered key={name} fontSize="xxxs">

--- a/frontend/src/views/WheresMyGene/components/RightSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/RightSideBar/index.tsx
@@ -40,14 +40,14 @@ export default memo(function RightSideBar({
     <SideBarWrapper
       sideBarWidth={width}
       position={Position.RIGHT}
-      data-test-id={testId}
+      data-testid={testId}
     >
       <RightSideBarPositioner
         isExpanded
         maxHeight={isSplit ? UPPER_SECTION_MAX_HEIGHT_VH : FULL_MAX_HEIGHT_VH}
       >
         <HeaderContainer>
-          <StyledTitle data-test-id="right-sidebar-title">
+          <StyledTitle data-testid="right-sidebar-title">
             {content[0].props.title}
           </StyledTitle>
           <ButtonIcon
@@ -55,7 +55,7 @@ export default memo(function RightSideBar({
             sdsSize="medium"
             onClick={() => content[0].props.handleClose()}
             sdsType="tertiary"
-            data-test-id="right-sidebar-close-button"
+            data-testid="right-sidebar-close-button"
           />
         </HeaderContainer>
         {content[0]}
@@ -64,7 +64,7 @@ export default memo(function RightSideBar({
       {isSplit && (
         <RightSideBarPositioner isExpanded maxHeight={DRAWER_MAX_HEIGHT_VH}>
           <HeaderContainer>
-            <StyledTitle data-test-id="gene-info-title-split">
+            <StyledTitle data-testid="gene-info-title-split">
               {content[1].props.title}
             </StyledTitle>
             <ButtonIcon
@@ -72,7 +72,7 @@ export default memo(function RightSideBar({
               sdsSize="medium"
               onClick={() => content[1].props.handleClose()}
               sdsType="tertiary"
-              data-test-id="gene-info-close-button-split"
+              data-testid="gene-info-close-button-split"
             />
           </HeaderContainer>
           {content[1]}

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -257,7 +257,7 @@ Where tests are skipped vs. run in different environments.
 
     1. Use utility function `tryUntil()`: There will be times when your test assertions will happen before the application is in the expected state due to the flaky factors above. So we have a utility function `tryUntil()` that allows you to retry defined actions/assertions until your expected condition is met. For examples, you can retry clicking on a button until the modal element exists, or retry asserting a certain element exists before throwing an error. There are examples available in the tests that you can look for them by global searching for `tryUntil`
 
-    1. Use `data-test-id` HTML attribute for target elements: Since our application's HTML structure changes over time, it's unreliable to select an element based on properties and structures that could easily change over time, such as css classes and element structures (e.g., first div child of a parent). The more reliable way is to add a `data-test-id` attribute to your test target, so when the element and/or its context changes, we can still reliably target the element
+    1. Use `data-testid` HTML attribute for target elements: Since our application's HTML structure changes over time, it's unreliable to select an element based on properties and structures that could easily change over time, such as css classes and element structures (e.g., first div child of a parent). The more reliable way is to add a `data-testid` attribute to your test target, so when the element and/or its context changes, we can still reliably target the element
 
 ## Maintain application in a predictable state
 

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -705,7 +705,7 @@ describe("Where's My Gene", () => {
         testId: DOWNLOAD_BUTTON_ID,
       });
 
-      await page.getByTestId("png-checkbox").click();
+      await page.getByTestId("svg-checkbox").click();
       await page.getByTestId("csv-checkbox").click();
 
       // Start waiting for download before clicking. Note no await.
@@ -762,7 +762,7 @@ describe("Where's My Gene", () => {
         testId: DOWNLOAD_BUTTON_ID,
       });
 
-      await page.getByTestId("png-checkbox").click();
+      await page.getByTestId("svg-checkbox").click();
       await page.getByTestId("csv-checkbox").click();
 
       // Start waiting for download before clicking. Note no await.

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -51,7 +51,7 @@ const EXPORT_OUTPUT_DIR = "playwright-report/";
 const { describe, skip } = test;
 
 describe("Where's My Gene", () => {
-  // skip(!isDevStagingProd, "WMG BE API does not work locally or in rdev");
+  skip(!isDevStagingProd, "WMG BE API does not work locally or in rdev");
 
   test("renders the getting started UI", async ({ page }) => {
     await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -875,7 +875,7 @@ async function clickUntilDownloadModalShowsUp({
       } else {
         throw Error("Either testId or locator must be defined");
       }
-      await page.locator("[class=bp4-dialog]").elementHandle();
+      await page.locator(".bp4-dialog").elementHandle();
     },
     { page }
   );
@@ -899,7 +899,7 @@ async function clickUntilSidebarShowsUp({
       } else {
         throw Error("Either testId or locator must be defined");
       }
-      await page.locator("[class=bp4-drawer-header]").elementHandle();
+      await page.locator(".bp4-drawer-header").elementHandle();
     },
     { page }
   );

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -310,7 +310,7 @@ describe("Where's My Gene", () => {
 
         // Testing single gene delete
         await page.hover(".gene-label-container");
-        await page.getByTestId(GENE_DELETE_BUTTON).click();
+        await getFirstButtonAndClick(page, GENE_DELETE_BUTTON);
 
         const afterGeneNames = await getGeneNames(page);
 
@@ -519,7 +519,7 @@ describe("Where's My Gene", () => {
 
       await waitForHeatmapToRender(page);
 
-      await getButtonAndClick(page, GENE_INFO_BUTTON_X_AXIS_TEST_ID);
+      await getFirstButtonAndClick(page, GENE_INFO_BUTTON_X_AXIS_TEST_ID);
 
       await waitForElement(page, GENE_INFO_HEADER_TEST_ID);
       await waitForElement(page, GENE_INFO_GENE_SYNONYMS_TEST_ID);
@@ -549,7 +549,7 @@ describe("Where's My Gene", () => {
 
       await getCellTypeFmgButtonAndClick(page, "muscle cell");
 
-      await getButtonAndClick(page, GENE_INFO_BUTTON_CELL_INFO_TEST_ID);
+      await getFirstButtonAndClick(page, GENE_INFO_BUTTON_CELL_INFO_TEST_ID);
 
       await waitForElement(page, GENE_INFO_HEADER_TEST_ID);
       await waitForElement(page, GENE_INFO_GENE_SYNONYMS_TEST_ID);
@@ -564,7 +564,7 @@ describe("Where's My Gene", () => {
 
       await waitForElementToBeRemoved(page, RIGHT_SIDEBAR_TITLE_TEST_ID);
 
-      await getButtonAndClick(page, GENE_INFO_BUTTON_X_AXIS_TEST_ID);
+      await getFirstButtonAndClick(page, GENE_INFO_BUTTON_X_AXIS_TEST_ID);
 
       await waitForElement(page, GENE_INFO_HEADER_TEST_ID);
       await waitForElement(page, RIGHT_SIDEBAR_TITLE_TEST_ID);
@@ -962,6 +962,17 @@ async function getButtonAndClick(page: Page, testID: string) {
   await tryUntil(
     async () => {
       await page.getByTestId(testID).click();
+    },
+    { page }
+  );
+}
+
+// for when there are multiple buttons with the same testID
+async function getFirstButtonAndClick(page: Page, testID: string) {
+  await tryUntil(
+    async () => {
+      const buttons = await page.getByTestId(testID).elementHandles();
+      await buttons[0].click();
     },
     { page }
   );

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -12,14 +12,14 @@ import AdmZip from "adm-zip";
 
 const HOMO_SAPIENS_TERM_ID = "NCBITaxon:9606";
 
-const GENE_LABELS_ID = "[data-test-id^=gene-label-]";
+const GENE_LABELS_ID = "[data-testid^=gene-label-]";
 const CELL_TYPE_LABELS_ID = "cell-type-name";
 const CELL_TYPE_LABEL_ROW_TEST_ID = "cell-type-label-count";
 const ADD_TISSUE_ID = "add-tissue";
 const ADD_GENE_ID = "add-gene";
 const GENE_DELETE_BUTTON = "gene-delete-button";
 const SOURCE_DATA_BUTTON_ID = "source-data-button";
-const SOURCE_DATA_LIST_SELECTOR = `[data-test-id="source-data-list"]`;
+const SOURCE_DATA_LIST_SELECTOR = `[data-testid="source-data-list"]`;
 const DOWNLOAD_BUTTON_ID = "download-button";
 
 const MARKER_GENE_BUTTON_TEST_ID = "marker-gene-button";

--- a/frontend/tests/features/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene.test.ts
@@ -1,10 +1,10 @@
-import { ElementHandle, expect, Page, test } from "@playwright/test";
+import { expect, Page, test, Locator } from "@playwright/test";
 import { ROUTES } from "src/common/constants/routes";
 import type { RawPrimaryFilterDimensionsResponse } from "src/common/queries/wheresMyGene";
 import { FMG_GENE_STRENGTH_THRESHOLD } from "src/views/WheresMyGene/common/constants";
 import { goToPage, isDevStagingProd, tryUntil } from "tests/utils/helpers";
 import { TEST_URL } from "../common/constants";
-import { getTestID, getText } from "../utils/selectors";
+import { getText } from "../utils/selectors";
 import { TISSUE_DENY_LIST } from "./fixtures/wheresMyGene/tissueRollup";
 import fs from "fs";
 import { parse } from "csv-parse/sync";
@@ -14,6 +14,7 @@ const HOMO_SAPIENS_TERM_ID = "NCBITaxon:9606";
 
 const GENE_LABELS_ID = "[data-test-id^=gene-label-]";
 const CELL_TYPE_LABELS_ID = "cell-type-name";
+const CELL_TYPE_LABEL_ROW_TEST_ID = "cell-type-label-count";
 const ADD_TISSUE_ID = "add-tissue";
 const ADD_GENE_ID = "add-gene";
 const GENE_DELETE_BUTTON = "gene-delete-button";
@@ -40,7 +41,6 @@ const RIGHT_SIDEBAR_CLOSE_BUTTON_TEST_ID = "right-sidebar-close-button";
 const GENE_INFO_BUTTON_CELL_INFO_TEST_ID = "gene-info-button-cell-info";
 
 const MUI_CHIP_ROOT = ".MuiChip-root";
-const FILTERS_PANEL_NOT_FOUND = "Filters panel not found";
 
 const CELL_TYPE_SANITY_CHECK_NUMBER = 100;
 
@@ -51,7 +51,7 @@ const EXPORT_OUTPUT_DIR = "playwright-report/";
 const { describe, skip } = test;
 
 describe("Where's My Gene", () => {
-  skip(!isDevStagingProd, "WMG BE API does not work locally or in rdev");
+  // skip(!isDevStagingProd, "WMG BE API does not work locally or in rdev");
 
   test("renders the getting started UI", async ({ page }) => {
     await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
@@ -66,25 +66,13 @@ describe("Where's My Gene", () => {
     await expect(page).toHaveSelector(getText("STEP 3"));
     await expect(page).toHaveSelector(getText("Explore Gene Expression"));
 
-    // Filters Panel
-    // (thuang): `*` is for intermediate match
-    // https://playwright.dev/docs/selectors#intermediate-matches
-
-    async function getTissueSelectorButton() {
-      return page.$(getTestID(ADD_TISSUE_ID));
-    }
-
-    async function getGeneSelectorButton() {
-      return page.$(getTestID(ADD_GENE_ID));
-    }
-
-    await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
     await selectFirstOption(page);
 
-    await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
     await selectFirstOption(page);
 
-    const filtersPanel = await page.$("*css=div >> text=Filters");
+    const filtersPanel = page.getByTestId("filters-panel");
 
     await expect(filtersPanel).toHaveSelector(getText("Dataset"));
     await expect(filtersPanel).toHaveSelector(getText("Disease"));
@@ -94,207 +82,132 @@ describe("Where's My Gene", () => {
     await expect(filtersPanel).toHaveSelector(getText("Sex"));
 
     // Legend
-    const Legend = await page.$("*css=div >> text=Gene Expression");
-
+    const Legend = page.getByTestId("legend-wrapper");
     await expect(Legend).toHaveSelector(getText("Gene Expression"));
     await expect(Legend).toHaveSelector(getText("Expressed in Cells (%)"));
 
     // Info Panel
-    const InfoPanel = await page.$("*css=div >> text=Filters");
-
-    await expect(InfoPanel).toHaveSelector(getText("Methodology"));
-    await expect(InfoPanel).toHaveSelector(
+    await expect(filtersPanel).toHaveSelector(getText("Methodology"));
+    await expect(filtersPanel).toHaveSelector(
       getText("After filtering cells with low coverage ")
     );
-    await expect(InfoPanel).toHaveSelector(getText("Source Data"));
+    await expect(filtersPanel).toHaveSelector(getText("Source Data"));
   });
 
   test("Filters and Heatmap", async ({ page }) => {
     await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-    async function getTissueSelectorButton() {
-      return page.$(getTestID(ADD_TISSUE_ID));
-    }
-
-    async function getGeneSelectorButton() {
-      return page.$(getTestID(ADD_GENE_ID));
-    }
-
-    await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
     await selectFirstOption(page);
 
-    await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
     await selectFirstOption(page);
 
     await waitForHeatmapToRender(page);
 
-    const sexSelector = await getSexSelector();
+    const sexSelector = getSexSelector();
+    const selectedSexesBefore = await sexSelector
+      .locator(MUI_CHIP_ROOT)
+      .elementHandles();
 
-    if (!sexSelector) throw Error("No sexSelector found");
+    expect(selectedSexesBefore.length).toBe(0);
 
-    const selectedSexesBefore = await sexSelector.$$(MUI_CHIP_ROOT);
-
-    await expect(selectedSexesBefore.length).toBe(0);
-
-    await clickUntilOptionsShowUp(getSexSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, locator: getSexSelectorButton() });
 
     await selectFirstOption(page);
 
-    const selectedSexesAfter = await sexSelector.$$(MUI_CHIP_ROOT);
+    const selectedSexesAfter = await sexSelector
+      .locator(MUI_CHIP_ROOT)
+      .elementHandles();
 
-    await expect(selectedSexesAfter.length).toBe(1);
+    expect(selectedSexesAfter.length).toBe(1);
 
-    async function getFiltersPanel() {
-      return page.$(getTestID("filters-panel"));
+    function getSexSelector() {
+      return page.getByTestId("filters-panel").getByTestId("sex-filter");
     }
 
-    async function getSexSelector() {
-      const filtersPanel = await getFiltersPanel();
-
-      if (!filtersPanel) {
-        throw Error(FILTERS_PANEL_NOT_FOUND);
-      }
-
-      return filtersPanel.$(getTestID("sex-filter"));
-    }
-
-    async function getSexSelectorButton() {
-      const filtersPanel = await getFiltersPanel();
-
-      if (!filtersPanel) {
-        throw Error(FILTERS_PANEL_NOT_FOUND);
-      }
-
-      await filtersPanel.$(getTestID("sex-filter"));
-      return filtersPanel.$("*css=button >> text=Sex");
+    function getSexSelectorButton() {
+      return getSexSelector().getByRole("button");
     }
   });
 
   test("Primary and secondary filter crossfiltering", async ({ page }) => {
     await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-    const diseaseSelector = await getDiseaseSelector();
-    const datasetSelector = await getDatasetSelector();
-
-    if (!diseaseSelector) throw Error("No diseaseSelector found");
-    if (!datasetSelector) throw Error("No datasetSelector found");
-
-    await clickUntilOptionsShowUp(getTissueSelectorButton, page);
-    const tissueOptionsBefore = await page.$$("[role=option]");
-    const numberOfTissuesBefore = tissueOptionsBefore.length;
+    await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
+    const numberOfTissuesBefore = await countLocator(page.getByRole("option"));
     await page.keyboard.press("Escape");
 
-    await clickUntilOptionsShowUp(getDiseaseSelectorButton, page);
-    const diseaseOptionsBefore = await page.$$("[role=option]");
-    const numberOfDiseasesBefore = diseaseOptionsBefore.length;
+    await clickUntilOptionsShowUp({
+      page,
+      locator: getDiseaseSelectorButton(),
+    });
+    const numberOfDiseasesBefore = await countLocator(page.getByRole("option"));
     await page.keyboard.press("Escape");
 
-    await clickUntilOptionsShowUp(getDatasetSelectorButton, page);
-    const datasetOptions = await page.$$("[role=option]");
+    await clickUntilOptionsShowUp({
+      page,
+      locator: getDatasetSelectorButton(),
+    });
+    const datasetOptions = await page.getByRole("option").elementHandles();
     await datasetOptions[0].click();
     await page.keyboard.press("Escape");
 
-    await clickUntilOptionsShowUp(getTissueSelectorButton, page);
-    const tissueOptionsAfter = await page.$$("[role=option]");
-    const numberOfTissuesAfter = tissueOptionsAfter.length;
+    await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
+    const numberOfTissuesAfter = await countLocator(page.getByRole("option"));
     await page.keyboard.press("Escape");
 
-    await clickUntilOptionsShowUp(getDiseaseSelectorButton, page);
-    const diseaseOptionsAfter = await page.$$("[role=option]");
-    const numberOfDiseasesAfter = diseaseOptionsAfter.length;
+    await clickUntilOptionsShowUp({
+      page,
+      locator: getDiseaseSelectorButton(),
+    });
+    const numberOfDiseasesAfter = await countLocator(page.getByRole("option"));
     await page.keyboard.press("Escape");
 
     expect(numberOfDiseasesBefore).toBeGreaterThan(numberOfDiseasesAfter);
     expect(numberOfTissuesBefore).toBeGreaterThan(numberOfTissuesAfter);
 
-    async function getTissueSelectorButton() {
-      return page.$(getTestID(ADD_TISSUE_ID));
+    function getDiseaseSelector() {
+      return page.getByTestId("filters-panel").getByTestId("disease-filter");
     }
 
-    async function getFiltersPanel() {
-      return page.$(getTestID("filters-panel"));
+    function getDiseaseSelectorButton() {
+      return getDiseaseSelector().getByRole("button");
     }
 
-    async function getDiseaseSelector() {
-      const filtersPanel = await getFiltersPanel();
-
-      if (!filtersPanel) {
-        throw Error(FILTERS_PANEL_NOT_FOUND);
-      }
-
-      return filtersPanel.$("*css=div >> text=Disease");
+    function getDatasetSelector() {
+      return page.getByTestId("filters-panel").getByTestId("dataset-filter");
     }
 
-    async function getDiseaseSelectorButton() {
-      const filtersPanel = await getFiltersPanel();
-
-      if (!filtersPanel) {
-        throw Error(FILTERS_PANEL_NOT_FOUND);
-      }
-
-      await filtersPanel.$("*css=div >> text=Disease");
-      return filtersPanel.$("*css=button >> text=Disease");
-    }
-
-    async function getDatasetSelector() {
-      const filtersPanel = await getFiltersPanel();
-
-      if (!filtersPanel) {
-        throw Error(FILTERS_PANEL_NOT_FOUND);
-      }
-
-      return filtersPanel.$("*css=div >> text=Dataset");
-    }
-
-    async function getDatasetSelectorButton() {
-      const filtersPanel = await getFiltersPanel();
-
-      if (!filtersPanel) {
-        throw Error(FILTERS_PANEL_NOT_FOUND);
-      }
-
-      await filtersPanel.$("*css=div >> text=Dataset");
-      return filtersPanel.$("*css=button >> text=Dataset");
+    function getDatasetSelectorButton() {
+      return getDatasetSelector().getByRole("button");
     }
   });
 
   test("Selected tissue and no genes displays cell types", async ({ page }) => {
     await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-    async function getTissueSelectorButton() {
-      return page.$(getTestID(ADD_TISSUE_ID));
-    }
-
-    await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
     await selectFirstOption(page);
 
-    await waitForElement(page, getTestID(CELL_TYPE_LABELS_ID));
-    const cellTypes = await page.$$(getTestID(CELL_TYPE_LABELS_ID));
-    expect(cellTypes.length).toBeGreaterThan(0);
+    await waitForElement(page, CELL_TYPE_LABELS_ID);
+    const numCellTypes = await countLocator(
+      page.getByTestId(CELL_TYPE_LABELS_ID)
+    );
+    expect(numCellTypes).toBeGreaterThan(0);
   });
 
   test("Source Data", async ({ page }) => {
     await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-    async function getSourceDataButton() {
-      return page.$(getTestID(SOURCE_DATA_BUTTON_ID));
-    }
-    async function getTissueSelectorButton() {
-      return page.$(getTestID(ADD_TISSUE_ID));
-    }
-
-    async function getGeneSelectorButton() {
-      return page.$(getTestID(ADD_GENE_ID));
-    }
-
-    await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
     await selectFirstOption(page);
 
-    await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
     await selectFirstOption(page);
 
     await waitForHeatmapToRender(page);
-    await clickUntilSidebarShowsUp(getSourceDataButton, page);
+    await clickUntilSidebarShowsUp({ page, testId: SOURCE_DATA_BUTTON_ID });
     await expect(page).toHaveSelector(
       getText(
         "After filtering cells with low coverage (less than 500 genes expressed)"
@@ -303,50 +216,31 @@ describe("Where's My Gene", () => {
 
     await tryUntil(
       async () => {
-        const sourceDataList = await page.$(SOURCE_DATA_LIST_SELECTOR);
-
-        if (!sourceDataList) throw Error("no source data displayed");
-
-        const sourceDataListItems = await sourceDataList?.$$(
-          ".MuiListItem-root"
+        const numSourceDataListItems = await countLocator(
+          page.locator(SOURCE_DATA_LIST_SELECTOR).locator(".MuiListItem-root")
         );
-
-        expect(sourceDataListItems?.length).toBeGreaterThan(0);
+        expect(numSourceDataListItems).toBeGreaterThan(0);
 
         await page.mouse.click(0, 0);
 
-        async function getFiltersPanel() {
-          return page.$(getTestID("filters-panel"));
+        function getDatasetSelector() {
+          return page
+            .getByTestId("filters-panel")
+            .getByTestId("dataset-filter");
         }
-        async function getDatasetSelector() {
-          const filtersPanel = await getFiltersPanel();
 
-          if (!filtersPanel) {
-            throw Error(FILTERS_PANEL_NOT_FOUND);
-          }
-
-          return filtersPanel.$("*css=button >> text=Dataset");
-        }
-        const datasetSelector = await getDatasetSelector();
-        if (!datasetSelector) throw Error("No datasetSelector found");
-        const selectedDatasetsBefore = await datasetSelector.$$(MUI_CHIP_ROOT);
-        await expect(selectedDatasetsBefore.length).toBe(0);
-        await clickUntilOptionsShowUp(getDatasetSelector, page);
-        await selectFirstOption(page);
-        await clickUntilSidebarShowsUp(getSourceDataButton, page);
-
-        const sourceDataListAfter = await page.$(SOURCE_DATA_LIST_SELECTOR);
-
-        if (!sourceDataListAfter)
-          throw Error(
-            "no source data displayed after selecting dataset filter"
-          );
-
-        const sourceDataListAfterItems = await sourceDataListAfter?.$$(
-          ".MuiListItem-root"
+        const numSelectedDatasetsBefore = await countLocator(
+          getDatasetSelector().locator(MUI_CHIP_ROOT)
         );
+        expect(numSelectedDatasetsBefore).toBe(0);
+        await clickUntilOptionsShowUp({ page, locator: getDatasetSelector() });
+        await selectFirstOption(page);
+        await clickUntilSidebarShowsUp({ page, testId: SOURCE_DATA_BUTTON_ID });
 
-        expect(sourceDataListAfterItems?.length).toBeGreaterThan(0);
+        const numSourceDataListAfterItems = await countLocator(
+          page.locator(SOURCE_DATA_LIST_SELECTOR).locator(".MuiListItem-root")
+        );
+        expect(numSourceDataListAfterItems).toBeGreaterThan(0);
       },
       { page }
     );
@@ -355,29 +249,17 @@ describe("Where's My Gene", () => {
   test("Hierarchical Clustering", async ({ page }) => {
     await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-    async function getTissueSelectorButton() {
-      return page.$(getTestID(ADD_TISSUE_ID));
-    }
-
-    async function getGeneSelectorButton() {
-      return page.$(getTestID(ADD_GENE_ID));
-    }
-
     const TISSUE_COUNT = 1;
     const GENE_COUNT = 3;
 
-    await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
     await selectFirstNOptions(TISSUE_COUNT, page);
 
-    await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
     await selectFirstNOptions(GENE_COUNT, page);
 
-    const beforeGeneNames = await page.$$(GENE_LABELS_ID);
-
-    const beforeCellTypeNames = await getNames(
-      `${getTestID(CELL_TYPE_LABELS_ID)}`,
-      page
-    );
+    const beforeGeneNames = await getGeneNames(page);
+    const beforeCellTypeNames = await getCellTypeNames(page);
 
     expect(beforeGeneNames.length).toBe(GENE_COUNT);
 
@@ -387,24 +269,15 @@ describe("Where's My Gene", () => {
       CELL_TYPE_SANITY_CHECK_NUMBER
     );
 
-    const cellTypeSortDropdown = await page.locator(
-      getTestID("cell-type-sort-dropdown")
-    );
-    await cellTypeSortDropdown.click();
+    await page.getByTestId("cell-type-sort-dropdown").click();
     await selectNthOption(2, page);
 
-    const geneSortDropdown = await page.locator(
-      getTestID("gene-sort-dropdown")
-    );
-    await geneSortDropdown.click();
+    await page.getByTestId("gene-sort-dropdown").click();
     await selectNthOption(2, page);
 
-    const afterGeneNames = await page.$$(GENE_LABELS_ID);
+    const afterGeneNames = await getGeneNames(page);
 
-    const afterCellTypeNames = await getNames(
-      `${getTestID(CELL_TYPE_LABELS_ID)}`,
-      page
-    );
+    const afterCellTypeNames = await getCellTypeNames(page);
 
     await tryUntil(
       async () => {
@@ -421,23 +294,15 @@ describe("Where's My Gene", () => {
   test("delete genes", async ({ page }) => {
     await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-    async function getTissueSelectorButton() {
-      return page.$(getTestID(ADD_TISSUE_ID));
-    }
-
-    async function getGeneSelectorButton() {
-      return page.$(getTestID(ADD_GENE_ID));
-    }
-
-    await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
     await selectFirstNOptions(1, page);
 
-    await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+    await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
     await selectFirstNOptions(3, page);
 
     await waitForHeatmapToRender(page);
 
-    const beforeGeneNames = await page.$$(GENE_LABELS_ID);
+    const beforeGeneNames = await getGeneNames(page);
 
     await tryUntil(
       async () => {
@@ -445,9 +310,9 @@ describe("Where's My Gene", () => {
 
         // Testing single gene delete
         await page.hover(".gene-label-container");
-        await page.click(getTestID(GENE_DELETE_BUTTON));
+        await page.getByTestId(GENE_DELETE_BUTTON).click();
 
-        const afterGeneNames = await page.$$(GENE_LABELS_ID);
+        const afterGeneNames = await getGeneNames(page);
 
         expect(afterGeneNames.length).toBe(beforeGeneNames.length - 1);
         expect(afterGeneNames).not.toEqual(beforeGeneNames);
@@ -487,26 +352,15 @@ describe("Where's My Gene", () => {
     }) => {
       await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-      async function getTissueSelectorButton() {
-        return page.$(getTestID(ADD_TISSUE_ID));
-      }
-
-      async function getGeneSelectorButton() {
-        return page.$(getTestID(ADD_GENE_ID));
-      }
-
-      await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
       await selectFirstNOptions(1, page);
 
-      await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
       await selectFirstNOptions(3, page);
 
       await waitForHeatmapToRender(page);
 
-      const beforeCellTypeNames = await getNames(
-        `${getTestID(CELL_TYPE_LABELS_ID)}`,
-        page
-      );
+      const beforeCellTypeNames = await getCellTypeNames(page);
 
       // (thuang): Sometimes when API response is slow, we'll not capture all the
       // cell type names, so a sanity check that we expect at least 100 names
@@ -528,15 +382,12 @@ describe("Where's My Gene", () => {
       await clickDropdownOptionByName({
         name: "Disease",
         page,
-        selector: getTestID(COMPARE_DROPDOWN_ID),
+        testId: COMPARE_DROPDOWN_ID,
       });
 
       await tryUntil(
         async () => {
-          const afterCellTypeNames = await getNames(
-            `${getTestID(CELL_TYPE_LABELS_ID)}`,
-            page
-          );
+          const afterCellTypeNames = await getCellTypeNames(page);
 
           expect(
             afterCellTypeNames.find((name) => name.includes("  normal"))
@@ -548,15 +399,12 @@ describe("Where's My Gene", () => {
       await clickDropdownOptionByName({
         name: "Sex",
         page,
-        selector: getTestID(COMPARE_DROPDOWN_ID),
+        testId: COMPARE_DROPDOWN_ID,
       });
 
       await tryUntil(
         async () => {
-          const afterCellTypeNames = await getNames(
-            `${getTestID(CELL_TYPE_LABELS_ID)}`,
-            page
-          );
+          const afterCellTypeNames = await getCellTypeNames(page);
 
           expect(
             afterCellTypeNames.find((name) => name.includes("  female"))
@@ -568,15 +416,12 @@ describe("Where's My Gene", () => {
       await clickDropdownOptionByName({
         name: "Ethnicity",
         page,
-        selector: getTestID(COMPARE_DROPDOWN_ID),
+        testId: COMPARE_DROPDOWN_ID,
       });
 
       await tryUntil(
         async () => {
-          const afterCellTypeNames = await getNames(
-            `${getTestID(CELL_TYPE_LABELS_ID)}`,
-            page
-          );
+          const afterCellTypeNames = await getCellTypeNames(page);
 
           expect(
             afterCellTypeNames.find((name) => name.includes("  multiethnic"))
@@ -589,7 +434,7 @@ describe("Where's My Gene", () => {
       await clickDropdownOptionByName({
         name: "None",
         page,
-        selector: getTestID(COMPARE_DROPDOWN_ID),
+        testId: COMPARE_DROPDOWN_ID,
       });
 
       expect(
@@ -606,17 +451,17 @@ describe("Where's My Gene", () => {
 
       await clickDropdownOptionByName({
         page,
-        selector: getTestID(ADD_TISSUE_ID),
+        testId: ADD_TISSUE_ID,
         name: "lung",
       });
 
       await getCellTypeFmgButtonAndClick(page, "muscle cell");
 
-      await getButtonAndClick(page, getTestID(ADD_TO_DOTPLOT_BUTTON_TEST_ID));
+      await getButtonAndClick(page, ADD_TO_DOTPLOT_BUTTON_TEST_ID);
 
       await waitForHeatmapToRender(page);
 
-      const geneLabels = await page.$$(GENE_LABELS_ID);
+      const geneLabels = await getGeneNames(page);
       const numGenes = geneLabels.length;
       expect(numGenes).toBeGreaterThan(0);
     });
@@ -628,34 +473,36 @@ describe("Where's My Gene", () => {
 
       await clickDropdownOptionByName({
         page,
-        selector: getTestID(ADD_TISSUE_ID),
+        testId: ADD_TISSUE_ID,
         name: "lung",
       });
 
       await getCellTypeFmgButtonAndClick(page, "native cell");
 
-      await waitForElement(page, getTestID(NO_MARKER_GENES_WARNING_TEST_ID));
+      await waitForElement(page, NO_MARKER_GENES_WARNING_TEST_ID);
     });
 
-    test(`Marker scores are always greater than ${FMG_GENE_STRENGTH_THRESHOLD}`, async ({
+    test(`Marker scores are always greater than or equal to ${FMG_GENE_STRENGTH_THRESHOLD}`, async ({
       page,
     }) => {
       await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
       await clickDropdownOptionByName({
         page,
-        selector: getTestID(ADD_TISSUE_ID),
+        testId: ADD_TISSUE_ID,
         name: "lung",
       });
 
       await getCellTypeFmgButtonAndClick(page, "club cell");
 
-      const markerScores = await page.$$(getTestID(MARKER_SCORES_FMG_TEST_ID));
+      const markerScores = await page
+        .getByTestId(MARKER_SCORES_FMG_TEST_ID)
+        .allTextContents();
 
       for (const markerScore of markerScores) {
-        expect(
-          parseFloat(await markerScore.innerText())
-        ).toBeGreaterThanOrEqual(FMG_GENE_STRENGTH_THRESHOLD);
+        expect(parseFloat(markerScore)).toBeGreaterThanOrEqual(
+          FMG_GENE_STRENGTH_THRESHOLD
+        );
       }
     });
   });
@@ -664,38 +511,24 @@ describe("Where's My Gene", () => {
     test("Display gene info panel in sidebar", async ({ page }) => {
       await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-      async function getTissueSelectorButton() {
-        return page.$(getTestID(ADD_TISSUE_ID));
-      }
-
-      async function getGeneSelectorButton() {
-        return page.$(getTestID(ADD_GENE_ID));
-      }
-
-      await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
       await selectFirstNOptions(1, page);
 
-      await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
       await selectFirstNOptions(3, page);
 
       await waitForHeatmapToRender(page);
 
-      await getButtonAndClick(page, getTestID(GENE_INFO_BUTTON_X_AXIS_TEST_ID));
+      await getButtonAndClick(page, GENE_INFO_BUTTON_X_AXIS_TEST_ID);
 
-      await waitForElement(page, getTestID(GENE_INFO_HEADER_TEST_ID));
-      await waitForElement(page, getTestID(GENE_INFO_GENE_SYNONYMS_TEST_ID));
-      await waitForElement(page, getTestID(GENE_INFO_NCBI_LINK_TEST_ID));
-      await waitForElement(page, getTestID(RIGHT_SIDEBAR_TITLE_TEST_ID));
+      await waitForElement(page, GENE_INFO_HEADER_TEST_ID);
+      await waitForElement(page, GENE_INFO_GENE_SYNONYMS_TEST_ID);
+      await waitForElement(page, GENE_INFO_NCBI_LINK_TEST_ID);
+      await waitForElement(page, RIGHT_SIDEBAR_TITLE_TEST_ID);
 
-      await getButtonAndClick(
-        page,
-        getTestID(RIGHT_SIDEBAR_CLOSE_BUTTON_TEST_ID)
-      );
+      await getButtonAndClick(page, RIGHT_SIDEBAR_CLOSE_BUTTON_TEST_ID);
 
-      await waitForElementToBeRemoved(
-        page,
-        getTestID(RIGHT_SIDEBAR_TITLE_TEST_ID)
-      );
+      await waitForElementToBeRemoved(page, RIGHT_SIDEBAR_TITLE_TEST_ID);
     });
 
     test("Display gene info bottom drawer in cell info sidebar", async ({
@@ -703,57 +536,38 @@ describe("Where's My Gene", () => {
     }) => {
       await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-      async function getGeneSelectorButton() {
-        return page.$(getTestID(ADD_GENE_ID));
-      }
-
       await clickDropdownOptionByName({
         page,
-        selector: getTestID(ADD_TISSUE_ID),
+        testId: ADD_TISSUE_ID,
         name: "lung",
       });
 
-      await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
       await selectFirstNOptions(3, page);
 
       await waitForHeatmapToRender(page);
 
       await getCellTypeFmgButtonAndClick(page, "muscle cell");
 
-      await getButtonAndClick(
-        page,
-        getTestID(GENE_INFO_BUTTON_CELL_INFO_TEST_ID)
-      );
+      await getButtonAndClick(page, GENE_INFO_BUTTON_CELL_INFO_TEST_ID);
 
-      await waitForElement(page, getTestID(GENE_INFO_HEADER_TEST_ID));
-      await waitForElement(page, getTestID(GENE_INFO_GENE_SYNONYMS_TEST_ID));
-      await waitForElement(page, getTestID(GENE_INFO_NCBI_LINK_TEST_ID));
-      await waitForElement(page, getTestID(GENE_INFO_TITLE_SPLIT_TEST_ID));
+      await waitForElement(page, GENE_INFO_HEADER_TEST_ID);
+      await waitForElement(page, GENE_INFO_GENE_SYNONYMS_TEST_ID);
+      await waitForElement(page, GENE_INFO_NCBI_LINK_TEST_ID);
+      await waitForElement(page, GENE_INFO_TITLE_SPLIT_TEST_ID);
 
-      await getButtonAndClick(
-        page,
-        getTestID(GENE_INFO_CLOSE_BUTTON_SPLIT_TEST_ID)
-      );
+      await getButtonAndClick(page, GENE_INFO_CLOSE_BUTTON_SPLIT_TEST_ID);
 
-      await waitForElementToBeRemoved(
-        page,
-        getTestID(GENE_INFO_TITLE_SPLIT_TEST_ID)
-      );
+      await waitForElementToBeRemoved(page, GENE_INFO_TITLE_SPLIT_TEST_ID);
 
-      await getButtonAndClick(
-        page,
-        getTestID(RIGHT_SIDEBAR_CLOSE_BUTTON_TEST_ID)
-      );
+      await getButtonAndClick(page, RIGHT_SIDEBAR_CLOSE_BUTTON_TEST_ID);
 
-      await waitForElementToBeRemoved(
-        page,
-        getTestID(RIGHT_SIDEBAR_TITLE_TEST_ID)
-      );
+      await waitForElementToBeRemoved(page, RIGHT_SIDEBAR_TITLE_TEST_ID);
 
-      await getButtonAndClick(page, getTestID(GENE_INFO_BUTTON_X_AXIS_TEST_ID));
+      await getButtonAndClick(page, GENE_INFO_BUTTON_X_AXIS_TEST_ID);
 
-      await waitForElement(page, getTestID(GENE_INFO_HEADER_TEST_ID));
-      await waitForElement(page, getTestID(RIGHT_SIDEBAR_TITLE_TEST_ID));
+      await waitForElement(page, GENE_INFO_HEADER_TEST_ID);
+      await waitForElement(page, RIGHT_SIDEBAR_TITLE_TEST_ID);
     });
   });
 
@@ -763,51 +577,28 @@ describe("Where's My Gene", () => {
 
       const SELECT_N_GENES = 3;
 
-      async function getTissueSelectorButton() {
-        return page.$(getTestID(ADD_TISSUE_ID));
-      }
-
-      async function getGeneSelectorButton() {
-        return page.$(getTestID(ADD_GENE_ID));
-      }
-
       // Select tissue
-      await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
       await selectFirstOption(page);
 
       // Select gene
-      await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
       await selectFirstNOptions(SELECT_N_GENES, page);
 
       await waitForHeatmapToRender(page);
 
-      const numCellTypes = (await page.$$(getTestID("cell-type-label-count")))
-        .length;
+      await clickUntilDownloadModalShowsUp({
+        page,
+        testId: DOWNLOAD_BUTTON_ID,
+      });
 
-      if (!numCellTypes) {
-        throw Error("No cell types");
-      }
-
-      async function getDownloadButton() {
-        return page.$(getTestID(DOWNLOAD_BUTTON_ID));
-      }
-
-      await clickUntilDownloadModalShowsUp(getDownloadButton, page);
-
-      const pngCheckbox = await page.$(getTestID("png-checkbox"));
-      if (!pngCheckbox) throw Error("No PNG checkbox");
-      await pngCheckbox.click();
-
-      const csvCheckbox = await page.$(getTestID("csv-checkbox"));
-      if (!csvCheckbox) throw Error("No CSV checkbox");
-      await csvCheckbox.click();
+      await page.getByTestId("png-checkbox").click();
+      await page.getByTestId("csv-checkbox").click();
 
       // Start waiting for download before clicking. Note no await.
       const downloadPromise = page.waitForEvent("download");
 
-      const downloadButton = await page.$(getTestID("dialog-download-button"));
-      if (!downloadButton) throw Error("No download button");
-      await downloadButton.click();
+      await page.getByTestId("dialog-download-button").click();
 
       // Wait for download
       const download = await downloadPromise;
@@ -830,7 +621,8 @@ describe("Where's My Gene", () => {
       });
 
       // Validate number of rows
-      expect(data.length).toBe(numCellTypes * SELECT_N_GENES);
+      const cellTypes = await getCellTypeNames(page);
+      expect(data.length).toBe(cellTypes.length * SELECT_N_GENES);
     });
 
     test("Download CSV and validate length - compare", async ({ page }) => {
@@ -838,58 +630,35 @@ describe("Where's My Gene", () => {
 
       const SELECT_N_GENES = 3;
 
-      async function getTissueSelectorButton() {
-        return page.$(getTestID(ADD_TISSUE_ID));
-      }
-
-      async function getGeneSelectorButton() {
-        return page.$(getTestID(ADD_GENE_ID));
-      }
-
       // Select tissue
-      await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
       await selectFirstOption(page);
 
       // Select gene
-      await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
       await selectFirstNOptions(SELECT_N_GENES, page);
 
       // Select a compare dimension
       await clickDropdownOptionByName({
         name: "Sex",
         page,
-        selector: getTestID(COMPARE_DROPDOWN_ID),
+        testId: COMPARE_DROPDOWN_ID,
       });
 
       await waitForHeatmapToRender(page);
 
-      const numCellTypes = (await page.$$(getTestID("cell-type-label-count")))
-        .length;
+      await clickUntilDownloadModalShowsUp({
+        page,
+        testId: DOWNLOAD_BUTTON_ID,
+      });
 
-      if (!numCellTypes) {
-        throw Error("No cell types");
-      }
-
-      async function getDownloadButton() {
-        return page.$(getTestID(DOWNLOAD_BUTTON_ID));
-      }
-
-      await clickUntilDownloadModalShowsUp(getDownloadButton, page);
-
-      const pngCheckbox = await page.$(getTestID("png-checkbox"));
-      if (!pngCheckbox) throw Error("No PNG checkbox");
-      await pngCheckbox.click();
-
-      const csvCheckbox = await page.$(getTestID("csv-checkbox"));
-      if (!csvCheckbox) throw Error("No CSV checkbox");
-      await csvCheckbox.click();
+      await page.getByTestId("png-checkbox").click();
+      await page.getByTestId("csv-checkbox").click();
 
       // Start waiting for download before clicking. Note no await.
       const downloadPromise = page.waitForEvent("download");
 
-      const downloadButton = await page.$(getTestID("dialog-download-button"));
-      if (!downloadButton) throw Error("No download button");
-      await downloadButton.click();
+      await page.getByTestId("dialog-download-button").click();
 
       // Wait for download
       const download = await downloadPromise;
@@ -912,7 +681,8 @@ describe("Where's My Gene", () => {
       });
 
       // Validate number of rows
-      expect(data.length).toBe(numCellTypes * SELECT_N_GENES);
+      const cellTypes = await getCellTypeNames(page);
+      expect(data.length).toBe(cellTypes.length * SELECT_N_GENES);
     });
   });
 
@@ -922,42 +692,26 @@ describe("Where's My Gene", () => {
     }) => {
       await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-      async function getTissueSelectorButton() {
-        return page.$(getTestID(ADD_TISSUE_ID));
-      }
-
-      async function getGeneSelectorButton() {
-        return page.$(getTestID(ADD_GENE_ID));
-      }
-
-      await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
       await selectFirstOption(page);
 
-      await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
       await selectFirstOption(page);
 
       await waitForHeatmapToRender(page);
 
-      async function getDownloadButton() {
-        return page.$(getTestID(DOWNLOAD_BUTTON_ID));
-      }
+      await clickUntilDownloadModalShowsUp({
+        page,
+        testId: DOWNLOAD_BUTTON_ID,
+      });
 
-      await clickUntilDownloadModalShowsUp(getDownloadButton, page);
-
-      const svgCheckbox = await page.$(getTestID("svg-checkbox"));
-      if (!svgCheckbox) throw Error("No SVG checkbox");
-      await svgCheckbox.click();
-
-      const csvCheckbox = await page.$(getTestID("csv-checkbox"));
-      if (!csvCheckbox) throw Error("No CSV checkbox");
-      await csvCheckbox.click();
+      await page.getByTestId("png-checkbox").click();
+      await page.getByTestId("csv-checkbox").click();
 
       // Start waiting for download before clicking. Note no await.
       const downloadPromise = page.waitForEvent("download");
 
-      const downloadButton = await page.$(getTestID("dialog-download-button"));
-      if (!downloadButton) throw Error("No download button");
-      await downloadButton.click();
+      await page.getByTestId("dialog-download-button").click();
 
       // Wait for download
       const download = await downloadPromise;
@@ -990,47 +744,31 @@ describe("Where's My Gene", () => {
     }) => {
       await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);
 
-      async function getTissueSelectorButton() {
-        return page.$(getTestID(ADD_TISSUE_ID));
-      }
-
-      async function getGeneSelectorButton() {
-        return page.$(getTestID(ADD_GENE_ID));
-      }
-
       // Select first tissue
-      await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
       await selectFirstOption(page);
 
       // Select second tissue
-      await clickUntilOptionsShowUp(getTissueSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_TISSUE_ID });
       await selectNthOption(2, page);
 
-      await clickUntilOptionsShowUp(getGeneSelectorButton, page);
+      await clickUntilOptionsShowUp({ page, testId: ADD_GENE_ID });
       await selectFirstOption(page);
 
       await waitForHeatmapToRender(page);
 
-      async function getDownloadButton() {
-        return page.$(getTestID(DOWNLOAD_BUTTON_ID));
-      }
+      await clickUntilDownloadModalShowsUp({
+        page,
+        testId: DOWNLOAD_BUTTON_ID,
+      });
 
-      await clickUntilDownloadModalShowsUp(getDownloadButton, page);
-
-      const svgCheckbox = await page.$(getTestID("svg-checkbox"));
-      if (!svgCheckbox) throw Error("No SVG checkbox");
-      await svgCheckbox.click();
-
-      const csvCheckbox = await page.$(getTestID("csv-checkbox"));
-      if (!csvCheckbox) throw Error("No CSV checkbox");
-      await csvCheckbox.click();
+      await page.getByTestId("png-checkbox").click();
+      await page.getByTestId("csv-checkbox").click();
 
       // Start waiting for download before clicking. Note no await.
       const downloadPromise = page.waitForEvent("download");
 
-      const downloadButton = await page.$(getTestID("dialog-download-button"));
-      if (!downloadButton) throw Error("No download button");
-      await downloadButton.click();
+      await page.getByTestId("dialog-download-button").click();
 
       // Wait for download
       const download = await downloadPromise;
@@ -1065,76 +803,103 @@ describe("Where's My Gene", () => {
   });
 });
 
-async function getNames(selector: string, page: Page): Promise<string[]> {
-  const geneLabelsLocator = await page.locator(selector);
+async function getNames({
+  page,
+  testId,
+  locator,
+}: {
+  page: Page;
+  testId?: string;
+  locator?: Locator;
+}): Promise<string[]> {
+  let labelsLocator: Locator;
+  if (testId) {
+    labelsLocator = page.getByTestId(testId);
+  } else if (locator) {
+    labelsLocator = locator;
+  } else {
+    throw Error("Either testId or locator must be defined");
+  }
   await tryUntil(
     async () => {
-      const names = await geneLabelsLocator.allTextContents();
+      const names = await labelsLocator.allTextContents();
       expect(typeof names[0]).toBe("string");
     },
     { page }
   );
 
-  return geneLabelsLocator.allTextContents();
+  return labelsLocator.allTextContents();
 }
 
-async function clickUntilOptionsShowUp(
-  getTarget: () => Promise<ElementHandle<SVGElement | HTMLElement> | null>,
-  page: Page
-) {
+async function clickUntilOptionsShowUp({
+  page,
+  testId,
+  locator,
+}: {
+  page: Page;
+  testId?: string;
+  locator?: Locator;
+}) {
+  // either testId or locator must be defined, not both
+  // locator is used when the element cannot be found using just the test Id from the page
   await tryUntil(
     async () => {
-      const target = await getTarget();
-
-      if (!target) throw Error("no target");
-
-      await target.click();
-      const tooltip = await page.$("[role=tooltip]");
-
-      if (!tooltip) throw Error("no tooltip");
-
-      const options = await tooltip.$$("[role=option]");
-
-      if (!options?.length) throw Error("no options");
+      if (testId) {
+        await page.getByTestId(testId).click();
+      } else if (locator) {
+        await locator.click();
+      } else {
+        throw Error("Either testId or locator must be defined");
+      }
+      await page.getByRole("tooltip").getByRole("option").elementHandles();
     },
     { page }
   );
 }
 
-async function clickUntilDownloadModalShowsUp(
-  getTarget: () => Promise<ElementHandle<SVGElement | HTMLElement> | null>,
-  page: Page
-) {
+async function clickUntilDownloadModalShowsUp({
+  page,
+  testId,
+  locator,
+}: {
+  page: Page;
+  testId?: string;
+  locator?: Locator;
+}) {
   await tryUntil(
     async () => {
-      const target = await getTarget();
-
-      if (!target) throw Error("no target");
-
-      await target.click();
-
-      const modal = await page.$("[class=bp4-dialog]");
-
-      if (modal) throw Error("No download modal");
+      if (testId) {
+        await page.getByTestId(testId).click();
+      } else if (locator) {
+        await locator.click();
+      } else {
+        throw Error("Either testId or locator must be defined");
+      }
+      await page.locator("[class=bp4-dialog]").elementHandle();
     },
     { page }
   );
 }
 
-async function clickUntilSidebarShowsUp(
-  getTarget: () => Promise<ElementHandle<SVGElement | HTMLElement> | null>,
-  page: Page
-) {
+async function clickUntilSidebarShowsUp({
+  page,
+  testId,
+  locator,
+}: {
+  page: Page;
+  testId?: string;
+  locator?: Locator;
+}) {
   await tryUntil(
     async () => {
-      const target = await getTarget();
-
-      if (!target) throw Error("no target");
-
-      await target.click();
-      const drawer = await page.$("[class=bp4-drawer-header]");
-
-      if (!drawer) throw Error("no drawer");
+      if (testId) {
+        await page.getByTestId(testId).click();
+      } else if (locator) {
+        await locator.click();
+      } else {
+        throw Error("Either testId or locator must be defined");
+      }
+      await page.locator("[class=bp4-drawer-header]").elementHandle();
     },
     { page }
   );
@@ -1169,59 +934,48 @@ async function selectNthOption(number: number, page: Page) {
 async function waitForHeatmapToRender(page: Page) {
   await tryUntil(
     async () => {
-      const canvases = await page.$$("canvas");
-      await expect(canvases.length).not.toBe(0);
+      await expect(page.locator("canvas")).not.toHaveCount(0);
     },
     { page }
   );
 }
 
-async function waitForElement(page: Page, selector: string) {
+async function waitForElement(page: Page, testId: string) {
   await tryUntil(
     async () => {
-      const element = await page.$(selector);
-      await expect(element).not.toBeNull();
+      await expect(page.getByTestId(testId)).not.toHaveCount(0);
     },
     { page }
   );
 }
 
-async function waitForElementToBeRemoved(page: Page, selector: string) {
+async function waitForElementToBeRemoved(page: Page, testId: string) {
   await tryUntil(
     async () => {
-      const element = await page.$(selector);
-      await expect(element).toBeNull();
+      await expect(page.getByTestId(testId)).toHaveCount(0);
     },
     { page }
   );
 }
 
-async function getButtonAndClick(page: Page, selector: string) {
+async function getButtonAndClick(page: Page, testID: string) {
   await tryUntil(
     async () => {
-      const button = await page.$(selector);
-      await expect(button).not.toBeNull();
-      await button?.click();
+      await page.getByTestId(testID).click();
     },
     { page }
   );
 }
 
 async function getCellTypeFmgButtonAndClick(page: Page, cellType: string) {
-  const selector = getTestID(MARKER_GENE_BUTTON_TEST_ID);
-  await waitForElement(page, getTestID(CELL_TYPE_LABELS_ID));
+  await waitForElement(page, CELL_TYPE_LABELS_ID);
   await tryUntil(
     async () => {
-      const buttons = await page.$$(selector);
-      for (let i = 0; i < buttons.length; i++) {
-        const button = buttons[i];
-        const parentCellTypeSpan = await button.$("xpath=../../..");
-        const text = await parentCellTypeSpan?.innerText();
-        if (text === cellType) {
-          await button.click();
-          return;
-        }
-      }
+      await page
+        .getByTestId(CELL_TYPE_LABEL_ROW_TEST_ID)
+        .filter({ hasText: new RegExp(`^${cellType}$`) })
+        .getByTestId(MARKER_GENE_BUTTON_TEST_ID)
+        .click();
     },
     { page }
   );
@@ -1229,17 +983,28 @@ async function getCellTypeFmgButtonAndClick(page: Page, cellType: string) {
 
 async function clickDropdownOptionByName({
   page,
-  selector,
+  testId,
   name,
 }: {
   page: Page;
-  selector: string;
+  testId: string;
   name: string;
 }) {
-  const dropdown = await page.locator(selector);
-  await dropdown.click();
-
-  const option = await page.locator(`[role=option] >> text=${name}`);
-  await option.click();
+  await page.getByTestId(testId).click();
+  await page.getByRole("option").filter({ hasText: name }).click();
   await page.keyboard.press("Escape");
+}
+
+async function getGeneNames(page: Page) {
+  return getNames({ page, locator: page.locator(GENE_LABELS_ID) });
+}
+
+async function getCellTypeNames(page: Page) {
+  return getNames({ page, testId: CELL_TYPE_LABELS_ID });
+}
+
+// (alec) use this instead of locator.count() to make sure that the element is actually present
+// when counting
+async function countLocator(locator: Locator) {
+  return (await locator.elementHandles()).length;
 }

--- a/frontend/tests/utils/selectors.ts
+++ b/frontend/tests/utils/selectors.ts
@@ -1,3 +1,3 @@
-export const getTestID = (id: string): string => `css=[data-test-id="${id}"]`;
+export const getTestID = (id: string): string => `css=[data-testid="${id}"]`;
 
 export const getText = (text: string): string => `text=${text}`;


### PR DESCRIPTION
## Reason for Change

- #3550 

## Changes

- added FMG e2e tests to test the following cases
  - Marker genes display and the add-to-dotplot button works
  - Native cell displays no markers genes
  - Marker scores are all > 0.5
- big refactor to use locators instead of `$`/`$$` invocations.

## Testing steps

- the new e2e tests were tested locally.
- all tests pass locally