### PR TITLE
chore(wmg): prevent majority of word-wrap by expanding right column of tooltip

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/style.ts
@@ -38,6 +38,10 @@ export const StyledTooltipTable = styled(TooltipTable)`
     padding-top: 0 !important;
   }
 
+  .MuiTableRow-root {
+    vertical-align: baseline;
+  }
+
   .MuiTable-root {
     margin-bottom: 0;
   }

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/style.ts
@@ -44,6 +44,8 @@ export const StyledTooltipTable = styled(TooltipTable)`
 
   .MuiTableCell-alignLeft {
     ${fontBodyXs}
+    width: 30%;
+    white-space: nowrap;
   }
 
   .MuiTableCell-alignRight {


### PR DESCRIPTION
## Reason for Change

- #4213

## Changes

- shrink left column of tooltip to 30% width
- make left column text not wrap
- vertical alignment baseline so word-wrap is easier to read

## Testing steps

- Tested locally
- tested on the longest cell type name in the corpus (below screenshot)
<img width="506" alt="image" src="https://user-images.githubusercontent.com/16548075/228048245-4c8a0b23-202b-4deb-a7bc-72af54d41c61.png">
