### PR TITLE
fix(wmg): Cell Type Name Label Tooltip

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/YAxisChart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/YAxisChart/index.tsx
@@ -12,9 +12,11 @@ import InfoSVG from "./icons/info-sign-icon.svg";
 import {
   CellCountLabelStyle,
   CellTypeLabelStyle,
+  CellTypeLabelTooltipStyle,
   Container,
   FlexRow,
   FlexRowJustified,
+  HiddenCellTypeLabelStyle,
   StyledImage,
   TissueName,
   TissueWrapper,
@@ -26,6 +28,7 @@ import { EVENTS } from "src/common/analytics/events";
 import { EXCLUDE_IN_SCREENSHOT_CLASS_NAME } from "../../../GeneSearchBar/components/SaveExport";
 import { COMPARE_OPTION_ID_FOR_AGGREGATED } from "src/common/queries/wheresMyGene";
 import { InfoButtonWrapper } from "src/components/common/Filter/common/style";
+import { Tooltip } from "czifui";
 
 interface Props {
   cellTypes?: CellType[];
@@ -86,7 +89,8 @@ export default memo(function YAxisChart({
             return (
               <CellTypeButton
                 key={`${cellType}-cell-type-button`}
-                name={paddedName}
+                formattedName={paddedName}
+                name={name}
                 metadata={cellType}
                 tissueID={tissueID}
                 tissue={tissue}
@@ -101,12 +105,14 @@ export default memo(function YAxisChart({
 });
 
 const CellTypeButton = ({
+  formattedName,
   name,
   metadata,
   generateMarkerGenes,
   tissueID,
   tissue,
 }: {
+  formattedName: string;
   name: string;
   metadata: CellTypeMetadata;
   generateMarkerGenes: (cellType: CellType, tissueID: string) => void;
@@ -125,8 +131,25 @@ const CellTypeButton = ({
   return (
     <FlexRowJustified data-test-id="cell-type-label-count">
       <FlexRow>
-        <CellTypeLabelStyle data-test-id="cell-type-name">
-          {name}
+        <CellTypeLabelStyle>
+          <Tooltip
+            title={
+              // Set tooltip content only if name is truncated
+              formattedName.includes("...") ? (
+                <CellTypeLabelTooltipStyle>{name}</CellTypeLabelTooltipStyle>
+              ) : null
+            }
+            sdsStyle="light"
+            arrow
+            placement="left"
+            enterNextDelay={700}
+          >
+            {/* Must be wrapped in div and not fragment or else tooltip content won't render */}
+            <div>
+              <HiddenCellTypeLabelStyle>{name}</HiddenCellTypeLabelStyle>
+              <div data-test-id="cell-type-name">{formattedName}</div>
+            </div>
+          </Tooltip>
         </CellTypeLabelStyle>
 
         {!FMG_EXCLUDE_TISSUES.includes(tissue) &&

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/YAxisChart/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/YAxisChart/style.ts
@@ -53,6 +53,19 @@ export const CellTypeLabelStyle = styled.div`
   text-align: left;
 `;
 
+export const HiddenCellTypeLabelStyle = styled.div`
+  /* Overlay invisible, un-intractable element with full name of cell type for ctrl+f page search */
+  position: absolute;
+  z-index: 1;
+  color: rgba(0, 0, 0, 0);
+  pointer-events: none;
+  user-select: none;
+`;
+
+export const CellTypeLabelTooltipStyle = styled.div`
+  text-align: center;
+`;
+
 export const CellCountLabelStyle = styled.div`
   height: ${HEAT_MAP_BASE_CELL_PX}px;
   background-color: white;

--- a/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
@@ -66,10 +66,13 @@ export function formatLabel(
   maxWidth: number,
   font: string
 ): string {
-  CTX!.font = font;
-  const ellipsisWidth = CTX!.measureText("...").width;
+  // failsafe, should never be falsy
+  if (!CTX) return name;
 
-  if (CTX!.measureText(name).width <= maxWidth) {
+  CTX.font = font;
+  const ellipsisWidth = CTX.measureText("...").width;
+
+  if (CTX.measureText(name).width <= maxWidth) {
     return name;
   }
 
@@ -96,12 +99,15 @@ export function getFixedWidth(
   font: string,
   reverse = false
 ): string {
-  CTX!.font = font;
+  // failsafe, should never be falsy
+  if (!CTX) return text;
+
+  CTX.font = font;
 
   if (reverse) {
     for (let i = text.length; i >= 0; i--) {
       const substring = text.substring(i - 1);
-      const textWidth = CTX!.measureText(substring).width;
+      const textWidth = CTX.measureText(substring).width;
       if (textWidth > maxWidth) {
         return text.substring(i);
       }
@@ -109,7 +115,7 @@ export function getFixedWidth(
   } else {
     for (let i = 0; i < text.length; i++) {
       const substring = text.substring(0, i + 1);
-      const textWidth = CTX!.measureText(substring).width;
+      const textWidth = CTX.measureText(substring).width;
       if (textWidth > maxWidth) {
         return text.substring(0, i);
       }


### PR DESCRIPTION
## Reason for Change

- #4315

## Changes

- add
    - Tooltip SDS component for cell type names
- remove
- modify

## Testing steps

- Select Tissue
- Hover over a truncated label
- A tooltip should appear
- Copy tooltip contents
- Ctrl+F to and paste full cell type name
- Full cell type name should be highlighted on page

Rdev: https://cell-type-names-tooltip-frontend.rdev.single-cell.czi.technology/gene-expression

Demo:

https://user-images.githubusercontent.com/109984998/228119256-5a363bec-f022-456c-89f7-12d6b385a10e.mov

## Notes for Reviewer
