### PR TITLE
feat: Curator can start a revision from the Collection page (#2647)

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -416,17 +416,14 @@ class BusinessLogic(BusinessLogicInterface):
         datasets, _ = self.database_provider.get_all_mapped_datasets_and_collections()
         return datasets
 
-    def get_datasets_for_collections(self, collections: Iterable[CollectionVersion])-> Iterable[DatasetVersion]:
-       
-        datasets =[]
+    def get_datasets_for_collections(self, collections: Iterable[CollectionVersion]) -> Iterable[DatasetVersion]:
+        datasets = []
         for collection in collections:
-            print("collection: ", collection)
             datasest_ids = [d.id for d in collection.datasets]
-            # datasets: List[DatasetVersion] = self.database_provider.get_datasets_by_id(ids)
-            collection_datasets: List[DatasetVersion] = [self.database_provider.get_dataset_version(DatasetVersionId(id)) for id in datasest_ids]
+            collection_datasets: List[DatasetVersion] = [
+                self.database_provider.get_dataset_version(DatasetVersionId(id)) for id in datasest_ids
+            ]
             datasets.extend(collection_datasets)
-           #  yield from (d for d in datasets if d.canonical_dataset.published_at is None)
-           ## yield (d for d in datasets if d.canonical_dataset.published_at is None)
         return datasets
 
     def get_all_mapped_collection_versions_with_datasets(self) -> List[CollectionVersionWithPublishedDatasets]:

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -416,6 +416,19 @@ class BusinessLogic(BusinessLogicInterface):
         datasets, _ = self.database_provider.get_all_mapped_datasets_and_collections()
         return datasets
 
+    def get_datasets_for_collections(self, collections: Iterable[CollectionVersion])-> Iterable[DatasetVersion]:
+       
+        datasets =[]
+        for collection in collections:
+            print("collection: ", collection)
+            datasest_ids = [d.id for d in collection.datasets]
+            # datasets: List[DatasetVersion] = self.database_provider.get_datasets_by_id(ids)
+            collection_datasets: List[DatasetVersion] = [self.database_provider.get_dataset_version(DatasetVersionId(id)) for id in datasest_ids]
+            datasets.extend(collection_datasets)
+           #  yield from (d for d in datasets if d.canonical_dataset.published_at is None)
+           ## yield (d for d in datasets if d.canonical_dataset.published_at is None)
+        return datasets
+
     def get_all_mapped_collection_versions_with_datasets(self) -> List[CollectionVersionWithPublishedDatasets]:
         """
         Retrieves all the datasets from the database that belong to a published collection

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -443,6 +443,8 @@ paths:
                   properties:
                     access_type:
                       $ref: "#/components/schemas/access_type"
+                    curator_name:
+                      type: string
                     id:
                       $ref: "#/components/schemas/collection_id"
                     name:

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -999,6 +999,8 @@ components:
           type: string
         publisher_metadata:
           $ref: "#/components/schemas/publisher_metadata"
+        revising_in:
+          $ref: "#/components/schemas/revising_in"
         datasets:
           type: array
           items:
@@ -1032,7 +1034,13 @@ components:
           type: number
         published_year:
           type: number
-
+    revising_in:
+      type: string
+      description: >
+        If there is a private Revision for a public Collection, then `revising_in` is set to the id of 
+        the private Revision in the metadata of the public Collection. The value is `None` if the user is not 
+        authorized or no private Revision exists.
+      nullable: true
     ontology_element:
       type: object
       properties:

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -418,6 +418,52 @@ paths:
         "400":
           $ref: "#/components/responses/400"
 
+  /v1/my-collections/index:
+    get:
+      tags:
+        - collections
+      summary: >-
+        Returns all public, non tombstoned collections. This endpoint is meant to be used for displaying collections
+        in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+      security:
+        - cxguserCookie: []
+      operationId: backend.portal.api.portal_api.get_my_collection_index
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    access_type:
+                      $ref: "#/components/schemas/access_type"
+                    id:
+                      $ref: "#/components/schemas/collection_id"
+                    name:
+                      type: string
+                    publisher_metadata:
+                      $ref: "#/components/schemas/publisher_metadata"
+                    published_at:
+                      type: number
+                      nullable: true
+                    revised_at:
+                      type: number
+                      nullable: true
+                    consortia:
+                      $ref: "#/components/schemas/consortia"
+                    visibility:
+                      $ref: "#/components/schemas/visibility"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+
   /v1/datasets/{dataset_id}:
     delete:
       tags:
@@ -824,6 +870,10 @@ paths:
 
 components:
   schemas:
+    access_type:
+      description: Indcates if the user will be allowd to make updates to the entity.
+      type: string
+      enum: [READ, WRITE]
     user_id:
       description: A unique identifier of a logged in User of Corpora.
       type: string
@@ -920,8 +970,7 @@ components:
         - data_submission_policy_version
       properties:
         access_type:
-          type: string
-          enum: [READ, WRITE]
+          $ref: "#/components/schemas/access_type"
         created_at:
           type: number
         updated_at:

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -750,7 +750,88 @@ paths:
                       type: number
         "400":
           $ref: "#/components/responses/400"
-
+  /v1/user-datasets/index:
+    get:
+      tags:
+        - datasets
+      summary: >-
+        Returns all public and private, non tombstoned datasets where the user has WRITE access. This endpoint is meant to be used for displaying datasets
+        in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+      security:
+        - cxguserCookieLenient: []
+        - {}
+      description: >-
+        Returns all datasets that belong to public and private, non tombstoned collections where the user has WRITE access. This endpoint is meant to be used 
+        for displaying datasets in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+      operationId: backend.portal.api.portal_api.get_user_datasets_index
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    collection_id:
+                      type: string
+                    assay:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    tissue:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    tissue_ancestors:
+                      type: array
+                      items:
+                        type: string
+                    disease:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    sex:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    self_reported_ethnicity:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    organism:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    development_stage:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    development_stage_ancestors:
+                      type: array
+                      items:
+                        type: string
+                    cell_count:
+                      type: integer
+                    cell_type:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    cell_type_ancestors:
+                      type: array
+                      items:
+                        type: string
+                    mean_genes_per_cell:
+                      type: number
+                    is_primary_data:
+                      $ref: "#/components/schemas/is_primary_data"
+                    donor_id:
+                      type: array
+                      items:
+                        type: string
+                    suspension_type:
+                      type: array
+                      items:
+                        type: string
+                    schema_version:
+                      type: string
+                    explorer_url:
+                      type: string
+                    published_at:
+                      type: number
+                    revised_at:
+                      type: number
+        "400":
+          $ref: "#/components/responses/400"
   /v1/login:
     get:
       tags:

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -443,10 +443,10 @@ def get_collection_index():
 
     return make_response(jsonify(response), 200)
 
-def get_user_writable_collections(token_info: dict):
 
+def get_user_writable_collections(token_info: dict):
     user_info = UserInfo(token_info)
-     # Get all public collections
+    # Get all public collections
     collections = get_business_logic().get_collections(CollectionQueryFilter(is_published=True))
 
     # Get all private collections the user has access to
@@ -457,7 +457,8 @@ def get_user_writable_collections(token_info: dict):
         all_owned_collections = get_business_logic().get_collections(
             CollectionQueryFilter(is_published=False, owner=user_info.user_id)
         )
-    return itertools.chain(all_owned_collections,  collections)
+    return itertools.chain(all_owned_collections, collections)
+
 
 def get_my_collection_index(token_info):
     """
@@ -773,14 +774,16 @@ def get_datasets_index(token_info: dict):
 
     return make_response(jsonify(response), 200)
 
+
 def get_user_datasets_index(token_info: dict):
     """
     Returns a list of all the datasets that currently belong to a published and active collection
     """
 
     collections = get_user_writable_collections(token_info)
+    # filter out collections that are revisions
+    collections = [c for c in collections if c.is_initial_unpublished_version]
     user_datasets = get_business_logic().get_datasets_for_collections(collections)
-
 
     response = []
     for dataset in user_datasets:

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -240,6 +240,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
     """
     Converts a CollectionVersion object to an object compliant to the API specifications
     """
+    revising_in = None
     if collection.is_unpublished_version():
         # In this case, the collection version is a revision of an already published collection.
         # We should expose version_id as the collection_id
@@ -258,7 +259,16 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
         # The last case is a published collection. We just return the canonical id and set revision_of to None
         revision_of = None
         collection_id = collection.collection_id.id
-        is_in_revision = False
+
+        is_published = collection.published_at is not None
+        _revising_in = None
+        if is_published and access_type is "WRITE":
+            _revising_in = get_business_logic().get_unpublished_collection_version_from_canonical(
+                collection.collection_id
+            )
+        revising_in = _revising_in.version_id.id if _revising_in else None
+
+        is_in_revision = True if _revising_in else None
 
     is_tombstoned = collection.canonical_collection.tombstoned
 
@@ -286,6 +296,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
             "published_at": collection.canonical_collection.originally_published_at,
             "publisher_metadata": collection.publisher_metadata,  # TODO: convert
             "revision_of": revision_of,
+            "revising_in": revising_in,
             "updated_at": collection.published_at or collection.created_at,
             "visibility": "PUBLIC" if collection.published_at is not None else "PRIVATE",
         }
@@ -455,7 +466,6 @@ def get_my_collection_index(token_info):
 
     response = []
     for collection in itertools.chain(collections, all_owned_collections):
-
         transformed_collection = {
             "access_type": "WRITE" if user_info.is_user_owner_or_allowed(collection.owner) else "READ",
             "created_at": collection.created_at,
@@ -581,7 +591,6 @@ def publish_post(collection_id: str, body: object, token_info: dict):
 
 
 def upload_from_link(collection_id: str, token_info: dict, url: str, dataset_id: str = None):
-
     version = lookup_collection(collection_id)
     if version is None or not UserInfo(token_info).is_user_owner_or_allowed(version.owner):
         raise ForbiddenHTTPException()

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -457,12 +457,13 @@ def get_my_collection_index(token_info):
     for collection in itertools.chain(collections, all_owned_collections):
 
         transformed_collection = {
+            "access_type": "WRITE" if user_info.is_user_owner_or_allowed(collection.owner) else "READ",
+            "created_at": collection.created_at,
+            "curator_name": collection.curator_name,
             "id": collection.collection_id.id,
             "name": collection.metadata.name,
-            "access_type": "WRITE" if user_info.is_user_owner_or_allowed(collection.owner) else "READ",
-            "visibility": "PRIVATE" if collection.published_at is None else "PUBLIC",
             "owner": collection.owner,
-            "created_at": collection.created_at,
+            "visibility": "PRIVATE" if collection.published_at is None else "PUBLIC",
         }
 
         if collection.publisher_metadata is not None:

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1684,7 +1684,36 @@ class TestDataset(BaseAPIPortalTest):
             )
             # self.assertEqual(actual_dataset["revised_at"], persisted_dataset.revised_at.timestamp())
 
-    # ✅
+    def test__get_all_datasets_for_user_index(self):
+        # reurn the datasets related to the collections the user has WRITE access to.
+
+        private_dataset = self.generate_dataset()
+        public_dataset = self.generate_dataset(publish=True)
+
+        test_url = furl(path="/dp/v1/user-datasets/index")
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
+        response = self.app.get(test_url.url, headers=headers)
+        self.assertEqual(200, response.status_code)
+        body = json.loads(response.data)
+    
+        # initialize an empty list to store the dataset ids
+        dataset_ids = set()
+
+        # iterate over the collections in the body list
+        for collection in body:
+            # iterate over the datasets in the "dataset_assets" list for each collection
+            for dataset in collection['dataset_assets']:
+                # append the dataset_id to the list of dataset ids
+                dataset_ids.add(dataset['dataset_id'])
+
+        dataset_ids = list(dataset_ids)
+        print("dataset_ids: ", dataset_ids)
+        print("public_dataset.dataset_version_id: ", public_dataset.dataset_version_id)
+        print("private_dataset.dataset_version_id: ", private_dataset.dataset_version_id)
+        self.assertIn(public_dataset.dataset_version_id, dataset_ids)
+        self.assertIn(private_dataset.dataset_version_id, dataset_ids)
+
+    # ✅    
     def test__get_all_datasets_for_index_with_ontology_expansion(self):
         import copy
 

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -859,14 +859,28 @@ class TestCollection(BaseAPIPortalTest):
 
         ids = [collection["id"] for collection in body]
 
-        self.assertIn(public_collection.collection_id.id, ids)
-        self.assertIn(private_collection.collection_id.id, ids)
-        self.assertIn(private_collection_not_owned.collection_id.id, ids)
+        collections_by_id = {collection["id"]: collection for collection in body}
 
-        self.assertNotIn(private_collection.version_id.id, ids)
-        self.assertNotIn(collection_to_tombstone.collection_id.id, ids)
-        self.assertNotIn(collection_to_tombstone.version_id.id, ids)
-        self.assertNotIn(private_collection_not_owned.version_id.id, ids)
+        self.assertIn(public_collection.collection_id.id, collections_by_id)
+        self.assertEqual(
+            collections_by_id[public_collection.collection_id.id]["curator_name"], public_collection.curator_name
+        )
+
+        self.assertIn(private_collection.collection_id.id, ids)
+        self.assertEqual(
+            collections_by_id[private_collection.collection_id.id]["curator_name"], private_collection.curator_name
+        )
+
+        self.assertIn(private_collection_not_owned.collection_id.id, collections_by_id)
+        self.assertEqual(
+            collections_by_id[private_collection_not_owned.collection_id.id]["curator_name"],
+            private_collection_not_owned.curator_name,
+        )
+
+        self.assertNotIn(private_collection.version_id.id, collections_by_id)
+        self.assertNotIn(collection_to_tombstone.collection_id.id, collections_by_id)
+        self.assertNotIn(collection_to_tombstone.version_id.id, collections_by_id)
+        self.assertNotIn(private_collection_not_owned.version_id.id, collections_by_id)
 
         # test that super curators can WRITE all collections
         for collection in body:

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -27,7 +27,6 @@ from tests.unit.backend.layers.common.base_test import DatasetArtifactUpdate, Da
 
 
 class TestCollection(BaseAPIPortalTest):
-
     # ✅
     def test__list_collection_options__allow(self):
         origin = "http://localhost:3000"
@@ -244,6 +243,39 @@ class TestCollection(BaseAPIPortalTest):
                     actual_body = json.loads(response.data)
                     self.assertEqual(expected_access_type, actual_body["access_type"])
 
+    
+    def test__get_collection_id_returns_revision_of_published_collection(self):
+        version = self.generate_published_collection()
+        revision = self.generate_revision(version.collection_id)
+        test_url = furl(path=f"/dp/v1/collections/{revision.version_id}")
+        headers = dict(host="localhost")
+        headers["Cookie"] = self.get_cxguser_token()
+        response = self.app.get(test_url.url, headers=headers)
+        assert response.status_code == 200
+        
+        body = json.loads(response.data)
+        self.assertEqual(body["visibility"], "PRIVATE")
+        self.assertEqual(body["access_type"], "WRITE")
+
+        # check revising_in is set if the collection has a revision and the
+        # user is logged in and has write access.
+        test_url = furl(path=f"/dp/v1/collections/{version.version_id}")
+        response = self.app.get(test_url.url, headers=headers)
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        self.assertEqual(body["visibility"], "PUBLIC")
+        self.assertEqual(body["access_type"], "WRITE")
+        self.assertEqual(body["revising_in"],revision.version_id.id)
+
+        # check revising_in is not set if the collection has a revision and the
+        # user is not logged in.
+        response = self.app.get(test_url.url, headers=dict(host="localhost"))
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        self.assertEqual(body["visibility"], "PUBLIC")
+        self.assertEqual(body["access_type"], "READ")
+        self.assertNotIn("revising_in", body)
+    
     def test__get_collection_id_retrieves_published_version_by_collection_id(self):
         """
         GET /collections/:collection_id retrieves the published version given a canonical collection_id
@@ -275,6 +307,7 @@ class TestCollection(BaseAPIPortalTest):
         self.assertEqual(200, response.status_code)
         body = json.loads(response.data)
         self.assertEqual(body["visibility"], "PRIVATE")
+
 
     def test__get_collection_id_retrieves_unpublished_version(self):
         """
@@ -528,7 +561,6 @@ class TestCollection(BaseAPIPortalTest):
 
     # ✅
     def test__post_collection_adds_publisher_metadata(self):
-
         self.crossref_provider.fetch_metadata = Mock(return_value=generate_mock_publisher_metadata())
 
         test_url = furl(path="/dp/v1/collections")
@@ -696,7 +728,6 @@ class TestCollection(BaseAPIPortalTest):
             self.assertEqual(link["link_url"], link["link_url"].strip())
 
     def test__list_collection__check_owner__no_auth(self):
-
         # Generate test collection
         public_owned = self.generate_published_collection(owner="test_user_id")
         private_owned = self.generate_unpublished_collection(owner="test_user_id")
@@ -1121,7 +1152,6 @@ class TestCollectionDeletion(BaseAPIPortalTest):
 
 
 class TestUpdateCollection(BaseAPIPortalTest):
-
     # ✅
     def test__update_collection__OK(self):
         collection = self.generate_unpublished_collection()
@@ -1359,7 +1389,6 @@ class TestUpdateCollection(BaseAPIPortalTest):
 
     # ✅
     def test__update_collection_new_doi_updates_metadata(self):
-
         # Generate a collection with "Old Journal" as publisher metadata
         self.crossref_provider.fetch_metadata = Mock(return_value=generate_mock_publisher_metadata("Old Journal"))
         collection = self.generate_unpublished_collection(links=[Link("Link 1", "DOI", "http://doi.org/123")])
@@ -1388,7 +1417,6 @@ class TestUpdateCollection(BaseAPIPortalTest):
 
     # ✅
     def test__update_collection_remove_doi_deletes_metadata(self):
-
         # Generate a collection with "Old Journal" as publisher metadata
         self.crossref_provider.fetch_metadata = Mock(return_value=generate_mock_publisher_metadata("Old Journal"))
         collection = self.generate_unpublished_collection(links=[Link("Link 1", "DOI", "http://doi.org/123")])
@@ -1507,7 +1535,6 @@ class TestCollectionsCurators(BaseAPIPortalTest):
 
 # TODO: these tests all require the generation of a dataset
 class TestDataset(BaseAPIPortalTest):
-
     # ✅
     def test__post_dataset_asset__OK(self):
         self.business_logic.get_dataset_artifact_download_data = Mock(
@@ -1631,7 +1658,6 @@ class TestDataset(BaseAPIPortalTest):
             return [dataclasses.asdict(o) for o in ontologies]
 
         if actual_dataset is not None and persisted_dataset is not None:  # pylance
-
             self.assertNotIn("description", actual_dataset)
             self.assertEqual(actual_dataset["id"], persisted_dataset.version_id.id)
             self.assertEqual(actual_dataset["name"], persisted_dataset.metadata.name)
@@ -1660,7 +1686,6 @@ class TestDataset(BaseAPIPortalTest):
 
     # ✅
     def test__get_all_datasets_for_index_with_ontology_expansion(self):
-
         import copy
 
         modified_metadata = copy.deepcopy(self.sample_dataset_metadata)
@@ -1687,7 +1712,6 @@ class TestDataset(BaseAPIPortalTest):
             return [dataclasses.asdict(o) for o in ontologies]
 
         if actual_dataset is not None:  # pylance
-
             self.assertEqual(actual_dataset["development_stage"], convert_ontology(modified_metadata.development_stage))
             self.assertEqual(
                 actual_dataset["development_stage_ancestors"],
@@ -1832,7 +1856,6 @@ class TestDataset(BaseAPIPortalTest):
 
     # ✅
     def test__delete_public_dataset_returns__405(self):
-
         dataset = self.generate_dataset(
             statuses=[DatasetStatusUpdate(DatasetStatusKey.UPLOAD, DatasetUploadStatus.UPLOADED)],
             publish=True,
@@ -1846,7 +1869,6 @@ class TestDataset(BaseAPIPortalTest):
 
     # ✅
     def test__cancel_dataset_download__user_not_collection_owner(self):
-
         dataset = self.generate_dataset(
             owner="someone_else",
             statuses=[DatasetStatusUpdate(DatasetStatusKey.UPLOAD, DatasetUploadStatus.WAITING)],
@@ -1859,7 +1881,6 @@ class TestDataset(BaseAPIPortalTest):
 
     # ✅
     def test__cancel_dataset_download__user_not_logged_in(self):
-
         dataset = self.generate_dataset(
             statuses=[DatasetStatusUpdate(DatasetStatusKey.UPLOAD, DatasetUploadStatus.WAITING)],
         )
@@ -1871,7 +1892,6 @@ class TestDataset(BaseAPIPortalTest):
 
     # ✅
     def test__dataset_meta__ok(self):
-
         headers = {"host": "localhost", "Content-Type": "application/json"}
 
         with self.subTest("dataset is public"):
@@ -1951,7 +1971,6 @@ class TestDataset(BaseAPIPortalTest):
             return json.loads(response.data)
 
         with self.subTest("Dataset belonging to an unpublished collection"):
-
             test_uri = "some_uri_0"
 
             dataset = self.generate_dataset(
@@ -1970,7 +1989,6 @@ class TestDataset(BaseAPIPortalTest):
             self.assertIn(returned_dataset_id, [dataset["id"] for dataset in datasets])
 
         with self.subTest("Dataset belonging to an unpublished collection, replaced"):
-
             test_uri = "some_uri_0"
 
             dataset = self.generate_dataset(
@@ -2001,7 +2019,6 @@ class TestDataset(BaseAPIPortalTest):
             self.assertIn(returned_dataset_id, [dataset["id"] for dataset in datasets])
 
         with self.subTest("Dataset belonging to a published collection"):
-
             test_uri = "some_uri_1"
 
             dataset = self.generate_dataset(
@@ -2019,7 +2036,6 @@ class TestDataset(BaseAPIPortalTest):
             self.assertIn(returned_dataset_id, [dataset["id"] for dataset in datasets])
 
         with self.subTest("Dataset belonging to a revision of a published collection, not replaced"):
-
             test_uri = "some_uri_2"
 
             dataset = self.generate_dataset(
@@ -2039,7 +2055,6 @@ class TestDataset(BaseAPIPortalTest):
             self.assertIn(returned_dataset_id, [dataset["id"] for dataset in datasets])
 
         with self.subTest("Dataset belonging to a revision of a published collection, replaced"):
-
             test_uri = "some_uri_1"
 
             dataset = self.generate_dataset(

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -243,7 +243,6 @@ class TestCollection(BaseAPIPortalTest):
                     actual_body = json.loads(response.data)
                     self.assertEqual(expected_access_type, actual_body["access_type"])
 
-    
     def test__get_collection_id_returns_revision_of_published_collection(self):
         version = self.generate_published_collection()
         revision = self.generate_revision(version.collection_id)
@@ -252,7 +251,7 @@ class TestCollection(BaseAPIPortalTest):
         headers["Cookie"] = self.get_cxguser_token()
         response = self.app.get(test_url.url, headers=headers)
         assert response.status_code == 200
-        
+
         body = json.loads(response.data)
         self.assertEqual(body["visibility"], "PRIVATE")
         self.assertEqual(body["access_type"], "WRITE")
@@ -265,7 +264,7 @@ class TestCollection(BaseAPIPortalTest):
         body = json.loads(response.data)
         self.assertEqual(body["visibility"], "PUBLIC")
         self.assertEqual(body["access_type"], "WRITE")
-        self.assertEqual(body["revising_in"],revision.version_id.id)
+        self.assertEqual(body["revising_in"], revision.version_id.id)
 
         # check revising_in is not set if the collection has a revision and the
         # user is not logged in.
@@ -275,7 +274,7 @@ class TestCollection(BaseAPIPortalTest):
         self.assertEqual(body["visibility"], "PUBLIC")
         self.assertEqual(body["access_type"], "READ")
         self.assertNotIn("revising_in", body)
-    
+
     def test__get_collection_id_retrieves_published_version_by_collection_id(self):
         """
         GET /collections/:collection_id retrieves the published version given a canonical collection_id
@@ -307,7 +306,6 @@ class TestCollection(BaseAPIPortalTest):
         self.assertEqual(200, response.status_code)
         body = json.loads(response.data)
         self.assertEqual(body["visibility"], "PRIVATE")
-
 
     def test__get_collection_id_retrieves_unpublished_version(self):
         """
@@ -1689,31 +1687,35 @@ class TestDataset(BaseAPIPortalTest):
 
         private_dataset = self.generate_dataset()
         public_dataset = self.generate_dataset(publish=True)
+        # how can I add a dataset to a revision?
+        revision = self.business_logic.create_collection_version(CollectionId(public_dataset.collection_id))
+        # revision_dataset = self.generate_dataset(collection_version=revision);
 
         test_url = furl(path="/dp/v1/user-datasets/index")
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
         response = self.app.get(test_url.url, headers=headers)
         self.assertEqual(200, response.status_code)
         body = json.loads(response.data)
-    
+
         # initialize an empty list to store the dataset ids
         dataset_ids = set()
 
         # iterate over the collections in the body list
         for collection in body:
             # iterate over the datasets in the "dataset_assets" list for each collection
-            for dataset in collection['dataset_assets']:
+            for dataset in collection["dataset_assets"]:
                 # append the dataset_id to the list of dataset ids
-                dataset_ids.add(dataset['dataset_id'])
+                dataset_ids.add(dataset["dataset_id"])
 
         dataset_ids = list(dataset_ids)
         print("dataset_ids: ", dataset_ids)
         print("public_dataset.dataset_version_id: ", public_dataset.dataset_version_id)
         print("private_dataset.dataset_version_id: ", private_dataset.dataset_version_id)
+
         self.assertIn(public_dataset.dataset_version_id, dataset_ids)
         self.assertIn(private_dataset.dataset_version_id, dataset_ids)
 
-    # ✅    
+    # ✅
     def test__get_all_datasets_for_index_with_ontology_expansion(self):
         import copy
 


### PR DESCRIPTION
## Reason for Change

- #2647

## Backend Changes

- added a `dp/v1/my-collections/index` API
- modified the `portal-api.yml`, `portal_api.py` and `test_portal_api.py`
- this API:
    - is authenticated
    - returns a superset of fields returned by  `/dp/v1/collections/index` 
    - returns the same rows as `/dp/v1/collections` that is, all public collections and 1) for curators, all private collections they created (are the owner of), and 2 ) for super curators all private collections. 

### Notes for BE reviewer

There is a bit of code duplication now between the `/dp/v1/collections` and `/dp/v1/my-collections/index implementations`. I did not address this as the `/dp/v1/collections` implementation will be deleted once we are live with the updated "My Collections" experience.

## Front End Changes
WIP (not yet in this PR)


