### PR TITLE
fix(wmg): rollup now applies to genes+cell types that have no data

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -2,6 +2,8 @@ from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Tuple
 
 import connexion
+import numpy as np
+import pandas as pd
 from flask import jsonify
 from pandas import DataFrame
 from server_timing import Timing as ServerTiming
@@ -257,17 +259,62 @@ def get_dot_plot_data(
 
 def rollup(dot_plot_matrix_df, cell_counts_cell_type_agg) -> Tuple[DataFrame, DataFrame]:
     # Roll up numeric columns in the input dataframes
-    ignore_cols = ["n_cells_tissue"]
 
     if dot_plot_matrix_df.shape[0] > 0:
-        dot_plot_matrix_df = rollup_across_cell_type_descendants(dot_plot_matrix_df, ignore_cols=ignore_cols)
+        ### Add missing cell types to the expression dataframe so they can be rolled up ###
+
+        # extract group-by terms and queried genes from the input dataframes
+        # if a queried gene is not present in the input dot plot dataframe, we can safely
+        # ignore it as it need not be rolled up anyway.
+        group_by_terms = list(cell_counts_cell_type_agg.index.names)
+        genes = list(set(dot_plot_matrix_df["gene_ontology_term_id"]))
+
+        # get the names of the numeric columns
+        numeric_columns = list(
+            dot_plot_matrix_df.columns[[np.issubdtype(dtype, np.number) for dtype in dot_plot_matrix_df.dtypes]]
+        )
+
+        # exclude n_cells_tissue as we do not wish to roll it up
+        if "n_cells_tissue" in numeric_columns:
+            numeric_columns.remove("n_cells_tissue")
+
+        # get the total number of cells per tissue to populate the n_cells_tissue in the added entries
+        n_cells_tissue_dict = dot_plot_matrix_df.groupby("tissue_ontology_term_id").first()["n_cells_tissue"].to_dict()
+
+        # get the set of available combinations of group-by terms from the aggregated cell counts
+        available_combinations = set(zip(*cell_counts_cell_type_agg.reset_index()[group_by_terms].values.T))
+
+        # for each gene, get the set of available combinations of group-by terms from the input expression dataframe
+        entries_to_add = []
+        for gene in genes:
+            dot_plot_matrix_df_per_gene = dot_plot_matrix_df[dot_plot_matrix_df["gene_ontology_term_id"] == gene]
+            available_combinations_per_gene = set(zip(*dot_plot_matrix_df_per_gene[group_by_terms].values.T))
+
+            # get the combinations that are missing in the input expression dataframe
+            # these combinations have no data but can be rescued by the roll-up operation
+            missing_combinations = available_combinations.symmetric_difference(available_combinations_per_gene)
+            for combo in missing_combinations:
+                entry = {dim: combo[i] for i, dim in enumerate(group_by_terms)}
+                entry.update({col: 0 for col in numeric_columns})
+                entry["n_cells_tissue"] = n_cells_tissue_dict[entry["tissue_ontology_term_id"]]
+                entry["gene_ontology_term_id"] = gene
+                entries_to_add.append(entry)
+
+        # add the missing entries to the input expression dataframe
+        dot_plot_matrix_df = pd.concat((dot_plot_matrix_df, pd.DataFrame(entries_to_add)), axis=0)
+
+        # Roll up expression dataframe
+        dot_plot_matrix_df = rollup_across_cell_type_descendants(dot_plot_matrix_df, ignore_cols=["n_cells_tissue"])
+
+        # Filter out the entries that were added to the dataframe that remain zero after roll-up
+        dot_plot_matrix_df = dot_plot_matrix_df[dot_plot_matrix_df[numeric_columns[0]] > 0]
 
     if cell_counts_cell_type_agg.shape[0] > 0:
         # make the cell counts dataframe tidy
         for col in cell_counts_cell_type_agg.index.names:
             cell_counts_cell_type_agg[col] = cell_counts_cell_type_agg.index.get_level_values(col)
         cell_counts_cell_type_agg = rollup_across_cell_type_descendants(
-            cell_counts_cell_type_agg, ignore_cols=ignore_cols
+            cell_counts_cell_type_agg, ignore_cols=["n_cells_tissue"]
         )
 
         # clean up columns that were added to the dataframe to make it tidy

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -257,57 +257,65 @@ def get_dot_plot_data(
     return dot_plot_matrix_df, cell_counts_cell_type_agg
 
 
+def add_missing_combinations_to_dot_plot_matrix(dot_plot_matrix_df, cell_counts_cell_type_agg) -> DataFrame:
+    ### Add missing cell types to the expression dataframe so they can be rolled up ###
+
+    # extract group-by terms and queried genes from the input dataframes
+    # if a queried gene is not present in the input dot plot dataframe, we can safely
+    # ignore it as it need not be rolled up anyway.
+    group_by_terms = list(cell_counts_cell_type_agg.index.names)
+    genes = list(set(dot_plot_matrix_df["gene_ontology_term_id"]))
+
+    # get the names of the numeric columns
+    numeric_columns = list(
+        dot_plot_matrix_df.columns[[np.issubdtype(dtype, np.number) for dtype in dot_plot_matrix_df.dtypes]]
+    )
+
+    # exclude n_cells_tissue as we do not wish to roll it up
+    if "n_cells_tissue" in numeric_columns:
+        numeric_columns.remove("n_cells_tissue")
+
+    # get the total number of cells per tissue to populate the n_cells_tissue in the added entries
+    n_cells_tissue_dict = dot_plot_matrix_df.groupby("tissue_ontology_term_id").first()["n_cells_tissue"].to_dict()
+
+    # get the set of available combinations of group-by terms from the aggregated cell counts
+    available_combinations = set(zip(*cell_counts_cell_type_agg.reset_index()[group_by_terms].values.T))
+
+    # for each gene, get the set of available combinations of group-by terms from the input expression dataframe
+    entries_to_add = []
+    for gene in genes:
+        dot_plot_matrix_df_per_gene = dot_plot_matrix_df[dot_plot_matrix_df["gene_ontology_term_id"] == gene]
+        available_combinations_per_gene = set(zip(*dot_plot_matrix_df_per_gene[group_by_terms].values.T))
+
+        # get the combinations that are missing in the input expression dataframe
+        # these combinations have no data but can be rescued by the roll-up operation
+        missing_combinations = available_combinations.symmetric_difference(available_combinations_per_gene)
+        for combo in missing_combinations:
+            entry = {dim: combo[i] for i, dim in enumerate(group_by_terms)}
+            entry.update({col: 0 for col in numeric_columns})
+            entry["n_cells_tissue"] = n_cells_tissue_dict[entry["tissue_ontology_term_id"]]
+            entry["gene_ontology_term_id"] = gene
+            entries_to_add.append(entry)
+
+    # add the missing entries to the input expression dataframe
+    dot_plot_matrix_df = pd.concat((dot_plot_matrix_df, pd.DataFrame(entries_to_add)), axis=0)
+    return dot_plot_matrix_df
+
+
 def rollup(dot_plot_matrix_df, cell_counts_cell_type_agg) -> Tuple[DataFrame, DataFrame]:
     # Roll up numeric columns in the input dataframes
 
     if dot_plot_matrix_df.shape[0] > 0:
-        ### Add missing cell types to the expression dataframe so they can be rolled up ###
 
-        # extract group-by terms and queried genes from the input dataframes
-        # if a queried gene is not present in the input dot plot dataframe, we can safely
-        # ignore it as it need not be rolled up anyway.
-        group_by_terms = list(cell_counts_cell_type_agg.index.names)
-        genes = list(set(dot_plot_matrix_df["gene_ontology_term_id"]))
-
-        # get the names of the numeric columns
-        numeric_columns = list(
-            dot_plot_matrix_df.columns[[np.issubdtype(dtype, np.number) for dtype in dot_plot_matrix_df.dtypes]]
-        )
-
-        # exclude n_cells_tissue as we do not wish to roll it up
-        if "n_cells_tissue" in numeric_columns:
-            numeric_columns.remove("n_cells_tissue")
-
-        # get the total number of cells per tissue to populate the n_cells_tissue in the added entries
-        n_cells_tissue_dict = dot_plot_matrix_df.groupby("tissue_ontology_term_id").first()["n_cells_tissue"].to_dict()
-
-        # get the set of available combinations of group-by terms from the aggregated cell counts
-        available_combinations = set(zip(*cell_counts_cell_type_agg.reset_index()[group_by_terms].values.T))
-
-        # for each gene, get the set of available combinations of group-by terms from the input expression dataframe
-        entries_to_add = []
-        for gene in genes:
-            dot_plot_matrix_df_per_gene = dot_plot_matrix_df[dot_plot_matrix_df["gene_ontology_term_id"] == gene]
-            available_combinations_per_gene = set(zip(*dot_plot_matrix_df_per_gene[group_by_terms].values.T))
-
-            # get the combinations that are missing in the input expression dataframe
-            # these combinations have no data but can be rescued by the roll-up operation
-            missing_combinations = available_combinations.symmetric_difference(available_combinations_per_gene)
-            for combo in missing_combinations:
-                entry = {dim: combo[i] for i, dim in enumerate(group_by_terms)}
-                entry.update({col: 0 for col in numeric_columns})
-                entry["n_cells_tissue"] = n_cells_tissue_dict[entry["tissue_ontology_term_id"]]
-                entry["gene_ontology_term_id"] = gene
-                entries_to_add.append(entry)
-
-        # add the missing entries to the input expression dataframe
-        dot_plot_matrix_df = pd.concat((dot_plot_matrix_df, pd.DataFrame(entries_to_add)), axis=0)
+        # For each gene in the query, add missing combinations (tissue, cell type, compare dimension)
+        # to the expression dataframe
+        dot_plot_matrix_df = add_missing_combinations_to_dot_plot_matrix(dot_plot_matrix_df, cell_counts_cell_type_agg)
 
         # Roll up expression dataframe
         dot_plot_matrix_df = rollup_across_cell_type_descendants(dot_plot_matrix_df, ignore_cols=["n_cells_tissue"])
 
         # Filter out the entries that were added to the dataframe that remain zero after roll-up
-        dot_plot_matrix_df = dot_plot_matrix_df[dot_plot_matrix_df[numeric_columns[0]] > 0]
+        dot_plot_matrix_df = dot_plot_matrix_df[dot_plot_matrix_df["sum"] > 0]
 
     if cell_counts_cell_type_agg.shape[0] > 0:
         # make the cell counts dataframe tidy

--- a/tests/unit/backend/wmg/api/test_expression_rollup.py
+++ b/tests/unit/backend/wmg/api/test_expression_rollup.py
@@ -136,12 +136,12 @@ class RollupExpressionsAcrossCellTypesTest(unittest.TestCase):
         cell_counts_cell_type_agg = cell_counts_cell_type_agg.groupby(
             ["cell_type_ontology_term_id", "tissue_ontology_term_id"]
         ).first()
-        test_dot_plot_matrix_df = add_missing_combinations_to_dot_plot_matrix(
+        actual_dot_plot_matrix_df = add_missing_combinations_to_dot_plot_matrix(
             dot_plot_matrix_df, cell_counts_cell_type_agg
         )
 
         # sort both dataframes to ensure comparable ordering
-        test_dot_plot_matrix_df = test_dot_plot_matrix_df.sort_values(
+        actual_dot_plot_matrix_df = actual_dot_plot_matrix_df.sort_values(
             ["cell_type_ontology_term_id", "tissue_ontology_term_id", "gene_ontology_term_id"]
         ).reset_index(drop=True)
         expected_dot_plot_matrix_df = expected_dot_plot_matrix_df.sort_values(
@@ -149,7 +149,7 @@ class RollupExpressionsAcrossCellTypesTest(unittest.TestCase):
         ).reset_index(drop=True)
 
         # assert equality
-        assert_frame_equal(test_dot_plot_matrix_df, expected_dot_plot_matrix_df)
+        assert_frame_equal(actual_dot_plot_matrix_df, expected_dot_plot_matrix_df)
 
         # now test the entire rollup function end-to-end, which includes `add_missing_combinations_to_dot_plot_matrix`
         dot_plot_matrix_df, cell_counts_cell_type_agg = rollup(dot_plot_matrix_df, cell_counts_cell_type_agg)

--- a/tests/unit/backend/wmg/api/test_expression_rollup.py
+++ b/tests/unit/backend/wmg/api/test_expression_rollup.py
@@ -2,8 +2,11 @@ import unittest
 
 import numpy as np
 import pandas as pd
+from pandas.testing import assert_frame_equal
 
+from backend.wmg.api.v1 import add_missing_combinations_to_dot_plot_matrix, rollup
 from backend.wmg.data.rollup import rollup_across_cell_type_descendants
+from backend.wmg.data.schemas.cube_schema import expression_summary_logical_attrs
 
 
 class RollupExpressionsAcrossCellTypesTest(unittest.TestCase):
@@ -41,3 +44,119 @@ class RollupExpressionsAcrossCellTypesTest(unittest.TestCase):
 
         df_rollup = rollup_across_cell_type_descendants(df)
         assert np.all(df == df_rollup)
+
+    def test__missing_combinations_added_to_expression_dataframe_before_rollup(self):
+        """
+        test that the `add_missing_combinations_to_dot_plot_matrix` function works as expected
+        this function is used to add missing (tissue, cell type) combinations to the expression dataframe
+        so that the expression dataframe can be rolled up correctly.
+
+        the cell counts dataframe has 100 cell types, 60 of which have expression data
+        the goal of this test is to make sure that `add_missing_combinations_to_dot_plot_matrix`
+        adds the missing (tissue, cell type) combinations for each gene to th expression dataframe.
+
+        there will be (100 cell types) * (2 tissues) = 200 rows in the cell counts dataframe
+        there will be (60 cell types) * (2 tissues) * (3 genes) = 360 rows in the expression dataframe
+        there will be (100 cell types) * (2 tissues) * (3 genes) = 600 rows in the expected expression dataframe
+
+
+        the input expression dataframe will have 1 for all numeric columns, excluding n_cells_tissue.
+        because we don't want to roll up the n_cells_tissue column, we set it to 100 for all rows and check
+        that it stays 100 after adding the missing combinations.
+
+        the expected expression dataframe will have the same rows as the input dataframe, with new rows added
+        that have 0 for all numeric columns, excluding n_cells_tissue, which stays 100.
+        """
+        num_cell_types = 100
+        num_cell_types_with_expression = 60
+        num_tissues = 2
+        num_genes = 3
+
+        cell_types_cell_counts_df = [f"cell_type_ontology_term_id_{i}" for i in range(num_cell_types)] * num_tissues
+        tissue_cell_counts_df = sum([[f"tissue_ontology_term_id_{i}"] * num_cell_types for i in range(num_tissues)], [])
+
+        cell_types_dot_plot_df = cell_types_cell_counts_df[:num_cell_types_with_expression] * num_tissues * num_genes
+        tissue_dot_plot_df = (
+            sum([[f"tissue_ontology_term_id_{i}"] * num_cell_types_with_expression for i in range(num_tissues)], [])
+            * num_genes
+        )
+        genes_dot_plot_df = sum(
+            [[f"gene_ontology_term_id_{i}"] * num_cell_types_with_expression * num_tissues for i in range(num_genes)],
+            [],
+        )
+
+        cell_counts_cell_type_agg = pd.DataFrame()
+        cell_counts_cell_type_agg["cell_type_ontology_term_id"] = cell_types_cell_counts_df
+        cell_counts_cell_type_agg["tissue_ontology_term_id"] = tissue_cell_counts_df
+        cell_counts_cell_type_agg["n_cells_cell_type"] = 1
+
+        dot_plot_matrix_df = pd.DataFrame()
+        dot_plot_matrix_df["cell_type_ontology_term_id"] = cell_types_dot_plot_df
+        dot_plot_matrix_df["tissue_ontology_term_id"] = tissue_dot_plot_df
+        dot_plot_matrix_df["gene_ontology_term_id"] = genes_dot_plot_df
+        for attr in expression_summary_logical_attrs:
+            dot_plot_matrix_df[attr.name] = 1
+        dot_plot_matrix_df["n_cells_cell_type"] = 1
+        dot_plot_matrix_df["n_cells_tissue"] = 100
+
+        expected_added_cell_types = (
+            [f"cell_type_ontology_term_id_{i}" for i in range(num_cell_types_with_expression, num_cell_types)]
+            * num_tissues
+            * num_genes
+        )
+        expected_added_tissues = (
+            sum(
+                [
+                    [f"tissue_ontology_term_id_{i}"] * (num_cell_types - num_cell_types_with_expression)
+                    for i in range(num_tissues)
+                ],
+                [],
+            )
+            * num_genes
+        )
+        expected_added_genes = sum(
+            [
+                [f"gene_ontology_term_id_{i}"] * (num_cell_types - num_cell_types_with_expression) * num_tissues
+                for i in range(num_genes)
+            ],
+            [],
+        )
+        expected_added_dataframe = pd.DataFrame()
+        expected_added_dataframe["cell_type_ontology_term_id"] = expected_added_cell_types
+        expected_added_dataframe["tissue_ontology_term_id"] = expected_added_tissues
+        expected_added_dataframe["gene_ontology_term_id"] = expected_added_genes
+        for attr in expression_summary_logical_attrs:
+            expected_added_dataframe[attr.name] = 0
+        expected_added_dataframe["n_cells_cell_type"] = 0
+        expected_added_dataframe["n_cells_tissue"] = 100
+
+        expected_dot_plot_matrix_df = pd.concat((dot_plot_matrix_df, expected_added_dataframe), axis=0)
+
+        # group by to get cell_counts_cell_type_agg into the right format (with multi-index)
+        cell_counts_cell_type_agg = cell_counts_cell_type_agg.groupby(
+            ["cell_type_ontology_term_id", "tissue_ontology_term_id"]
+        ).first()
+        test_dot_plot_matrix_df = add_missing_combinations_to_dot_plot_matrix(
+            dot_plot_matrix_df, cell_counts_cell_type_agg
+        )
+
+        # sort both dataframes to ensure comparable ordering
+        test_dot_plot_matrix_df = test_dot_plot_matrix_df.sort_values(
+            ["cell_type_ontology_term_id", "tissue_ontology_term_id", "gene_ontology_term_id"]
+        ).reset_index(drop=True)
+        expected_dot_plot_matrix_df = expected_dot_plot_matrix_df.sort_values(
+            ["cell_type_ontology_term_id", "tissue_ontology_term_id", "gene_ontology_term_id"]
+        ).reset_index(drop=True)
+
+        # assert equality
+        assert_frame_equal(test_dot_plot_matrix_df, expected_dot_plot_matrix_df)
+
+        # now test the entire rollup function end-to-end, which includes `add_missing_combinations_to_dot_plot_matrix`
+        dot_plot_matrix_df, cell_counts_cell_type_agg = rollup(dot_plot_matrix_df, cell_counts_cell_type_agg)
+
+        # assert that the n_cells_tissue column is still 100
+        assert (dot_plot_matrix_df["n_cells_tissue"] == 100).all()
+
+        # assert that the added rows that could not be rescued via rollup are properly filtered out
+        # these rows will still have 0 for all numeric columns, excluding n_cells_tissue
+        assert (dot_plot_matrix_df["sum"] > 0).all()


### PR DESCRIPTION
## Reason for Change

- [Context](https://czi-sci.slack.com/archives/C0247APK621/p1680121082202219?thread_ts=1680118996.135129&cid=C0247APK621)
- The rollup operation only applied to (gene, cell type, tissue) combinations for which we had data. For example, if a gene isn't expressed in `native cell` pre-rollup, then the rollup operation would not be able to rescue its expression as there is nothing to rollup into.

## Changes

- For each gene, identify the missing combinations in `dot_plot_matrix_df` (the expression dataframe) based on the available combinations in `cell_counts_cell_type_agg` (the cell counts dataframe) and add them as zero's to `dot_plot_matrix_df` before rollup. Here, "combinations" refers to `<tissue, cell type, compare dimension if selected>`. Rolling up the dataframe can now potentially add expression data to the newly added rows. After rollup, filter out rows that remain zero.
  - Added `add_missing_combinations_to_dot_plot_matrix` to add missing combinations to the dot plot matrix
  - Modified `rollup` to filter out added entries that remained zero after rollup

## Testing steps
- [RDEV STACK](https://atar-rollup-fix-frontend.rdev.single-cell.czi.technology/gene-expression)
- Added unit test `test__missing_combinations_added_to_expression_dataframe_before_rollup` to `test_expression_rollup.py`.
  - This test ensures that missing combinations are properly added to the dot plot matrix dataframe.
  - This test also makes sure that `rollup` properly filters out rows that remain zero after rollup.

## Demo
The specific issue identified in linked context:
<img width="355" alt="image" src="https://user-images.githubusercontent.com/16548075/228855970-672ecd5d-23cf-493d-9ce6-989458541089.png">
Note how GDI1 is not expressed in native cell even though native cell should include all cells in the lung.

After applying this fix (in the rdev stack linked above):
<img width="332" alt="image" src="https://user-images.githubusercontent.com/16548075/228856126-d7035b79-ee10-4b74-974a-6887e1c325c3.png">
Note how GDI1 is now properly expressed in native cell.