### PR TITLE
fix(wmg): Adding /scExpression redirect to /gene-expression #4448

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -96,6 +96,11 @@ module.exports = {
         permanent: true,
         source: "/landing-page",
       },
+      {
+        destination: "/gene-expression",
+        permanent: true,
+        source: "/scExpression",
+      },
     ];
   },
   sassOptions: {


### PR DESCRIPTION
## Reason for Change

- #4448 

## Changes

- add
    - /scExpression to /gene-expression redirect in `next.config.js`
- remove
- modify

## Testing steps

1. Navigate to https://localhost:3000/scExpression
2. Make sure it redirects to https://localhost:3000/gene-expression

## Notes for Reviewer
