### PR TITLE
fix(wmg): Fixing PNG+SVG Download Banner Cut Off

### DIFF
--- a/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveExport/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/GeneSearchBar/components/SaveExport/index.tsx
@@ -63,6 +63,7 @@ import { InputCheckbox } from "czifui";
 import {
   DATA_MESSAGE_BANNER_HEIGHT_PX,
   DATA_MESSAGE_BANNER_ID,
+  DATA_MESSAGE_BANNER_WIDTH_PX,
   UnderlyingDataChangeBanner,
 } from "./ExportBanner";
 import {
@@ -354,9 +355,9 @@ function generateSvg({
 
   // Used to create room for the banner
   const paddedBannerHeight =
-    banner.clientHeight + CONTENT_WRAPPER_TOP_BOTTOM_PADDING_PX;
+    DATA_MESSAGE_BANNER_HEIGHT_PX + CONTENT_WRAPPER_TOP_BOTTOM_PADDING_PX;
   const paddedBannerWidth =
-    banner.clientWidth + CONTENT_WRAPPER_LEFT_RIGHT_PADDING_PX * 2;
+    DATA_MESSAGE_BANNER_WIDTH_PX + CONTENT_WRAPPER_LEFT_RIGHT_PADDING_PX * 2;
 
   // Render elements to SVG
   const xAxisSvg = renderXAxis({
@@ -398,7 +399,7 @@ function generateSvg({
   applyAttributes(banner, {
     x:
       svgWidth > paddedBannerWidth
-        ? svgWidth / 2 - banner.clientWidth / 2
+        ? svgWidth / 2 - DATA_MESSAGE_BANNER_WIDTH_PX / 2
         : CONTENT_WRAPPER_LEFT_RIGHT_PADDING_PX,
     y: CONTENT_WRAPPER_TOP_BOTTOM_PADDING_PX,
   });


### PR DESCRIPTION
## Reason for Change

- #4315

When selecting both PNG and SVG, when selecting one gene, the banner was shrinking to match the heatmap width. Which causes an issue for the SVG generation because it was using shrunk width instead of the actual dimensions of the banner.

## Changes

- add
- remove
- modify
    - Using default width/height explicitly for paddedBannerWidth

## Testing steps

1. Select tissue(s)
2. Select just one gene
3. Download both PNG and SVG
4. Ensure that banner is not being cut off

## Notes for Reviewer
