### PR TITLE
feat: script to migrate dataset assets from corpora-data-<env> bucket to dataset-assets-<env> bucket

### DIFF
--- a/scripts/migrate_s3_data.sh
+++ b/scripts/migrate_s3_data.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Migrate S3 data from corpora-data-<env> bucket to dataset-assets-public-<env> bucket
+set -e
+export ENV=${1}
+
+echo mirroring data in $ENV
+if [[ "$ENV" == dev || "$ENV" == staging ]]; then
+  export AWS_PROFILE=single-cell-dev
+elif [[ "$ENV" == prod ]]; then
+  export AWS_PROFILE=single-cell-prod
+else
+  echo "invalid env input"
+  exit 1
+fi
+
+aws s3 ls s3://corpora-data-${ENV}/ | awk '{print $2}' | sed 's:/*$::' > filenames.txt
+for file in `cat filenames.txt`; do
+  echo "dry run copying s3://corpora-data-${ENV}/$file/local.h5ad TO s3://dataset-assets-public-${ENV}/$file.h5ad"
+  # aws s3 cp s3://corpora-data-${ENV}/$file/local.h5ad s3://dataset-assets-public-${ENV}/$file.h5ad
+  # aws s3 cp s3://corpora-data-${ENV}/$file/local.rds s3://dataset-assets-public-${ENV}/$file.rds
+done
+
+


### PR DESCRIPTION
## Reason for Change

- #4268

## Changes
- taking all <uuid>/local.<filetype> h5ads and rds files in corpora-data bucket and copying them to dataset-assets as <uuid>.<filetype>, without the additional directory layer and replacing the 'local' filename with the dataset version UUID.

## Testing steps
n/a

## Notes for Reviewer
- Not meant to merge, intended for one-time use per env locally. Sharing just to sync on approach for migration 
- Currently set up just to do a dry-run, 
- Will require temporarily allowing poweruser PutObjects on the dataset-asset destination bucket
