### PR TITLE
fix(homepage): 4514-temp-remove-twitter-wistia

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -36,7 +36,8 @@ const defaultSecureHeaders = {
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       formAction: "'self'",
       frameAncestors: ["'none'"],
-      frameSrc: [TWITTER_URL, WISTIA_URL],
+      // 4513(thuang): Comment out frameSrc for now until we figure out a compliant way to embed
+      // frameSrc: [TWITTER_URL, WISTIA_URL],
       imgSrc: ["'self'", "data:"],
       manifestSrc: ["'self'"],
       mediaSrc: ["'self'"],

--- a/frontend/src/views/Landing/index.tsx
+++ b/frontend/src/views/Landing/index.tsx
@@ -3,7 +3,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRef, useState } from "react";
 import { useInView } from "react-intersection-observer";
-import TweetEmbed from "react-tweet-embed";
+// 4513(thuang): Comment out frameSrc for now until we figure out a compliant way to embed
+// import TweetEmbed from "react-tweet-embed";
 import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
 import { ROUTES } from "src/common/constants/routes";
@@ -662,7 +663,8 @@ const LandingPage = (): JSX.Element => {
               </div>
             </div>
           </div>
-          <div className={styles.freethinkVideoSection}>
+          {/* 4513(thuang): Comment out frameSrc for now until we figure out a compliant way to embed */}
+          {/* <div className={styles.freethinkVideoSection}>
             <div className={styles.freethinkVideoSectionWrapper}>
               <div className={styles.freethinkVideoSectionTextContainer}>
                 <h2>Behind-the-scenes of Chan Zuckerberg CELLxGENE</h2>
@@ -682,7 +684,7 @@ const LandingPage = (): JSX.Element => {
                 src="https://fast.wistia.net/embed/iframe/fgzei2rjkl"
               ></iframe>
             </div>
-          </div>
+          </div> */}
           <div className={styles.publications}>
             <div className={styles.sciencePublications}>
               <span className={styles.pubSectionTitle}>Publications</span>
@@ -744,12 +746,13 @@ const LandingPage = (): JSX.Element => {
               <span className={`${styles.pubSectionTitle} ${styles.newsTitle}`}>
                 CELL X GENE IN THE NEWS
               </span>
-              <div className={styles.pubSectionImage}>
+              {/* 4513(thuang): Comment out frameSrc for now until we figure out a compliant way to embed */}
+              {/* <div className={styles.pubSectionImage}>
                 <TweetEmbed tweetId="1404822000464433158" />
               </div>
               <div className={styles.pubSectionImage}>
                 <TweetEmbed tweetId="1396854799908282376" />
-              </div>
+              </div> */}
               {newsLinks && (
                 <div className={styles.newsLinkContainer}>
                   {newsLinks.map((link, index) => (


### PR DESCRIPTION
## Reason for Change

- #4514 

## Changes

Temporarily remove Twitter and Wistia until in #4513 we figure out a way to add them back in a compliant way

## Testing steps

**RDEV link incoming**

1. Navigate to homepage
2. Scroll down and you should no longer see embedded video and twitter timelines
3. You should also no longer see cookies for both Wistia and Twitter domains

<img width="1056" alt="Screenshot 2023-04-10 at 6 58 12 AM" src="https://user-images.githubusercontent.com/6309723/230915988-c96cd325-af71-4e32-a151-8d25f7933e2a.png">

https://user-images.githubusercontent.com/6309723/230915967-85775f4e-cee1-499c-8682-a3650420ce93.mov


## Notes for Reviewer
