### PR TITLE
feat: Allow exploration of datasets up to 4.3 million cells (#4510)

### DIFF
--- a/frontend/src/components/common/Grid/common/constants.ts
+++ b/frontend/src/components/common/Grid/common/constants.ts
@@ -2,9 +2,9 @@
  * Message displayed when dataset's Explorer button is not available.
  * */
 export const OVER_MAX_CELL_COUNT_TOOLTIP =
-  "Exploration is currently unavailable for datasets with more than 2 million cells";
+  "Exploration is currently unavailable for datasets with more than 4.3 million cells";
 
 /**
  * Maximum number of cells a dataset can have in order to be included for display.
  */
-export const DATASET_MAX_CELL_COUNT = 2_000_000;
+export const DATASET_MAX_CELL_COUNT = 4_300_000;


### PR DESCRIPTION
## Reason for Change
Exploration of datasets of up to 4.3 million cells is now possible. Datasets with a cell count exceeding 4.3 million cells will not be explorable; the "Explore" button will be disabled with a corresponding updated tooltip message "Exploration is currently unavailable for datasets with more than 4.3 million cells".

- #4510 

## Changes

- Modified the `DATASET_MAX_CELL_COUNT` to be `4,300,000` and the corresponding hover message to be `Exploration is currently unavailable for datasets with more than 4.3 million cells`.

## Testing steps

- Any dataset with a cell count greater than 4.3 million cells will not be explorable; the "Explore" button will be disabled and the tooltip message should show "Exploration is currently unavailable for datasets with more than 4.3 million cells".

## Note

- It has been confirmed that this feature will not be needed in the future and therefore the code may be deleted.
- Currently there are no datasets with a cell count > 4.3 million cells, therefore we should expect that all existing datasets are explorable.