### PR TITLE
feat: Update NTag UI to match mocks (#4556)

### DIFF
--- a/frontend/src/components/common/Grid/components/NTag/index.tsx
+++ b/frontend/src/components/common/Grid/components/NTag/index.tsx
@@ -1,11 +1,6 @@
-import {
-  Popover,
-  PopoverInteractionKind,
-  Position,
-  Tag,
-} from "@blueprintjs/core";
+import { Popover, PopoverInteractionKind, Position } from "@blueprintjs/core";
 import { PLURALIZED_METADATA_LABEL } from "src/common/constants/metadata";
-import { ContentColumn, ContentWrapper, FieldValues } from "./style";
+import { ContentColumn, ContentWrapper, FieldValues, Tag } from "./style";
 
 const CHUNK_SIZE = 25;
 
@@ -43,9 +38,13 @@ export default function NTag({ label, values }: Props): JSX.Element {
       }}
       placement={Position.RIGHT}
     >
-      <Tag minimal>
-        {values.length} {label}
-      </Tag>
+      <Tag
+        color="gray"
+        hover={false}
+        label={`${values.length} ${label}`}
+        sdsStyle="square"
+        sdsType="primary"
+      />
     </Popover>
   );
 }

--- a/frontend/src/components/common/Grid/components/NTag/style.ts
+++ b/frontend/src/components/common/Grid/components/NTag/style.ts
@@ -1,6 +1,9 @@
 import styled from "@emotion/styled";
 import { textClippingCSS } from "src/components/Collections/components/Grid/common/style";
 import { GRAY, PT_GRID_SIZE_PX } from "src/components/common/theme";
+import { CommonThemeProps, fontBodyXs, getColors, Tag as SDSTag } from "czifui";
+
+const gray100 = (props: CommonThemeProps) => getColors(props)?.gray[100];
 
 export const FieldValues = styled.div`
   ${textClippingCSS}
@@ -16,8 +19,24 @@ export const ContentWrapper = styled.div`
 export const ContentColumn = styled.div`
   display: flex;
   flex-direction: column;
+
   &:not(:last-child) {
     margin-right: ${PT_GRID_SIZE_PX * 3}px;
   }
+
   min-width: 160px;
+`;
+
+export const Tag = styled(SDSTag)`
+  &.MuiChip-root {
+    background-color: ${gray100};
+    margin: 0;
+    padding: 2px 8px;
+
+    .MuiChip-label {
+      ${fontBodyXs};
+      color: #000000;
+      letter-spacing: -0.003em;
+    }
+  }
 `;

--- a/frontend/src/components/common/Grid/components/NTag/style.ts
+++ b/frontend/src/components/common/Grid/components/NTag/style.ts
@@ -34,7 +34,7 @@ export const Tag = styled(SDSTag)`
     padding: 2px 8px;
 
     .MuiChip-label {
-      ${fontBodyXs};
+      ${fontBodyXs}
       color: #000000;
       letter-spacing: -0.003em;
     }


### PR DESCRIPTION
## Reason for Change
- The collections and datasets index NTag UI has been updated.

- #4556

## Changes

- Modified the NTag to use `czifui` Tag component instead of `blueprintjs` and updated the style to match the [mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=4626-40099&t=fyFhxksWKZ4mSlsA-0) .e.g  padding, colour, font styles.

## Testing steps

- Go to collections index, the NTag UI should be updated.
