### PR TITLE
feat: Update collection and datasets tables to match mocks (#4557)

### DIFF
--- a/frontend/src/components/Collections/components/Grid/components/CollectionsGrid/style.ts
+++ b/frontend/src/components/Collections/components/Grid/components/CollectionsGrid/style.ts
@@ -5,4 +5,10 @@ export const CollectionsGrid = styled(Grid)`
   grid-template-columns:
     minmax(0, 8fr)
     minmax(0, 6fr) repeat(2, minmax(0, 5fr)) minmax(0, 3fr);
+
+  /* Collections heading */
+
+  th:first-of-type {
+    padding: 0;
+  }
 `;

--- a/frontend/src/components/Datasets/components/Grid/components/DatasetsGrid/style.ts
+++ b/frontend/src/components/Datasets/components/Grid/components/DatasetsGrid/style.ts
@@ -3,7 +3,12 @@ import Grid from "src/components/common/Grid";
 
 export const DatasetsGrid = styled(Grid)`
   grid-template-columns:
-    minmax(0, 8fr) minmax(0, 5fr) minmax(0, 4fr)
-    repeat(2, minmax(0, 3fr))
+    minmax(0, 8fr) minmax(0, 5fr) minmax(0, 4fr) repeat(2, minmax(0, 3fr))
     minmax(0, 2fr) auto;
+
+  /* Datasets heading */
+
+  th:first-of-type {
+    padding: 0;
+  }
 `;

--- a/frontend/src/components/common/Filter/common/entities.ts
+++ b/frontend/src/components/common/Filter/common/entities.ts
@@ -677,11 +677,6 @@ export interface TableCountSummary {
 }
 
 /**
- * "tableCountSummary" prop passed to react-table's Header function.
- */
-export type HeaderPropsValue = { tableCountSummary?: TableCountSummary };
-
-/**
  * "row" prop passed to react-table's Cell function.
  */
 export type RowPropsValue<T extends Categories> = { row: Row<T> };

--- a/frontend/src/components/common/Grid/common/entities.ts
+++ b/frontend/src/components/common/Grid/common/entities.ts
@@ -1,0 +1,15 @@
+/**
+ * Grid column configuration, extends React Table's ColumnInstance.
+ */
+export interface GridColumnProps {
+  alignment?: ALIGNMENT;
+  showCountAndTotal?: boolean;
+}
+
+/**
+ * Table header and data cell alignment.
+ */
+export enum ALIGNMENT {
+  LEFT = "LEFT",
+  RIGHT = "RIGHT",
+}

--- a/frontend/src/components/common/Grid/components/ActionsCell/style.ts
+++ b/frontend/src/components/common/Grid/components/ActionsCell/style.ts
@@ -5,4 +5,5 @@ export const Actions = styled.div`
   display: grid;
   gap: 0 8px;
   grid-auto-flow: column;
+  justify-content: flex-start;
 `;

--- a/frontend/src/components/common/Grid/components/ActionsCell/style.ts
+++ b/frontend/src/components/common/Grid/components/ActionsCell/style.ts
@@ -1,9 +1,12 @@
 import styled from "@emotion/styled";
+import { CommonThemeProps, getSpaces } from "czifui";
+
+const spacesS = (props: CommonThemeProps) => getSpaces(props)?.s;
 
 export const Actions = styled.div`
   align-items: center; /* required for the "more" dropdown button to center align with buttons i.e. "Download" and "Explore" */
   display: grid;
-  gap: 0 8px;
+  gap: 0 ${spacesS}px;
   grid-auto-flow: column;
   justify-content: flex-start;
 `;

--- a/frontend/src/components/common/Grid/components/HeaderCell/components/CountAndTotal/index.tsx
+++ b/frontend/src/components/common/Grid/components/HeaderCell/components/CountAndTotal/index.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { TableCountSummary } from "src/components/common/Filter/common/entities";
+import { CountAndTotal as Tag } from "./style";
+
+interface Props {
+  tableCountSummary?: TableCountSummary;
+}
+
+export default function CountAndTotal({
+  tableCountSummary,
+}: Props): JSX.Element {
+  const rowCount = tableCountSummary?.row;
+  const totalCount = tableCountSummary?.total;
+  const countAndTotal =
+    rowCount && totalCount ? `${rowCount} of ${totalCount}` : "";
+  return (
+    <>
+      {countAndTotal && (
+        <Tag
+          color="gray"
+          hover={false}
+          label={countAndTotal}
+          sdsStyle="square"
+          sdsType="primary"
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/common/Grid/components/HeaderCell/components/CountAndTotal/style.ts
+++ b/frontend/src/components/common/Grid/components/HeaderCell/components/CountAndTotal/style.ts
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+import { CommonThemeProps, fontBodyXs, getColors, Tag } from "czifui";
+
+const gray100 = (props: CommonThemeProps) => getColors(props)?.gray[100];
+const gray600 = (props: CommonThemeProps) => getColors(props)?.gray[600];
+
+export const CountAndTotal = styled(Tag)`
+  &.MuiChip-root {
+    background-color: ${gray100};
+    margin: 0;
+
+    .MuiChip-label {
+      ${fontBodyXs};
+      color: ${gray600};
+      font-weight: 500;
+      letter-spacing: -0.003em;
+    }
+  }
+`;

--- a/frontend/src/components/common/Grid/components/HeaderCell/components/CountAndTotal/style.ts
+++ b/frontend/src/components/common/Grid/components/HeaderCell/components/CountAndTotal/style.ts
@@ -10,7 +10,7 @@ export const CountAndTotal = styled(Tag)`
     margin: 0;
 
     .MuiChip-label {
-      ${fontBodyXs};
+      ${fontBodyXs}
       color: ${gray600};
       font-weight: 500;
       letter-spacing: -0.003em;

--- a/frontend/src/components/common/Grid/components/HeaderCell/index.tsx
+++ b/frontend/src/components/common/Grid/components/HeaderCell/index.tsx
@@ -1,27 +1,25 @@
-import React from "react";
-import { TableCountSummary } from "src/components/common/Filter/common/entities";
+import React, { ReactNode } from "react";
 import {
-  CountAndTotal,
+  Header,
   HeaderCell as Cell,
 } from "src/components/common/Grid/components/HeaderCell/style";
+import { ALIGNMENT } from "src/components/common/Grid/common/entities";
 
 interface Props {
-  label: string;
-  tableCountSummary?: TableCountSummary;
+  alignment?: ALIGNMENT;
+  label: ReactNode;
+  tag?: ReactNode;
 }
 
 export default function HeaderCell({
+  alignment = ALIGNMENT.LEFT,
   label,
-  tableCountSummary,
+  tag,
 }: Props): JSX.Element {
-  const rowCount = tableCountSummary?.row;
-  const totalCount = tableCountSummary?.total;
-  const countAndTotal =
-    rowCount && totalCount ? `${rowCount} of ${totalCount}` : "";
   return (
-    <Cell>
-      <span>{label}</span>
-      {countAndTotal && <CountAndTotal>{countAndTotal}</CountAndTotal>}
+    <Cell alignment={alignment}>
+      <Header>{label}</Header>
+      {tag}
     </Cell>
   );
 }

--- a/frontend/src/components/common/Grid/components/HeaderCell/style.ts
+++ b/frontend/src/components/common/Grid/components/HeaderCell/style.ts
@@ -1,28 +1,25 @@
 import styled from "@emotion/styled";
-import { fontBodyXxs, getColors } from "czifui";
+import { ALIGNMENT } from "src/components/common/Grid/common/entities";
+import { CommonThemeProps } from "czifui";
 
-export const HeaderCell = styled.span`
+interface Props extends CommonThemeProps {
+  alignment: ALIGNMENT;
+}
+
+export const Header = styled("span")`
+  align-items: center;
+  align-self: center;
   display: flex;
-  gap: 4px;
+  gap: 4px; /* gap between header and sort icon */
 
   span {
     min-width: 0; /* facilitates breaking of word on columns; flex default for min width is "auto" */
   }
 `;
 
-export const CountAndTotal = styled.span`
-  ${fontBodyXxs}
-  ${(props) => {
-    const colors = getColors(props);
-    return `
-      background-color: ${colors?.gray[200]};
-    `;
-  }}
-  border-radius: 20px;
-  color: #000000;
+export const HeaderCell = styled("th")<Props>`
   display: flex;
-  flex: none;
-  font-weight: 500;
-  height: 20px;
-  padding: 2px 8px;
+  gap: 4px; /* gap between header and count */
+  justify-content: ${(props) =>
+    props.alignment === ALIGNMENT.LEFT ? "flex-start" : "flex-end"};
 `;

--- a/frontend/src/components/common/Grid/components/HeaderCell/style.ts
+++ b/frontend/src/components/common/Grid/components/HeaderCell/style.ts
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
 import { ALIGNMENT } from "src/components/common/Grid/common/entities";
-import { CommonThemeProps } from "czifui";
+import { CommonThemeProps, getSpaces } from "czifui";
+
+const spacesXxs = (props: CommonThemeProps) => getSpaces(props)?.xxs;
 
 interface Props extends CommonThemeProps {
   alignment: ALIGNMENT;
@@ -10,7 +12,7 @@ export const Header = styled("span")`
   align-items: center;
   align-self: center;
   display: flex;
-  gap: 4px; /* gap between header and sort icon */
+  gap: ${spacesXxs}px; /* gap between header and sort icon */
 
   span {
     min-width: 0; /* facilitates breaking of word on columns; flex default for min width is "auto" */
@@ -19,7 +21,7 @@ export const Header = styled("span")`
 
 export const HeaderCell = styled("th")<Props>`
   display: flex;
-  gap: 4px; /* gap between header and count */
+  gap: ${spacesXxs}px; /* gap between header and count */
   justify-content: ${(props) =>
     props.alignment === ALIGNMENT.LEFT ? "flex-start" : "flex-end"};
 `;

--- a/frontend/src/components/common/Grid/components/LinkCell/style.ts
+++ b/frontend/src/components/common/Grid/components/LinkCell/style.ts
@@ -1,8 +1,12 @@
 import styled from "@emotion/styled";
-import { PRIMARY_BLUE, PRIMARY_BLUE_500 } from "src/components/common/theme";
+import { CommonThemeProps, getColors } from "czifui";
+
+const primary400 = (props: CommonThemeProps) => getColors(props)?.primary[400];
+const primary500 = (props: CommonThemeProps) => getColors(props)?.primary[500];
 
 export const StyledAnchor = styled.a`
-  color: ${PRIMARY_BLUE};
+  color: ${primary400};
+  display: block;
 
   &:focus {
     outline: none;
@@ -10,7 +14,7 @@ export const StyledAnchor = styled.a`
 
   &:hover {
     background: transparent;
-    color: ${PRIMARY_BLUE_500};
+    color: ${primary500};
     text-decoration: none;
   }
 `;

--- a/frontend/src/components/common/Grid/index.tsx
+++ b/frontend/src/components/common/Grid/index.tsx
@@ -4,6 +4,9 @@ import {
   TableCountSummary,
 } from "src/components/common/Filter/common/entities";
 import { Grid as StyledGrid } from "./style";
+import React from "react";
+import HeaderCell from "src/components/common/Grid/components/HeaderCell";
+import CountAndTotal from "src/components/common/Grid/components/HeaderCell/components/CountAndTotal";
 
 interface Props<T extends Categories> {
   className?: string;
@@ -30,9 +33,17 @@ export default function Grid<T extends Categories>({
                 const { key, ...restColumnHeaderProps } =
                   column.getHeaderProps();
                 return (
-                  <th key={key} {...restColumnHeaderProps}>
-                    {column.render("Header", { tableCountSummary })}
-                  </th>
+                  <HeaderCell
+                    key={key}
+                    alignment={column.alignment}
+                    label={column.render("Header")}
+                    tag={
+                      column.showCountAndTotal ? (
+                        <CountAndTotal tableCountSummary={tableCountSummary} />
+                      ) : undefined
+                    }
+                    {...restColumnHeaderProps}
+                  />
                 );
               })}
             </tr>

--- a/frontend/src/components/common/Grid/style.ts
+++ b/frontend/src/components/common/Grid/style.ts
@@ -1,14 +1,23 @@
 import styled from "@emotion/styled";
-import { CommonThemeProps, fontBodyS, getColors, getFontWeights } from "czifui";
+import {
+  CommonThemeProps,
+  fontBodyS,
+  getColors,
+  getFontWeights,
+  getSpaces,
+} from "czifui";
 
 const gray300 = (props: CommonThemeProps) => getColors(props)?.gray[300];
 const gray500 = (props: CommonThemeProps) => getColors(props)?.gray[500];
 const semiBold = (props: CommonThemeProps) => getFontWeights(props)?.semibold;
+const spacesM = (props: CommonThemeProps) => getSpaces(props)?.m;
+const spacesS = (props: CommonThemeProps) => getSpaces(props)?.s;
+const spacesXxxs = (props: CommonThemeProps) => getSpaces(props)?.xxxs;
 
 export const Grid = styled.table`
   display: grid;
   grid-auto-rows: auto;
-  grid-gap: 0 12px;
+  grid-gap: 0 ${spacesM}px;
   margin: 0;
 
   thead,
@@ -20,7 +29,7 @@ export const Grid = styled.table`
   /* row lines; span across grid gap */
 
   tr::after {
-    box-shadow: inset 0px -0.5px 0px ${gray300};
+    box-shadow: inset 0 -0.5px 0 ${gray300};
     content: "";
     height: 0.5px;
     grid-column: 1 / -1; /* spans grid column's entire set out */
@@ -41,11 +50,11 @@ export const Grid = styled.table`
     align-self: center;
     color: ${gray500};
     font-weight: ${semiBold};
-    margin-bottom: 8px;
-    padding: 2px 0;
+    margin-bottom: ${spacesS}px;
+    padding: ${spacesXxxs}px 0;
   }
 
   td {
-    padding: 12px 0;
+    padding: ${spacesM}px 0;
   }
 `;

--- a/frontend/src/components/common/Grid/style.ts
+++ b/frontend/src/components/common/Grid/style.ts
@@ -1,10 +1,14 @@
 import styled from "@emotion/styled";
-import { GRAY, PT_TEXT_COLOR } from "src/components/common/theme";
+import { CommonThemeProps, fontBodyS, getColors, getFontWeights } from "czifui";
+
+const gray300 = (props: CommonThemeProps) => getColors(props)?.gray[300];
+const gray500 = (props: CommonThemeProps) => getColors(props)?.gray[500];
+const semiBold = (props: CommonThemeProps) => getFontWeights(props)?.semibold;
 
 export const Grid = styled.table`
   display: grid;
   grid-auto-rows: auto;
-  grid-gap: 0 16px;
+  grid-gap: 0 12px;
   margin: 0;
 
   thead,
@@ -16,32 +20,32 @@ export const Grid = styled.table`
   /* row lines; span across grid gap */
 
   tr::after {
-    box-shadow: inset 0px -1px 0px rgba(16, 22, 26, 0.15);
+    box-shadow: inset 0px -0.5px 0px ${gray300};
     content: "";
-    height: 1px;
+    height: 0.5px;
     grid-column: 1 / -1; /* spans grid column's entire set out */
-    margin-top: -1px; /* positions box shadow 1px above lower bounds of tr */
+    margin-top: -0.5px; /* positions box shadow 0.5px above lower bounds of tr */
   }
 
   /* basic head and cell styles */
 
   th,
   td {
+    ${fontBodyS};
     border: none;
     font-feature-settings: normal; /* required; overrides layout.css specification */
-    font-size: 14px;
-    letter-spacing: -0.1px;
-    line-height: 20px;
+    letter-spacing: -0.006em;
   }
 
   th {
-    color: ${GRAY.A};
-    font-weight: 500;
-    padding: 0 0 14px 0;
+    align-self: center;
+    color: ${gray500};
+    font-weight: ${semiBold};
+    margin-bottom: 8px;
+    padding: 2px 0;
   }
 
   td {
-    color: ${PT_TEXT_COLOR};
     padding: 12px 0;
   }
 `;

--- a/frontend/src/components/common/Grid/style.ts
+++ b/frontend/src/components/common/Grid/style.ts
@@ -31,7 +31,7 @@ export const Grid = styled.table`
 
   th,
   td {
-    ${fontBodyS};
+    ${fontBodyS}
     border: none;
     font-feature-settings: normal; /* required; overrides layout.css specification */
     letter-spacing: -0.006em;

--- a/frontend/src/types/react-table-config.d.ts
+++ b/frontend/src/types/react-table-config.d.ts
@@ -12,6 +12,7 @@ import {
   UseSortByOptions,
   UseSortByState,
 } from "react-table";
+import { GridColumnProps } from "src/components/common/Grid/common/entities";
 
 declare module "react-table" {
   export interface TableOptions<D extends Record<string, unknown>>
@@ -35,10 +36,12 @@ declare module "react-table" {
   export interface ColumnInterface<
     D extends Record<string, unknown> = Record<string, unknown>
   > extends UseFiltersColumnOptions<D>,
-      UseSortByColumnOptions<D> {}
+      UseSortByColumnOptions<D>,
+      GridColumnProps {}
 
   export interface ColumnInstance<
     D extends Record<string, unknown> = Record<string, unknown>
   > extends UseFiltersColumnProps<D>,
-      UseSortByColumnProps<D> {}
+      UseSortByColumnProps<D>,
+      GridColumnProps {}
 }

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -1,14 +1,6 @@
 import Head from "next/head";
 import { useEffect, useMemo } from "react";
-import {
-  Column,
-  Filters,
-  HeaderProps,
-  Renderer,
-  useFilters,
-  useSortBy,
-  useTable,
-} from "react-table";
+import { Column, Filters, useFilters, useSortBy, useTable } from "react-table";
 import { PLURALIZED_METADATA_LABEL } from "src/common/constants/metadata";
 import { ROUTES } from "src/common/constants/routes";
 import { useCategoryFilter } from "src/common/hooks/useCategoryFilter/useCategoryFilter";
@@ -22,14 +14,12 @@ import {
   CATEGORY_FILTER_ID,
   CellPropsValue,
   CollectionRow,
-  HeaderPropsValue,
   MultiPanelSelectedUIState,
   RowPropsValue,
 } from "src/components/common/Filter/common/entities";
 import { ontologyLabelCellAccessorFn } from "src/components/common/Filter/common/utils";
 import { buildTableCountSummary } from "src/components/common/Grid/common/utils";
 import DiseaseCell from "src/components/common/Grid/components/DiseaseCell";
-import HeaderCell from "src/components/common/Grid/components/HeaderCell";
 import { GridHero } from "src/components/common/Grid/components/Hero";
 import LinkCell from "src/components/common/Grid/components/LinkCell";
 import NTagCell from "src/components/common/Grid/components/NTagCell";
@@ -80,15 +70,9 @@ export default function Collections(): JSX.Element {
             </Title>
           );
         },
-        Header: (({ tableCountSummary }: HeaderPropsValue) => {
-          return (
-            <HeaderCell
-              label={"Collections"}
-              tableCountSummary={tableCountSummary}
-            />
-          );
-        }) as Renderer<HeaderProps<CollectionRow>>,
+        Header: "Collections",
         accessor: COLLECTION_NAME,
+        showCountAndTotal: true,
       },
       {
         Cell: ({ row }: RowPropsValue<CollectionRow>) => {

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -4,7 +4,6 @@ import {
   CellProps,
   Column,
   Filters,
-  HeaderProps,
   Renderer,
   useFilters,
   useSortBy,
@@ -21,7 +20,6 @@ import {
   CATEGORY_FILTER_ID,
   CellPropsValue,
   DatasetRow,
-  HeaderPropsValue,
   MultiPanelSelectedUIState,
   RowPropsValue,
 } from "src/components/common/Filter/common/entities";
@@ -29,7 +27,6 @@ import { ontologyLabelCellAccessorFn } from "src/components/common/Filter/common
 import { buildTableCountSummary } from "src/components/common/Grid/common/utils";
 import CountCell from "src/components/common/Grid/components/CountCell";
 import DiseaseCell from "src/components/common/Grid/components/DiseaseCell";
-import HeaderCell from "src/components/common/Grid/components/HeaderCell";
 import { GridHero } from "src/components/common/Grid/components/Hero";
 import NTagCell from "src/components/common/Grid/components/NTagCell";
 import { RightAlignCell } from "src/components/common/Grid/components/RightAlignCell";
@@ -38,6 +35,7 @@ import DatasetsActionsCell from "src/components/Datasets/components/Grid/compone
 import DatasetNameCell from "src/components/Datasets/components/Grid/components/DatasetNameCell";
 import { DatasetsGrid } from "src/components/Datasets/components/Grid/components/DatasetsGrid/style";
 import { View } from "../globalStyle";
+import { ALIGNMENT } from "src/components/common/Grid/common/entities";
 
 /**
  * Collection ID object key.
@@ -101,15 +99,9 @@ export default function Datasets(): JSX.Element {
             />
           );
         },
-        Header: (({ tableCountSummary }: HeaderPropsValue) => {
-          return (
-            <HeaderCell
-              label={"Datasets"}
-              tableCountSummary={tableCountSummary}
-            />
-          );
-        }) as Renderer<HeaderProps<DatasetRow>>,
+        Header: "Datasets",
         accessor: DATASET_NAME,
+        showCountAndTotal: true,
       },
       {
         Cell: (({ value }: CellPropsValue<string[]>) => (
@@ -155,8 +147,9 @@ export default function Datasets(): JSX.Element {
             <CountCell cellCount={value || 0} />
           </RightAlignCell>
         ),
-        Header: <RightAlignCell>Cells</RightAlignCell>,
+        Header: "Cells",
         accessor: "cell_count",
+        alignment: ALIGNMENT.RIGHT,
         filter: "between",
         id: CATEGORY_FILTER_ID.CELL_COUNT,
       },


### PR DESCRIPTION
## Reason for Change
- Collections and Datasets index table ui updated to match [mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=4626-40099&t=0WAYPzpZ8eh7QPpT-0).

- #4557

## Changes

- modified collections and datasets table ui to match the [mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=4626-40099&t=0WAYPzpZ8eh7QPpT-0).
- added a new header component with updated styles, in preparation for [sorting](https://github.com/chanzuckerberg/single-cell-data-portal/issues/4559).

## Testing steps

- Go to collections page and review:
  - header and cell spacing, font styles, colour, and
  - collection cell font styles and colour, and
  - collection and datasets heading count tag, and
  - table spacing and borders.

## Notes for Reviewer

- Update: font-weight specification import resolved by #4617. Commentary below is out of date.
- The table header specification for font-weight is `600` as per the [mock](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=4626-40099&t=0WAYPzpZ8eh7QPpT-0). The theme `fontWeights` are as follows:

```
light: 300
regular: 400
semibold: 600
bold: 700
medium: 800
```

In the instance of the table header, the `semibold` font-weight has been specified. However, this font-weight has not been embedded see `frontend/src/pages/_document.tsx` lines `34-37`. 

Updating the resource to include font-weight `600` will have a material impact on any styles currently using a font-weight of 600, that is, currently, any element with a font-weight of `600` is probably defaulting to font-weight `700`.

Some examples include:
- All theme typography headers styles.
- All theme typography "caps" styles.
- Where's My Gene Filter Label `frontend/src/views/WheresMyGene/components/Filters/components/common/style.ts`, e.g. "Organism".
- Where's My Gene Side Bar Label `frontend/src/views/WheresMyGene/components/Main/style.ts` e.g. "Filters".
- Where's My Gene Cell Info Side Bar `frontend/src/views/WheresMyGene/components/CellInfoSideBar/style.ts` e.g. "Marker Genes"
- Landing Header Hiring Link `frontend/src/components/LandingHeader/style.ts` e.g. "We're hiring".
- Landing Page - the hero heading "Discover the mechanisms of human health" and other elements.