### PR TITLE
feat: Add create collection button to collections list for curators (#4560)

### DIFF
--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -24,7 +24,9 @@ const AsyncCTA = loadable(
 );
 
 const CreateCollectionButton = (props: Partial<IButtonProps>) => (
-  <StyledButton {...props}>Create Collection</StyledButton>
+  <StyledButton sdsStyle="square" sdsType="primary" {...props}>
+    Create Collection
+  </StyledButton>
 );
 
 const CreateCollection: FC<{

--- a/frontend/src/components/CreateCollectionModal/style.ts
+++ b/frontend/src/components/CreateCollectionModal/style.ts
@@ -1,7 +1,10 @@
 import styled from "@emotion/styled";
-import { Button } from "../common/Button";
+import { Button } from "czifui";
 
 export const StyledButton = styled(Button)`
-  height: 30px;
-  padding: 0 12px;
+  font-weight: 500;
+  height: 32px; /* overrides czifui height style declaration */
+  justify-self: flex-end;
+  letter-spacing: -0.006em;
+  padding: 6px 12px;
 `;

--- a/frontend/src/views/Collections/common/constants.ts
+++ b/frontend/src/views/Collections/common/constants.ts
@@ -1,0 +1,32 @@
+/**
+ * Collection ID object key.
+ */
+export const COLLECTION_ID = "id";
+
+/**
+ * Collection name object key.
+ */
+export const COLLECTION_NAME = "name";
+
+/**
+ * Collection recency object key.
+ */
+export const COLLECTION_RECENCY = "recency";
+
+/**
+ * Collection summary citation object key.
+ */
+export const COLLECTION_SUMMARY_CITATION = "summaryCitation";
+
+/**
+ * Key identifying recency sort by column.
+ */
+export const COLUMN_ID_RECENCY = "recency";
+
+/**
+ * Collections mode (collections or my-collections).
+ */
+export enum COLLECTIONS_MODE {
+  COLLECTIONS = "COLLECTIONS",
+  MY_COLLECTIONS = "MY_COLLECTIONS",
+}

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -35,34 +35,30 @@ import LinkCell from "src/components/common/Grid/components/LinkCell";
 import NTagCell from "src/components/common/Grid/components/NTagCell";
 import { Title } from "src/components/common/Grid/components/Title";
 import SideBar from "src/components/common/SideBar";
-import { View } from "src/views/globalStyle";
-
-/**
- * Collection ID object key.
- */
-const COLLECTION_ID = "id";
-
-/**
- * Collection name object key.
- */
-const COLLECTION_NAME = "name";
-
-/**
- * Collection summary citation object key.
- */
-const COLLECTION_SUMMARY_CITATION = "summaryCitation";
-
-/**
- * Key identifying recency sort by column.
- */
-const COLUMN_ID_RECENCY = "recency";
-
-/**
- * Recency object key.
- */
-const RECENCY = "recency";
+import CreateCollection from "src/components/CreateCollectionModal";
+import { CollectionsView as View } from "./style";
+import { FEATURES } from "src/common/featureFlags/features";
+import { useUserInfo } from "src/common/queries/auth";
+import {
+  COLLECTION_ID,
+  COLLECTION_NAME,
+  COLLECTION_RECENCY,
+  COLLECTION_SUMMARY_CITATION,
+  COLLECTIONS_MODE,
+  COLUMN_ID_RECENCY,
+} from "src/views/Collections/common/constants";
+import { get } from "src/common/featureFlags";
+import { BOOLEAN } from "src/common/localStorage/set";
 
 export default function Collections(): JSX.Element {
+  const isCuratorEnabled = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
+  const { status } = useUserInfo(isCuratorEnabled);
+  const mode = useMemo((): COLLECTIONS_MODE => {
+    return status === "success"
+      ? COLLECTIONS_MODE.MY_COLLECTIONS
+      : COLLECTIONS_MODE.COLLECTIONS;
+  }, [status]);
+
   // Pop toast if user has been redirected from a tombstoned collection.
   useExplainTombstoned();
 
@@ -132,7 +128,7 @@ export default function Collections(): JSX.Element {
       },
       // Hidden, required for sorting
       {
-        accessor: RECENCY,
+        accessor: COLLECTION_RECENCY,
         id: COLUMN_ID_RECENCY,
       },
       // Hidden, required for accessing collection ID via row.values, for building link to collection detail page.
@@ -303,6 +299,7 @@ export default function Collections(): JSX.Element {
             <Filter {...filterInstance} />
           </SideBar>
           <View>
+            {mode === COLLECTIONS_MODE.MY_COLLECTIONS && <CreateCollection />}
             {!rows || rows.length === 0 ? (
               <GridHero>
                 <h3>No Results</h3>

--- a/frontend/src/views/Collections/style.ts
+++ b/frontend/src/views/Collections/style.ts
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+import { View } from "src/views/globalStyle";
+
+export const CollectionsView = styled(View)`
+  display: grid;
+  gap: 24px;
+  place-content: flex-start stretch;
+`;


### PR DESCRIPTION
## Reason for Change

Curators are able to create a collection from the collections index.

- #4560

## Changes

- Added Create Collection button to collections index, for curators only.
- Updated Create Collection button from `blueprint` to `czifui`, and styles to match [mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?node-id=4626-40099&t=0WAYPzpZ8eh7QPpT-0).

## Testing steps

- Go to collections index, the "Create Collection" button should not be visible.
- Use the curator feature flag, the "Create Collection" button should not be visible.
- Log in, the "Create Collection" button should be visible.
- Click on the "Create Collection" button and add a new collection. Flow should be unchanged i.e. when a new private collection is created the page should route to the private collection.
- Cancelling the "Create Collection" modal should close the modal, and return the user to the collections index.