### PR TITLE
feat: fix response shape for curation API datasets/<dataset_id>/versions endpoint

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -520,7 +520,7 @@ paths:
         in reverse-chronological order.
       operationId: backend.curation.api.v1.curation.collections.collection_id.versions.get
       tags:
-        - collection
+        - collection_version
       parameters:
         - $ref: "#/components/parameters/path_collection_id"
       responses:
@@ -581,7 +581,7 @@ paths:
     get:
       summary: List all versions for a Dataset
       tags:
-        - dataset
+        - dataset_version
       description: |
         List all versions for a given Dataset. The `dataset_id` must reference a *Dataset*, **NOT** a *Dataset version*.
         Dataset versions are returned in reverse-chronological order.

--- a/backend/curation/api/v1/curation/datasets/dataset_id/versions/actions.py
+++ b/backend/curation/api/v1/curation/datasets/dataset_id/versions/actions.py
@@ -23,4 +23,6 @@ def get(dataset_id: str):
     # business function returns in chronological order; must return in reverse chronological
     dataset_versions.reverse()
 
-    return make_response(jsonify(reshape_datasets_for_curation_api(dataset_versions, use_canonical_url=False)), 200)
+    return make_response(
+        jsonify(reshape_datasets_for_curation_api(dataset_versions, use_canonical_url=False, as_version=True)), 200
+    )


### PR DESCRIPTION
## Reason for Change

- #4581
- #4582

## Changes
-  Passed arg that will 1) remove unexpected revised_at timestamp from dataset version history endpoint entries, and 2) populate published_at timestamp with the expected logic for the version history endpoint (logic for both already exists in common function, call was just missing the right arg)
- Updated curation API spec to clarify that dataset_versions are returned by  datasets/<dataset_id>/versions endpoint. In the Swagger, the different meaning of the published_at timestamp for dataset_versions objects (vs dataset objects) is documented, but the Open API spec had tagged this endpoint under 'datasets' instead, so the distinction wasn't clear.
- Added test case for bug scenario

## Testing steps
- unit tests 

## Notes for Reviewer
- I think we need to clean up the arg names / branching logic in the reshape functions (i.e. as_canonical vs. use_canonical_url sound too similar, but datasets in revisions returned in the canonical collection/dataset endpoints represent a scenario where you want as_canonical = True but use_canonical_url = False). We should make the distinction more clear. 
- We should also try to fix the fact we use as_version as the arg in some reshape functions, but as_canonical in others.
- Above is not in scope for the bug fix
