### PR TITLE
feat: Update inter font weights to match app theme requirements (#4617)

### DIFF
--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -32,7 +32,7 @@ export default class Document extends RawDocument {
           <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
           <meta name="theme-color" content="#000000" />
           <link
-            href="https://fonts.googleapis.com/css?family=Inter:400,500,700&amp;display=swap"
+            href="https://fonts.googleapis.com/css?family=Inter:300,400,500,600,700,800&amp;display=swap"
             rel="stylesheet"
           />
 


### PR DESCRIPTION
## Specified app theme font-weights should render their corresponding font-weight. Currently font-weights `300`, `600` and `800` are not imported.

- #4617 

## Changes

- added font-weight `300`, `600` and `800` to Inter import.

## Testing steps

- Review all elements using a font-weight of `300`, or `600` or `800` (`light`, `semibold`, or `medium`) to confirm correct rendering of the specified font-weight.

## Notes for Reviewer
- See https://github.com/chanzuckerberg/single-cell-data-portal/issues/4207 and https://github.com/chanzuckerberg/single-cell-data-portal/pull/4562