### PR TITLE
feat: always return dataset_version_id dataset permalink

### DIFF
--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -40,9 +40,7 @@ def extract_dataset_assets(dataset_version: DatasetVersion):
         filesize = get_business_logic().s3_provider.get_file_size(asset.uri)
         if filesize is None:
             filesize = -1
-        # Note: this key parsing assumes asset.uri from DB has `<bucket>/<uuid>/local.<file_type>` directory structure
-        key_uuid = urlparse(asset.uri).path.split("/")[-2]
-        url = f"{base_url}/{key_uuid}.{asset.type}"
+        url = f"{base_url}/{dataset_version.version_id.id}.{asset.type}"
         result = {
             "filesize": filesize,
             "filetype": asset.type.upper(),

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -24,7 +24,7 @@ from backend.layers.common.entities import (
 from backend.layers.thirdparty.crossref_provider import CrossrefDOINotFoundException
 from tests.unit.backend.layers.api.test_portal_api import generate_mock_publisher_metadata
 from tests.unit.backend.layers.common.base_api_test import BaseAPIPortalTest
-from tests.unit.backend.layers.common.base_test import DatasetStatusUpdate
+from tests.unit.backend.layers.common.base_test import DatasetArtifactUpdate, DatasetStatusUpdate
 
 mock_config_attr = {
     "curator_role_arn": "test_role_arn",
@@ -632,6 +632,12 @@ class TestGetCollectionID(BaseAPIPortalTest):
         self.generate_dataset(
             collection_version=collection_version,
             metadata=dataset_metadata,
+            artifacts=[
+                DatasetArtifactUpdate(type="h5ad", uri="http://test_filename/1234-5678-9/local.h5ad"),
+                DatasetArtifactUpdate(type="rds", uri="http://test_filename/1234-5678-9/local.rds"),
+                DatasetArtifactUpdate(type="cxg", uri="http://test_filename/1234-5678-9/local.cxg"),
+                DatasetArtifactUpdate(type="raw_h5ad", uri="http://test_filename/1234-5678-9/raw.h5ad"),
+            ],
         )
         self.business_logic.publish_collection_version(collection_version.version_id)
         collection_version = self.business_logic.get_collection_version(collection_version.version_id)

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -24,7 +24,7 @@ from backend.layers.common.entities import (
 from backend.layers.thirdparty.crossref_provider import CrossrefDOINotFoundException
 from tests.unit.backend.layers.api.test_portal_api import generate_mock_publisher_metadata
 from tests.unit.backend.layers.common.base_api_test import BaseAPIPortalTest
-from tests.unit.backend.layers.common.base_test import DatasetArtifactUpdate, DatasetStatusUpdate
+from tests.unit.backend.layers.common.base_test import DatasetStatusUpdate
 
 mock_config_attr = {
     "curator_role_arn": "test_role_arn",
@@ -632,12 +632,6 @@ class TestGetCollectionID(BaseAPIPortalTest):
         self.generate_dataset(
             collection_version=collection_version,
             metadata=dataset_metadata,
-            artifacts=[
-                DatasetArtifactUpdate(type="h5ad", uri="http://test_filename/1234-5678-9/local.h5ad"),
-                DatasetArtifactUpdate(type="rds", uri="http://test_filename/1234-5678-9/local.rds"),
-                DatasetArtifactUpdate(type="cxg", uri="http://test_filename/1234-5678-9/local.cxg"),
-                DatasetArtifactUpdate(type="raw_h5ad", uri="http://test_filename/1234-5678-9/raw.h5ad"),
-            ],
         )
         self.business_logic.publish_collection_version(collection_version.version_id)
         collection_version = self.business_logic.get_collection_version(collection_version.version_id)
@@ -657,12 +651,12 @@ class TestGetCollectionID(BaseAPIPortalTest):
                     {
                         "filesize": -1,
                         "filetype": "H5AD",
-                        "url": "http://domain/1234-5678-9.h5ad",
+                        "url": f"http://domain/{dataset.version_id.id}.h5ad",
                     },
                     {
                         "filesize": -1,
                         "filetype": "RDS",
-                        "url": "http://domain/1234-5678-9.rds",
+                        "url": f"http://domain/{dataset.version_id.id}.rds",
                     },
                 ],
                 "is_primary_data": [True, False],


### PR DESCRIPTION
Previously, all pre-redesign datasets lived under a key in the public-access datasets bucket that was different from their dataset version ids. Now, all past and future assets live under their dataset version id.

## Reason for Change

- #4621 
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- modify asset uri to reflect dataset version id, and not the uuid that is part of the corpora prod asset

## Testing steps

- unit tested

## Notes for Reviewer
