### PR TITLE
fix: make s3 layer throw its own exceptions

### DIFF
--- a/backend/layers/business/exceptions.py
+++ b/backend/layers/business/exceptions.py
@@ -95,3 +95,11 @@ class CollectionPublishException(BusinessException):
 
 class ArtifactNotFoundException(BusinessException):
     pass
+
+
+class CollectionDeleteException(BusinessException):
+    """
+    Raised when an attempt to delete a Collection fails
+    """
+
+    pass

--- a/backend/layers/processing/requirements.txt
+++ b/backend/layers/processing/requirements.txt
@@ -1,5 +1,4 @@
 git+https://github.com/chanzuckerberg/single-cell-curation.git@51907ef539b8e2a11ad442e2514431c18d991e20#egg=cellxgene-schema&subdirectory=cellxgene_schema_cli
-connexion==2.13.0
 dataclasses-json
 matplotlib==3.6.3 # 3.7.0 isn't compatible with scanpy: https://github.com/scverse/scanpy/issues/2411
 numba==0.56.2
@@ -10,7 +9,6 @@ psycopg2-binary>=2.8.5
 pyarrow>=1.0
 pydantic>=1.9.0
 python-json-logger
-requests>=2.22.0
 scanpy==1.6.0
 SQLAlchemy-Utils>=0.36.8
 SQLAlchemy>=1.4.0,<1.5

--- a/backend/layers/thirdparty/s3_exceptions.py
+++ b/backend/layers/thirdparty/s3_exceptions.py
@@ -1,0 +1,12 @@
+from typing import List, Optional
+
+
+class S3Exception(Exception):
+    # TODO maybe useful as a base class, maybe not
+    pass
+
+
+class S3DeleteException(S3Exception):
+    def __init__(self, errors: Optional[List[dict]] = None) -> None:
+        self.errors: Optional[List[dict]] = errors
+        super().__init__()

--- a/backend/layers/thirdparty/s3_provider.py
+++ b/backend/layers/thirdparty/s3_provider.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 import boto3
 
-from backend.common.utils.http_exceptions import ServerErrorHTTPException
+from backend.layers.thirdparty.s3_exceptions import S3DeleteException
 from backend.layers.thirdparty.s3_provider_interface import S3ProviderInterface
 
 AWS_S3_MAX_ITEMS_PER_BATCH = 1000
@@ -69,7 +69,7 @@ class S3Provider(S3ProviderInterface):
                 logger.info(f"Deleted: {deleted}")
             if errors := resp.get("Errors"):
                 logger.info(f"Errors: {errors}")
-                raise ServerErrorHTTPException()
+                raise S3DeleteException(errors)
 
     def download_file(self, bucket_name: str, object_key: str, local_filename: str):
         """

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -22,6 +22,7 @@ from backend.layers.business.entities import CollectionMetadataUpdate, Collectio
 from backend.layers.business.exceptions import (
     ArtifactNotFoundException,
     CollectionCreationException,
+    CollectionDeleteException,
     CollectionIsPublishedException,
     CollectionNotFoundException,
     CollectionPublishException,
@@ -454,7 +455,10 @@ def delete_collection(collection_id: str, token_info: dict):
         except CollectionIsPublishedException:
             raise ForbiddenHTTPException() from None
     elif isinstance(resource_id, CollectionId):
-        get_business_logic().tombstone_collection(resource_id)
+        try:
+            get_business_logic().tombstone_collection(resource_id)
+        except CollectionDeleteException() as e:
+            raise ServerErrorHTTPException(e.errors) from e
 
 
 def update_collection(collection_id: str, body: dict, token_info: dict):

--- a/backend/wmg/pipeline/requirements.txt
+++ b/backend/wmg/pipeline/requirements.txt
@@ -1,4 +1,3 @@
-connexion==2.13.0
 dataclasses_json>=0.5.7
 numpy>=1.23.2
 numba>=0.56.2
@@ -9,6 +8,5 @@ psycopg2-binary>=2.8.5
 pyarrow>=11.0.0
 pydantic>=1.9.0
 pygraphviz>=1.10
-requests>=2.22.0
 scanpy>=1.9.1
 scipy>=1.9.1

--- a/tests/unit/backend/layers/thirdparty/test_s3_provider.py
+++ b/tests/unit/backend/layers/thirdparty/test_s3_provider.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from backend.common.utils.http_exceptions import ServerErrorHTTPException
+from backend.layers.thirdparty.s3_exceptions import S3DeleteException
 from backend.layers.thirdparty.s3_provider import S3Provider
 
 
@@ -13,7 +13,7 @@ class TestS3Provider(unittest.TestCase):
                 "Objects": ["object"],
                 "Errors": ["error"],
             }
-            with self.assertRaises(ServerErrorHTTPException):
+            with self.assertRaises(S3DeleteException):
                 S3Provider().delete_files("bucket", ["key"])
         with self.subTest("Does not raise errors when Errors list is empty and Objects list is not empty"):
             mock_client_constructor.return_value.delete_objects.return_value = {"Objects": ["object"], "Errors": []}


### PR DESCRIPTION
## Reason for Change

- #4641 

## Changes

- decouple s3 layer from api layer
- remove unnecessary imports that were imperfectly bandaiding dependency hell
- import s3 *interface* in business logic, not s3 *provider*

## Testing steps

- Tests updated

## Notes for Reviewer
