### PR TITLE
docs: introduce Collection versions and Dataset versions

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -554,7 +554,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/collection"
+                  $ref: "#/components/schemas/collection_version"
         "403":
           $ref: "#/components/responses/403"
         "404":

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -26,12 +26,12 @@ info:
     #### Version identifiers
     While the *Collection* identifier `collection_id` will always refer to the latest published instance of a Collection
     (like the "head" in version-control terminology), and must be used with `../collections/..` endpoints, the
-    *Collection version* identifier `collection_version_id` points always to one specific published instance (version)
+    *Collection Version* identifier `collection_version_id` points always to one specific published instance (version)
     of a Collection (like a commit hash) and must be used with `../collection_version/..`
-    endpoints. The same is true for *Datasets* and *Dataset versions*, though it is important to note that if a given Dataset
-    is not updated during the course of a revision of its parent Collection, then its *Dataset version* identifier
-    `dataset_version_id` will not change and will appear identically in the list of *Dataset versions* associated with the
-    Collection version from *before* the revision as well as with the Collection version from *after* the revision. Private Collections,
+    endpoints. The same is true for *Datasets* and *Dataset Versions*, though it is important to note that if a given Dataset
+    is not updated during the course of a revision of its parent Collection, then its *Dataset Version* identifier
+    `dataset_version_id` will not change and will appear identically in the list of *Dataset Versions* associated with the
+    Collection Version from *before* the revision as well as with the Collection Version from *after* the revision. Private Collections,
     private revisions of published Collections, and their constituent (private) Datasets are not available as *versions*
     until they are published, and therefore must be referenced via their `collection_id` and `dataset_id` identifiers
     using `../collections/..` and `../datasets/..` endpoints, respectively. As such, mutation actions cannot be
@@ -536,14 +536,14 @@ paths:
 
   /v1/collections/{collection_id}/versions:
     get:
-      summary: Fetch all versions of a Collection with corresponding Dataset versions
+      summary: Fetch all versions of a Collection with corresponding Dataset Versions
       description: >
-        Fetch full metadata for all versions of a Collection and their corresponding Dataset versions. The
-        `collection_id` must reference a *Collection*, **NOT** a *Collection version*. Collection versions are returned
+        Fetch full metadata for all versions of a Collection and their corresponding Dataset Versions. The
+        `collection_id` must reference a *Collection*, **NOT** a *Collection Version*. Collection Versions are returned
         in reverse-chronological order.
       operationId: backend.curation.api.v1.curation.collections.collection_id.versions.get
       tags:
-        - Collection version
+        - Collection Version
       parameters:
         - $ref: "#/components/parameters/path_collection_id"
       responses:
@@ -564,13 +564,13 @@ paths:
 
   /v1/collection_versions/{collection_version_id}:
     get:
-      summary: Fetch a Collection version with Dataset versions
+      summary: Fetch a Collection Version with Dataset Versions
       description: >
-        Fetch full metadata for a published Collection version and its Dataset versions. The `collection_version_id` 
-        must reference a *Collection version*, **NOT** a *Collection*.
+        Fetch full metadata for a published Collection Version and its Dataset Versions. The `collection_version_id`
+        must reference a *Collection Version*, **NOT** a *Collection*.
       operationId: backend.curation.api.v1.curation.collection_versions.collection_version_id.actions.get
       tags:
-        - Collection version
+        - Collection Version
       parameters:
         - $ref: "#/components/parameters/path_collection_version_id"
       responses:
@@ -610,10 +610,10 @@ paths:
     get:
       summary: List all versions for a Dataset
       tags:
-        - Dataset version
+        - Dataset Version
       description: |
-        List all versions for a given Dataset. The `dataset_id` must reference a *Dataset*, **NOT** a *Dataset version*.
-        Dataset versions are returned in reverse-chronological order.
+        List all versions for a given Dataset. The `dataset_id` must reference a *Dataset*, **NOT** a *Dataset Version*.
+        Dataset Versions are returned in reverse-chronological order.
       operationId: backend.curation.api.v1.curation.datasets.dataset_id.versions.actions.get
       parameters:
         - $ref: "#/components/parameters/path_dataset_id"
@@ -633,11 +633,11 @@ paths:
 
   /v1/dataset_versions/{dataset_version_id}:
     get:
-      summary: Get full metadata for a Dataset version
+      summary: Get full metadata for a Dataset Version
       tags:
-        - Dataset version
+        - Dataset Version
       description: |
-        Fetch Dataset metadata for a Dataset version. The `dataset_version_id` must reference a *Dataset version*,
+        Fetch Dataset metadata for a Dataset Version. The `dataset_version_id` must reference a *Dataset Version*,
         **NOT** a *Dataset*.
       operationId: backend.curation.api.v1.curation.dataset_versions.dataset_version_id.actions.get
       parameters:
@@ -869,7 +869,7 @@ components:
           $ref: "#/components/schemas/visibility"
       type: object
     collection_version:
-      description: Collection version metadata
+      description: Collection Version metadata
       properties:
         collection_id:
           $ref: "#/components/schemas/collection_id"
@@ -889,7 +889,7 @@ components:
           $ref: "#/components/schemas/curator_name"
         datasets:
           type: array
-          description: A list of Dataset metadata associated with the Collection version
+          description: A list of Dataset metadata associated with the Collection Version
           items:
             $ref: "#/components/schemas/dataset_version"
         description:
@@ -1138,7 +1138,7 @@ components:
           $ref: "#/components/schemas/collection_id"
         collection_version_id:
           description: |
-            The *Collection Version* in which this *Dataset version* was first published.
+            The *Collection Version* in which this *Dataset Version* was first published.
           type: string
           format: uuid
         dataset_id:

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -37,22 +37,6 @@ info:
     using `../collections/..` and `../datasets/..` endpoints, respectively. As such, mutation actions cannot be
     performed using version identifiers.
 
-    #### Interpreting `published_at` and `revised_at` timestamps with versions
-    When retrieving data about *Collections* or *Datasets*, these fields convey the following:
-
-    * `published_at`: the timestamp of the first publication of the *Collection*/*Dataset*, i.e., the publication
-    of the first version.
-
-    * `revised_at`: the timestamp of the publication of the most recent revision of the *Collection*/*Dataset*
-
-    However, when retrieving data about *Collection versions* or *Dataset versions*:
-
-    * `published_at`: the timestamp of the publication of this particular version
-
-    Therefore, in the case of a Collection, the `published_at` timestamp for its latest *Collection version* will be
-    equal to the `revised_at` timestamp for the *Collection*. There is no `revised_at` attribute associated with an
-    entity version.
-
 servers:
   - description: Production environment
     url: https://api.cellxgene.cziscience.com/
@@ -814,6 +798,9 @@ components:
       description: A timestamp indicating the last time a Revision for this Dataset was published.
       nullable: true
       type: string
+    collection_version_published_at:
+      description: A timestamp of when this Collection Version was published.
+      type: string
     collection_revising_in:
       type: string
       description: >
@@ -914,7 +901,7 @@ components:
         name:
           $ref: "#/components/schemas/collection_name"
         published_at:
-          $ref: "#/components/schemas/published_at"
+          $ref: "#/components/schemas/collection_version_published_at"
         publisher_metadata:
           $ref: "#/components/schemas/publisher_metadata"
         visibility:

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -26,13 +26,13 @@ info:
     While the *Collection* identifier `collection_id` will always refer to the latest published instance of a Collection
     (like the "head" in version-control terminology), and must be used with `Collection` endpoints, the
     *Collection Version* identifier `collection_version_id` points always to one specific published instance (version)
-    of a Collection (like a commit hash) and must be used with `Collection Version` endpoints.
-    endpoints. The same is true for *Datasets* and *Dataset Versions*, though it is important to note that if a given Dataset
+    of a Collection (like a commit hash) and must be used with `Collection Version` endpoints. The same is true for
+    *Datasets* and *Dataset Versions*, though it is important to note that if a given Dataset
     is not updated during the course of a revision of its parent Collection, then its Dataset Version (and identifier
     `dataset_version_id`) will not change even though a new Collection Version has been published. Private Collections,
-    private revisions of published Collections, and their constituent (private) Datasets are not available as *Versions*
+    private revisions of published Collections, and their constituent (private) Datasets are not available as Versions
     until they are published, and therefore must be referenced via their `collection_id` and `dataset_id` identifiers
-    using `Collection` and `Dataset` endpoints, respectively. As such, mutation actions cannot be
+    using `Collection` and `Dataset` endpoints. As such, mutation actions cannot be
     performed using version identifiers.
 
 servers:

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -17,7 +17,7 @@ info:
 
     ## Working with versions
 
-    #### Access to prior published version history
+    #### Access to published version history
     The CZ CELLxGENE Discover API supports access to all published versions of Collections and Datasets. For example,
     if a Dataset was published and then later updated and published again, then both Dataset Versions can be accessed.
 

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -24,15 +24,15 @@ info:
 
     #### Version identifiers
     While the *Collection* identifier `collection_id` will always refer to the latest published instance of a Collection
-    (like the "head" in version-control terminology), and must be used with `../collections/..` endpoints, the
+    (like the "head" in version-control terminology), and must be used with `Collection` endpoints, the
     *Collection Version* identifier `collection_version_id` points always to one specific published instance (version)
-    of a Collection (like a commit hash) and must be used with `../collection_version/..`
+    of a Collection (like a commit hash) and must be used with `Collection Version` endpoints.
     endpoints. The same is true for *Datasets* and *Dataset Versions*, though it is important to note that if a given Dataset
     is not updated during the course of a revision of its parent Collection, then its *Dataset Version* identifier
     `dataset_version_id` will not change even though a new Collection Version has been published. Private Collections,
     private revisions of published Collections, and their constituent (private) Datasets are not available as *Versions*
     until they are published, and therefore must be referenced via their `collection_id` and `dataset_id` identifiers
-    using `../collections/..` and `../datasets/..` endpoints, respectively. As such, mutation actions cannot be
+    using `Collection` and `Dataset` endpoints, respectively. As such, mutation actions cannot be
     performed using version identifiers.
 
 servers:

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -18,19 +18,18 @@ info:
     ## Working with versions
 
     #### Access to prior published version history
-    The CZ CELLxGENE Discover API employs the concept of *Versions* for our two core entities, *Collections* and
-    *Datasets*. This is to permit access to prior published instances (versions) of these entities even as new updates
-    for them are published.
+    The CZ CELLxGENE Discover API supports access to all published versions of Collections and Datasets. For example,
+    if a Dataset was published and then later updated and published again, then both Dataset Versions can be accessed.
 
     #### Version identifiers
-    While the *Collection* identifier `collection_id` will always refer to the latest published instance of a Collection
+    While the *Collection* identifier `collection_id` will always refer to the latest published version of a Collection
     (like the "head" in version-control terminology), and must be used with `Collection` endpoints, the
-    *Collection Version* identifier `collection_version_id` points always to one specific published instance (version)
-    of a Collection (like a commit hash) and must be used with `Collection Version` endpoints. The same is true for
+    *Collection Version* identifier `collection_version_id` refers to one specific published version
+    of a Collection and must be used with `Collection Version` endpoints. The same is true for
     *Datasets* and *Dataset Versions*, though it is important to note that if a given Dataset
     is not updated during the course of a revision of its parent Collection, then its Dataset Version (and identifier
     `dataset_version_id`) will not change even though a new Collection Version has been published. Private Collections,
-    private revisions of published Collections, and their constituent (private) Datasets are not available as Versions
+    private revisions of published Collections, and any new or updated Datasets are not available as Versions
     until they are published, and therefore must be referenced via their `collection_id` and `dataset_id` identifiers
     using `Collection` and `Dataset` endpoints. As such, mutation actions cannot be
     performed using Version identifiers.

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -22,11 +22,10 @@ info:
     if a Dataset was published and then later updated and published again, then both Dataset Versions can be accessed.
 
     #### Version identifiers
-    While the *Collection* identifier `collection_id` will always refer to the latest published version of a Collection
-    (like the "head" in version-control terminology), and must be used with `Collection` endpoints, the
-    *Collection Version* identifier `collection_version_id` refers to one specific published version
-    of a Collection and must be used with `Collection Version` endpoints. The same is true for
-    *Datasets* and *Dataset Versions*, though it is important to note that if a given Dataset
+    While the *Collection* identifier `collection_id` will always refer to the latest published version of a Collection,
+    and must be used with `Collection` endpoints, the *Collection Version* identifier `collection_version_id`
+    refers to one specific published version of a Collection and must be used with `Collection Version` endpoints.
+    The same is true for *Datasets* and *Dataset Versions*, though it is important to note that if a given Dataset
     is not updated during the course of a revision of its parent Collection, then its Dataset Version (and identifier
     `dataset_version_id`) will not change even though a new Collection Version has been published.
 

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -28,11 +28,7 @@ info:
     of a Collection and must be used with `Collection Version` endpoints. The same is true for
     *Datasets* and *Dataset Versions*, though it is important to note that if a given Dataset
     is not updated during the course of a revision of its parent Collection, then its Dataset Version (and identifier
-    `dataset_version_id`) will not change even though a new Collection Version has been published. Private Collections,
-    private revisions of published Collections, and any new or updated Datasets are not available as Versions
-    until they are published, and therefore must be referenced via their `collection_id` and `dataset_id` identifiers
-    using `Collection` and `Dataset` endpoints. As such, mutation actions cannot be
-    performed using Version identifiers.
+    `dataset_version_id`) will not change even though a new Collection Version has been published.
 
 servers:
   - description: Production environment

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -33,7 +33,7 @@ info:
     private revisions of published Collections, and their constituent (private) Datasets are not available as Versions
     until they are published, and therefore must be referenced via their `collection_id` and `dataset_id` identifiers
     using `Collection` and `Dataset` endpoints. As such, mutation actions cannot be
-    performed using version identifiers.
+    performed using Version identifiers.
 
 servers:
   - description: Production environment
@@ -534,9 +534,9 @@ paths:
 
   /v1/collections/{collection_id}/versions:
     get:
-      summary: Fetch all versions of a Collection with corresponding Dataset Versions
+      summary: Fetch all Collection Versions for a given Collection
       description: >
-        Fetch full metadata for all versions of a Collection and their corresponding Dataset Versions. The
+        Fetch full metadata for all published Collection Versions and their constituent Dataset Versions. The
         `collection_id` must reference a *Collection*, **NOT** a *Collection Version*. Collection Versions are returned
         in reverse-chronological order.
       operationId: backend.curation.api.v1.curation.collections.collection_id.versions.get
@@ -606,12 +606,12 @@ paths:
 
   /v1/datasets/{dataset_id}/versions:
     get:
-      summary: List all versions for a Dataset
+      summary: List all Dataset Versions for a given Dataset
       tags:
         - Dataset
       description: |
-        List all versions for a given Dataset. The `dataset_id` must reference a *Dataset*, **NOT** a *Dataset Version*.
-        Dataset Versions are returned in reverse-chronological order.
+        List all published Dataset Versions for a given Dataset. The `dataset_id` must reference a *Dataset*, **NOT** a
+        *Dataset Version*. Dataset Versions are returned in reverse-chronological order.
       operationId: backend.curation.api.v1.curation.datasets.dataset_id.versions.actions.get
       parameters:
         - $ref: "#/components/parameters/path_dataset_id"

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -18,10 +18,9 @@ info:
     ## Working with versions
 
     #### Access to prior published version history
-    The CZ CELLxGENE Discover API employs the concept of *versions* for our two core entities, *Collections* and
-    *Datasets*. This is to permit access to prior published instances (versions) of these entities even as they are
-    changed over time via revisions (at present the Data Portal web application UI offers access to only the latest
-    published version of a given Collection and/or Dataset).
+    The CZ CELLxGENE Discover API employs the concept of *Versions* for our two core entities, *Collections* and
+    *Datasets*. This is to permit access to prior published instances (versions) of these entities even as new updates
+    for them are published.
 
     #### Version identifiers
     While the *Collection* identifier `collection_id` will always refer to the latest published instance of a Collection
@@ -30,9 +29,8 @@ info:
     of a Collection (like a commit hash) and must be used with `../collection_version/..`
     endpoints. The same is true for *Datasets* and *Dataset Versions*, though it is important to note that if a given Dataset
     is not updated during the course of a revision of its parent Collection, then its *Dataset Version* identifier
-    `dataset_version_id` will not change and will appear identically in the list of *Dataset Versions* associated with the
-    Collection Version from *before* the revision as well as with the Collection Version from *after* the revision. Private Collections,
-    private revisions of published Collections, and their constituent (private) Datasets are not available as *versions*
+    `dataset_version_id` will not change even though a new Collection Version has been published. Private Collections,
+    private revisions of published Collections, and their constituent (private) Datasets are not available as *Versions*
     until they are published, and therefore must be referenced via their `collection_id` and `dataset_id` identifiers
     using `../collections/..` and `../datasets/..` endpoints, respectively. As such, mutation actions cannot be
     performed using version identifiers.
@@ -543,7 +541,7 @@ paths:
         in reverse-chronological order.
       operationId: backend.curation.api.v1.curation.collections.collection_id.versions.get
       tags:
-        - Collection Version
+        - Collection
       parameters:
         - $ref: "#/components/parameters/path_collection_id"
       responses:
@@ -610,7 +608,7 @@ paths:
     get:
       summary: List all versions for a Dataset
       tags:
-        - Dataset Version
+        - Dataset
       description: |
         List all versions for a given Dataset. The `dataset_id` must reference a *Dataset*, **NOT** a *Dataset Version*.
         Dataset Versions are returned in reverse-chronological order.

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -28,8 +28,8 @@ info:
     *Collection Version* identifier `collection_version_id` points always to one specific published instance (version)
     of a Collection (like a commit hash) and must be used with `Collection Version` endpoints.
     endpoints. The same is true for *Datasets* and *Dataset Versions*, though it is important to note that if a given Dataset
-    is not updated during the course of a revision of its parent Collection, then its *Dataset Version* identifier
-    `dataset_version_id` will not change even though a new Collection Version has been published. Private Collections,
+    is not updated during the course of a revision of its parent Collection, then its Dataset Version (and identifier
+    `dataset_version_id`) will not change even though a new Collection Version has been published. Private Collections,
     private revisions of published Collections, and their constituent (private) Datasets are not available as *Versions*
     until they are published, and therefore must be referenced via their `collection_id` and `dataset_id` identifiers
     using `Collection` and `Dataset` endpoints, respectively. As such, mutation actions cannot be

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -885,9 +885,9 @@ components:
           $ref: "#/components/schemas/created_at"
         curator_name:
           $ref: "#/components/schemas/curator_name"
-        datasets:
+        dataset_versions:
           type: array
-          description: A list of Dataset metadata associated with the Collection Version
+          description: A list of Dataset Versions associated with the Collection Version
           items:
             $ref: "#/components/schemas/dataset_version"
         description:

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -1136,7 +1136,7 @@ components:
           $ref: "#/components/schemas/collection_id"
         collection_version_id:
           description: |
-            The *Collection Version* in which this *Dataset Version* was first published.
+            The Collection Version in which this Dataset Version was first published.
           type: string
           format: uuid
         dataset_id:

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -49,7 +49,7 @@ paths:
     post:
       summary: Generate an access token
       tags:
-        - authentication
+        - Authentication
       description: |
         Returns a bearer access token that must be passed in an Authorization header to requests that
         require authorization such as creating a new Collection.
@@ -99,7 +99,7 @@ paths:
         - curatorAccessLenient: []
         - {}
       tags:
-        - collection
+        - Collection
       parameters:
         - description: |
             The visibility of the Collections to query for (and its constituent Datasets).
@@ -146,7 +146,7 @@ paths:
         * Required: provide your access token in the request header as `Authorization: Bearer <access_token>`.
       operationId: backend.curation.api.v1.curation.collections.actions.post
       tags:
-        - collection
+        - Collection
       security:
         - curatorAccess: []
       requestBody:
@@ -189,7 +189,7 @@ paths:
         - curatorAccessLenient: []
         - {}
       tags:
-        - collection
+        - Collection
       parameters:
         - $ref: "#/components/parameters/path_collection_id"
       responses:
@@ -216,7 +216,7 @@ paths:
       security:
         - curatorAccess: []
       tags:
-        - collection
+        - Collection
       parameters:
         - $ref: "#/components/parameters/path_collection_id"
       requestBody:
@@ -272,7 +272,7 @@ paths:
       security:
         - curatorAccess: []
       tags:
-        - collection
+        - Collection
       parameters:
         - $ref: "#/components/parameters/path_collection_id"
       responses:
@@ -300,7 +300,7 @@ paths:
       security:
         - curatorAccess: []
       tags:
-        - collection
+        - Collection
       parameters:
         - $ref: "#/components/parameters/path_collection_id"
       responses:
@@ -330,7 +330,7 @@ paths:
       security:
         - curatorAccess: []
       tags:
-        - collection
+        - Collection
       parameters:
         - $ref: "#/components/parameters/path_collection_id"
       responses:
@@ -364,7 +364,7 @@ paths:
         * Required: provide your access token in the request header as `Authorization: bearer <access_token>`.
       operationId: backend.curation.api.v1.curation.collections.collection_id.datasets.dataset_id.actions.delete
       tags:
-        - collection
+        - Collection
       security:
         - curatorAccess: []
       parameters:
@@ -393,7 +393,7 @@ paths:
         Fetch Dataset metadata for `dataset_id` in a `collection_id`.
       operationId: backend.curation.api.v1.curation.collections.collection_id.datasets.dataset_id.actions.get
       tags:
-        - collection
+        - Collection
       parameters:
         - $ref: "#/components/parameters/path_collection_id"
         - $ref: "#/components/parameters/path_dataset_id"
@@ -418,7 +418,7 @@ paths:
         * Required: provide your access token in the request header as `Authorization: Bearer <access_token>`.
       operationId: backend.curation.api.v1.curation.collections.collection_id.datasets.dataset_id.actions.put
       tags:
-        - collection
+        - Collection
       security:
         - curatorAccess: []
       parameters:
@@ -456,7 +456,7 @@ paths:
     get:
       summary: Get credentials for uploading local files
       tags:
-        - collection
+        - Collection
       description: |
         Retrieve temporary AWS credentials for uploading Dataset source files to S3 to create
         or update Datasets for the specified Collection.
@@ -543,7 +543,7 @@ paths:
         in reverse-chronological order.
       operationId: backend.curation.api.v1.curation.collections.collection_id.versions.get
       tags:
-        - collection_version
+        - Collection version
       parameters:
         - $ref: "#/components/parameters/path_collection_id"
       responses:
@@ -570,7 +570,7 @@ paths:
         must reference a *Collection version*, **NOT** a *Collection*.
       operationId: backend.curation.api.v1.curation.collection_versions.collection_version_id.actions.get
       tags:
-        - collection_version
+        - Collection version
       parameters:
         - $ref: "#/components/parameters/path_collection_version_id"
       responses:
@@ -592,7 +592,7 @@ paths:
     get:
       summary: List all Datasets
       tags:
-        - dataset
+        - Dataset
       description: |
         List all public Datasets with full metadata as well as Collection name and Collection doi.
       operationId: backend.curation.api.v1.curation.datasets.actions.get
@@ -610,7 +610,7 @@ paths:
     get:
       summary: List all versions for a Dataset
       tags:
-        - dataset_version
+        - Dataset version
       description: |
         List all versions for a given Dataset. The `dataset_id` must reference a *Dataset*, **NOT** a *Dataset version*.
         Dataset versions are returned in reverse-chronological order.
@@ -635,7 +635,7 @@ paths:
     get:
       summary: Get full metadata for a Dataset version
       tags:
-        - dataset_version
+        - Dataset version
       description: |
         Fetch Dataset metadata for a Dataset version. The `dataset_version_id` must reference a *Dataset version*,
         **NOT** a *Dataset*.

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -14,6 +14,45 @@ info:
     ## Data Model
     <!-- Data model diagram created via Lucid: https://lucid.app/lucidchart/8d085832-34f4-4413-9c1d-44e77d06e326/edit?invitationId=inv_ed354532-7256-4e0a-9ad0-b622905e5198&page=Vfzkzdv~I1fL# -->
     <img src="/static/discover-api-data-model.png" width="50%"/>
+
+    ## Working with versions
+
+    #### Access to prior published version history
+    The CZ CELLxGENE Discover API employs the concept of *versions* for our two core entities, *Collections* and
+    *Datasets*. This is to permit access to prior published instances (versions) of these entities even as they are
+    changed over time via revisions (at present the Data Portal web application UI offers access to only the latest
+    published version of a given Collection and/or Dataset).
+
+    #### Version identifiers
+    While the *Collection* identifier `collection_id` will always refer to the latest published instance of a Collection
+    (like the "head" in version-control terminology), and must be used with `../collections/..` endpoints, the
+    *Collection version* identifier `collection_version_id` points always to one specific published instance (version)
+    of a Collection (like a commit hash) and must be used with `../collection_version/..`
+    endpoints. The same is true for *Datasets* and *Dataset versions*, though it is important to note that if a given Dataset
+    is not updated during the course of a revision of its parent Collection, then its *Dataset version* identifier
+    `dataset_version_id` will not change and will appear identically in the list of *Dataset versions* associated with the
+    Collection version from *before* the revision as well as with the Collection version from *after* the revision. Private Collections,
+    private revisions of published Collections, and their constituent (private) Datasets are not available as *versions*
+    until they are published, and therefore must be referenced via their `collection_id` and `dataset_id` identifiers
+    using `../collections/..` and `../datasets/..` endpoints, respectively. As such, mutation actions cannot be
+    performed using version identifiers.
+
+    #### Interpreting `published_at` and `revised_at` timestamps with versions
+    When retrieving data about *Collections* or *Datasets*, these fields convey the following:
+
+    * `published_at`: the timestamp of the first publication of the *Collection*/*Dataset*, i.e., the publication
+    of the first version.
+
+    * `revised_at`: the timestamp of the publication of the most recent revision of the *Collection*/*Dataset*
+
+    However, when retrieving data about *Collection versions* or *Dataset versions*:
+
+    * `published_at`: the timestamp of the publication of this particular version
+
+    Therefore, in the case of a Collection, the `published_at` timestamp for its latest *Collection version* will be
+    equal to the `revised_at` timestamp for the *Collection*. There is no `revised_at` attribute associated with an
+    entity version.
+
 servers:
   - description: Production environment
     url: https://api.cellxgene.cziscience.com/
@@ -803,7 +842,7 @@ components:
         collection_url:
           $ref: "#/components/schemas/collection_url"
         collection_version_id:
-          $ref: "#/components/schemas/collection_id"
+          $ref: "#/components/schemas/collection_version_id"
         consortia:
           $ref: "#/components/schemas/consortia"
         contact_email:
@@ -850,7 +889,7 @@ components:
         collection_url:
           $ref: "#/components/schemas/collection_url"
         collection_version_id:
-          $ref: "#/components/schemas/collection_id"
+          $ref: "#/components/schemas/collection_version_id"
         consortia:
           $ref: "#/components/schemas/consortia"
         contact_email:
@@ -1112,7 +1151,7 @@ components:
           $ref: "#/components/schemas/collection_id"
         collection_version_id:
           description: |
-            The first Collection Version this Dataset Version was published under
+            The *Collection Version* in which this *Dataset version* was first published.
           type: string
           format: uuid
         dataset_id:


### PR DESCRIPTION
## Reason for Change

- #4386 

## Changes

- add clear description of how the concept of 'version' impinges on Collections/Datasets and interacting with them via the Discover API.

## Testing steps

- https://dan-docs-backend.rdev.single-cell.czi.technology/curation/ui/#/

## Notes for Reviewer
