### PR TITLE
chore: pin Flask to be less than 2.3.0

### DIFF
--- a/backend/api_server/requirements.txt
+++ b/backend/api_server/requirements.txt
@@ -19,3 +19,4 @@ scanpy
 SQLAlchemy-Utils>=0.36.8
 SQLAlchemy>=1.4.0,<1.5
 flask-server-timing==0.1.2
+Werkzeug==2.2.3

--- a/backend/api_server/requirements.txt
+++ b/backend/api_server/requirements.txt
@@ -1,7 +1,7 @@
 Authlib==0.14.3
 connexion[swagger-ui]==2.13.0
 dataclasses-json==0.5.7
-Flask<2.3.0
+Flask==2.2.3
 Flask-Cors>=3.0.6
 gunicorn[gevent] >=20.1.0, <21.0.0
 matplotlib==3.6.3 # 3.7.0 isn't compatible with scanpy: https://github.com/scverse/scanpy/issues/2411

--- a/backend/api_server/requirements.txt
+++ b/backend/api_server/requirements.txt
@@ -1,6 +1,7 @@
 Authlib==0.14.3
 connexion[swagger-ui]==2.13.0
 dataclasses-json==0.5.7
+Flask<2.3.0
 Flask-Cors>=3.0.6
 gunicorn[gevent] >=20.1.0, <21.0.0
 matplotlib==3.6.3 # 3.7.0 isn't compatible with scanpy: https://github.com/scverse/scanpy/issues/2411


### PR DESCRIPTION
## Reason for Change
Pins Flask to be less than 2.3.0.

This is to avoid the `AttributeError: module 'flask.json' has no attribute 'JSONEncoder'` issue.
