### PR TITLE
feat: add revising_in to the authenticated /collection/(id) endpoint (#4579)

### DIFF
--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -824,6 +824,10 @@ paths:
 
 components:
   schemas:
+    access_type:
+      description: Indicates if the user will be allowed to make updates to the entity.
+      type: string
+      enum: [READ, WRITE]
     user_id:
       description: A unique identifier of a logged in User of Corpora.
       type: string
@@ -948,6 +952,8 @@ components:
           type: string
         publisher_metadata:
           $ref: "#/components/schemas/publisher_metadata"
+        revising_in:
+          $ref: "#/components/schemas/revising_in"
         datasets:
           type: array
           items:
@@ -981,7 +987,13 @@ components:
           type: number
         published_year:
           type: number
-
+    revising_in:
+      type: string
+      description: >-
+        If the Collection is published and has an outstanding private Revision, and the user has write access, then
+        `revising_in` is set to the id of the private Revision. The value is `None` if the user is not authorized or no
+        private Revision exists.
+      nullable: true
     ontology_element:
       type: object
       properties:


### PR DESCRIPTION
## Reason for Change

- #TICKET_NUMBER #4579
- to allow the FE to avoid calling `/collections` retrieving all collections and scanning the list to determine the revising_of value of the current collection when viewing a collection detail as a curator (logged in) `/collection/{jd}`

## Changes

- add `revising_in` to the _collection_to_response method to modify the  /collection/(id) response for authenticated requests. This will also modify the response for post collection revision and update collection responses.
- added tests
- modified the portal_api.yml openAPI file to indicate  `revising_in` will be  in the /collection/{id} response optionally.
- some blank lines were removed by the formatter

## Testing steps

