### PR TITLE
feat: user and dataset collections (#4577, #4578)

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -425,6 +425,16 @@ class BusinessLogic(BusinessLogicInterface):
         datasets, _ = self.database_provider.get_all_mapped_datasets_and_collections()
         return datasets
 
+    def get_datasets_for_collections(self, collections: Iterable[CollectionVersion]) -> Iterable[DatasetVersion]:
+        datasets = []
+        for collection in collections:
+            datasest_ids = [d.id for d in collection.datasets]
+            collection_datasets: List[DatasetVersion] = [
+                self.database_provider.get_dataset_version(DatasetVersionId(id)) for id in datasest_ids
+            ]
+            datasets.extend(collection_datasets)
+        return datasets
+
     def get_all_mapped_collection_versions_with_datasets(self) -> List[CollectionVersionWithPublishedDatasets]:
         """
         Retrieves all the datasets from the database that belong to a published collection

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -1080,6 +1080,8 @@ components:
           type: string
         publisher_metadata:
           $ref: "#/components/schemas/publisher_metadata"
+        revising_in:
+          $ref: "#/components/schemas/revising_in"
         datasets:
           type: array
           items:
@@ -1113,7 +1115,13 @@ components:
           type: number
         published_year:
           type: number
-
+    revising_in:
+      type: string
+      description: >-
+        If the Collection is published and has an outstanding private Revision, and the user has write access, then
+        `revising_in` is set to the id of the private Revision. The value is `None` if the user is not authorized or no
+        private Revision exists.
+      nullable: true
     ontology_element:
       type: object
       properties:

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -418,6 +418,54 @@ paths:
         "400":
           $ref: "#/components/responses/400"
 
+  /v1/user-collections/index:
+    get:
+      tags:
+        - collections
+      summary: >-
+        Returns all public, non tombstoned collections. This endpoint is meant to be used for displaying collections
+        in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+      security:
+        - cxguserCookie: []
+      operationId: backend.portal.api.portal_api.get_user_collection_index
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    access_type:
+                      $ref: "#/components/schemas/access_type"
+                    curator_name:
+                      type: string
+                    id:
+                      $ref: "#/components/schemas/collection_id"
+                    name:
+                      type: string
+                    publisher_metadata:
+                      $ref: "#/components/schemas/publisher_metadata"
+                    published_at:
+                      type: number
+                      nullable: true
+                    revised_at:
+                      type: number
+                      nullable: true
+                    consortia:
+                      $ref: "#/components/schemas/consortia"
+                    visibility:
+                      $ref: "#/components/schemas/visibility"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+
   /v1/datasets/{dataset_id}:
     delete:
       tags:
@@ -702,7 +750,88 @@ paths:
                       type: number
         "400":
           $ref: "#/components/responses/400"
-
+  /v1/user-datasets/index:
+    get:
+      tags:
+        - datasets
+      summary: >-
+        Returns all public and private, non tombstoned datasets where the user has WRITE access. This endpoint is meant to be used for displaying datasets
+        in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+      security:
+        - cxguserCookieLenient: []
+        - {}
+      description: >-
+        Returns all datasets that belong to public and private, non tombstoned collections where the user has WRITE access. This endpoint is meant to be used 
+        for displaying datasets in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+      operationId: backend.portal.api.portal_api.get_user_datasets_index
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    collection_id:
+                      type: string
+                    assay:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    tissue:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    tissue_ancestors:
+                      type: array
+                      items:
+                        type: string
+                    disease:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    sex:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    self_reported_ethnicity:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    organism:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    development_stage:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    development_stage_ancestors:
+                      type: array
+                      items:
+                        type: string
+                    cell_count:
+                      type: integer
+                    cell_type:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    cell_type_ancestors:
+                      type: array
+                      items:
+                        type: string
+                    mean_genes_per_cell:
+                      type: number
+                    is_primary_data:
+                      $ref: "#/components/schemas/is_primary_data"
+                    donor_id:
+                      type: array
+                      items:
+                        type: string
+                    suspension_type:
+                      type: array
+                      items:
+                        type: string
+                    schema_version:
+                      type: string
+                    explorer_url:
+                      type: string
+                    published_at:
+                      type: number
+                    revised_at:
+                      type: number
+        "400":
+          $ref: "#/components/responses/400"
   /v1/login:
     get:
       tags:
@@ -824,6 +953,10 @@ paths:
 
 components:
   schemas:
+    access_type:
+      description: Indicates if the user will be allowed to make updates to the entity.
+      type: string
+      enum: [READ, WRITE]
     user_id:
       description: A unique identifier of a logged in User of Corpora.
       type: string
@@ -920,8 +1053,7 @@ components:
         - data_submission_policy_version
       properties:
         access_type:
-          type: string
-          enum: [READ, WRITE]
+          $ref: "#/components/schemas/access_type"
         created_at:
           type: number
         updated_at:

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -423,7 +423,10 @@ paths:
       tags:
         - collections
       summary: >-
-        Returns all public, non tombstoned collections. This endpoint is meant to be used for displaying collections
+        Returns all public collections and any private collections that the user can update.
+      description: >-
+        Returns all public, non tombstoned collections and any private collections or revisions the user
+        has WRITE access to. This endpoint is meant to be used for displaying collections
         in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
       security:
         - cxguserCookie: []
@@ -755,14 +758,13 @@ paths:
       tags:
         - datasets
       summary: >-
-        Returns all public and private, non tombstoned datasets where the user has WRITE access. This endpoint is meant to be used for displaying datasets
-        in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+        Returns datasets related to all public non-tombstoned collections and all private non-revision collections the user can update.
       security:
-        - cxguserCookieLenient: []
-        - {}
+        - cxguserCookie: []
       description: >-
-        Returns all datasets that belong to public and private, non tombstoned collections where the user has WRITE access. This endpoint is meant to be used 
-        for displaying datasets in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+        Returns datasets related to all public non-tombstoned collections and all private non-revision collections
+        where the user has WRITE access. This endpoint is meant to be used for displaying datasets in a compact view.
+        It doesn't return all the fields, so it is not suitable for general usage.
       operationId: backend.portal.api.portal_api.get_user_datasets_index
       responses:
         "200":
@@ -832,6 +834,8 @@ paths:
                       type: number
         "400":
           $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
   /v1/login:
     get:
       tags:

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -232,6 +232,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
     """
     Converts a CollectionVersion object to an object compliant to the API specifications
     """
+    revising_in = None
     if collection.is_unpublished_version():
         # In this case, the collection version is a revision of an already published collection.
         # We should expose version_id as the collection_id
@@ -250,7 +251,15 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
         # The last case is a published collection. We just return the canonical id and set revision_of to None
         revision_of = None
         collection_id = collection.collection_id.id
-        is_in_revision = False
+        is_published = collection.published_at is not None
+
+        _revising_in = None
+        if is_published and access_type == "WRITE":  # can ony be WRITE if authenticated
+            _revising_in = get_business_logic().get_unpublished_collection_version_from_canonical(
+                collection.collection_id
+            )
+        revising_in = _revising_in.version_id.id if _revising_in else None
+        is_in_revision = True if _revising_in else None
 
     is_tombstoned = collection.canonical_collection.tombstoned
 
@@ -278,6 +287,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
             "published_at": collection.canonical_collection.originally_published_at,
             "publisher_metadata": collection.publisher_metadata,  # TODO: convert
             "revision_of": revision_of,
+            "revising_in": revising_in,
             "updated_at": collection.published_at or collection.created_at,
             "visibility": "PUBLIC" if collection.published_at is not None else "PRIVATE",
         }

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -761,7 +761,7 @@ def get_user_datasets_index(token_info: dict):
 
     private_collections = get_user_private_collections(token_info)
     # filter out collections that are revisions
-    non_revisions = [c for c in private_collections if c.is_unpublished_version() is False]
+    non_revisions = [c for c in private_collections if not c.is_unpublished_version()]
     private_datasets = get_business_logic().get_datasets_for_collections(non_revisions)
 
     response = enrich_dataset_response(itertools.chain(public_datasets, private_datasets))

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -744,7 +744,7 @@ def get_datasets_index():
 
 def get_user_datasets_index(token_info: dict):
     """
-    Returns a list of all datasets associated with public or private collections where
+    Returns a list of all Datasets associated with public Collections or with private Collections where
     the user has WRITE access and the collection is not a revision.
     """
     public_datasets = get_business_logic().get_all_mapped_datasets()

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1686,8 +1686,7 @@ class TestDataset(BaseAPIPortalTest):
 
         private_dataset = self.generate_dataset()
         public_dataset = self.generate_dataset(publish=True)
-        # how can I add a dataset to a revision?
-        revision = self.business_logic.create_collection_version(CollectionId(public_dataset.collection_id))
+        self.business_logic.create_collection_version(CollectionId(public_dataset.collection_id))
 
         test_url = furl(path="/dp/v1/user-datasets/index")
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1715,6 +1715,13 @@ class TestDataset(BaseAPIPortalTest):
         self.assertIn(public_dataset.dataset_version_id, dataset_ids)
         self.assertIn(private_dataset.dataset_version_id, dataset_ids)
 
+    def test__get_all_user_datasets_for_index_requires_auth(self):
+        # test that non logged user returns 401
+        test_url = furl(path="/dp/v1/user-datasets/index")
+        headers = {"host": "localhost", "Content-Type": "application/json"}
+        response = self.app.get(test_url.url, headers=headers)
+        self.assertEqual(response.status_code, 401)
+
     # ✅
     def test__get_all_datasets_for_index_with_ontology_expansion(self):
         import copy


### PR DESCRIPTION
## Reason for Change

- #TICKET_NUMBER
#4577,
#4578

## Changes

- adds API endpoints for /user-collections/index and /user-datasets/index


## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Could you describe how you made sure to know that your changes worked? Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Notes for Reviewer
