### PR TITLE
chore(wmg): Remove newsletter banner from Collections and Datasets pages

### DIFF
--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -16,7 +16,6 @@ import {
 } from "src/common/queries/collections";
 import { removeParams } from "src/common/utils/removeParams";
 import { isTombstonedCollection } from "src/common/utils/typeGuards";
-import BottomBanner from "src/components/BottomBanner";
 import CollectionDescription from "src/components/Collection/components/CollectionDescription";
 import CollectionMetadata from "src/components/Collection/components/CollectionMetadata";
 import CollectionRevisionStatusCallout from "src/components/Collection/components/CollectionRevisionStatusCallout";

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -39,7 +39,6 @@ import {
 } from "src/views/Collections/common/constants";
 import { get } from "src/common/featureFlags";
 import { BOOLEAN } from "src/common/localStorage/set";
-import BottomBanner from "src/components/BottomBanner";
 
 export default function Collections(): JSX.Element {
   const isCuratorEnabled = get(FEATURES.CURATOR) === BOOLEAN.TRUE;

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -15,7 +15,6 @@ import { useExplainNewTab } from "src/common/hooks/useExplainNewTab";
 import { useSessionStorage } from "src/common/hooks/useSessionStorage";
 import { useFetchDatasetRows } from "src/common/queries/filter";
 import { KEYS } from "src/common/sessionStorage/set";
-import BottomBanner from "src/components/BottomBanner";
 import Filter from "src/components/common/Filter";
 import {
   CATEGORY_FILTER_ID,


### PR DESCRIPTION
## Reason for Change

- #4453 

## Changes

- add
- remove
    - Remove banner from Collections, Collection, and Datasets pages
- modify

## Testing steps

- Navigate to Collections, Collection, and Datasets pages and ensure banner does not show

## Notes for Reviewer

Modification to PR https://github.com/chanzuckerberg/single-cell-data-portal/pull/4679
