### PR TITLE
test(wmg): Fix wmg e2e tests

### DIFF
--- a/frontend/tests/features/wheresMyGene/shareLink.test.ts
+++ b/frontend/tests/features/wheresMyGene/shareLink.test.ts
@@ -42,8 +42,11 @@ const sexes = [
   { id: "PATO:0000384", text: "male" },
 ];
 const COMPARE = "disease";
+
 const initialState =
-  "https://localhost:3000/gene-expression?datasets=c874f155-9bf9-4928-b821-f52c876b3e48%2Cdb59611b-42de-4035-93aa-1ed39f38b467%2Ceeacb0c1-2217-4cf6-b8ce-1f0fedf1b569%2C881fe679-c6e0-45a3-9427-c4e81be6921f%2Cea786a06-5855-48b7-80d7-0313a21a2044%2C456e8b9b-f872-488b-871d-94534090a865&diseases=MONDO%3A0100096&ethnicities=unknown&sexes=PATO%3A0000383%2CPATO%3A0000384&tissues=blood%2Clung&genes=DPM1%2CTNMD%2CTSPAN6&ver=2&compare=disease";
+  `${TEST_URL}/gene-expression?` +
+  "datasets=c874f155-9bf9-4928-b821-f52c876b3e48%2Cdb59611b-42de-4035-93aa-1ed39f38b467%2Ceeacb0c1-2217-4cf6-b8ce-1f0fedf1b569%2C881fe679-c6e0-45a3-9427-c4e81be6921f%2Cea786a06-5855-48b7-80d7-0313a21a2044%2C456e8b9b-f872-488b-871d-94534090a865&diseases=MONDO%3A0100096&ethnicities=unknown&sexes=PATO%3A0000383%2CPATO%3A0000384&tissues=blood%2Clung&genes=DPM1%2CTNMD%2CTSPAN6&ver=2&compare=disease";
+
 describe("Share link tests", () => {
   skip(!isDevStagingProd, "WMG BE API does not work locally or in rdev");
   test("Should share link with single tissue and single gene", async ({


### PR DESCRIPTION
@charles-testco I updated the `initialState` to use `TEST_URL`, so the tests won't fail in `dev`, `staging`, and `prod`!

Thank you!