### PR TITLE
chore: Fix test report GH page

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -433,6 +433,8 @@ jobs:
       - processing-unit-test
       - e2e-test
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
## Reason for Change

1. Currently we're getting 403 when trying to create test report page. 
    [Example](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/4917592967/jobs/8783425751)
    [Log link](https://pipelines.actions.githubusercontent.com/serviceHosts/78ca9276-3e2b-466e-90c0-b7f09d6f2881/_apis/pipelines/1/runs/47296/signedlogcontent/111?urlExpires=2023-05-08T18%3A09%3A04.8265171Z&urlSigningMethod=HMACV1&urlSignature=kgsyDCNGbS1Cro%2F4WHtq6Ozdc3q2G1oRGR8oKdetjKE%3D)
    
    <img width="1700" alt="Screenshot 2023-05-08 at 11 17 01 AM" src="https://user-images.githubusercontent.com/6309723/236900249-03ef9026-35b6-4240-9259-be2ae9ac5714.png">

3. According to [this instruction](https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-first-deployment-with-github_token), we need to specify `permissions write` for the job to make it work



## Changes

- add
- remove
- modify

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Notes for Reviewer
