### PR TITLE
fix: Fix rollup implementation to include compare dimension

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -71,9 +71,8 @@ def query():
                     expression_summary=build_expression_summary(dot_plot_matrix_df, compare),
                     term_id_labels=dict(
                         genes=build_gene_id_label_mapping(criteria.gene_ontology_term_ids),
-                        cell_types=_aggregated_cell_counts_by_tissue_cell_type_with_metadata(
-                            cell_counts_cell_type_agg,
-                            compare,
+                        cell_types=build_ordered_cell_types_by_tissue(
+                            cell_counts_cell_type_agg, snapshot.cell_type_orderings, compare
                         ),
                     ),
                 )
@@ -623,7 +622,7 @@ def build_ordered_cell_types_by_tissue(
     joined = distinct_tissues_cell_types[indexer_bool_filter]
 
     for column in cell_type_orderings:
-        joined[column] = list(cell_type_orderings[column][indexer])
+        joined[column] = list(cell_type_orderings[column][indexer_filter])
 
     # Remove cell types without counts
     joined = joined[joined["n_total_cells"].notnull()]

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -256,68 +256,82 @@ def get_dot_plot_data(
     return dot_plot_matrix_df, cell_counts_cell_type_agg
 
 
-def build_universe_dataframe(cell_counts_cell_type_agg) -> DataFrame:
-    """"""
-    cartesian_product = list(
-        itertools.product(
-            *[cell_counts_cell_type_agg.index.levels[i] for i in range(len(cell_counts_cell_type_agg.index.names))]
-        )
-    )
-    cartesian_product_index = pd.Index(cartesian_product)
-    cartesian_product_index.set_names(cell_counts_cell_type_agg.index.names, inplace=True)
-    universe_df = pd.DataFrame(index=cartesian_product_index)
-    for c in cell_counts_cell_type_agg.columns:
-        universe_df[c] = 0
-        universe_df[c][cell_counts_cell_type_agg.index] = cell_counts_cell_type_agg[c]
-    return universe_df
+def rollup(gene_expression_df, cell_counts_grouped_df) -> Tuple[DataFrame, DataFrame]:
+    """
+    Accumulates (or rolls up) cell count values and gene-expression values FOR EACH expressed gene
+    up the cell type ANCESTOR paths grouped by the ontology term IDs in the multi-index of the
+    input cell counts dataframe.
+
+    Parameters
+    ----------
+    gene_expression_df : pandas DataFrame
+        Tidy gene expression dataframe containing the dimensions across which the numeric columns will be
+        aggregated.
+
+    cell_counts_grouped_df : pandas DataFrame
+        Multi-indexed cell counts dataframe containing the dimensions across which the cell count values will be
+        aggregated.
+
+    Returns
+    -------
+    rolled_up_gene_expression_df : pandas DataFrame
+        Tidy gene expression dataframe with the same columns as the input gene expression dataframe,
+        and likely greater size than the input gene expression dataframe, but with the numeric
+        columns aggregated across the cell type's descendants.
+
+    rolled_up_cell_counts_grouped_df : pandas DataFrame
+        Multi-indexed cell counts dataframe with the same columns as the input cell counts dataframe,
+        and likely greater size than the input cell counts dataframe, but with the cell count
+        values aggregated across the cell type's descendants.
+    """
+    # An implementation detail note:
+
+    # The order of operation is important: The cell counts are rolled up first to produce a the
+    # `rolled_up_cell_counts_grouped_df` dataframe. Then this `rolled_up_cell_counts_grouped_df` is
+    # an input into the operation to roll up gene expression values.
+
+    # This is done for efficiency reasons where the `rolled_up_cell_counts_grouped_df` is made sparse
+    # by the first operation that rolls up the cell counts. Having a sparse
+    # `rolled_up_cell_counts_grouped_df` significantly improves the running time and memory footprint of
+    # the second operation: rolling up the gene expression values.
+
+    rolled_up_cell_counts_grouped_df = _rollup_cell_counts(cell_counts_grouped_df)
+    rolled_up_gene_expression_df = _rollup_gene_expression(gene_expression_df, rolled_up_cell_counts_grouped_df)
+    return rolled_up_gene_expression_df, rolled_up_cell_counts_grouped_df
 
 
-def rollup(dot_plot_matrix_df, universe_cell_counts_cell_type_agg) -> Tuple[DataFrame, DataFrame]:
-    # Roll up numeric columns in the input dataframes
-    if universe_cell_counts_cell_type_agg.shape[0] > 0:
-        universe_cell_counts_cell_type_agg = build_universe_dataframe(universe_cell_counts_cell_type_agg)
+def _add_missing_combinations_to_gene_expression_df_for_rollup(
+    gene_expression_df, universal_set_cell_counts_df
+) -> DataFrame:
+    """
+    Augments the input gene expression dataframe to include
+    (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>)
+    combinations for which numeric expression values should be aggregated during the rollup operation.
 
-        # make the cell counts dataframe tidy
-        for col in universe_cell_counts_cell_type_agg.index.names:
-            universe_cell_counts_cell_type_agg[col] = universe_cell_counts_cell_type_agg.index.get_level_values(col)
+    Parameters
+    ----------
+    gene_expression_df : pandas DataFrame
+        Tidy gene expression dataframe.
 
-        universe_cell_counts_cell_type_agg = rollup_across_cell_type_descendants(universe_cell_counts_cell_type_agg)
+    universal_set_cell_counts_df : pandas DataFrame
+        Multi-indexed cell counts dataframe that contains "The Universal Set Of GroupBy Ontology Terms".
 
-        universe_cell_counts_cell_type_agg = universe_cell_counts_cell_type_agg[
-            universe_cell_counts_cell_type_agg["n_cells_cell_type"] > 0
-        ]
-        # clean up columns that were added to the dataframe to make it tidy
-        universe_cell_counts_cell_type_agg.drop(columns=universe_cell_counts_cell_type_agg.index.names, inplace=True)
-
-    if dot_plot_matrix_df.shape[0] > 0:
-        # For each gene in the query, add missing combinations (tissue, cell type, compare dimension)
-        # to the expression dataframe
-
-        dot_plot_matrix_df = add_missing_combinations_to_dot_plot_matrix(
-            dot_plot_matrix_df, universe_cell_counts_cell_type_agg
-        )
-
-        # Roll up expression dataframe
-        dot_plot_matrix_df = rollup_across_cell_type_descendants(dot_plot_matrix_df, ignore_cols=["n_cells_tissue"])
-
-        # Filter out the entries that were added to the dataframe that remain zero after roll-up
-        dot_plot_matrix_df = dot_plot_matrix_df[dot_plot_matrix_df["sum"] > 0]
-
-    return dot_plot_matrix_df, universe_cell_counts_cell_type_agg
-
-
-def add_missing_combinations_to_dot_plot_matrix(dot_plot_matrix_df, universe_df) -> DataFrame:
-    ### Add missing cell types to the expression dataframe so they can be rolled up ###
-
+    Returns
+    -------
+    gene_expression_with_missing_combos_df : pandas DataFrame
+        Tidy gene expression dataframe with the same columns as the input gene expression dataframe,
+        and likely greater size than the input gene expression dataframe that includes combinations
+        for which numeric values should be aggregated during the rollup operation.
+    """
     # extract group-by terms and queried genes from the input dataframes
     # if a queried gene is not present in the input dot plot dataframe, we can safely
     # ignore it as it need not be rolled up anyway.
-    group_by_terms = list(universe_df.index.names)
-    genes = list(set(dot_plot_matrix_df["gene_ontology_term_id"]))
+    group_by_terms = list(universal_set_cell_counts_df.index.names)
+    genes = list(set(gene_expression_df["gene_ontology_term_id"]))
 
     # get the names of the numeric columns
     numeric_columns = list(
-        dot_plot_matrix_df.columns[[np.issubdtype(dtype, np.number) for dtype in dot_plot_matrix_df.dtypes]]
+        gene_expression_df.columns[[np.issubdtype(dtype, np.number) for dtype in gene_expression_df.dtypes]]
     )
 
     # exclude n_cells_tissue as we do not wish to roll it up
@@ -325,16 +339,16 @@ def add_missing_combinations_to_dot_plot_matrix(dot_plot_matrix_df, universe_df)
         numeric_columns.remove("n_cells_tissue")
 
     # get the total number of cells per tissue to populate the n_cells_tissue in the added entries
-    n_cells_tissue_dict = dot_plot_matrix_df.groupby("tissue_ontology_term_id").first()["n_cells_tissue"].to_dict()
+    n_cells_tissue_dict = gene_expression_df.groupby("tissue_ontology_term_id").first()["n_cells_tissue"].to_dict()
 
     # get the set of available combinations of group-by terms from the aggregated cell counts
-    available_combinations = set(universe_df.index.values)
+    available_combinations = set(universal_set_cell_counts_df.index.values)
 
     # for each gene, get the set of available combinations of group-by terms from the input expression dataframe
     entries_to_add = []
     for gene in genes:
-        dot_plot_matrix_df_per_gene = dot_plot_matrix_df[dot_plot_matrix_df["gene_ontology_term_id"] == gene]
-        available_combinations_per_gene = set(zip(*dot_plot_matrix_df_per_gene[group_by_terms].values.T))
+        gene_expression_df_per_gene = gene_expression_df[gene_expression_df["gene_ontology_term_id"] == gene]
+        available_combinations_per_gene = set(zip(*gene_expression_df_per_gene[group_by_terms].values.T))
 
         # get the combinations that are missing in the input expression dataframe
         # these combinations have no data but can be rescued by the roll-up operation
@@ -347,9 +361,155 @@ def add_missing_combinations_to_dot_plot_matrix(dot_plot_matrix_df, universe_df)
             entries_to_add.append(entry)
 
     # add the missing entries to the input expression dataframe
-    dot_plot_matrix_df = pd.concat((dot_plot_matrix_df, pd.DataFrame(entries_to_add)), axis=0)
+    gene_expression_with_missing_combos_df = pd.concat((gene_expression_df, pd.DataFrame(entries_to_add)), axis=0)
 
-    return dot_plot_matrix_df
+    return gene_expression_with_missing_combos_df
+
+
+def _build_cell_count_groups_universal_set(cell_counts_grouped_df) -> DataFrame:
+    """
+    Constructs a dataframe that contains all valid combination of
+    (tissue, cell_type, <compare_dimension>) for which aggregation should be performed.
+    We call this set of all valid combinations "The Universal Set Of GroupBy Ontology Terms".
+
+    The combinations are encoded as a multi-index in the input cell counts dataframe.
+    The "compare dimension" is optional and may not be present in the multi-index; In that case,
+    the combinations considered are (tissue, cell_type) pairs.
+
+    In this implementation, "The Universal Set Of GroupBy Ontology Terms" is constructed by
+    computing the cartesian product of the (tissue, cell_type, <compare_dimension>) values
+    in the input cell counts dataframe.
+
+    Parameters
+    ----------
+    cell_counts_grouped_df : pandas DataFrame
+        MultiIndexed cell counts dataframe containing the dimensions across which the cell count values exist.
+
+    Returns
+    -------
+    universal_set_cell_counts_grouped_df : pandas DataFrame
+        Multi-indexed cell counts dataframe that contains "The Universal Set Of GroupBy Ontology Terms"
+        with the same columns as the input cell counts dataframe, and likely greater size than the
+        input cell counts dataframe.
+    """
+    cartesian_product = list(
+        itertools.product(
+            *[cell_counts_grouped_df.index.levels[i] for i in range(len(cell_counts_grouped_df.index.names))]
+        )
+    )
+    cartesian_product_index = pd.Index(cartesian_product)
+    cartesian_product_index.set_names(cell_counts_grouped_df.index.names, inplace=True)
+    universal_set_cell_counts_grouped_df = pd.DataFrame(index=cartesian_product_index)
+    for c in cell_counts_grouped_df.columns:
+        universal_set_cell_counts_grouped_df[c] = 0
+        universal_set_cell_counts_grouped_df[c][cell_counts_grouped_df.index] = cell_counts_grouped_df[c]
+    return universal_set_cell_counts_grouped_df
+
+
+def _rollup_cell_counts(cell_counts_grouped_df) -> DataFrame:
+    """
+    Roll up cell count values across cell type descendants in the input cell counts dataframe.
+
+    Accumulate cell count values up the cell type ontology ancestor paths for every
+    (tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>) combination in the
+    input cell counts dataframe. The compare dimension is an optional
+    field and in the case that it is missing, then accumulation happens for every
+    (tissue_ontology_term_id, cell_type_ontology_term_id) combination.
+
+    For example:
+
+    If (T1, C1) has cell counts in the input cell counts dataframe, and the tissue labeled T1
+    has another cell labeled C2 where C2 is an ANCESTOR of C1, then the rolled up cell counts dataframe
+    must include CUMULATIVE cell counts values for the combination (T1, C2) by adding in the
+    cell count for (T1, C1).
+
+    Parameters
+    ----------
+    cell_counts_grouped_df : pandas DataFrame
+        Multi-indexed cell counts dataframe containing the dimensions across which the cell count values will be
+        aggregated.
+
+    Returns
+    -------
+    rolled_up_cell_counts_grouped_df : pandas DataFrame
+        Multi-indexed cell counts dataframe with the same columns as the input cell counts dataframe,
+        and likely greater size than the input cell counts dataframe, but with the cell count
+        values aggregated across the cell type's descendants.
+    """
+    rolled_up_cell_counts_grouped_df = cell_counts_grouped_df
+
+    if cell_counts_grouped_df.shape[0] > 0:
+        universal_set_cell_counts_grouped_df = _build_cell_count_groups_universal_set(cell_counts_grouped_df)
+
+        # Add index columns to the universal_set_cell_counts_grouped_df so that these columns can be
+        # DIRECTLY accessed in the dataframe during the rollup operation while traversing the cell type descendants
+        for col in universal_set_cell_counts_grouped_df.index.names:
+            universal_set_cell_counts_grouped_df[col] = universal_set_cell_counts_grouped_df.index.get_level_values(col)
+
+        # rollup cell counts across cell type descendants
+        rolled_up_cell_counts_grouped_df = rollup_across_cell_type_descendants(universal_set_cell_counts_grouped_df)
+
+        rolled_up_cell_counts_grouped_df = rolled_up_cell_counts_grouped_df[
+            rolled_up_cell_counts_grouped_df["n_cells_cell_type"] > 0
+        ]
+        # Remove columns that were added to the cell counts dataframe for the purpose of rollup.
+        # This is make it congruent with the structure of the input cell counts dataframe
+        rolled_up_cell_counts_grouped_df.drop(columns=rolled_up_cell_counts_grouped_df.index.names, inplace=True)
+
+    return rolled_up_cell_counts_grouped_df
+
+
+def _rollup_gene_expression(gene_expression_df, universal_set_cell_counts_df) -> DataFrame:
+    """
+    Roll up numeric values across cell type descendants in the input gene expression dataframe.
+
+    Accumulate gene expression values up the cell type ontology ancestor paths for every
+    (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>)
+    combination in the input gene expression dataframe. The compare dimension is an optional
+    field and in the case that it is missing, then accumulation happens for every
+    (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id) combination.
+
+    For example:
+
+    If (G1, T1, C1) has gene expression values in the input expression dataframe,
+    and the tissue labeled T1 has another cell labeled C2 where C2 is an ANCESTOR of C1,
+    then the rolled up gene expression dataframe must include CUMULATIVE gene expression values for the
+    combination (G1, T1, C2) by adding in the gene expression for (G1, T1, C1).
+
+    Parameters
+    ----------
+    gene_expression_df : pandas DataFrame
+        Tidy gene expression dataframe containing the dimensions across which the numeric columns will be
+        aggregated.
+
+    universal_set_cell_counts_df : pandas DataFrame
+        Multi-indexed cell counts dataframe that contains "The Universal Set Of GroupBy Ontology Terms".
+
+    Returns
+    -------
+    rolled_up_gene_expression_df : pandas DataFrame
+        Tidy gene expression dataframe with the same columns as the input gene expression dataframe,
+        and likely greater size than the input gene expression dataframe, but with the numeric
+        columns aggregated across the cell type's descendants.
+    """
+    rolled_up_gene_expression_df = gene_expression_df
+
+    if gene_expression_df.shape[0] > 0:
+        # For each gene in the query, add missing combinations (tissue, cell type, compare dimension)
+        # to the expression dataframe
+        gene_expression_with_missing_combos_df = _add_missing_combinations_to_gene_expression_df_for_rollup(
+            gene_expression_df, universal_set_cell_counts_df
+        )
+
+        # Roll up expression dataframe
+        rolled_up_gene_expression_df = rollup_across_cell_type_descendants(
+            gene_expression_with_missing_combos_df, ignore_cols=["n_cells_tissue"]
+        )
+
+        # Filter out the entries that were added to the dataframe that remain zero after roll-up
+        rolled_up_gene_expression_df = rolled_up_gene_expression_df[rolled_up_gene_expression_df["sum"] > 0]
+
+    return rolled_up_gene_expression_df
 
 
 def build_dot_plot_matrix(

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -364,56 +364,6 @@ def _add_missing_combinations_to_gene_expression_df_for_rollup(
     return gene_expression_with_missing_combos_df
 
 
-def _aggregated_cell_counts_by_tissue_cell_type_with_metadata(
-    cell_counts_grouped_df, compare_col
-) -> Dict[str, Dict[str, Dict[str, Any]]]:
-    """ """
-    tissue_col = "tissue_ontology_term_id"
-    cell_type_col = "cell_type_ontology_term_id"
-    cell_type_name_col = "cell_type_name"
-
-    result: Dict[str, Dict[str, Dict[str, Any]]] = defaultdict(lambda: defaultdict(dict))
-
-    df = cell_counts_grouped_df.reset_index()
-    df[cell_type_name_col] = df[cell_type_col].map(lambda x: ontology_term_label(x).lower())
-
-    sort_columns = [tissue_col, cell_type_name_col]
-    if compare_col:
-        sort_columns.append(compare_col)
-    df.sort_values(sort_columns, inplace=True)
-
-    df["n_cell_agg_tissue_cell_type"] = df.groupby([tissue_col, cell_type_name_col], as_index=False)[
-        "n_cells_cell_type"
-    ].transform("sum")
-
-    previous_tissue = previous_cell_type = None
-    order_number = -1
-
-    for _, row in df.iterrows():
-        if (previous_tissue is None) or row[tissue_col] != previous_tissue or row[cell_type_col] != previous_cell_type:
-            order_number += 1
-
-        result[row[tissue_col]][row[cell_type_col]]["aggregated"] = {
-            "cell_type_ontology_term_id": row[cell_type_col],
-            "name": row[cell_type_name_col],
-            "total_count": row["n_cell_agg_tissue_cell_type"],
-            "order": order_number,
-        }
-
-        if compare_col:
-            result[row[tissue_col]][row[cell_type_col]][row[compare_col]] = {
-                "cell_type_ontology_term_id": row[cell_type_col],
-                "name": ontology_term_label(row[compare_col]),
-                "total_count": row["n_cells_cell_type"],
-                "order": order_number,
-            }
-
-        previous_tissue = row[tissue_col]
-        previous_cell_type = row[cell_type_col]
-
-    return result
-
-
 def _build_cell_count_groups_universal_set(cell_counts_grouped_df) -> DataFrame:
     """
     Constructs a dataframe that contains all valid combination of

--- a/backend/wmg/data/rollup.py
+++ b/backend/wmg/data/rollup.py
@@ -139,12 +139,11 @@ def rollup_across_cell_type_descendants(
     dim_shapes = tuple(dim_shapes)
     array_to_sum = np.zeros(dim_shapes)
     # slot the numeric data into the multi-dimensional numpy array
-    array_to_sum[tuple(dim_indices)] = numeric_df.to_numpy()
 
+    array_to_sum[tuple(dim_indices)] = numeric_df.to_numpy()
     cell_types = cell_type_column.unique()
 
     summed = rollup_across_cell_type_descendants_array(array_to_sum, cell_types)
-
     # extract numeric data and write back into the dataframe
     summed = summed[tuple(dim_indices)]
     dtypes = numeric_df.dtypes

--- a/tests/unit/backend/wmg/api/test_expression_rollup.py
+++ b/tests/unit/backend/wmg/api/test_expression_rollup.py
@@ -11,7 +11,7 @@ from backend.wmg.data.schemas.cube_schema import expression_summary_logical_attr
 
 class RollupExpressionsAcrossCellTypesTest(unittest.TestCase):
     # test that the rollup function works as expected
-    def test__expression_rollup(self):
+    def test__expression_rollup_across_cell_type_descendants(self):
         # second cell type is descendant of first cell type
         # fourth cell type is descendant of third cell type
         cell_types = ["CL:0000786", "CL:0000986", "CL:0000980", "CL:0001202"]
@@ -169,3 +169,120 @@ class RollupExpressionsAcrossCellTypesTest(unittest.TestCase):
         # assert that the added rows that could not be rescued via rollup are properly filtered out
         # these rows will still have 0 for all numeric columns, excluding n_cells_tissue
         assert (dot_plot_matrix_df["sum"] > 0).all()
+
+    def test__gene_expression_rollup(self):
+        """
+        Test that the `rollup` function sums up relevant numeric values for gene expression for
+        each cell type from its descendant cell types for every (tissue, gene) combination
+        in the input expression dataframe.
+
+        The input:
+
+        1. A cell type ontology subgraph consisting of 4 cell types.
+        2. 2 tissues.
+        3. 2 genes.
+        4. A gene expression dataframe consisting of expression numeric values for each
+           (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id) tuple.
+        5. The gene expression datafram also holds total cell counts per tissue_ontology_term_id.
+           This value is held in a column called `n_cells_tissue`.
+        6. A cell counts dataframe that consists of cell counts for each
+           (tissue_ontology_term_id, cell_type_ontology_term_id) tuple.
+        7. We set the `n_cells_tissue` column values to 10_000_000 for all rows
+           in the gene expression dataframe.
+        8. We set all other numeric column values to `1` in the gene expression dataframe.
+
+        The expected output:
+
+        1. A rolled up gene expression dataframe.
+        2. A rolled up cell counts dataframe.
+        3. Assert that `n_cells_tissue` column value in the rolled up gene expression dataframe
+           does not change for all rows because it should not be rolled up the cell type ontology
+           ancestor path.
+        4. Assert that other numeric column values (i.e the columns that are not `n_cells_tissue`)
+           in the rolled up gene expression dataframe sum up to the correct value for each cell type
+           for every (tissue, gene) combination.
+        5. Assert that the cell counts in the rolled up cell counts dataframe sum up to the correct
+           value for each cell type for every (tissue, cell_type) combination.
+        """
+        # Arrange
+
+        # Cell Type Ontology Subgraph
+        #    CL:0000127
+        #    ├── CL:0000644
+        #    ├── CL:0002605
+        #    └── CL:0002627
+        cell_counts_col_names = ["tissue_ontology_term_id", "cell_type_ontology_term_id", "n_cells_cell_type"]
+
+        input_cell_counts_rows = [
+            ["UBERON:0000955", "CL:0000127", 100000],
+            ["UBERON:0000955", "CL:0000644", 8034],
+            ["UBERON:0000955", "CL:0002605", 70009],
+            ["UBERON:0000955", "CL:0002627", 9871],
+            ["UBERON:0002113", "CL:0000127", 100000],
+            ["UBERON:0002113", "CL:0000644", 8034],
+            ["UBERON:0002113", "CL:0002605", 70009],
+            ["UBERON:0002113", "CL:0002627", 9871],
+        ]
+        cell_counts_df = pd.DataFrame(input_cell_counts_rows, columns=cell_counts_col_names)
+        cell_counts_df = cell_counts_df.set_index(["tissue_ontology_term_id", "cell_type_ontology_term_id"])
+
+        gene_expr_col_names = [
+            "gene_ontology_term_id",
+            "tissue_ontology_term_id",
+            "cell_type_ontology_term_id",
+            "nnz",
+            "sum",
+            "n_cells_cell_type",
+            "n_cells_tissue",
+        ]
+
+        input_gene_expr_rows = [
+            ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 8034, 10000000],
+            ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 70009, 10000000],
+            ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 9871, 10000000],
+            ["ENSG00000085265", "UBERON:0002113", "CL:0000644", 1, 1, 8034, 10000000],
+            ["ENSG00000085265", "UBERON:0002113", "CL:0002605", 1, 1, 70009, 10000000],
+            ["ENSG00000169429", "UBERON:0002113", "CL:0002627", 1, 1, 9871, 10000000],
+        ]
+
+        gene_expr_df = pd.DataFrame(input_gene_expr_rows, columns=gene_expr_col_names)
+
+        # Act
+        rolled_up_gene_expr_df, rolled_up_cell_counts_df = rollup(gene_expr_df.copy(), cell_counts_df.copy())
+
+        # Assert
+        expected_cell_counts_rows = [
+            ["UBERON:0000955", "CL:0000127", 187914],
+            ["UBERON:0000955", "CL:0000644", 8034],
+            ["UBERON:0000955", "CL:0002605", 70009],
+            ["UBERON:0000955", "CL:0002627", 9871],
+            ["UBERON:0002113", "CL:0000127", 187914],
+            ["UBERON:0002113", "CL:0000644", 8034],
+            ["UBERON:0002113", "CL:0002605", 70009],
+            ["UBERON:0002113", "CL:0002627", 9871],
+        ]
+
+        rolled_up_cell_counts_df.reset_index(inplace=True)
+        rolled_up_cell_counts_df_list = rolled_up_cell_counts_df.values.tolist()
+
+        assert rolled_up_cell_counts_df_list == expected_cell_counts_rows
+
+        expected_gene_expr_rows = [
+            ["ENSG00000085265", "UBERON:0000955", "CL:0000127", 2, 2, 78043, 10000000],
+            ["ENSG00000169429", "UBERON:0000955", "CL:0000127", 1, 1, 9871, 10000000],
+            ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 8034, 10000000],
+            ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 70009, 10000000],
+            ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 9871, 10000000],
+            ["ENSG00000085265", "UBERON:0002113", "CL:0000127", 2, 2, 78043, 10000000],
+            ["ENSG00000169429", "UBERON:0002113", "CL:0000127", 1, 1, 9871, 10000000],
+            ["ENSG00000085265", "UBERON:0002113", "CL:0000644", 1, 1, 8034, 10000000],
+            ["ENSG00000085265", "UBERON:0002113", "CL:0002605", 1, 1, 70009, 10000000],
+            ["ENSG00000169429", "UBERON:0002113", "CL:0002627", 1, 1, 9871, 10000000],
+        ]
+
+        rolled_up_gene_expr_df.sort_values(
+            ["tissue_ontology_term_id", "cell_type_ontology_term_id", "gene_ontology_term_id"], inplace=True
+        )
+        rolled_up_gene_expr_list = rolled_up_gene_expr_df.values.tolist()
+
+        assert rolled_up_gene_expr_list == expected_gene_expr_rows

--- a/tests/unit/backend/wmg/api/test_expression_rollup.py
+++ b/tests/unit/backend/wmg/api/test_expression_rollup.py
@@ -2,7 +2,9 @@ import unittest
 
 import numpy as np
 import pandas as pd
+from pandas import DataFrame
 from pandas.testing import assert_frame_equal
+from parameterized import parameterized
 
 from backend.wmg.api.v1 import _add_missing_combinations_to_gene_expression_df_for_rollup, rollup
 from backend.wmg.data.rollup import are_cell_types_colinear, rollup_across_cell_type_descendants
@@ -55,124 +57,314 @@ class TestLowLevelRollupFunctionsTraversingCellTypeLineage(unittest.TestCase):
             assert are_cell_types_colinear(a, b) == expected
 
 
-class TestHighLevelRollupFunctionWithoutCompareDimension(unittest.TestCase):
-    def test__rollup_without_compare_dimension(self):
+def _create_cell_counts_df_helper(cell_counts_rows: list[list], columns: list[str], index_cols: list[str]) -> DataFrame:
+    cell_counts_df = pd.DataFrame(cell_counts_rows, columns=columns)
+    cell_counts_df = cell_counts_df.set_index(index_cols)
+    return cell_counts_df
+
+
+def _create_gene_expression_df_helper(gene_expr_rows: list[list], columns: list[str]) -> DataFrame:
+    gene_expr_df = pd.DataFrame(gene_expr_rows, columns=columns)
+    return gene_expr_df
+
+
+def _cell_counts_df_without_compare_dim(cell_counts_rows: list[list]) -> DataFrame:
+    cell_counts_col_names = ["tissue_ontology_term_id", "cell_type_ontology_term_id", "n_cells_cell_type"]
+    cell_counts_index_col_names = ["tissue_ontology_term_id", "cell_type_ontology_term_id"]
+    return _create_cell_counts_df_helper(
+        cell_counts_rows, columns=cell_counts_col_names, index_cols=cell_counts_index_col_names
+    )
+
+
+def _cell_counts_df_with_ethnicity_compare_dim(cell_counts_rows: list[list]) -> DataFrame:
+    cell_counts_col_names = [
+        "tissue_ontology_term_id",
+        "cell_type_ontology_term_id",
+        "self_reported_ethnicity_ontology_term_id",
+        "n_cells_cell_type",
+    ]
+
+    cell_counts_index_col_names = [
+        "tissue_ontology_term_id",
+        "cell_type_ontology_term_id",
+        "self_reported_ethnicity_ontology_term_id",
+    ]
+
+    return _create_cell_counts_df_helper(
+        cell_counts_rows, columns=cell_counts_col_names, index_cols=cell_counts_index_col_names
+    )
+
+
+def _gene_expression_df_without_compare_dim(gene_expr_rows: list[list]) -> DataFrame:
+    gene_expr_col_names = [
+        "gene_ontology_term_id",
+        "tissue_ontology_term_id",
+        "cell_type_ontology_term_id",
+        "nnz",
+        "sum",
+        "n_cells_cell_type",
+        "n_cells_tissue",
+    ]
+    return _create_gene_expression_df_helper(gene_expr_rows, columns=gene_expr_col_names)
+
+
+def _gene_expression_df_with_ethnicity_compare_dim(gene_expr_rows: list[list]) -> DataFrame:
+    gene_expr_col_names = [
+        "gene_ontology_term_id",
+        "tissue_ontology_term_id",
+        "cell_type_ontology_term_id",
+        "self_reported_ethnicity_ontology_term_id",
+        "nnz",
+        "sum",
+        "n_cells_cell_type",
+        "n_cells_tissue",
+    ]
+
+    return _create_gene_expression_df_helper(gene_expr_rows, columns=gene_expr_col_names)
+
+
+class TestHighLevelRollupFunction(unittest.TestCase):
+    """
+    Test that the `rollup` function correctly accumulates (or rolls up) gene-expression
+    values FOR EACH expressed gene and cell count values up the cell type ANCESTOR paths
+    grouped by (tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>).
+
+    The input:
+
+    1. A cell type ontology subgraph consisting of 4 cell types.
+
+    CL:0000127
+    ├── CL:0000644
+    ├── CL:0002605
+    └── CL:0002627
+
+    2. A gene expression dataframe consisting of expression numeric values for each
+    (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>) tuple.
+    3. The gene expression dataframe also holds total cell counts per tissue_ontology_term_id.
+    This value is held in a column called `n_cells_tissue`.
+    6. A cell counts dataframe that consists of cell counts for each
+    (tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>) tuple.
+    7. We set the `n_cells_tissue` column values to 1000 for all rows
+    in the gene expression dataframe.
+    8. We set all other numeric column values to `1` in the gene expression dataframe.
+
+    The expected output:
+
+    1. A rolled up gene expression dataframe.
+    2. A rolled up cell counts dataframe.
+    3. Assert that `n_cells_tissue` column value in the rolled up gene expression dataframe
+    does not change for all rows because it should not be rolled up the cell type ontology
+    ancestor paths.
+    4. Assert that other numeric column values (i.e the columns that are not `n_cells_tissue`)
+    in the rolled up gene expression dataframe hold the correct rolled up values.
+    5. Assert that the cell counts in the rolled up cell counts dataframe hold the correct
+    rolled up values.
+    """
+
+    @staticmethod
+    def _rollup_testcases():
         """
-        Test that the `rollup` function correctly accumulates (or rolls up) gene-expression
-        values FOR EACH expressed gene and cell count values up the cell type ANCESTOR paths
-        grouped by (tissue_ontology_term_id, cell_type_ontology_term_id).
+        Testcases for the `rollup` function.
 
-        The input:
+        An important note about how the expected values are laid out in the testcases:
 
-        1. A cell type ontology subgraph consisting of 4 cell types.
-        2. 2 tissues.
-        3. 2 genes.
-        4. A gene expression dataframe consisting of expression numeric values for each
-        (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id) tuple.
-        5. The gene expression datafram also holds total cell counts per tissue_ontology_term_id.
-        This value is held in a column called `n_cells_tissue`.
-        6. A cell counts dataframe that consists of cell counts for each
-        (tissue_ontology_term_id, cell_type_ontology_term_id) tuple.
-        7. We set the `n_cells_tissue` column values to 10_000_000 for all rows
-        in the gene expression dataframe.
-        8. We set all other numeric column values to `1` in the gene expression dataframe.
+        1. Expected values for rows in the rolled up cell counts dataframe are sorted by
+        (tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>)
 
-        The expected output:
-
-        1. A rolled up gene expression dataframe.
-        2. A rolled up cell counts dataframe.
-        3. Assert that `n_cells_tissue` column value in the rolled up gene expression dataframe
-        does not change for all rows because it should not be rolled up the cell type ontology
-        ancestor paths.
-        4. Assert that other numeric column values (i.e the columns that are not `n_cells_tissue`)
-        in the rolled up gene expression dataframe hold the correct rolled up values.
-        5. Assert that the cell counts in the rolled up cell counts dataframe hold the correct
-        rolled up values.
+        2. Expected values for rows in the rolled up gene expression dataframe are sorted by
+        (tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>, gene_ontology_term_id)
         """
+        test_1 = {
+            "name": "no_compare_dim_all_tissues_have_all_cell_types",
+            "input_cell_counts": [
+                ["UBERON:0000955", "CL:0000127", 300],
+                ["UBERON:0000955", "CL:0000644", 70],
+                ["UBERON:0000955", "CL:0002605", 80],
+                ["UBERON:0000955", "CL:0002627", 90],
+                ["UBERON:0002113", "CL:0000127", 300],
+                ["UBERON:0002113", "CL:0000644", 70],
+                ["UBERON:0002113", "CL:0002605", 80],
+                ["UBERON:0002113", "CL:0002627", 90],
+            ],
+            "expected_rolled_up_cell_counts": [
+                ["UBERON:0000955", "CL:0000127", 540],
+                ["UBERON:0000955", "CL:0000644", 70],
+                ["UBERON:0000955", "CL:0002605", 80],
+                ["UBERON:0000955", "CL:0002627", 90],
+                ["UBERON:0002113", "CL:0000127", 540],
+                ["UBERON:0002113", "CL:0000644", 70],
+                ["UBERON:0002113", "CL:0002605", 80],
+                ["UBERON:0002113", "CL:0002627", 90],
+            ],
+            "input_gene_expression": [
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0002113", "CL:0002627", 1, 1, 90, 1000],
+            ],
+            "expected_rolled_up_gene_expression": [
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000127", 2, 2, 150, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0000127", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0000127", 2, 2, 150, 1000],
+                ["ENSG00000169429", "UBERON:0002113", "CL:0000127", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0002113", "CL:0002627", 1, 1, 90, 1000],
+            ],
+        }
+
+        test_2 = {
+            "name": "no_compare_dim_one_ancestor_cell_type_missing_in_one_tissue_but_exists_in_all_others",
+            # Tissue: "UBERON:0000955" MISSING cell type: "CL:0000127" in input cell counts
+            "input_cell_counts": [
+                ["UBERON:0000955", "CL:0000644", 70],
+                ["UBERON:0000955", "CL:0002605", 80],
+                ["UBERON:0000955", "CL:0002627", 90],
+                ["UBERON:0002113", "CL:0000127", 300],
+                ["UBERON:0002113", "CL:0000644", 70],
+                ["UBERON:0002113", "CL:0002605", 80],
+                ["UBERON:0002113", "CL:0002627", 90],
+            ],
+            # cell count for cell type: "CL:0000127" in Tissue: "UBERON:0000955" GETS AGGREGATED
+            # count because Tissue "UBERON:0000955" CONTAINS cell counts for
+            # descendants of cell type: "CL:0000127"
+            "expected_rolled_up_cell_counts": [
+                ["UBERON:0000955", "CL:0000127", 240],
+                ["UBERON:0000955", "CL:0000644", 70],
+                ["UBERON:0000955", "CL:0002605", 80],
+                ["UBERON:0000955", "CL:0002627", 90],
+                ["UBERON:0002113", "CL:0000127", 540],
+                ["UBERON:0002113", "CL:0000644", 70],
+                ["UBERON:0002113", "CL:0002605", 80],
+                ["UBERON:0002113", "CL:0002627", 90],
+            ],
+            "input_gene_expression": [
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0002113", "CL:0002627", 1, 1, 90, 1000],
+            ],
+            "expected_rolled_up_gene_expression": [
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000127", 2, 2, 150, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0000127", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0000127", 2, 2, 150, 1000],
+                ["ENSG00000169429", "UBERON:0002113", "CL:0000127", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0002113", "CL:0002627", 1, 1, 90, 1000],
+            ],
+        }
+
+        test_3 = {
+            "name": "with_ethnicity_compare_dim_on_single_tissue",
+            "input_cell_counts": [
+                ["UBERON:0000955", "CL:0000127", "unknown", 300],
+                ["UBERON:0000955", "CL:0000644", "unknown", 70],
+                ["UBERON:0000955", "CL:0002605", "HANCESTRO:0005", 10],
+                ["UBERON:0000955", "CL:0002605", "HANCESTRO:0008", 30],
+                ["UBERON:0000955", "CL:0002605", "multiethnic", 40],
+                ["UBERON:0000955", "CL:0002627", "HANCESTRO:0006", 10],
+                ["UBERON:0000955", "CL:0002627", "HANCESTRO:0008", 20],
+                ["UBERON:0000955", "CL:0002627", "multiethnic", 30],
+                ["UBERON:0000955", "CL:0002627", "unknown", 40],
+            ],
+            "expected_rolled_up_cell_counts": [
+                ["UBERON:0000955", "CL:0000127", "HANCESTRO:0005", 10],
+                ["UBERON:0000955", "CL:0000127", "HANCESTRO:0006", 10],
+                ["UBERON:0000955", "CL:0000127", "HANCESTRO:0008", 50],
+                ["UBERON:0000955", "CL:0000127", "multiethnic", 70],
+                ["UBERON:0000955", "CL:0000127", "unknown", 410],
+                ["UBERON:0000955", "CL:0000644", "unknown", 70],
+                ["UBERON:0000955", "CL:0002605", "HANCESTRO:0005", 10],
+                ["UBERON:0000955", "CL:0002605", "HANCESTRO:0008", 30],
+                ["UBERON:0000955", "CL:0002605", "multiethnic", 40],
+                ["UBERON:0000955", "CL:0002627", "HANCESTRO:0006", 10],
+                ["UBERON:0000955", "CL:0002627", "HANCESTRO:0008", 20],
+                ["UBERON:0000955", "CL:0002627", "multiethnic", 30],
+                ["UBERON:0000955", "CL:0002627", "unknown", 40],
+            ],
+            "input_gene_expression": [
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000644", "unknown", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", "HANCESTRO:0008", 1, 1, 30, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", "multiethnic", 1, 1, 40, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002627", "HANCESTRO:0008", 1, 1, 20, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0002627", "multiethnic", 1, 1, 30, 1000],
+            ],
+            "expected_rolled_up_gene_expression": [
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000127", "HANCESTRO:0008", 2, 2, 50, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000127", "multiethnic", 1, 1, 40, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0000127", "multiethnic", 1, 1, 30, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000127", "unknown", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000644", "unknown", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", "HANCESTRO:0008", 1, 1, 30, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", "multiethnic", 1, 1, 40, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002627", "HANCESTRO:0008", 1, 1, 20, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0002627", "multiethnic", 1, 1, 30, 1000],
+            ],
+        }
+
+        return [
+            (
+                test_1["name"],
+                _cell_counts_df_without_compare_dim(test_1["input_cell_counts"]),
+                _cell_counts_df_without_compare_dim(test_1["expected_rolled_up_cell_counts"]),
+                _gene_expression_df_without_compare_dim(test_1["input_gene_expression"]),
+                _gene_expression_df_without_compare_dim(test_1["expected_rolled_up_gene_expression"]),
+            ),
+            (
+                test_2["name"],
+                _cell_counts_df_without_compare_dim(test_2["input_cell_counts"]),
+                _cell_counts_df_without_compare_dim(test_2["expected_rolled_up_cell_counts"]),
+                _gene_expression_df_without_compare_dim(test_2["input_gene_expression"]),
+                _gene_expression_df_without_compare_dim(test_2["expected_rolled_up_gene_expression"]),
+            ),
+            (
+                test_3["name"],
+                _cell_counts_df_with_ethnicity_compare_dim(test_3["input_cell_counts"]),
+                _cell_counts_df_with_ethnicity_compare_dim(test_3["expected_rolled_up_cell_counts"]),
+                _gene_expression_df_with_ethnicity_compare_dim(test_3["input_gene_expression"]),
+                _gene_expression_df_with_ethnicity_compare_dim(test_3["expected_rolled_up_gene_expression"]),
+            ),
+        ]
+
+    @parameterized.expand(_rollup_testcases)
+    def test__rollup(self, _, input_cell_counts_df, expected_cell_counts_df, input_gene_expr_df, expected_gene_expr_df):
         # Arrange
-
-        # Cell Type Ontology Subgraph
-        #    CL:0000127
-        #    ├── CL:0000644
-        #    ├── CL:0002605
-        #    └── CL:0002627
-        cell_counts_col_names = ["tissue_ontology_term_id", "cell_type_ontology_term_id", "n_cells_cell_type"]
-
-        input_cell_counts_rows = [
-            ["UBERON:0000955", "CL:0000127", 100000],
-            ["UBERON:0000955", "CL:0000644", 8034],
-            ["UBERON:0000955", "CL:0002605", 70009],
-            ["UBERON:0000955", "CL:0002627", 9871],
-            ["UBERON:0002113", "CL:0000127", 100000],
-            ["UBERON:0002113", "CL:0000644", 8034],
-            ["UBERON:0002113", "CL:0002605", 70009],
-            ["UBERON:0002113", "CL:0002627", 9871],
-        ]
-        cell_counts_df = pd.DataFrame(input_cell_counts_rows, columns=cell_counts_col_names)
-        cell_counts_df = cell_counts_df.set_index(["tissue_ontology_term_id", "cell_type_ontology_term_id"])
-
-        gene_expr_col_names = [
-            "gene_ontology_term_id",
-            "tissue_ontology_term_id",
-            "cell_type_ontology_term_id",
-            "nnz",
-            "sum",
-            "n_cells_cell_type",
-            "n_cells_tissue",
-        ]
-
-        input_gene_expr_rows = [
-            ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 8034, 10000000],
-            ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 70009, 10000000],
-            ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 9871, 10000000],
-            ["ENSG00000085265", "UBERON:0002113", "CL:0000644", 1, 1, 8034, 10000000],
-            ["ENSG00000085265", "UBERON:0002113", "CL:0002605", 1, 1, 70009, 10000000],
-            ["ENSG00000169429", "UBERON:0002113", "CL:0002627", 1, 1, 9871, 10000000],
-        ]
-
-        gene_expr_df = pd.DataFrame(input_gene_expr_rows, columns=gene_expr_col_names)
+        cell_counts_df_index_list = list(input_cell_counts_df.index.names)
 
         # Act
 
         # Note that we are creating copies of the input dataframes before passing them as
         # arguments to the `rollup` function so that if the `rollup` function mutates the
         # argument values, the input to the test is not affected.
-        rolled_up_gene_expr_df, rolled_up_cell_counts_df = rollup(gene_expr_df.copy(), cell_counts_df.copy())
+        rolled_up_gene_expr_df, rolled_up_cell_counts_df = rollup(
+            input_gene_expr_df.copy(), input_cell_counts_df.copy()
+        )
 
         # Assert
-        expected_cell_counts_rows = [
-            ["UBERON:0000955", "CL:0000127", 187914],
-            ["UBERON:0000955", "CL:0000644", 8034],
-            ["UBERON:0000955", "CL:0002605", 70009],
-            ["UBERON:0000955", "CL:0002627", 9871],
-            ["UBERON:0002113", "CL:0000127", 187914],
-            ["UBERON:0002113", "CL:0000644", 8034],
-            ["UBERON:0002113", "CL:0002605", 70009],
-            ["UBERON:0002113", "CL:0002627", 9871],
-        ]
-        expected_cell_counts_df = pd.DataFrame(expected_cell_counts_rows, columns=cell_counts_col_names)
-
         rolled_up_cell_counts_df.reset_index(inplace=True)
-        assert np.array_equal(rolled_up_cell_counts_df.values, expected_cell_counts_df.values)
+        expected_cell_counts_df.reset_index(inplace=True)
 
-        expected_gene_expr_rows = [
-            ["ENSG00000085265", "UBERON:0000955", "CL:0000127", 2, 2, 78043, 10000000],
-            ["ENSG00000169429", "UBERON:0000955", "CL:0000127", 1, 1, 9871, 10000000],
-            ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 8034, 10000000],
-            ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 70009, 10000000],
-            ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 9871, 10000000],
-            ["ENSG00000085265", "UBERON:0002113", "CL:0000127", 2, 2, 78043, 10000000],
-            ["ENSG00000169429", "UBERON:0002113", "CL:0000127", 1, 1, 9871, 10000000],
-            ["ENSG00000085265", "UBERON:0002113", "CL:0000644", 1, 1, 8034, 10000000],
-            ["ENSG00000085265", "UBERON:0002113", "CL:0002605", 1, 1, 70009, 10000000],
-            ["ENSG00000169429", "UBERON:0002113", "CL:0002627", 1, 1, 9871, 10000000],
-        ]
-        expected_gene_expr_df = pd.DataFrame(expected_gene_expr_rows, columns=gene_expr_col_names)
-
-        rolled_up_gene_expr_df.sort_values(
-            ["tissue_ontology_term_id", "cell_type_ontology_term_id", "gene_ontology_term_id"], inplace=True
+        assert_frame_equal(
+            rolled_up_cell_counts_df.reset_index(drop=True), expected_cell_counts_df.reset_index(drop=True)
         )
-        assert np.array_equal(rolled_up_gene_expr_df.values, expected_gene_expr_df.values)
+
+        # sort the rolled up gene expression dataframe so that the correct rows are compared with
+        # the expected gene expression rows in the assert call
+        sort_columns_for_rolled_gene_expr_df = list(cell_counts_df_index_list) + ["gene_ontology_term_id"]
+        rolled_up_gene_expr_df.sort_values(sort_columns_for_rolled_gene_expr_df, inplace=True)
+
+        assert_frame_equal(rolled_up_gene_expr_df.reset_index(drop=True), expected_gene_expr_df.reset_index(drop=True))
 
 
 class TestHighLevelRollupHelperFunctions(unittest.TestCase):

--- a/tests/unit/backend/wmg/api/test_expression_rollup.py
+++ b/tests/unit/backend/wmg/api/test_expression_rollup.py
@@ -59,7 +59,7 @@ class TestLowLevelRollupFunctionsTraversingCellTypeLineage(unittest.TestCase):
 
 def _create_cell_counts_df_helper(cell_counts_rows: list[list], columns: list[str], index_cols: list[str]) -> DataFrame:
     cell_counts_df = pd.DataFrame(cell_counts_rows, columns=columns)
-    cell_counts_df = cell_counts_df.set_index(index_cols)
+    cell_counts_df = cell_counts_df.set_index(index_cols, verify_integrity=True)
     return cell_counts_df
 
 


### PR DESCRIPTION
## Reason for Change

- #4575 

## Changes

Modified the gene expression rollup code to also rollup the compare dimension cell counts correctly. Particularly, the change is in computation for set of ancestor cell types that should included rolled up numeric values from its descendant cell types.

## Testing steps

- Visual inspection of the dot plot and cell counts in [rdev](https://rdev-ps-fix-rollup2-frontend.rdev.single-cell.czi.technology/gene-expression) based on manual testing.
- Added unit tests for the top level rollup functionality which is public function
- Added unit tests for the private functions that the public rollup function calls

## Notes for Reviewer
