### PR TITLE
 fix: add revising_in to ignored collection fields (#4775)

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -433,6 +433,8 @@ jobs:
       - processing-unit-test
       - e2e-test
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -43,9 +43,9 @@ resource aws_batch_job_definition batch_job_def {
       "value": "${var.frontend_url}"
     }
   ],
-  "vcpus": 2,
+  "vcpus": 8,
   "linuxParameters": {
-     "maxSwap": 1000000,
+     "maxSwap": 800000,
      "swappiness": 60
   },
   "logConfiguration": {

--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -102,7 +102,7 @@ resource "aws_sfn_state_machine" "state_machine" {
                   }
                 },
                 "ResultPath": null,
-                "TimeoutSeconds": 36000
+                "TimeoutSeconds": 360000
               }
             }
           },

--- a/backend/common/utils/cxg_generation_utils.py
+++ b/backend/common/utils/cxg_generation_utils.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 import numpy as np
 import pandas as pd
@@ -181,6 +182,7 @@ def convert_matrices_to_cxg_arrays(matrix_name, matrix, encode_as_sparse_array, 
     def create_matrix_array(
         matrix_name, number_of_rows, number_of_columns, encode_as_sparse_array, compression=22, row=True
     ):
+        logging.info(f"create {matrix_name}")
         dim_filters = tiledb.FilterList([tiledb.ByteShuffleFilter(), tiledb.ZstdFilter(level=compression)])
         if not encode_as_sparse_array:
             attrs = [tiledb.Attr(dtype=np.float32, filters=tiledb.FilterList([tiledb.ZstdFilter(level=compression)]))]
@@ -266,6 +268,7 @@ def convert_matrices_to_cxg_arrays(matrix_name, matrix, encode_as_sparse_array, 
         array_r = tiledb.open(matrix_name + "r", mode="w", ctx=ctx)
         array_c = tiledb.open(matrix_name + "c", mode="w", ctx=ctx)
 
+        logging.info(f"Store rows: {number_of_rows}")
         for start_row_index in range(0, number_of_rows, stride_rows):
             end_row_index = min(start_row_index + stride_rows, number_of_rows)
             matrix_subset = matrix[start_row_index:end_row_index, :]
@@ -279,6 +282,7 @@ def convert_matrices_to_cxg_arrays(matrix_name, matrix, encode_as_sparse_array, 
             obs, var, data = _sort_by_primary_obs_and_secondary_var(data_dict)
             array_r[obs] = {"var": var, "": data}
 
+        logging.info(f"Store columns: {number_of_columns}")
         for start_col_index in range(0, number_of_columns, stride_columns):
             end_col_index = min(start_col_index + stride_columns, number_of_columns)
             matrix_subset = matrix[:, start_col_index:end_col_index]

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -425,6 +425,16 @@ class BusinessLogic(BusinessLogicInterface):
         datasets, _ = self.database_provider.get_all_mapped_datasets_and_collections()
         return datasets
 
+    def get_datasets_for_collections(self, collections: Iterable[CollectionVersion]) -> Iterable[DatasetVersion]:
+        datasets = []
+        for collection in collections:
+            datasest_ids = [d.id for d in collection.datasets]
+            collection_datasets: List[DatasetVersion] = [
+                self.database_provider.get_dataset_version(DatasetVersionId(id)) for id in datasest_ids
+            ]
+            datasets.extend(collection_datasets)
+        return datasets
+
     def get_all_mapped_collection_versions_with_datasets(self) -> List[CollectionVersionWithPublishedDatasets]:
         """
         Retrieves all the datasets from the database that belong to a published collection

--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -98,6 +98,7 @@ class H5ADDataFile:
         convert_matrices_to_cxg_arrays(matrix_container, x_matrix_data, is_sparse, ctx)
 
         suffixes = ["r", "c"] if is_sparse else [""]
+        logging.info("start consolidating")
         for suffix in suffixes:
             tiledb.consolidate(matrix_container + suffix, ctx=ctx)
             if hasattr(tiledb, "vacuum"):

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -1080,6 +1080,8 @@ components:
           type: string
         publisher_metadata:
           $ref: "#/components/schemas/publisher_metadata"
+        revising_in:
+          $ref: "#/components/schemas/revising_in"
         datasets:
           type: array
           items:
@@ -1113,7 +1115,13 @@ components:
           type: number
         published_year:
           type: number
-
+    revising_in:
+      type: string
+      description: >-
+        If the Collection is published and has an outstanding private Revision, and the user has write access, then
+        `revising_in` is set to the id of the private Revision. The value is `None` if the user is not authorized or no
+        private Revision exists.
+      nullable: true
     ontology_element:
       type: object
       properties:

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -418,6 +418,54 @@ paths:
         "400":
           $ref: "#/components/responses/400"
 
+  /v1/user-collections/index:
+    get:
+      tags:
+        - collections
+      summary: >-
+        Returns all public, non tombstoned collections. This endpoint is meant to be used for displaying collections
+        in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+      security:
+        - cxguserCookie: []
+      operationId: backend.portal.api.portal_api.get_user_collection_index
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    access_type:
+                      $ref: "#/components/schemas/access_type"
+                    curator_name:
+                      type: string
+                    id:
+                      $ref: "#/components/schemas/collection_id"
+                    name:
+                      type: string
+                    publisher_metadata:
+                      $ref: "#/components/schemas/publisher_metadata"
+                    published_at:
+                      type: number
+                      nullable: true
+                    revised_at:
+                      type: number
+                      nullable: true
+                    consortia:
+                      $ref: "#/components/schemas/consortia"
+                    visibility:
+                      $ref: "#/components/schemas/visibility"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+
   /v1/datasets/{dataset_id}:
     delete:
       tags:
@@ -702,7 +750,88 @@ paths:
                       type: number
         "400":
           $ref: "#/components/responses/400"
-
+  /v1/user-datasets/index:
+    get:
+      tags:
+        - datasets
+      summary: >-
+        Returns all public and private, non tombstoned datasets where the user has WRITE access. This endpoint is meant to be used for displaying datasets
+        in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+      security:
+        - cxguserCookieLenient: []
+        - {}
+      description: >-
+        Returns all datasets that belong to public and private, non tombstoned collections where the user has WRITE access. This endpoint is meant to be used 
+        for displaying datasets in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+      operationId: backend.portal.api.portal_api.get_user_datasets_index
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    collection_id:
+                      type: string
+                    assay:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    tissue:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    tissue_ancestors:
+                      type: array
+                      items:
+                        type: string
+                    disease:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    sex:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    self_reported_ethnicity:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    organism:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    development_stage:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    development_stage_ancestors:
+                      type: array
+                      items:
+                        type: string
+                    cell_count:
+                      type: integer
+                    cell_type:
+                      $ref: "#/components/schemas/ontology_element_array"
+                    cell_type_ancestors:
+                      type: array
+                      items:
+                        type: string
+                    mean_genes_per_cell:
+                      type: number
+                    is_primary_data:
+                      $ref: "#/components/schemas/is_primary_data"
+                    donor_id:
+                      type: array
+                      items:
+                        type: string
+                    suspension_type:
+                      type: array
+                      items:
+                        type: string
+                    schema_version:
+                      type: string
+                    explorer_url:
+                      type: string
+                    published_at:
+                      type: number
+                    revised_at:
+                      type: number
+        "400":
+          $ref: "#/components/responses/400"
   /v1/login:
     get:
       tags:
@@ -824,6 +953,10 @@ paths:
 
 components:
   schemas:
+    access_type:
+      description: Indicates if the user will be allowed to make updates to the entity.
+      type: string
+      enum: [READ, WRITE]
     user_id:
       description: A unique identifier of a logged in User of Corpora.
       type: string
@@ -920,8 +1053,7 @@ components:
         - data_submission_policy_version
       properties:
         access_type:
-          type: string
-          enum: [READ, WRITE]
+          $ref: "#/components/schemas/access_type"
         created_at:
           type: number
         updated_at:

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -423,7 +423,10 @@ paths:
       tags:
         - collections
       summary: >-
-        Returns all public, non tombstoned collections. This endpoint is meant to be used for displaying collections
+        Returns all public collections and any private collections that the user can update.
+      description: >-
+        Returns all public, non tombstoned collections and any private collections or revisions the user
+        has WRITE access to. This endpoint is meant to be used for displaying collections
         in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
       security:
         - cxguserCookie: []
@@ -755,14 +758,13 @@ paths:
       tags:
         - datasets
       summary: >-
-        Returns all public and private, non tombstoned datasets where the user has WRITE access. This endpoint is meant to be used for displaying datasets
-        in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+        Returns datasets related to all public non-tombstoned collections and all private non-revision collections the user can update.
       security:
-        - cxguserCookieLenient: []
-        - {}
+        - cxguserCookie: []
       description: >-
-        Returns all datasets that belong to public and private, non tombstoned collections where the user has WRITE access. This endpoint is meant to be used 
-        for displaying datasets in a compact view. It doesn't return all the fields, so it is not suitable for general usage.
+        Returns datasets related to all public non-tombstoned collections and all private non-revision collections
+        where the user has WRITE access. This endpoint is meant to be used for displaying datasets in a compact view.
+        It doesn't return all the fields, so it is not suitable for general usage.
       operationId: backend.portal.api.portal_api.get_user_datasets_index
       responses:
         "200":
@@ -832,6 +834,8 @@ paths:
                       type: number
         "400":
           $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
   /v1/login:
     get:
       tags:

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -232,6 +232,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
     """
     Converts a CollectionVersion object to an object compliant to the API specifications
     """
+    revising_in = None
     if collection.is_unpublished_version():
         # In this case, the collection version is a revision of an already published collection.
         # We should expose version_id as the collection_id
@@ -250,7 +251,15 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
         # The last case is a published collection. We just return the canonical id and set revision_of to None
         revision_of = None
         collection_id = collection.collection_id.id
-        is_in_revision = False
+        is_published = collection.published_at is not None
+
+        _revising_in = None
+        if is_published and access_type == "WRITE":  # can ony be WRITE if authenticated
+            _revising_in = get_business_logic().get_unpublished_collection_version_from_canonical(
+                collection.collection_id
+            )
+        revising_in = _revising_in.version_id.id if _revising_in else None
+        is_in_revision = True if _revising_in else None
 
     is_tombstoned = collection.canonical_collection.tombstoned
 
@@ -278,6 +287,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
             "published_at": collection.canonical_collection.originally_published_at,
             "publisher_metadata": collection.publisher_metadata,  # TODO: convert
             "revision_of": revision_of,
+            "revising_in": revising_in,
             "updated_at": collection.published_at or collection.created_at,
             "visibility": "PUBLIC" if collection.published_at is not None else "PRIVATE",
         }

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -761,7 +761,7 @@ def get_user_datasets_index(token_info: dict):
 
     private_collections = get_user_private_collections(token_info)
     # filter out collections that are revisions
-    non_revisions = [c for c in private_collections if c.is_unpublished_version() is False]
+    non_revisions = [c for c in private_collections if not c.is_unpublished_version()]
     private_datasets = get_business_logic().get_datasets_for_collections(non_revisions)
 
     response = enrich_dataset_response(itertools.chain(public_datasets, private_datasets))

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -744,7 +744,7 @@ def get_datasets_index():
 
 def get_user_datasets_index(token_info: dict):
     """
-    Returns a list of all datasets associated with public or private collections where
+    Returns a list of all Datasets associated with public Collections or with private Collections where
     the user has WRITE access and the collection is not a revision.
     """
     public_datasets = get_business_logic().get_all_mapped_datasets()

--- a/frontend/src/common/entities.ts
+++ b/frontend/src/common/entities.ts
@@ -95,6 +95,7 @@ export interface Collection {
   revision_diff: boolean;
   summaryCitation?: string;
   tombstone?: boolean;
+  revising_in?: Collection["id"];
   revision_of?: Collection["id"];
   revisioning_in?: Collection["id"];
 }

--- a/frontend/src/common/utils/checkForRevisionChange.ts
+++ b/frontend/src/common/utils/checkForRevisionChange.ts
@@ -9,6 +9,7 @@ const IGNORED_COLLECTION_FIELDS = [
   "created_at",
   "updated_at",
   "revisioning_in",
+  "revising_in",
   "revision_of",
   "revision_diff",
   "published_at",

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -16,7 +16,6 @@ import {
 } from "src/common/queries/collections";
 import { removeParams } from "src/common/utils/removeParams";
 import { isTombstonedCollection } from "src/common/utils/typeGuards";
-import BottomBanner from "src/components/BottomBanner";
 import CollectionDescription from "src/components/Collection/components/CollectionDescription";
 import CollectionMetadata from "src/components/Collection/components/CollectionMetadata";
 import CollectionRevisionStatusCallout from "src/components/Collection/components/CollectionRevisionStatusCallout";
@@ -226,7 +225,8 @@ const Collection: FC = () => {
           visibility={collection.visibility}
         />
       </ViewCollection>
-      <BottomBanner />
+      {/* May be added in the future after sign off */}
+      {/* <BottomBanner /> */}
     </>
   );
 };

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -39,7 +39,6 @@ import {
 } from "src/views/Collections/common/constants";
 import { get } from "src/common/featureFlags";
 import { BOOLEAN } from "src/common/localStorage/set";
-import BottomBanner from "src/components/BottomBanner";
 
 export default function Collections(): JSX.Element {
   const isCuratorEnabled = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
@@ -301,7 +300,8 @@ export default function Collections(): JSX.Element {
               />
             )}
           </View>
-          <BottomBanner />
+          {/* May be added in the future after sign off */}
+          {/* <BottomBanner /> */}
         </>
       )}
     </>

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -15,7 +15,6 @@ import { useExplainNewTab } from "src/common/hooks/useExplainNewTab";
 import { useSessionStorage } from "src/common/hooks/useSessionStorage";
 import { useFetchDatasetRows } from "src/common/queries/filter";
 import { KEYS } from "src/common/sessionStorage/set";
-import BottomBanner from "src/components/BottomBanner";
 import Filter from "src/components/common/Filter";
 import {
   CATEGORY_FILTER_ID,
@@ -374,7 +373,8 @@ export default function Datasets(): JSX.Element {
               />
             )}
           </View>
-          <BottomBanner />
+          {/* May be added in the future after sign off */}
+          {/* <BottomBanner /> */}
         </>
       )}
     </>

--- a/frontend/tests/features/wheresMyGene/shareLink.test.ts
+++ b/frontend/tests/features/wheresMyGene/shareLink.test.ts
@@ -42,8 +42,11 @@ const sexes = [
   { id: "PATO:0000384", text: "male" },
 ];
 const COMPARE = "disease";
+
 const initialState =
-  "https://localhost:3000/gene-expression?datasets=c874f155-9bf9-4928-b821-f52c876b3e48%2Cdb59611b-42de-4035-93aa-1ed39f38b467%2Ceeacb0c1-2217-4cf6-b8ce-1f0fedf1b569%2C881fe679-c6e0-45a3-9427-c4e81be6921f%2Cea786a06-5855-48b7-80d7-0313a21a2044%2C456e8b9b-f872-488b-871d-94534090a865&diseases=MONDO%3A0100096&ethnicities=unknown&sexes=PATO%3A0000383%2CPATO%3A0000384&tissues=blood%2Clung&genes=DPM1%2CTNMD%2CTSPAN6&ver=2&compare=disease";
+  `${TEST_URL}/gene-expression?` +
+  "datasets=c874f155-9bf9-4928-b821-f52c876b3e48%2Cdb59611b-42de-4035-93aa-1ed39f38b467%2Ceeacb0c1-2217-4cf6-b8ce-1f0fedf1b569%2C881fe679-c6e0-45a3-9427-c4e81be6921f%2Cea786a06-5855-48b7-80d7-0313a21a2044%2C456e8b9b-f872-488b-871d-94534090a865&diseases=MONDO%3A0100096&ethnicities=unknown&sexes=PATO%3A0000383%2CPATO%3A0000384&tissues=blood%2Clung&genes=DPM1%2CTNMD%2CTSPAN6&ver=2&compare=disease";
+
 describe("Share link tests", () => {
   skip(!isDevStagingProd, "WMG BE API does not work locally or in rdev");
   test("Should share link with single tissue and single gene", async ({

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1686,8 +1686,7 @@ class TestDataset(BaseAPIPortalTest):
 
         private_dataset = self.generate_dataset()
         public_dataset = self.generate_dataset(publish=True)
-        # how can I add a dataset to a revision?
-        revision = self.business_logic.create_collection_version(CollectionId(public_dataset.collection_id))
+        self.business_logic.create_collection_version(CollectionId(public_dataset.collection_id))
 
         test_url = furl(path="/dp/v1/user-datasets/index")
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1715,6 +1715,13 @@ class TestDataset(BaseAPIPortalTest):
         self.assertIn(public_dataset.dataset_version_id, dataset_ids)
         self.assertIn(private_dataset.dataset_version_id, dataset_ids)
 
+    def test__get_all_user_datasets_for_index_requires_auth(self):
+        # test that non logged user returns 401
+        test_url = furl(path="/dp/v1/user-datasets/index")
+        headers = {"host": "localhost", "Content-Type": "application/json"}
+        response = self.app.get(test_url.url, headers=headers)
+        self.assertEqual(response.status_code, 401)
+
     # ✅
     def test__get_all_datasets_for_index_with_ontology_expansion(self):
         import copy


### PR DESCRIPTION
## Reason for Change

- #4775

## Changes

- added `revising_in` to the ignored collection fields used to determine if a revision has been edited or is fresh.

## Testing steps
- have not yet been able to test this.


## Notes for Reviewer
