### PR TITLE
chore: update push-rdev to use only first 7 github sha characters for image tags

### DIFF
--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -44,9 +44,9 @@ jobs:
       - name: Build component
         shell: bash
         run: |
-          happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8}
+          happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:7}
       - name: Create Summary With Happy Commands
         run: |
           echo "### Happy Commands :rocket: :upside_down_face:" >> $GITHUB_STEP_SUMMARY
-          echo "* \`happy create <_stack-name_> --tag ${GITHUB_SHA:0:8} --create-tag=false --skip-check-tag\`" >> $GITHUB_STEP_SUMMARY
-          echo "* \`happy update <_stack-name_> --tag ${GITHUB_SHA:0:8} --create-tag=false --skip-check-tag\`" >> $GITHUB_STEP_SUMMARY
+          echo "* \`happy create <_stack-name_> --tag ${GITHUB_SHA:0:7} --create-tag=false --skip-check-tag\`" >> $GITHUB_STEP_SUMMARY
+          echo "* \`happy update <_stack-name_> --tag ${GITHUB_SHA:0:7} --create-tag=false --skip-check-tag\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Reason for Change
- In elite programmer fashion, I always try to use the github UI to copy and paste the commit hash corresponding to the image tag only to be thwarted by the fact that github only displays the first 7 characters in the abbreviated hash, whereas the images are being tagged with the first 8 characters. 

## Changes

- Modify image tags to use first 7 characters of github SHAs
