### PR TITLE
fix: set is_in_revision false for collections with revisions (#4775)

### DIFF
--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -259,7 +259,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
                 collection.collection_id
             )
         revising_in = _revising_in.version_id.id if _revising_in else None
-        is_in_revision = True if _revising_in else None
+        is_in_revision = False
 
     is_tombstoned = collection.canonical_collection.tombstoned
 


### PR DESCRIPTION
## Reason for Change

- #4775

## Changes

- I reverted a change that set `is_in_revision` dynamically based on the value of `revising_in` for collections in `_collection_to_response.`  I mistakenly thought `is_in_revision` applied to the original public collection (canonical); instead, it seems `is_in_revision` applies to the actual revisions themselves.  The incorrect value for `is_in_revision` for the canonical collection was causing datasets to be marked as `published = false` on the canonical collection and making the front-end code think the collection had been modified since it was last published. 

## Testing steps
- I ran the back-end tests
- I validated the functionality first broken, then fixed on [cc-rdev-2](https://cc-rdev-2-frontend.rdev.single-cell.czi.technology/)


## Notes for Reviewer
#4766 is still required to fix this bug so I have not reverted it. I tested reverting #4766 and was able to bring back the error after this current fix fixed it.

We might want to change the name of `is_in_revision` as @danieljhegeman had suggested to me.
