### PR TITLE
refactor: Create a strawman V2 version of the WMG API

### DIFF
--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -1,0 +1,625 @@
+import itertools
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, Tuple
+
+import connexion
+import numpy as np
+import pandas as pd
+from flask import jsonify
+from pandas import DataFrame
+from server_timing import Timing as ServerTiming
+
+from backend.wmg.data.ontology_labels import gene_term_label, ontology_term_label
+from backend.wmg.data.query import (
+    MarkerGeneQueryCriteria,
+    WmgFiltersQueryCriteria,
+    WmgQuery,
+    WmgQueryCriteria,
+    retrieve_top_n_markers,
+)
+from backend.wmg.data.rollup import rollup_across_cell_type_descendants
+from backend.wmg.data.schemas.cube_schema import expression_summary_non_indexed_dims
+from backend.wmg.data.snapshot import WmgSnapshot, load_snapshot
+from backend.wmg.data.utils import depluralize, find_all_dim_option_values, find_dim_option_values
+
+# TODO: add cache directives: no-cache (i.e. revalidate); impl etag
+#  https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data
+#  -portal/2132
+
+DEFAULT_GROUP_BY_TERMS = ["tissue_ontology_term_id", "cell_type_ontology_term_id"]
+
+
+def primary_filter_dimensions():
+    snapshot: WmgSnapshot = load_snapshot()
+    return jsonify(snapshot.primary_filter_dimensions)
+
+
+def query():
+    request = connexion.request.json
+    is_rollup = request.get("is_rollup", True)
+    compare = request.get("compare", None)
+
+    if compare:
+        compare = find_dimension_id_from_compare(compare)
+
+    criteria = WmgQueryCriteria(**request["filter"])
+
+    with ServerTiming.time("query and build response"):
+        snapshot: WmgSnapshot = load_snapshot()
+        q = WmgQuery(snapshot)
+        default = snapshot.expression_summary_default_cube is not None and compare is None
+        for dim in criteria.dict():
+            if len(criteria.dict()[dim]) > 0 and depluralize(dim) in expression_summary_non_indexed_dims:
+                default = False
+                break
+
+        expression_summary = q.expression_summary_default(criteria) if default else q.expression_summary(criteria)
+
+        cell_counts = q.cell_counts(criteria)
+        if expression_summary.shape[0] > 0 or cell_counts.shape[0] > 0:
+            group_by_terms = ["tissue_ontology_term_id", "cell_type_ontology_term_id", compare] if compare else None
+
+            dot_plot_matrix_df, cell_counts_cell_type_agg = get_dot_plot_data(
+                expression_summary, cell_counts, group_by_terms
+            )
+            if is_rollup:
+                dot_plot_matrix_df, cell_counts_cell_type_agg = rollup(dot_plot_matrix_df, cell_counts_cell_type_agg)
+
+            response = jsonify(
+                dict(
+                    snapshot_id=snapshot.snapshot_identifier,
+                    expression_summary=build_expression_summary(dot_plot_matrix_df, compare),
+                    term_id_labels=dict(
+                        genes=build_gene_id_label_mapping(criteria.gene_ontology_term_ids),
+                        cell_types=build_ordered_cell_types_by_tissue(
+                            cell_counts_cell_type_agg, snapshot.cell_type_orderings, compare
+                        ),
+                    ),
+                )
+            )
+        else:  # no data, return empty json
+            response = jsonify(dict(snapshot_id=snapshot.snapshot_identifier, expression_summary={}, term_id_labels={}))
+    return response
+
+
+def filters():
+    request = connexion.request.json
+    criteria = WmgFiltersQueryCriteria(**request["filter"])
+
+    with ServerTiming.time("calculate filters and build response"):
+        snapshot: WmgSnapshot = load_snapshot()
+        response_filter_dims_values = build_filter_dims_values(criteria, snapshot)
+        response = jsonify(
+            dict(
+                snapshot_id=snapshot.snapshot_identifier,
+                filter_dims=response_filter_dims_values,
+            )
+        )
+    return response
+
+
+def markers():
+    request = connexion.request.json
+    cell_type = request["celltype"]
+    tissue = request["tissue"]
+    organism = request["organism"]
+    n_markers = request["n_markers"]
+    test = request["test"]
+    snapshot: WmgSnapshot = load_snapshot()
+
+    criteria = MarkerGeneQueryCriteria(
+        tissue_ontology_term_id=tissue,
+        organism_ontology_term_id=organism,
+        cell_type_ontology_term_id=cell_type,
+    )
+    q = WmgQuery(snapshot)
+    df = q.marker_genes(criteria)
+    marker_genes = retrieve_top_n_markers(df, test, n_markers)
+    return jsonify(
+        dict(
+            snapshot_id=snapshot.snapshot_identifier,
+            marker_genes=marker_genes,
+        )
+    )
+
+
+def fetch_datasets_metadata(snapshot: WmgSnapshot, dataset_ids: Iterable[str]) -> List[Dict]:
+    return [
+        snapshot.dataset_dict.get(dataset_id, dict(id=dataset_id, label="", collection_id="", collection_label=""))
+        for dataset_id in dataset_ids
+    ]
+
+
+def find_dimension_id_from_compare(compare: str) -> str:
+    if compare == "sex":
+        return "sex_ontology_term_id"
+    elif compare == "self_reported_ethnicity":
+        return "self_reported_ethnicity_ontology_term_id"
+    elif compare == "disease":
+        return "disease_ontology_term_id"
+    else:
+        return None
+
+
+def is_criteria_empty(criteria: WmgFiltersQueryCriteria) -> bool:
+    criteria = criteria.dict()
+    for key in criteria:
+        if key != "organism_ontology_term_id":
+            if isinstance(criteria[key], list):
+                if len(criteria[key]) > 0:
+                    return False
+            else:
+                if criteria[key] != "":
+                    return False
+    return True
+
+
+def build_filter_dims_values(criteria: WmgFiltersQueryCriteria, snapshot: WmgSnapshot) -> Dict:
+    dims = {
+        "dataset_id": "",
+        "disease_ontology_term_id": "",
+        "sex_ontology_term_id": "",
+        "development_stage_ontology_term_id": "",
+        "self_reported_ethnicity_ontology_term_id": "",
+        "tissue_ontology_term_id": "",
+        "cell_type_ontology_term_id": "",
+    }
+    for dim in dims:
+        dims[dim] = (
+            find_all_dim_option_values(snapshot, dim)
+            if is_criteria_empty(criteria)
+            else find_dim_option_values(criteria, snapshot, dim)
+        )
+
+    response_filter_dims_values = dict(
+        datasets=fetch_datasets_metadata(snapshot, dims["dataset_id"]),
+        disease_terms=build_ontology_term_id_label_mapping(dims["disease_ontology_term_id"]),
+        sex_terms=build_ontology_term_id_label_mapping(dims["sex_ontology_term_id"]),
+        development_stage_terms=build_ontology_term_id_label_mapping(dims["development_stage_ontology_term_id"]),
+        self_reported_ethnicity_terms=build_ontology_term_id_label_mapping(
+            dims["self_reported_ethnicity_ontology_term_id"]
+        ),
+        cell_type_terms=build_ontology_term_id_label_mapping(dims["cell_type_ontology_term_id"]),
+        tissue_terms=build_ontology_term_id_label_mapping(dims["tissue_ontology_term_id"]),
+    )
+
+    return response_filter_dims_values
+
+
+def build_expression_summary(query_result: DataFrame, compare: str) -> dict:
+    # Create nested dicts with gene_ontology_term_id, tissue_ontology_term_id keys, cell_type_ontology_term_id respectively
+    structured_result: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]] = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(dict))
+    )
+
+    # Populate aggregated gene expressions
+    query_result_agg = query_result.groupby(
+        ["gene_ontology_term_id", "tissue_ontology_term_id", "cell_type_ontology_term_id"], as_index=False
+    ).agg({"nnz": "sum", "sum": "sum", "n_cells_cell_type": "sum", "n_cells_tissue": "first"})
+
+    for i in range(query_result_agg.shape[0]):
+        row = query_result_agg.iloc[i]
+        structured_result[row.gene_ontology_term_id][row.tissue_ontology_term_id][row.cell_type_ontology_term_id][
+            "aggregated"
+        ] = dict(
+            n=int(row["nnz"]),
+            me=float(row["sum"] / row["nnz"]),
+            pc=float(row["nnz"] / row["n_cells_cell_type"]),
+            tpc=float(row["nnz"] / row["n_cells_tissue"]),
+        )
+
+    # Populate compare filter gene expressions
+    if compare:
+        for i in range(query_result.shape[0]):
+            row = query_result.iloc[i]
+            structured_result[row.gene_ontology_term_id][row.tissue_ontology_term_id][row.cell_type_ontology_term_id][
+                row[compare]
+            ] = dict(
+                n=int(row["nnz"]),
+                me=float(row["sum"] / row["nnz"]),
+                pc=float(row["nnz"] / row["n_cells_cell_type"]),
+                tpc=float(row["nnz"] / row["n_cells_tissue"]),
+            )
+
+    return structured_result
+
+
+def agg_cell_type_counts(cell_counts: DataFrame, group_by_terms: List[str] = None) -> DataFrame:
+    # Aggregate cube data by tissue, cell type
+    if group_by_terms is None:
+        group_by_terms = DEFAULT_GROUP_BY_TERMS
+    cell_counts_cell_type_agg = cell_counts.groupby(group_by_terms, as_index=True).sum(numeric_only=True)
+    cell_counts_cell_type_agg.rename(columns={"n_total_cells": "n_cells_cell_type"}, inplace=True)
+    return cell_counts_cell_type_agg
+
+
+def agg_tissue_counts(cell_counts: DataFrame) -> DataFrame:
+    # Aggregate cube data by tissue
+    cell_counts_tissue_agg = cell_counts.groupby(["tissue_ontology_term_id"], as_index=True).sum(numeric_only=True)
+    cell_counts_tissue_agg.rename(columns={"n_total_cells": "n_cells_tissue"}, inplace=True)
+    return cell_counts_tissue_agg
+
+
+def get_dot_plot_data(
+    query_result: DataFrame,
+    cell_counts: DataFrame,
+    group_by_terms: List[str] = None,
+) -> Tuple[DataFrame, DataFrame]:
+    if group_by_terms is None:
+        group_by_terms = DEFAULT_GROUP_BY_TERMS
+    # Get the dot plot matrix dataframe and aggregated cell counts per cell type
+    cell_counts_cell_type_agg = agg_cell_type_counts(cell_counts, group_by_terms)
+    cell_counts_tissue_agg = agg_tissue_counts(cell_counts)
+    dot_plot_matrix_df = build_dot_plot_matrix(
+        query_result, cell_counts_cell_type_agg, cell_counts_tissue_agg, group_by_terms
+    )
+    return dot_plot_matrix_df, cell_counts_cell_type_agg
+
+
+def rollup(gene_expression_df, cell_counts_grouped_df) -> Tuple[DataFrame, DataFrame]:
+    """
+    Accumulates (or rolls up) cell count values and gene-expression values FOR EACH expressed gene
+    up the cell type ANCESTOR paths grouped by the ontology term IDs in the multi-index of the
+    input cell counts dataframe.
+
+    Parameters
+    ----------
+    gene_expression_df : pandas DataFrame
+        Tidy gene expression dataframe containing the dimensions across which the numeric columns will be
+        aggregated.
+
+    cell_counts_grouped_df : pandas DataFrame
+        Multi-indexed cell counts dataframe containing the dimensions across which the cell count values will be
+        aggregated.
+
+    Returns
+    -------
+    rolled_up_gene_expression_df : pandas DataFrame
+        Tidy gene expression dataframe with the same columns as the input gene expression dataframe,
+        and likely greater size than the input gene expression dataframe, but with the numeric
+        columns aggregated across the cell type's descendants.
+
+    rolled_up_cell_counts_grouped_df : pandas DataFrame
+        Multi-indexed cell counts dataframe with the same columns as the input cell counts dataframe,
+        and likely greater size than the input cell counts dataframe, but with the cell count
+        values aggregated across the cell type's descendants.
+    """
+    # An implementation detail note:
+
+    # The order of operation is important: The cell counts are rolled up first to produce a the
+    # `rolled_up_cell_counts_grouped_df` dataframe. Then this `rolled_up_cell_counts_grouped_df` is
+    # an input into the operation to roll up gene expression values.
+
+    # This is done for efficiency reasons where the `rolled_up_cell_counts_grouped_df` is made sparse
+    # by the first operation that rolls up the cell counts. Having a sparse
+    # `rolled_up_cell_counts_grouped_df` significantly improves the running time and memory footprint of
+    # the second operation: rolling up the gene expression values.
+
+    rolled_up_cell_counts_grouped_df = _rollup_cell_counts(cell_counts_grouped_df)
+    rolled_up_gene_expression_df = _rollup_gene_expression(gene_expression_df, rolled_up_cell_counts_grouped_df)
+    return rolled_up_gene_expression_df, rolled_up_cell_counts_grouped_df
+
+
+def _add_missing_combinations_to_gene_expression_df_for_rollup(
+    gene_expression_df, universal_set_cell_counts_df
+) -> DataFrame:
+    """
+    Augments the input gene expression dataframe to include
+    (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>)
+    combinations for which numeric expression values should be aggregated during the rollup operation.
+
+    Parameters
+    ----------
+    gene_expression_df : pandas DataFrame
+        Tidy gene expression dataframe.
+
+    universal_set_cell_counts_df : pandas DataFrame
+        Multi-indexed cell counts dataframe that contains "The Universal Set Of GroupBy Ontology Terms".
+
+    Returns
+    -------
+    gene_expression_with_missing_combos_df : pandas DataFrame
+        Tidy gene expression dataframe with the same columns as the input gene expression dataframe,
+        and likely greater size than the input gene expression dataframe that includes combinations
+        for which numeric values should be aggregated during the rollup operation.
+    """
+    # extract group-by terms and queried genes from the input dataframes
+    # if a queried gene is not present in the input dot plot dataframe, we can safely
+    # ignore it as it need not be rolled up anyway.
+    group_by_terms = list(universal_set_cell_counts_df.index.names)
+    genes = list(set(gene_expression_df["gene_ontology_term_id"]))
+
+    # get the names of the numeric columns
+    numeric_columns = list(
+        gene_expression_df.columns[[np.issubdtype(dtype, np.number) for dtype in gene_expression_df.dtypes]]
+    )
+
+    # exclude n_cells_tissue as we do not wish to roll it up
+    if "n_cells_tissue" in numeric_columns:
+        numeric_columns.remove("n_cells_tissue")
+
+    # get the total number of cells per tissue to populate the n_cells_tissue in the added entries
+    n_cells_tissue_dict = gene_expression_df.groupby("tissue_ontology_term_id").first()["n_cells_tissue"].to_dict()
+
+    # get the set of available combinations of group-by terms from the aggregated cell counts
+    available_combinations = set(universal_set_cell_counts_df.index.values)
+
+    # for each gene, get the set of available combinations of group-by terms from the input expression dataframe
+    entries_to_add = []
+    for gene in genes:
+        gene_expression_df_per_gene = gene_expression_df[gene_expression_df["gene_ontology_term_id"] == gene]
+        available_combinations_per_gene = set(zip(*gene_expression_df_per_gene[group_by_terms].values.T))
+
+        # get the combinations that are missing in the input expression dataframe
+        # these combinations have no data but can be rescued by the roll-up operation
+        missing_combinations = available_combinations.difference(available_combinations_per_gene)
+        for combo in missing_combinations:
+            entry = {dim: combo[i] for i, dim in enumerate(group_by_terms)}
+
+            # If a tissue, T1, DOES NOT have ANY of the QUERIED GENES expressed, then entirely
+            # omit all combos that contain tissue T1 from the candidate list of combos
+            # that should be considered for rollup. Otherwise, include combos containing T1
+            # in the candidate list of combos for rollup.
+            if entry["tissue_ontology_term_id"] in n_cells_tissue_dict:
+                entry.update({col: 0 for col in numeric_columns})
+                entry["n_cells_tissue"] = n_cells_tissue_dict[entry["tissue_ontology_term_id"]]
+                entry["gene_ontology_term_id"] = gene
+                entries_to_add.append(entry)
+
+    # add the missing entries to the input expression dataframe
+    gene_expression_with_missing_combos_df = pd.concat((gene_expression_df, pd.DataFrame(entries_to_add)), axis=0)
+
+    return gene_expression_with_missing_combos_df
+
+
+def _build_cell_count_groups_universal_set(cell_counts_grouped_df) -> DataFrame:
+    """
+    Constructs a dataframe that contains all valid combination of
+    (tissue, cell_type, <compare_dimension>) for which aggregation should be performed.
+    We call this set of all valid combinations "The Universal Set Of GroupBy Ontology Terms".
+
+    The combinations are encoded as a multi-index in the input cell counts dataframe.
+    The "compare dimension" is optional and may not be present in the multi-index; In that case,
+    the combinations considered are (tissue, cell_type) pairs.
+
+    In this implementation, "The Universal Set Of GroupBy Ontology Terms" is constructed by
+    computing the cartesian product of the (tissue, cell_type, <compare_dimension>) values
+    in the input cell counts dataframe.
+
+    Parameters
+    ----------
+    cell_counts_grouped_df : pandas DataFrame
+        MultiIndexed cell counts dataframe containing the dimensions across which the cell count values exist.
+
+    Returns
+    -------
+    universal_set_cell_counts_grouped_df : pandas DataFrame
+        Multi-indexed cell counts dataframe that contains "The Universal Set Of GroupBy Ontology Terms"
+        with the same columns as the input cell counts dataframe, and likely greater size than the
+        input cell counts dataframe.
+    """
+    cartesian_product = list(
+        itertools.product(
+            *[cell_counts_grouped_df.index.levels[i] for i in range(len(cell_counts_grouped_df.index.names))]
+        )
+    )
+    cartesian_product_index = pd.Index(cartesian_product)
+    cartesian_product_index.set_names(cell_counts_grouped_df.index.names, inplace=True)
+    universal_set_cell_counts_grouped_df = pd.DataFrame(index=cartesian_product_index)
+    for c in cell_counts_grouped_df.columns:
+        universal_set_cell_counts_grouped_df[c] = 0
+        universal_set_cell_counts_grouped_df[c][cell_counts_grouped_df.index] = cell_counts_grouped_df[c]
+    return universal_set_cell_counts_grouped_df
+
+
+def _rollup_cell_counts(cell_counts_grouped_df) -> DataFrame:
+    """
+    Roll up cell count values across cell type descendants in the input cell counts dataframe.
+
+    Accumulate cell count values up the cell type ontology ancestor paths for every
+    (tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>) combination in the
+    input cell counts dataframe. The compare dimension is an optional
+    field and in the case that it is missing, then accumulation happens for every
+    (tissue_ontology_term_id, cell_type_ontology_term_id) combination.
+
+    For example:
+
+    If (T1, C1) has cell counts in the input cell counts dataframe, and the tissue labeled T1
+    has another cell labeled C2 where C2 is an ANCESTOR of C1, then the rolled up cell counts dataframe
+    must include CUMULATIVE cell counts values for the combination (T1, C2) by adding in the
+    cell count for (T1, C1).
+
+    Parameters
+    ----------
+    cell_counts_grouped_df : pandas DataFrame
+        Multi-indexed cell counts dataframe containing the dimensions across which the cell count values will be
+        aggregated.
+
+    Returns
+    -------
+    rolled_up_cell_counts_grouped_df : pandas DataFrame
+        Multi-indexed cell counts dataframe with the same columns as the input cell counts dataframe,
+        and likely greater size than the input cell counts dataframe, but with the cell count
+        values aggregated across the cell type's descendants.
+    """
+    rolled_up_cell_counts_grouped_df = cell_counts_grouped_df
+
+    if cell_counts_grouped_df.shape[0] > 0:
+        universal_set_cell_counts_grouped_df = _build_cell_count_groups_universal_set(cell_counts_grouped_df)
+
+        # Add index columns to the universal_set_cell_counts_grouped_df so that these columns can be
+        # DIRECTLY accessed in the dataframe during the rollup operation while traversing the cell type descendants
+        for col in universal_set_cell_counts_grouped_df.index.names:
+            universal_set_cell_counts_grouped_df[col] = universal_set_cell_counts_grouped_df.index.get_level_values(col)
+
+        # rollup cell counts across cell type descendants
+        rolled_up_cell_counts_grouped_df = rollup_across_cell_type_descendants(universal_set_cell_counts_grouped_df)
+
+        rolled_up_cell_counts_grouped_df = rolled_up_cell_counts_grouped_df[
+            rolled_up_cell_counts_grouped_df["n_cells_cell_type"] > 0
+        ]
+        # Remove columns that were added to the cell counts dataframe for the purpose of rollup.
+        # This is make it congruent with the structure of the input cell counts dataframe
+        rolled_up_cell_counts_grouped_df.drop(columns=rolled_up_cell_counts_grouped_df.index.names, inplace=True)
+
+    return rolled_up_cell_counts_grouped_df
+
+
+def _rollup_gene_expression(gene_expression_df, universal_set_cell_counts_df) -> DataFrame:
+    """
+    Roll up numeric values across cell type descendants in the input gene expression dataframe.
+
+    Accumulate gene expression values up the cell type ontology ancestor paths for every
+    (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>)
+    combination in the input gene expression dataframe. The compare dimension is an optional
+    field and in the case that it is missing, then accumulation happens for every
+    (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id) combination.
+
+    For example:
+
+    If (G1, T1, C1) has gene expression values in the input expression dataframe,
+    and the tissue labeled T1 has another cell labeled C2 where C2 is an ANCESTOR of C1,
+    then the rolled up gene expression dataframe must include CUMULATIVE gene expression values for the
+    combination (G1, T1, C2) by adding in the gene expression for (G1, T1, C1).
+
+    Parameters
+    ----------
+    gene_expression_df : pandas DataFrame
+        Tidy gene expression dataframe containing the dimensions across which the numeric columns will be
+        aggregated.
+
+    universal_set_cell_counts_df : pandas DataFrame
+        Multi-indexed cell counts dataframe that contains "The Universal Set Of GroupBy Ontology Terms".
+
+    Returns
+    -------
+    rolled_up_gene_expression_df : pandas DataFrame
+        Tidy gene expression dataframe with the same columns as the input gene expression dataframe,
+        and likely greater size than the input gene expression dataframe, but with the numeric
+        columns aggregated across the cell type's descendants.
+    """
+    rolled_up_gene_expression_df = gene_expression_df
+
+    if gene_expression_df.shape[0] > 0:
+        # For each gene in the query, add missing combinations (tissue, cell type, compare dimension)
+        # to the expression dataframe
+        gene_expression_with_missing_combos_df = _add_missing_combinations_to_gene_expression_df_for_rollup(
+            gene_expression_df, universal_set_cell_counts_df
+        )
+
+        # Roll up expression dataframe
+        rolled_up_gene_expression_df = rollup_across_cell_type_descendants(
+            gene_expression_with_missing_combos_df, ignore_cols=["n_cells_tissue"]
+        )
+
+        # Filter out the entries that were added to the dataframe that remain zero after roll-up
+        rolled_up_gene_expression_df = rolled_up_gene_expression_df[rolled_up_gene_expression_df["sum"] > 0]
+
+    return rolled_up_gene_expression_df
+
+
+def build_dot_plot_matrix(
+    query_result: DataFrame,
+    cell_counts_cell_type_agg: DataFrame,
+    cell_counts_tissue_agg: DataFrame,
+    group_by_terms: List[str] = None,
+) -> DataFrame:
+    if group_by_terms is None:
+        group_by_terms = DEFAULT_GROUP_BY_TERMS
+
+    # Aggregate cube data by gene, tissue, cell type
+    expr_summary_agg = query_result.groupby(["gene_ontology_term_id"] + group_by_terms, as_index=False).sum(
+        numeric_only=True
+    )
+    return expr_summary_agg.join(cell_counts_cell_type_agg, on=group_by_terms, how="left").join(
+        cell_counts_tissue_agg, on=["tissue_ontology_term_id"], how="left"
+    )
+
+
+def build_gene_id_label_mapping(gene_ontology_term_ids: List[str]) -> List[dict]:
+    return [
+        {gene_ontology_term_id: gene_term_label(gene_ontology_term_id)}
+        for gene_ontology_term_id in gene_ontology_term_ids
+    ]
+
+
+def build_ontology_term_id_label_mapping(ontology_term_ids: Iterable[str]) -> List[dict]:
+    return [{ontology_term_id: ontology_term_label(ontology_term_id)} for ontology_term_id in ontology_term_ids]
+
+
+# getting only cell type metadata, no genes
+def build_ordered_cell_types_by_tissue(
+    cell_counts_cell_type_agg: DataFrame,
+    cell_type_orderings: DataFrame,
+    compare: str,
+) -> Dict[str, Dict[str, Dict[str, Any]]]:
+
+    distinct_tissues_cell_types = cell_counts_cell_type_agg.reset_index().rename(
+        columns={"n_cells_cell_type": "n_total_cells"}
+    )
+
+    # building order for cell types for FE to use
+    cell_type_orderings["order"] = range(cell_type_orderings.shape[0])
+
+    # make a multi index
+    cell_type_orderings = cell_type_orderings.groupby(["tissue_ontology_term_id", "cell_type_ontology_term_id"]).first()
+
+    indexer = list(
+        zip(
+            distinct_tissues_cell_types["tissue_ontology_term_id"],
+            distinct_tissues_cell_types["cell_type_ontology_term_id"],
+        )
+    )
+    indexer_bool_filter = []
+    indexer_filter = []
+    for index in indexer:
+        indexer_bool_filter.append(index in cell_type_orderings.index)
+        if index in cell_type_orderings.index:
+            indexer_filter.append(index)
+
+    joined = distinct_tissues_cell_types[indexer_bool_filter]
+
+    for column in cell_type_orderings:
+        joined[column] = list(cell_type_orderings[column][indexer_filter])
+
+    # Remove cell types without counts
+    joined = joined[joined["n_total_cells"].notnull()]
+
+    # Create nested dicts with tissue_ontology_term_id keys, cell_type_ontology_term_id respectively
+    structured_result: Dict[str, Dict[str, Dict[str, Any]]] = defaultdict(lambda: defaultdict(dict))
+
+    # Populate aggregated gene expressions
+    joined_agg = joined.groupby(["tissue_ontology_term_id", "cell_type_ontology_term_id"], as_index=False).agg(
+        {"n_total_cells": "sum", "depth": "first", "order": "first"}
+    )
+
+    agg = cell_counts_cell_type_agg.groupby(["tissue_ontology_term_id", "cell_type_ontology_term_id"]).sum().T
+
+    for i in range(joined_agg.shape[0]):
+        row = joined_agg.iloc[i]
+        structured_result[row.tissue_ontology_term_id][row.cell_type_ontology_term_id]["aggregated"] = {
+            "cell_type_ontology_term_id": row.cell_type_ontology_term_id,
+            "name": ontology_term_label(row.cell_type_ontology_term_id),
+            "total_count": int(agg[row.tissue_ontology_term_id][row.cell_type_ontology_term_id]["n_cells_cell_type"]),
+            "order": int(row.order),
+        }
+
+    # Populate compare filter gene expressions
+    cell_counts_cell_type_agg_T = cell_counts_cell_type_agg.T
+    if compare:
+        for i in range(joined.shape[0]):
+            row = joined.iloc[i]
+            id_to_label = build_ontology_term_id_label_mapping([row[compare]])[0]
+            name = id_to_label.pop(row[compare])
+            structured_result[row.tissue_ontology_term_id][row.cell_type_ontology_term_id][row[compare]] = {
+                "cell_type_ontology_term_id": row.cell_type_ontology_term_id,
+                "name": name if name else row[compare],
+                "total_count": int(
+                    cell_counts_cell_type_agg_T[row.tissue_ontology_term_id][row.cell_type_ontology_term_id][
+                        row[compare]
+                    ]["n_cells_cell_type"]
+                ),
+                "order": int(row.order),
+            }
+
+    return structured_result

--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -14,7 +14,7 @@ from backend.wmg.data.query import (
     MarkerGeneQueryCriteria,
     WmgFiltersQueryCriteria,
     WmgQuery,
-    WmgQueryCriteria,
+    WmgQueryCriteriaV2,
     retrieve_top_n_markers,
 )
 from backend.wmg.data.rollup import rollup_across_cell_type_descendants
@@ -42,7 +42,7 @@ def query():
     if compare:
         compare = find_dimension_id_from_compare(compare)
 
-    criteria = WmgQueryCriteria(**request["filter"])
+    criteria = WmgQueryCriteriaV2(**request["filter"])
 
     with ServerTiming.time("query and build response"):
         snapshot: WmgSnapshot = load_snapshot()

--- a/backend/wmg/data/query.py
+++ b/backend/wmg/data/query.py
@@ -22,6 +22,20 @@ class WmgQueryCriteria(BaseModel):
     sex_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
 
 
+class WmgQueryCriteriaV2(BaseModel):
+    gene_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=1)
+    organism_ontology_term_id: str  # required!
+    tissue_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+    tissue_original_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+    dataset_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+    # excluded per product requirements, but keeping in, commented-out, to reduce future head-scratching
+    # assay_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+    development_stage_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+    disease_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+    self_reported_ethnicity_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+    sex_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+
+
 class WmgFiltersQueryCriteria(BaseModel):
     organism_ontology_term_id: str  # required!
     tissue_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)

--- a/tests/unit/backend/wmg/api/test_v2.py
+++ b/tests/unit/backend/wmg/api/test_v2.py
@@ -1,0 +1,911 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from backend.api_server.app import app
+from backend.wmg.api.v1 import find_dimension_id_from_compare
+from backend.wmg.data.query import MarkerGeneQueryCriteria
+from tests.unit.backend.fixtures.environment_setup import EnvironmentSetup
+from tests.unit.backend.wmg.fixtures.test_cube_schema import expression_summary_non_indexed_dims
+from tests.unit.backend.wmg.fixtures.test_primary_filters import (
+    test_gene_terms,
+    test_organism_terms,
+    test_snapshot_id,
+    test_tissue_terms,
+)
+from tests.unit.backend.wmg.fixtures.test_snapshot import (
+    all_ones_expression_summary_values,
+    all_tens_cell_counts_values,
+    all_X_cell_counts_values,
+    create_temp_wmg_snapshot,
+    exclude_all_but_one_gene_per_organism,
+    exclude_dev_stage_and_ethnicity_for_secondary_filter_test,
+    load_realistic_test_snapshot,
+    reverse_cell_type_ordering,
+)
+from tests.unit.backend.wmg.test_query import generate_expected_marker_gene_data_with_pandas
+
+TEST_SNAPSHOT = "realistic-test-snapshot"
+
+
+# this should only be used for generating expected outputs when using the test snapshot (see test_snapshot.py)
+def generate_expected_term_id_labels_dictionary(genes, tissues, cell_types, total_count, compare_terms=None):
+    result = {}
+    result["cell_types"] = {}
+    # assume tissues are sorted, and cell types are sorted within each tissue
+    # assume the length of cell types is the dimensionality of each column in the
+    # test snapshot (i.e. each tissue contains all fake cell types).
+    # this line determines the starting order for each cell type in each tissue.
+    orders = [int(tissue.split("_")[-1]) * len(cell_types) for tissue in tissues]
+    for tissue, order in zip(tissues, orders):
+        result["cell_types"][tissue] = {}
+        for cell_type in cell_types:
+            result["cell_types"][tissue][cell_type] = {}
+            result["cell_types"][tissue][cell_type]["aggregated"] = {
+                "cell_type_ontology_term_id": cell_type,
+                "name": f"{cell_type}_label",
+                "total_count": total_count,
+                "order": order,
+            }
+            if compare_terms:
+                for term in compare_terms:
+                    result["cell_types"][tissue][cell_type][term] = {
+                        "cell_type_ontology_term_id": cell_type,
+                        "name": f"{term}_label",
+                        "total_count": total_count // len(compare_terms),
+                        "order": order,
+                    }
+            order += 1
+
+    result["genes"] = []
+    for gene in genes:
+        result["genes"].append({gene: f"{gene}_label"})
+
+    return result
+
+
+def generate_expected_expression_summary_dictionary(genes, tissues, cell_types, n, me, pc, tpc, compare_terms=None):
+    result = {}
+    for gene in genes:
+        if gene != ".":
+            result[gene] = {}
+            for tissue in tissues:
+                result[gene][tissue] = {}
+                for cell_type in cell_types:
+                    result[gene][tissue][cell_type] = {}
+                    result[gene][tissue][cell_type]["aggregated"] = {
+                        "n": n,
+                        "me": me,
+                        "pc": pc,
+                        "tpc": tpc,
+                    }
+                    if compare_terms:
+                        for term in compare_terms:
+                            result[gene][tissue][cell_type][term] = {
+                                "n": n // len(compare_terms),
+                                "me": me,
+                                "pc": pc,
+                                "tpc": tpc / len(compare_terms),
+                            }
+
+    return result
+
+
+def generate_test_inputs_and_expected_outputs(genes, tissues, organism, dim_size, me, expected_count, compare_dim=None):
+    """
+    Generates test inputs and expected outputs for the /wmg/v1/query endpoint.
+
+    Arguments
+    ---------
+    genes: list of gene ontology term IDs
+    tissues: list of tissue ontology term IDs
+    organism: organism ontology term ID
+    dim_size: size of each dimension of the test cube
+    me: mean expression value to use for each gene/tissue/cell_type combination (scalar)
+    expected_count: expected number of cells for each gene/tissue/cell_type combination (scalar)
+    compare_dim: dimension to use for compare feature (optional). None if compare isn't used.
+
+    Returns
+    -------
+    tuple of (request, expected_expression_summary, expected_term_id_labels)
+    request: dictionary containing the request body to send to the /wmg/v1/query endpoint
+    expected_expression_summary: dictionary containing the expected expression summary values
+    expected_term_id_labels: dictionary containing the expected term ID labels
+    """
+    cell_types = [f"cell_type_ontology_term_id_{i}" for i in range(dim_size)]
+
+    expected_combinations_per_cell_type = dim_size ** len(
+        set(expression_summary_non_indexed_dims).difference({"cell_type_ontology_term_id"})
+    )
+    compare_terms = (
+        [f"{find_dimension_id_from_compare(compare_dim)}_{i}" for i in range(dim_size)] if compare_dim else None
+    )
+
+    expected_term_id_labels = generate_expected_term_id_labels_dictionary(
+        genes,
+        tissues,
+        cell_types,
+        expected_combinations_per_cell_type * expected_count,
+        compare_terms=compare_terms,
+    )
+    expected_expression_summary = generate_expected_expression_summary_dictionary(
+        genes,
+        tissues,
+        cell_types,
+        expected_combinations_per_cell_type,
+        me,
+        1 / expected_count,
+        expected_combinations_per_cell_type / (expected_count * (dim_size ** len(expression_summary_non_indexed_dims))),
+        compare_terms=compare_terms,
+    )
+
+    request = dict(
+        filter=dict(
+            gene_ontology_term_ids=genes,
+            organism_ontology_term_id=organism,
+            tissue_ontology_term_ids=tissues,
+        )
+    )
+    if compare_dim:
+        request["compare"] = compare_dim
+
+    return (
+        request,
+        expected_expression_summary,
+        expected_term_id_labels,
+    )
+
+
+class WmgApiV1Tests(unittest.TestCase):
+    """
+    Tests WMG API endpoints. Tests the flask app only, and not other stack dependencies, such as S3. Builds and uses a
+    temporary WMG cube on local filesystem to avoid dependency on localstack S3.
+    """
+
+    def setUp(self):
+        super().setUp()
+        with EnvironmentSetup(dict(APP_NAME="corpora-api")):
+            self.app = app.test_client(use_cookies=False)
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.maxDiff = None
+
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__primary_filter_dimensions__returns_200(self, load_snapshot):
+        # This test appears to be hitting a TileDB (<=0.13.1) bug and fails (intermittently) if dim_size=3
+        with create_temp_wmg_snapshot(dim_size=1) as snapshot:
+            # setup up API endpoints to use a mocked cube
+            load_snapshot.return_value = snapshot
+            response = self.app.get("/wmg/v1/primary_filter_dimensions")
+
+        self.assertEqual(200, response.status_code)
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__primary_filter_dimensions__returns_valid_response_body(
+        self, load_snapshot, ontology_term_label, gene_term_label
+    ):
+        with create_temp_wmg_snapshot(
+            dim_size=3, exclude_logical_coord_fn=exclude_all_but_one_gene_per_organism
+        ) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            response = self.app.get("/wmg/v1/primary_filter_dimensions")
+
+        expected = dict(
+            snapshot_id=test_snapshot_id,
+            organism_terms=test_organism_terms,
+            tissue_terms=test_tissue_terms,
+            gene_terms=test_gene_terms,
+        )
+
+        self.assertEqual(expected, json.loads(response.data))
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_single_primary_dims__returns_200_and_correct_response(
+        self, load_snapshot, ontology_term_label, gene_term_label
+    ):
+        dim_size = 1
+        with create_temp_wmg_snapshot(
+            dim_size=dim_size,
+            expression_summary_vals_fn=all_ones_expression_summary_values,
+            cell_counts_generator_fn=all_tens_cell_counts_values,
+        ) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            genes = ["gene_ontology_term_id_0"]
+            tissues = ["tissue_ontology_term_id_0"]
+            organism = "organism_ontology_term_id_0"
+
+            (request, expected_expression_summary, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
+                genes, tissues, organism, dim_size, 1.0, 10
+            )
+
+            response = self.app.post("/wmg/v1/query", json=request)
+
+            self.assertEqual(200, response.status_code)
+
+            expected_response = {
+                "snapshot_id": "dummy-snapshot",
+                "expression_summary": expected_expression_summary,
+                "term_id_labels": expected_term_id_labels,
+            }
+            self.assertEqual(expected_response, json.loads(response.data))
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_single_tissue_no_genes__returns_200_and_correct_response(
+        self, load_snapshot, ontology_term_label, gene_term_label
+    ):
+        dim_size = 3
+        with create_temp_wmg_snapshot(
+            dim_size=dim_size,
+            expression_summary_vals_fn=all_ones_expression_summary_values,
+            cell_counts_generator_fn=all_tens_cell_counts_values,
+        ) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            # this is the convention used by the FE to indicate no genes are selected
+            # see https://github.com/chanzuckerberg/single-cell-data-portal/pull/2729
+            genes = ["."]
+
+            tissues = ["tissue_ontology_term_id_0"]
+            organism = "organism_ontology_term_id_0"
+
+            (request, expected_expression_summary, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
+                genes, tissues, organism, dim_size, 1.0, 10
+            )
+
+            response = self.app.post("/wmg/v1/query", json=request)
+
+            self.assertEqual(200, response.status_code)
+
+            expected_response = {
+                "snapshot_id": "dummy-snapshot",
+                "expression_summary": expected_expression_summary,
+                "term_id_labels": expected_term_id_labels,
+            }
+            self.assertEqual(expected_response, json.loads(response.data))
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_multiple_tissues_no_genes__returns_200_and_correct_response(
+        self, load_snapshot, ontology_term_label, gene_term_label
+    ):
+        dim_size = 3
+        with create_temp_wmg_snapshot(
+            dim_size=dim_size,
+            expression_summary_vals_fn=all_ones_expression_summary_values,
+            cell_counts_generator_fn=all_tens_cell_counts_values,
+        ) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            # this is the convention used by the FE to indicate no genes are selected
+            # see https://github.com/chanzuckerberg/single-cell-data-portal/pull/2729
+            genes = ["."]
+
+            tissues = ["tissue_ontology_term_id_0", "tissue_ontology_term_id_1", "tissue_ontology_term_id_2"]
+            organism = "organism_ontology_term_id_0"
+
+            (request, expected_expression_summary, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
+                genes, tissues, organism, dim_size, 1.0, 10
+            )
+
+            response = self.app.post("/wmg/v1/query", json=request)
+
+            self.assertEqual(200, response.status_code)
+
+            expected_response = {
+                "snapshot_id": "dummy-snapshot",
+                "expression_summary": expected_expression_summary,
+                "term_id_labels": expected_term_id_labels,
+            }
+            self.assertEqual(expected_response, json.loads(response.data))
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_request_multi_primary_dims_only__returns_200_and_correct_response(
+        self, load_snapshot, ontology_term_label, gene_term_label
+    ):
+        dim_size = 3
+        with create_temp_wmg_snapshot(
+            dim_size=dim_size,
+            expression_summary_vals_fn=all_ones_expression_summary_values,
+            cell_counts_generator_fn=all_tens_cell_counts_values,
+        ) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            genes = ["gene_ontology_term_id_0", "gene_ontology_term_id_2"]
+            tissues = ["tissue_ontology_term_id_1", "tissue_ontology_term_id_2"]
+            organism = "organism_ontology_term_id_0"
+
+            (request, expected_expression_summary, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
+                genes, tissues, organism, dim_size, 1.0, 10
+            )
+
+            response = self.app.post("/wmg/v1/query", json=request)
+
+            self.assertEqual(200, response.status_code)
+
+            expected = {
+                "snapshot_id": "dummy-snapshot",
+                "expression_summary": expected_expression_summary,
+                "term_id_labels": expected_term_id_labels,
+            }
+            self.assertEqual(expected, json.loads(response.data))
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_request_multi_primary_dims_only_with_compare__returns_200_and_correct_response(
+        self, load_snapshot, ontology_term_label, gene_term_label
+    ):
+        dim_size = 3
+        with create_temp_wmg_snapshot(
+            dim_size=dim_size,
+            expression_summary_vals_fn=all_ones_expression_summary_values,
+            cell_counts_generator_fn=all_tens_cell_counts_values,
+        ) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            genes = ["gene_ontology_term_id_0", "gene_ontology_term_id_2"]
+            tissues = ["tissue_ontology_term_id_1", "tissue_ontology_term_id_2"]
+            organism = "organism_ontology_term_id_0"
+
+            (request, expected_expression_summary, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
+                genes, tissues, organism, dim_size, 1.0, 10, compare_dim="self_reported_ethnicity"
+            )
+
+            response = self.app.post("/wmg/v1/query", json=request)
+
+            self.assertEqual(200, response.status_code)
+
+            expected = {
+                "snapshot_id": "dummy-snapshot",
+                "expression_summary": expected_expression_summary,
+                "term_id_labels": expected_term_id_labels,
+            }
+            self.assertEqual(expected, json.loads(response.data))
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_explicit_cell_ordering__returns_correct_cell_ordering(
+        self, load_snapshot, ontology_term_label, gene_term_label
+    ):
+        dim_size = 2
+        with create_temp_wmg_snapshot(
+            dim_size=dim_size,
+            expression_summary_vals_fn=all_ones_expression_summary_values,
+            cell_counts_generator_fn=all_tens_cell_counts_values,
+            cell_ordering_generator_fn=reverse_cell_type_ordering,
+        ) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            genes = ["gene_ontology_term_id_0"]
+            tissues = ["tissue_ontology_term_id_0", "tissue_ontology_term_id_1"]
+            organism = "organism_ontology_term_id_0"
+
+            (request, _, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
+                genes, tissues, organism, dim_size, 1.0, 10
+            )
+
+            response = self.app.post("/wmg/v1/query", json=request)
+
+            self.assertEqual(200, response.status_code)
+
+            expected = expected_term_id_labels["cell_types"]
+            self.assertEqual(expected, json.loads(response.data)["term_id_labels"]["cell_types"])
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_total_cell_count_per_cell_type(self, load_snapshot, ontology_term_label, gene_term_label):
+        expected_count = 42
+        dim_size = 2
+        with create_temp_wmg_snapshot(
+            dim_size=dim_size,
+            expression_summary_vals_fn=all_ones_expression_summary_values,
+            cell_counts_generator_fn=lambda coords: all_X_cell_counts_values(coords, expected_count),
+            cell_ordering_generator_fn=reverse_cell_type_ordering,
+        ) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            genes = ["gene_ontology_term_id_0"]
+            tissues = ["tissue_ontology_term_id_0", "tissue_ontology_term_id_1"]
+            organism = "organism_ontology_term_id_0"
+
+            (request, _, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
+                genes, tissues, organism, dim_size, 1.0, expected_count
+            )
+
+            response = self.app.post("/wmg/v1/query", json=request)
+
+            self.assertEqual(200, response.status_code)
+
+            expected = expected_term_id_labels["cell_types"]
+            self.assertEqual(expected, json.loads(response.data)["term_id_labels"]["cell_types"])
+
+    def test__query_empty_request__returns_400(self):
+        response = self.app.post("/wmg/v1/query", json={})
+
+        self.assertEqual(400, response.status_code)
+        self.assertEqual("'filter' is a required property", json.loads(response.data)["detail"])
+
+    def test__query_missing_gene__request_returns_400(self):
+        request = dict(
+            filter=dict(
+                organism_ontology_term_id="organism_ontology_term_id_0",
+                tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+            ),
+        )
+
+        response = self.app.post("/wmg/v1/query", json=request)
+
+        self.assertEqual(400, response.status_code)
+
+    def test__query_missing_organism__request_returns_400(self):
+        request = dict(
+            filter=dict(
+                gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+            ),
+        )
+
+        response = self.app.post("/wmg/v1/query", json=request)
+
+        self.assertEqual(400, response.status_code)
+
+    def test__query_missing_tissue_request__returns_400(self):
+        request = dict(
+            filter=dict(
+                gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                organism_ontology_term_id="organism_ontology_term_id_0",
+            ),
+        )
+
+        response = self.app.post("/wmg/v1/query", json=request)
+
+        self.assertEqual(400, response.status_code)
+
+    @patch("backend.wmg.api.v1.fetch_datasets_metadata")
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_request_with_filter_dims__returns_valid_filter_dims__base_case(
+        self, load_snapshot, ontology_term_label, gene_term_label, fetch_datasets_metadata
+    ):
+        # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+        # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+        # module is separately unit tested, and here we just want to verify the response building logic is correct.
+        dim_size = 1
+        with create_temp_wmg_snapshot(dim_size=dim_size) as snapshot:
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+            fetch_datasets_metadata.return_value = mock_datasets_metadata([f"dataset_id_{i}" for i in range(dim_size)])
+            load_snapshot.return_value = snapshot
+            filter_0 = dict(
+                # these don't matter for the expected result
+                gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                organism_ontology_term_id="organism_ontology_term_id_0",
+                tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+                # these matter for the expected result
+                development_stage_ontology_term_ids=["development_stage_ontology_term_id_0"],
+                self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
+            )
+
+            filter_0_request = dict(
+                filter=filter_0,
+                is_rollup=True,
+            )
+
+            response = self.app.post("/wmg/v1/filters", json=filter_0_request)
+
+            expected_filters = {
+                "datasets": [
+                    {
+                        "collection_id": "dataset_id_0_coll_id",
+                        "collection_label": "dataset_id_0_coll_name",
+                        "id": "dataset_id_0",
+                        "label": "dataset_id_0_name",
+                    }
+                ],
+                "development_stage_terms": [
+                    {"development_stage_ontology_term_id_0": "development_stage_ontology_term_id_0_label"}
+                ],
+                "disease_terms": [],
+                "self_reported_ethnicity_terms": [
+                    {"self_reported_ethnicity_ontology_term_id_0": "self_reported_ethnicity_ontology_term_id_0_label"}
+                ],
+                "sex_terms": [],
+                "tissue_terms": [{"tissue_ontology_term_id_0": "tissue_ontology_term_id_0_label"}],
+                "cell_type_terms": [{"cell_type_ontology_term_id_0": "cell_type_ontology_term_id_0_label"}],
+            }
+            self.assertEqual(json.loads(response.data)["filter_dims"], expected_filters)
+
+    @patch("backend.wmg.api.v1.fetch_datasets_metadata")
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__query_request_with_filter_dims__returns_valid_filter_dims(
+        self, load_snapshot, ontology_term_label, gene_term_label, fetch_datasets_metadata
+    ):
+        # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+        # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+        # module is separately unit tested, and here we just want to verify the response building logic is correct.
+        dim_size = 3
+        self.maxDiff = None
+        with create_temp_wmg_snapshot(
+            dim_size=dim_size, exclude_logical_coord_fn=exclude_dev_stage_and_ethnicity_for_secondary_filter_test
+        ) as snapshot:
+            # set up the expression summary cube for secondary filtering
+            # drop all rows where ethnicity_1 and ethnicity_2 are associated with dev_stage_1 and dev_stage_2
+            # thus filtering for dev_stage_0 should return filter options that include ethnicity 0,1 &2 but
+            # filtering for dev_stage_1 or dev_stage_2 should only return ethnicity 0 (and vice versa)
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+            fetch_datasets_metadata.return_value = mock_datasets_metadata([f"dataset_id_{i}" for i in range(dim_size)])
+            # setup up API endpoints to use a mocked cube
+            load_snapshot.return_value = snapshot
+            with self.subTest("when a secondary dimension has criteria, it's own values are not restricted"):
+                filter_0 = dict(
+                    # these don't matter for the expected result
+                    gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                    organism_ontology_term_id="organism_ontology_term_id_0",
+                    tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+                    # these matter for the expected result
+                    development_stage_ontology_term_ids=["development_stage_ontology_term_id_0"],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
+                )
+
+                filter_0_request = dict(
+                    filter=filter_0,
+                    # matters for this test
+                    is_rollup=True,
+                )
+
+                filter_0_no_dev_stage_filter = dict(
+                    # these don't matter for the expected result
+                    gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                    organism_ontology_term_id="organism_ontology_term_id_0",
+                    tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+                    # these matter for the expected result
+                    development_stage_ontology_term_ids=[],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
+                )
+                filter_0_no_dev_stage_request = dict(filter=filter_0_no_dev_stage_filter, is_rollup=True)
+
+                filter_0_no_ethnicity_filter = dict(
+                    # these don't matter for the expected result
+                    gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                    organism_ontology_term_id="organism_ontology_term_id_0",
+                    tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+                    # these matter for the expected result
+                    development_stage_ontology_term_ids=["development_stage_ontology_term_id_0"],
+                    self_reported_ethnicity_ontology_term_ids=[],
+                )
+                filter_0_no_ethnicity_request = dict(filter=filter_0_no_ethnicity_filter, is_rollup=True)
+                # the values for dev_stage terms when a dev stage filter is included should match the values returned
+                # if no filter is passed in for dev stage
+                response = self.app.post("/wmg/v1/filters", json=filter_0_request)
+                dev_stage_terms = json.loads(response.data)["filter_dims"]["development_stage_terms"]
+                self_reported_ethnicity_terms = json.loads(response.data)["filter_dims"][
+                    "self_reported_ethnicity_terms"
+                ]
+
+                no_dev_stage_filter_response = self.app.post("/wmg/v1/filters", json=filter_0_no_dev_stage_request)
+                dev_stage_terms_if_no_dev_stage_filters = json.loads(no_dev_stage_filter_response.data)["filter_dims"][
+                    "development_stage_terms"
+                ]
+
+                no_ethnicity_filter_response = self.app.post("/wmg/v1/filters", json=filter_0_no_ethnicity_request)
+                self_reported_ethnicity_terms_if_no_dev_stage_filters = json.loads(no_ethnicity_filter_response.data)[
+                    "filter_dims"
+                ]["self_reported_ethnicity_terms"]
+
+                # filter options for dev_stage
+                self.assertEqual(dev_stage_terms, dev_stage_terms_if_no_dev_stage_filters)
+                self.assertEqual(self_reported_ethnicity_terms, self_reported_ethnicity_terms_if_no_dev_stage_filters)
+
+            with self.subTest(
+                "when a secondary dimension has criteria, the remaining filter values for other "
+                "secondary dimensions are properly restricted"
+            ):
+                # filtering for dev_stage_0 should return all possible ethnicity terms
+                # filtering for dev_stage_1 should only return ethnicity_0
+                # filtering for dev_stage_2 should only return ethnicity_0
+                # filtering for ethnicity_1 should only return dev_stage_0
+                # filtering for ethnicity_2 should only return dev_stage_0
+
+                # filtering for ethnicity_0 should return all dev stages
+                # not filtering for dev should return all ethnicities
+                self_reported_ethnicity_0_filter = dict(
+                    # these don't matter for the expected result
+                    gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                    organism_ontology_term_id="organism_ontology_term_id_0",
+                    tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+                    # these matter for the expected result
+                    development_stage_ontology_term_ids=[],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
+                )
+                all_development_stage_terms = [
+                    {"development_stage_ontology_term_id_0": "development_stage_ontology_term_id_0_label"},
+                    {"development_stage_ontology_term_id_1": "development_stage_ontology_term_id_1_label"},
+                    {"development_stage_ontology_term_id_2": "development_stage_ontology_term_id_2_label"},
+                ]
+                all_self_reported_ethnicity_terms = [
+                    {"self_reported_ethnicity_ontology_term_id_0": "self_reported_ethnicity_ontology_term_id_0_label"},
+                    {"self_reported_ethnicity_ontology_term_id_1": "self_reported_ethnicity_ontology_term_id_1_label"},
+                    {"self_reported_ethnicity_ontology_term_id_2": "self_reported_ethnicity_ontology_term_id_2_label"},
+                ]
+                self_reported_ethnicity_0_request = dict(filter=self_reported_ethnicity_0_filter, is_rollup=True)
+                response = self.app.post("/wmg/v1/filters", json=self_reported_ethnicity_0_request)
+                dev_stage_terms = _sort_list_by_dictionary_keys(
+                    json.loads(response.data)["filter_dims"]["development_stage_terms"]
+                )
+                self_reported_ethnicity_terms = _sort_list_by_dictionary_keys(
+                    json.loads(response.data)["filter_dims"]["self_reported_ethnicity_terms"]
+                )
+                self.assertEqual(all_development_stage_terms, dev_stage_terms)
+                self.assertEqual(all_self_reported_ethnicity_terms, self_reported_ethnicity_terms)
+
+                # filtering for ethnicity_1 should return dev_stage_0 (even when filtering for dev_stage_1 or 2)
+                self_reported_ethnicity_1_filter = dict(
+                    # these don't matter for the expected result
+                    gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                    organism_ontology_term_id="organism_ontology_term_id_0",
+                    tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+                    # these matter for the expected result
+                    development_stage_ontology_term_ids=[],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_1"],
+                )
+                # since secondary filters should not affect term options for their own category, filtering (or not
+                # filtering) for dev stage 1 should not affect the terms returned
+                expected_development_stage_terms = [
+                    {"development_stage_ontology_term_id_0": "development_stage_ontology_term_id_0_label"},
+                ]
+                expected_self_reported_ethnicity_term = [
+                    {"self_reported_ethnicity_ontology_term_id_0": "self_reported_ethnicity_ontology_term_id_0_label"}
+                ]
+                self_reported_ethnicity_1_request = dict(filter=self_reported_ethnicity_1_filter, is_rollup=True)
+                response = self.app.post("/wmg/v1/filters", json=self_reported_ethnicity_1_request)
+                dev_stage_terms_no_dev_filter = _sort_list_by_dictionary_keys(
+                    json.loads(response.data)["filter_dims"]["development_stage_terms"]
+                )
+                self_reported_ethnicity_terms_no_dev_filter = _sort_list_by_dictionary_keys(
+                    json.loads(response.data)["filter_dims"]["self_reported_ethnicity_terms"]
+                )
+                self.assertEqual(expected_development_stage_terms, dev_stage_terms_no_dev_filter)
+                self.assertEqual(all_self_reported_ethnicity_terms, self_reported_ethnicity_terms_no_dev_filter)
+
+                self_reported_ethnicity_1_dev_1_filter = dict(
+                    # these don't matter for the expected result
+                    gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                    organism_ontology_term_id="organism_ontology_term_id_0",
+                    tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+                    # these matter for the expected result
+                    development_stage_ontology_term_ids=["development_stage_ontology_term_id_1"],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_1"],
+                )
+                self_reported_ethnicity_1_dev_1_request = dict(
+                    filter=self_reported_ethnicity_1_dev_1_filter, is_rollup=True
+                )
+
+                response = self.app.post("/wmg/v1/filters", json=self_reported_ethnicity_1_dev_1_request)
+                dev_stage_terms_dev_filter = _sort_list_by_dictionary_keys(
+                    json.loads(response.data)["filter_dims"]["development_stage_terms"]
+                )
+                self_reported_ethnicity_terms_dev_filter = _sort_list_by_dictionary_keys(
+                    json.loads(response.data)["filter_dims"]["self_reported_ethnicity_terms"]
+                )
+
+                self.assertEqual(expected_development_stage_terms, dev_stage_terms_dev_filter)
+                self.assertEqual(dev_stage_terms_no_dev_filter, dev_stage_terms_dev_filter)
+                self.assertEqual(expected_self_reported_ethnicity_term, self_reported_ethnicity_terms_dev_filter)
+                self.assertNotEqual(
+                    self_reported_ethnicity_terms_no_dev_filter, self_reported_ethnicity_terms_dev_filter
+                )
+
+                # filtering for ethnicity_2 should return dev_stage_0 (even when filtering for dev_stage_1 or 2)
+                self_reported_ethnicity_2_filter = dict(
+                    # these don't matter for the expected result
+                    gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                    organism_ontology_term_id="organism_ontology_term_id_0",
+                    tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+                    # these matter for the expected result
+                    development_stage_ontology_term_ids=[],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_2"],
+                )
+                self_reported_ethnicity_2_dev_2_filter = dict(
+                    # these don't matter for the expected result
+                    gene_ontology_term_ids=["gene_ontology_term_id_0"],
+                    organism_ontology_term_id="organism_ontology_term_id_0",
+                    tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+                    # these matter for the expected result
+                    development_stage_ontology_term_ids=["development_stage_ontology_term_id_2"],
+                    self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_2"],
+                )
+                self_reported_ethnicity_2_request = dict(filter=self_reported_ethnicity_2_filter, is_rollup=True)
+                eth_2_dev_2_request = dict(filter=self_reported_ethnicity_2_dev_2_filter, is_rollup=True)
+                response = self.app.post("/wmg/v1/filters", json=self_reported_ethnicity_2_request)
+                dev_stage_terms_eth_2_no_dev_filter = _sort_list_by_dictionary_keys(
+                    json.loads(response.data)["filter_dims"]["development_stage_terms"]
+                )
+                self_reported_ethnicity_terms_eth_2_no_dev_filter = _sort_list_by_dictionary_keys(
+                    json.loads(response.data)["filter_dims"]["self_reported_ethnicity_terms"]
+                )
+                self.assertEqual(expected_development_stage_terms, dev_stage_terms_eth_2_no_dev_filter)
+                self.assertEqual(all_self_reported_ethnicity_terms, self_reported_ethnicity_terms_eth_2_no_dev_filter)
+
+                response = self.app.post("/wmg/v1/filters", json=eth_2_dev_2_request)
+                dev_stage_terms_eth_2_dev_2 = _sort_list_by_dictionary_keys(
+                    json.loads(response.data)["filter_dims"]["development_stage_terms"]
+                )
+                eth_stage_terms_eth_2_dev_2 = _sort_list_by_dictionary_keys(
+                    json.loads(response.data)["filter_dims"]["self_reported_ethnicity_terms"]
+                )
+
+                self.assertEqual(expected_development_stage_terms, dev_stage_terms_eth_2_dev_2)
+                self.assertEqual(expected_self_reported_ethnicity_term, eth_stage_terms_eth_2_dev_2)
+                self.assertEqual(dev_stage_terms_eth_2_dev_2, dev_stage_terms_eth_2_no_dev_filter)
+                self.assertNotEqual(eth_stage_terms_eth_2_dev_2, self_reported_ethnicity_terms_eth_2_no_dev_filter)
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__markers_returns_200_and_correct_response(self, load_snapshot, ontology_term_label, gene_term_label):
+        with load_realistic_test_snapshot(TEST_SNAPSHOT) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            request = dict(
+                celltype="CL:0000786",
+                organism="NCBITaxon:9606",
+                tissue="UBERON:0002048",
+                n_markers=10,
+                test="ttest",
+            )
+
+            response = self.app.post("/wmg/v1/markers", json=request)
+            received = json.loads(response.data)
+            criteria = MarkerGeneQueryCriteria(
+                tissue_ontology_term_id=request["tissue"],
+                cell_type_ontology_term_id=request["celltype"],
+                organism_ontology_term_id=request["organism"],
+            )
+            expected = {
+                "marker_genes": generate_expected_marker_gene_data_with_pandas(snapshot, criteria, "ttest", 10),
+                "snapshot_id": "realistic-test-snapshot",
+            }
+            self.assertDictEqual(received, expected)
+            self.assertEqual(200, response.status_code)
+
+    @patch("backend.wmg.api.v1.gene_term_label")
+    @patch("backend.wmg.api.v1.ontology_term_label")
+    @patch("backend.wmg.api.v1.load_snapshot")
+    def test__markers_returns_200_and_empty_dictionary_for_bad_celltypes(
+        self, load_snapshot, ontology_term_label, gene_term_label
+    ):
+        with load_realistic_test_snapshot(TEST_SNAPSHOT) as snapshot:
+            # setup up API endpoints to use a mocked cube containing all stat values of 1, for a deterministic
+            # expected query response
+            load_snapshot.return_value = snapshot
+
+            # mock the functions in the ontology_labels module, so we can assert deterministic values in the
+            # "term_id_labels" portion of the response body; note that the correct behavior of the ontology_labels
+            # module is separately unit tested, and here we just want to verify the response building logic is correct.
+            ontology_term_label.side_effect = lambda ontology_term_id: f"{ontology_term_id}_label"
+            gene_term_label.side_effect = lambda gene_term_id: f"{gene_term_id}_label"
+
+            request = dict(
+                celltype="CL:9999999",  # bad celltype
+                organism="NCBITaxon:9606",
+                tissue="UBERON:0002048",
+                n_markers=10,
+                test="ttest",
+            )
+
+            response = self.app.post("/wmg/v1/markers", json=request)
+            received = json.loads(response.data)
+
+            expected = {"marker_genes": [], "snapshot_id": "realistic-test-snapshot"}
+            self.assertDictEqual(received, expected)
+            self.assertEqual(200, response.status_code)
+
+
+# mock the dataset and collection entity data that would otherwise be fetched from the db; in this test
+# we only care that we're building the response correctly from the cube; WMG API integration tests verify
+# with real datasets
+def mock_datasets_metadata(dataset_ids):
+    return [
+        dict(
+            id=dataset_id,
+            label=f"{dataset_id}_name",
+            collection_id=f"{dataset_id}_coll_id",
+            collection_label=f"{dataset_id}_coll_name",
+        )
+        for dataset_id in dataset_ids
+    ]
+
+
+def _sort_list_by_dictionary_keys(d):
+    return sorted(d, key=lambda k: list(k.keys())[0])


### PR DESCRIPTION
## Reason for Change

- #4863
- This ticket requires multiple commits. This commit **addresses steps 1 to 3** as described in the ticket. _**Specifically, this commit versions the WMG API (make a `v2` version) instead of making changes in the existing API version (`v1`) so as to prevent backward incompatible changes in the API (ex: structure of payload sent back to the frontend) from breaking the current production version of frontend rendering code.**_

## Changes
- add v2 version of the WMG query API and accompanying unit test file
- add v2 version of the `WMGQueryCriteria` class called `WMGQueryCriteriaV2` to isolate the WMG V2 requirement of querying without specifying `tissue_ontology_term_id`

## Testing steps

- Currently has no tests since this is effectively unreachable code. Moreover it is effectively prototype code meant to unblock the frontend developer. Tests will come in subsequent commits after the frontend developer is unblocked by this commit.

## Notes for Reviewer
This is done be creating an exact copy of the files: `v1.py` and `test_v1.py` and renaming them as `v2.py` and `test_v2.py` respectively. The aim of this commit is to create an isolated fork of the API code in which to develop the new functionality specified by the WMG V2 requirements. _**The reason for this is to mitigate against the case of making API code changes that are backward incompatible with the current frontend code running in production. For example, if the API changes require changes to the structure of the data sent to the frontend that the current production version of frontend is not prepared to handle, then it is safer to simply version the API**_

This V2 version contiains the functionality for the client to make queries without specifying `tissue_ontology_term_id` in the request body. However, the implementation is not entirely functional at this commit. This is not a problem because the incomplete implementation is hidden from the main line of code execution and therefore poses no risk due in the production environment.
