### PR TITLE
fix: Fix rollup bug when selected tissue has no gene expressions

### DIFF
--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -355,13 +355,12 @@ def _add_missing_combinations_to_gene_expression_df_for_rollup(
         missing_combinations = available_combinations.difference(available_combinations_per_gene)
         for combo in missing_combinations:
             entry = {dim: combo[i] for i, dim in enumerate(group_by_terms)}
-            tissue_has_gene_expression = n_cells_tissue_dict.get(entry["tissue_ontology_term_id"], False)
 
             # If a tissue, T1, DOES NOT have ANY of the QUERIED GENES expressed, then entirely
             # omit all combos that contain tissue T1 from the candidate list of combos
             # that should be considered for rollup. Otherwise, include combos containing T1
             # in the candidate list of combos for rollup.
-            if tissue_has_gene_expression:
+            if entry["tissue_ontology_term_id"] in n_cells_tissue_dict:
                 entry.update({col: 0 for col in numeric_columns})
                 entry["n_cells_tissue"] = n_cells_tissue_dict[entry["tissue_ontology_term_id"]]
                 entry["gene_ontology_term_id"] = gene

--- a/tests/unit/backend/wmg/api/test_expression_rollup.py
+++ b/tests/unit/backend/wmg/api/test_expression_rollup.py
@@ -266,6 +266,86 @@ class TestHighLevelRollupFunction(unittest.TestCase):
         }
 
         test_3 = {
+            "name": "no_compare_dim_gene_expressed_in_one_tissue_but_not_other",
+            "input_cell_counts": [
+                ["UBERON:0000955", "CL:0000127", 300],
+                ["UBERON:0000955", "CL:0000644", 70],
+                ["UBERON:0000955", "CL:0002605", 80],
+                ["UBERON:0000955", "CL:0002627", 90],
+                ["UBERON:0002113", "CL:0000127", 300],
+                ["UBERON:0002113", "CL:0000644", 70],
+                ["UBERON:0002113", "CL:0002605", 80],
+                ["UBERON:0002113", "CL:0002627", 90],
+            ],
+            "expected_rolled_up_cell_counts": [
+                ["UBERON:0000955", "CL:0000127", 540],
+                ["UBERON:0000955", "CL:0000644", 70],
+                ["UBERON:0000955", "CL:0002605", 80],
+                ["UBERON:0000955", "CL:0002627", 90],
+                ["UBERON:0002113", "CL:0000127", 540],
+                ["UBERON:0002113", "CL:0000644", 70],
+                ["UBERON:0002113", "CL:0002605", 80],
+                ["UBERON:0002113", "CL:0002627", 90],
+            ],
+            # Gene "ENSG00000169429" expressed in Tissue "UBERON:0000955" but not expressed
+            # in Tissue "UBERON:0002113"
+            "input_gene_expression": [
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0002605", 1, 1, 80, 1000],
+            ],
+            "expected_rolled_up_gene_expression": [
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000127", 2, 2, 150, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0000127", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0000127", 2, 2, 150, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0002113", "CL:0002605", 1, 1, 80, 1000],
+            ],
+        }
+
+        test_4 = {
+            "name": "no_compare_dim_one_of_the_tissues_has_no_gene_expressions_at_all",
+            "input_cell_counts": [
+                ["UBERON:0000955", "CL:0000127", 300],
+                ["UBERON:0000955", "CL:0000644", 70],
+                ["UBERON:0000955", "CL:0002605", 80],
+                ["UBERON:0000955", "CL:0002627", 90],
+                ["UBERON:0002113", "CL:0000127", 300],
+                ["UBERON:0002113", "CL:0000644", 70],
+                ["UBERON:0002113", "CL:0002605", 80],
+                ["UBERON:0002113", "CL:0002627", 90],
+            ],
+            "expected_rolled_up_cell_counts": [
+                ["UBERON:0000955", "CL:0000127", 540],
+                ["UBERON:0000955", "CL:0000644", 70],
+                ["UBERON:0000955", "CL:0002605", 80],
+                ["UBERON:0000955", "CL:0002627", 90],
+                ["UBERON:0002113", "CL:0000127", 540],
+                ["UBERON:0002113", "CL:0000644", 70],
+                ["UBERON:0002113", "CL:0002605", 80],
+                ["UBERON:0002113", "CL:0002627", 90],
+            ],
+            # Tissue issue "UBERON:0002113" has no gene expressions
+            "input_gene_expression": [
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 90, 1000],
+            ],
+            "expected_rolled_up_gene_expression": [
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000127", 2, 2, 150, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0000127", 1, 1, 90, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0000644", 1, 1, 70, 1000],
+                ["ENSG00000085265", "UBERON:0000955", "CL:0002605", 1, 1, 80, 1000],
+                ["ENSG00000169429", "UBERON:0000955", "CL:0002627", 1, 1, 90, 1000],
+            ],
+        }
+
+        test_5 = {
             "name": "with_ethnicity_compare_dim_on_single_tissue",
             "input_cell_counts": [
                 ["UBERON:0000955", "CL:0000127", "unknown", 300],
@@ -330,10 +410,24 @@ class TestHighLevelRollupFunction(unittest.TestCase):
             ),
             (
                 test_3["name"],
-                _cell_counts_df_with_ethnicity_compare_dim(test_3["input_cell_counts"]),
-                _cell_counts_df_with_ethnicity_compare_dim(test_3["expected_rolled_up_cell_counts"]),
-                _gene_expression_df_with_ethnicity_compare_dim(test_3["input_gene_expression"]),
-                _gene_expression_df_with_ethnicity_compare_dim(test_3["expected_rolled_up_gene_expression"]),
+                _cell_counts_df_without_compare_dim(test_3["input_cell_counts"]),
+                _cell_counts_df_without_compare_dim(test_3["expected_rolled_up_cell_counts"]),
+                _gene_expression_df_without_compare_dim(test_3["input_gene_expression"]),
+                _gene_expression_df_without_compare_dim(test_3["expected_rolled_up_gene_expression"]),
+            ),
+            (
+                test_4["name"],
+                _cell_counts_df_without_compare_dim(test_4["input_cell_counts"]),
+                _cell_counts_df_without_compare_dim(test_4["expected_rolled_up_cell_counts"]),
+                _gene_expression_df_without_compare_dim(test_4["input_gene_expression"]),
+                _gene_expression_df_without_compare_dim(test_4["expected_rolled_up_gene_expression"]),
+            ),
+            (
+                test_5["name"],
+                _cell_counts_df_with_ethnicity_compare_dim(test_5["input_cell_counts"]),
+                _cell_counts_df_with_ethnicity_compare_dim(test_5["expected_rolled_up_cell_counts"]),
+                _gene_expression_df_with_ethnicity_compare_dim(test_5["input_gene_expression"]),
+                _gene_expression_df_with_ethnicity_compare_dim(test_5["expected_rolled_up_gene_expression"]),
             ),
         ]
 


### PR DESCRIPTION
## Reason for Change

- #4867 

## Changes

When the query API gets a list of tissues and genes, and it is the case that one of the tissues in the query arguments does not express any of the genes in the query argument, the rollup function would throw a KeyError when looking up the "gene expression free" tissue in one of the data structures.

The fix is to prevent this look up by filtering these "expression free tissues".

## Testing steps

- Follow reproduction steps in the ticket on rdev
- Added unit tests to verify the fix at the function level

## Notes for Reviewer
