### PR TITLE
feat(cell-guide): cell type search bar added

### DIFF
--- a/frontend/src/common/queries/cellCards.ts
+++ b/frontend/src/common/queries/cellCards.ts
@@ -61,10 +61,10 @@ async function fetchQuery({
 /**
  * Generic cell cards hook
  */
-export function useCellCardQuery(
+export function useCellCardQuery<T = CellCardResponse>(
   dataType: TYPES,
   cellTypeId = "" // Empty string if cell type is not needed for fetch function
-): UseQueryResult<CellCardResponse> {
+): UseQueryResult<T> {
   const { queryKey, url: rawUrl } = QUERY_MAPPING[dataType];
 
   return useQuery(
@@ -96,6 +96,11 @@ export interface CellOntologyTreeResponse {
   _children?: this[];
 }
 
+export const useCellOntologyTree =
+  (): UseQueryResult<CellOntologyTreeResponse> => {
+    return useCellCardQuery<CellOntologyTreeResponse>(TYPES.CELL_ONTOLOGY_TREE);
+  };
+
 /* ========== ontology_tree_state ========== */
 export const USE_INITIAL_CELL_ONTOLOGY_TREE_STATE_QUERY = {
   entities: [ENTITIES.CELL_CARDS_INITIAL_CELL_ONTOLOGY_TREE_STATE],
@@ -108,6 +113,15 @@ export interface InitialCellOntologyTreeStateResponse {
     [key: string]: string[];
   };
 }
+
+export const useCellOntologyTreeState = (
+  cellTypeId: string
+): UseQueryResult<InitialCellOntologyTreeStateResponse> => {
+  return useCellCardQuery<InitialCellOntologyTreeStateResponse>(
+    TYPES.INITIAL_CELL_ONTOLOGY_TREE,
+    cellTypeId
+  );
+};
 
 /* ========== source_data ========== */
 export const USE_SOURCE_DATA_QUERY = {
@@ -127,6 +141,15 @@ interface SourceDataQueryResponseEntry {
 
 export type SourceDataQueryResponse = SourceDataQueryResponseEntry[];
 
+export const useSourceData = (
+  cellTypeId: string
+): UseQueryResult<SourceDataQueryResponse> => {
+  return useCellCardQuery<SourceDataQueryResponse>(
+    TYPES.SOURCE_DATA,
+    cellTypeId
+  );
+};
+
 /* ========== enriched_genes ========== */
 export const USE_ENRICHED_GENES_QUERY = {
   entities: [ENTITIES.CELL_CARDS_ENRICHED_GENES],
@@ -142,6 +165,15 @@ interface EnrichedGenesQueryResponseEntry {
 }
 
 export type EnrichedGenesQueryResponse = EnrichedGenesQueryResponseEntry[];
+
+export const useEnrichedGenes = (
+  cellTypeId: string
+): UseQueryResult<EnrichedGenesQueryResponse> => {
+  return useCellCardQuery<EnrichedGenesQueryResponse>(
+    TYPES.ENRICHED_GENES,
+    cellTypeId
+  );
+};
 
 /* ========== canonical_markers ========== */
 export const USE_CANONICAL_MARKERS_QUERY = {
@@ -161,6 +193,15 @@ interface CanonicalMarkersQueryResponseEntry {
 export type CanonicalMarkersQueryResponse =
   CanonicalMarkersQueryResponseEntry[];
 
+export const useCanonicalMarkers = (
+  cellTypeId: string
+): UseQueryResult<CanonicalMarkersQueryResponse> => {
+  return useCellCardQuery<CanonicalMarkersQueryResponse>(
+    TYPES.CANONICAL_MARKERS,
+    cellTypeId
+  );
+};
+
 /* ========== CL description ========== */
 export const USE_CL_DESCRIPTION_QUERY = {
   entities: [ENTITIES.CELL_CARDS_CL_DESCRIPTION],
@@ -168,6 +209,12 @@ export const USE_CL_DESCRIPTION_QUERY = {
 };
 
 export type ClDescriptionQueryResponse = string;
+
+export const useClDescription = (
+  cellTypeId: string
+): UseQueryResult<string> => {
+  return useCellCardQuery<string>(TYPES.CL_DESCRIPTION, cellTypeId);
+};
 
 /* ========== description ========== */
 export const USE_DESCRIPTION_QUERY = {
@@ -177,7 +224,11 @@ export const USE_DESCRIPTION_QUERY = {
 
 export type DescriptionQueryResponse = string;
 
-/* ========== cell_guides ========== */
+export const useDescription = (cellTypeId: string): UseQueryResult<string> => {
+  return useCellCardQuery<string>(TYPES.DESCRIPTION, cellTypeId);
+};
+
+/* ========== cell_cards ========== */
 export const USE_CELL_CARDS_QUERY = {
   entities: [ENTITIES.CELL_CARDS_CELL_CARDS],
   id: "cell-cards-query",
@@ -190,11 +241,14 @@ interface CellCardsQueryResponseEntry {
 
 export type CellCardsQueryResponse = CellCardsQueryResponseEntry[];
 
+export const useCellTypes = (): UseQueryResult<CellCardsQueryResponse> => {
+  return useCellCardQuery<CellCardsQueryResponse>(TYPES.CELL_CARDS);
+};
+
 /* ========== cell types by Id ========== */
+
 export function useCellTypesById(): { [id: string]: string } | undefined {
-  const { data, isLoading } = useCellCardQuery(
-    TYPES.CELL_CARDS
-  ) as UseQueryResult<CellCardsQueryResponse>; //useCellTypes();
+  const { data, isLoading } = useCellTypes();
 
   return useMemo(() => {
     if (!data || isLoading) return;

--- a/frontend/src/views/CellCards/components/CellCardSearchBar/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCardSearchBar/index.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import { TextField } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+import InputAdornment from "@mui/material/InputAdornment";
+import { SectionItem, SectionTitle, StyledAutocomplete } from "./style";
+import { ROUTES } from "src/common/constants/routes";
+import { useCellTypes } from "src/common/queries/cellCards";
+import { useRouter } from "next/router";
+
+interface CellType {
+  id: string;
+  label: string;
+}
+
+export default function CellCardSearchBar(): JSX.Element {
+  const router = useRouter();
+  const { data: cellTypes } = useCellTypes();
+
+  const [open, setOpen] = useState(false);
+  const [inputValue, setValue] = useState("");
+
+  // Used for keyboard navigation for cell type search
+  const [highlightedCellType, setHighlightedCellType] =
+    useState<CellType | null>(null);
+
+  const handleFocus = () => {
+    setOpen(true);
+  };
+
+  const handleBlur = () => {
+    setOpen(false);
+  };
+
+  function changeCellType(cellTypeId: string) {
+    if (cellTypeId) {
+      router.push(`${ROUTES.CELL_CARDS}/${cellTypeId.replace(":", "_")}`);
+      document.getElementById("cell-cards-search-bar")?.blur();
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div data-testid="cell-card-search-bar">
+      <StyledAutocomplete
+        open={open}
+        value={inputValue}
+        onChange={() => {
+          // Clears the input after selection
+          setValue("");
+        }}
+        onKeyDown={(event) => {
+          if (highlightedCellType && event.key === "Enter") {
+            changeCellType(highlightedCellType.id);
+          }
+        }}
+        onHighlightChange={(_, value) => {
+          const cellType = value as CellType;
+          setHighlightedCellType(cellType);
+        }}
+        disablePortal
+        id="cell-cards-search-bar"
+        options={cellTypes ?? []}
+        groupBy={(option) => {
+          const cellType = option as CellType;
+          return cellType.id.split(":").at(0) ?? "";
+        }}
+        renderGroup={(params) => {
+          return (
+            <div key={params.key}>
+              <SectionTitle> Cell Type </SectionTitle>
+              {params.children}
+            </div>
+          );
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            data-testid="cell-card-search-bar-text-input"
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <SearchIcon />
+                </InputAdornment>
+              ),
+            }}
+            label="Search cell types or tissues"
+          />
+        )}
+        renderOption={(props, option) => {
+          const cellType = option as CellType;
+          return (
+            <SectionItem
+              {...props}
+              key={cellType.id}
+              onClick={() => {
+                changeCellType(cellType.id);
+              }}
+            >
+              {cellType.label}
+            </SectionItem>
+          );
+        }}
+        autoComplete
+        filterOptions={(options, state) => {
+          return options
+            .filter((option) => {
+              const cellType = option as CellType;
+              return (
+                cellType.label &&
+                cellType.label
+                  .toLowerCase()
+                  .includes(state.inputValue.toLowerCase())
+              );
+            })
+            .sort((cellTypeA, cellTypeB) => {
+              const aRaw = (cellTypeA as CellType).label;
+              const bRaw = (cellTypeB as CellType).label;
+              const a = aRaw.toLowerCase();
+              const b = bRaw.toLowerCase();
+              const searchTerm = state.inputValue.toLowerCase();
+              if (a.startsWith(searchTerm) && !b.startsWith(searchTerm)) {
+                return -1;
+              }
+              if (!a.startsWith(searchTerm) && b.startsWith(searchTerm)) {
+                return 1;
+              }
+              return a.localeCompare(b);
+            });
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/views/CellCards/components/CellCardSearchBar/style.ts
+++ b/frontend/src/views/CellCards/components/CellCardSearchBar/style.ts
@@ -1,0 +1,49 @@
+import styled from "@emotion/styled";
+import { Autocomplete } from "@mui/material";
+import { fontBodyXs, fontCapsXxxs, getColors } from "czifui";
+
+export const StyledAutocomplete = styled(Autocomplete)`
+  height: 32px;
+
+  .MuiInputBase-root {
+    padding-right: 8px !important;
+  }
+  & .MuiAutocomplete-inputRoot[class*="MuiInput-root"] {
+    padding: 0px;
+  }
+  &
+    .MuiAutocomplete-inputRoot[class*="MuiOutlinedInput-root"]
+    .MuiAutocomplete-input {
+    padding: 0px;
+  }
+  & .MuiInputLabel-root {
+    margin-top: -8px;
+  }
+  & .MuiInputLabel-root.MuiInputLabel-shrink {
+    margin-top: 0px;
+  }
+`;
+
+export const SectionTitle = styled.div`
+  ${fontCapsXxxs}
+  font-weight: 600;
+  margin-bottom: 0px !important;
+  cursor: default;
+  padding-left: 12px !important;
+
+  ${(props) => {
+    const colors = getColors(props);
+    return `
+      color: ${colors?.gray[500]};
+      `;
+  }}
+`;
+
+export const SectionItem = styled.li`
+  ${fontBodyXs}
+  font-weight: 400;
+  cursor: pointer;
+  height: 32px;
+  padding-left: 20px !important;
+  margin-bottom: 0px !important;
+`;

--- a/frontend/src/views/CellCards/components/LandingPage/index.tsx
+++ b/frontend/src/views/CellCards/components/LandingPage/index.tsx
@@ -1,11 +1,13 @@
+import CellCardSearchBar from "../CellCardSearchBar";
 import { StyledHeader, Wrapper } from "./style";
 
 export default function LandingPage(): JSX.Element {
   return (
     <Wrapper>
-      <StyledHeader>
+      <StyledHeader data-testid="landing-page-header">
         CellGuide is a comprehensive resource for knowledge about cell types
       </StyledHeader>
+      <CellCardSearchBar />
     </Wrapper>
   );
 }

--- a/frontend/tests/features/cellCards/cellCards.test.ts
+++ b/frontend/tests/features/cellCards/cellCards.test.ts
@@ -1,21 +1,59 @@
-import { test } from "@playwright/test";
+import { test, Page, expect, Locator } from "@playwright/test";
 import { ROUTES } from "src/common/constants/routes";
-import { goToPage, isDevStagingProd } from "tests/utils/helpers";
+import { goToPage, tryUntil } from "tests/utils/helpers";
 import { TEST_URL } from "../../common/constants";
 
-const { describe, skip } = test;
+const { describe } = test;
+
+const LANDING_PAGE_HEADER = "landing-page-header";
+const CELL_CARD_SEARCH_BAR = "cell-card-search-bar";
+const CELL_CARD_SEARCH_BAR_TEXT_INPUT = "cell-card-search-bar-text-input";
 
 describe("Cell Cards", () => {
-  skip(!isDevStagingProd, "WMG BE API does not work locally or in rdev");
-
   describe("Landing Page", () => {
     test("All LandingPage components are present", async ({ page }) => {
       await goToPage(`${TEST_URL}${ROUTES.CELL_CARDS}`, page);
+      await isElementVisible(page, LANDING_PAGE_HEADER);
+      await isElementVisible(page, CELL_CARD_SEARCH_BAR);
     });
     test("Cell type search bar filters properly and links to a CellCard", async ({
       page,
     }) => {
       await goToPage(`${TEST_URL}${ROUTES.CELL_CARDS}`, page);
+      const element = page.getByTestId(CELL_CARD_SEARCH_BAR_TEXT_INPUT);
+      await element.waitFor();
+      await element.click();
+      // get number of elements with role option in dropdown
+      const numOptionsBefore = await countLocator(page.getByRole("option"));
+      // type in search bar
+      await element.type("neuron");
+      // get number of elements with role option in dropdown
+      const numOptionsAfter = await countLocator(page.getByRole("option"));
+      // check that number of elements with role option in dropdown has decreased
+      expect(numOptionsAfter).toBeLessThan(numOptionsBefore);
+      // check that the first element in the dropdown is the one we searched for
+      const firstOption = (await page.getByRole("option").elementHandles())[0];
+      const firstOptionText = await firstOption?.textContent();
+      expect(firstOptionText).toBe("neuron");
+      // click on first element in dropdown
+      await firstOption?.click();
+      // check that the url has changed to the correct cell card
+      await page.waitForURL(`${TEST_URL}${ROUTES.CELL_CARDS}/CL_0000540`);
+    });
+    test("Cell type search bar keyboard input works properly", async ({
+      page,
+    }) => {
+      await goToPage(`${TEST_URL}${ROUTES.CELL_CARDS}`, page);
+      const element = page.getByTestId(CELL_CARD_SEARCH_BAR_TEXT_INPUT);
+      await element.waitFor();
+      await element.click();
+      await element.type("neuron");
+      // input down arrow key
+      await element.press("ArrowDown");
+      // input enter
+      await element.press("Enter");
+      // check that the url has changed to the correct cell card after browser finishes navigating
+      await page.waitForURL(`${TEST_URL}${ROUTES.CELL_CARDS}/CL_0000540`);
     });
   });
 
@@ -31,14 +69,16 @@ describe("Cell Cards", () => {
   });
 });
 
-// async function waitForElement(page: Page, testId: string) {
-//   await tryUntil(
-//     async () => {
-//       await expect(page.getByTestId(testId)).not.toHaveCount(0);
-//     },
-//     { page }
-//   );
-// }
+async function isElementVisible(page: Page, testId: string) {
+  await tryUntil(
+    async () => {
+      const element = page.getByTestId(testId);
+      const isVisible = await element.isVisible();
+      expect(isVisible).toBe(true);
+    },
+    { page }
+  );
+}
 
 // async function getElementAndClick(page: Page, testID: string) {
 //   await tryUntil(
@@ -48,3 +88,9 @@ describe("Cell Cards", () => {
 //     { page }
 //   );
 // }
+
+// (alec) use this instead of locator.count() to make sure that the element is actually present
+// when counting
+async function countLocator(locator: Locator) {
+  return (await locator.elementHandles()).length;
+}


### PR DESCRIPTION
## Reason for Change

- Add cell type search bar feature to Cell Guide landing page.

## Changes

- added cell type search bar 
- added e2e tests for landing page and search bar
- modified the `useCellCardQuery` hook to use generics
- added `use<Endpoint>` wrapper hooks for convenience.

## Testing steps

- Tested locally
- e2e tests pass