### PR TITLE
fix: Fix WMG landing page filter test (#4879)

### DIFF
--- a/frontend/src/components/common/SideBar/index.tsx
+++ b/frontend/src/components/common/SideBar/index.tsx
@@ -81,6 +81,7 @@ export default function SideBar({
       <SideBarPositionerComponent isExpanded={isExpanded}>
         <SideBarToggleButtonWrapper>
           <Button
+            data-testid="side-bar-toggle-button"
             disabled={disabled}
             endIcon={
               <Icon

--- a/frontend/tests/features/wheresMyGene/landingPageFilter.test.ts
+++ b/frontend/tests/features/wheresMyGene/landingPageFilter.test.ts
@@ -8,7 +8,8 @@ import {
   selectTissueAndGeneOption,
 } from "../../utils/wmgUtils";
 import { isDevStagingProd, tryUntil } from "tests/utils/helpers";
-const CHEVRON_LEFT = '[data-icon="chevron-left"]';
+
+const SIDE_BAR_TOGGLE_BUTTON_ID = "side-bar-toggle-button";
 
 const { describe, skip } = test;
 
@@ -23,7 +24,7 @@ describe("Left side bar", () => {
     await selectTissueAndGeneOption(page);
 
     // click chevron left to collapse the left tab
-    await page.locator(CHEVRON_LEFT).click();
+    await page.getByTestId(SIDE_BAR_TOGGLE_BUTTON_ID).click();
 
     // verify the left tab is collapsed
     expect(await page.getByTestId("add-organism").isVisible()).toBeFalsy();


### PR DESCRIPTION
## Reason for Change

- #4879 

## Changes

- Added `data-testid` to `SideBar` toggle button and updated `landingPageFilter` test to use the test id.