### PR TITLE
fix: documentation outline when you enter from an external source

### DIFF
--- a/frontend/src/pages/docs/[...slug].tsx
+++ b/frontend/src/pages/docs/[...slug].tsx
@@ -15,7 +15,7 @@ import Head from "next/head";
 import Image, { ImageProps } from "next/image";
 import NextLink from "next/link";
 import pathTool from "path";
-import { Fragment, memo, useState } from "react";
+import { Fragment, memo, useState, useMemo } from "react";
 import rehypeSlug from "rehype-slug";
 import { noop } from "src/common/constants/utils";
 import { OFF_WHITE, PINK } from "src/common/theme";
@@ -179,8 +179,13 @@ const DirectoryListItem = ({
   directory: Directory;
   activeFile: string;
 }) => {
+  const initialState = useMemo(() => {
+    return directory.files.includes(activeFile) ? 1 : 0;
+  }, [directory.files, activeFile]);
+
   // 0 = default collapse, 1 = default expand, 2 = user collapse, 3 = user expand
-  const [isExpanded, setIsExpanded] = useState<0 | 1 | 2 | 3>(0);
+  const [isExpanded, setIsExpanded] = useState<0 | 1 | 2 | 3>(initialState);
+
   return (
     <Fragment>
       <li onClick={() => setIsExpanded(isExpanded % 2 == 0 ? 3 : 2)}>

--- a/frontend/src/pages/docs/[...slug].tsx
+++ b/frontend/src/pages/docs/[...slug].tsx
@@ -32,6 +32,13 @@ interface Directory {
   subDirectories: Array<Directory>;
 }
 
+enum ExpandedValue {
+  DEFAULT_COLLAPSE = 0,
+  DEFAULT_EXPAND = 1,
+  USER_COLLAPSE = 2,
+  USER_EXPAND = 3,
+}
+
 const CACHED_FILE_PATHS = new Map<string, Directory>();
 function filePaths(...root: Array<string>): Directory {
   const cacheStore = CACHED_FILE_PATHS && CACHED_FILE_PATHS.get(root.join("/"));
@@ -73,6 +80,20 @@ function generatePaths(
     });
   }
   return slugs;
+}
+
+function containsActiveFile(directory: Directory, activeFile: string): boolean {
+  if (directory.files.includes(activeFile)) {
+    return true;
+  }
+
+  for (const subDirectory of directory.subDirectories) {
+    if (containsActiveFile(subDirectory, activeFile)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -180,15 +201,24 @@ const DirectoryListItem = ({
   activeFile: string;
 }) => {
   const initialState = useMemo(() => {
-    return directory.files.includes(activeFile) ? 1 : 0;
+    return directory.files.includes(activeFile)
+      ? ExpandedValue.DEFAULT_EXPAND
+      : ExpandedValue.DEFAULT_COLLAPSE;
   }, [directory.files, activeFile]);
 
-  // 0 = default collapse, 1 = default expand, 2 = user collapse, 3 = user expand
-  const [isExpanded, setIsExpanded] = useState<0 | 1 | 2 | 3>(initialState);
+  const [isExpanded, setIsExpanded] = useState<ExpandedValue>(initialState);
 
   return (
     <Fragment>
-      <li onClick={() => setIsExpanded(isExpanded % 2 == 0 ? 3 : 2)}>
+      <li
+        onClick={() =>
+          setIsExpanded(
+            isExpanded % 2 == 0
+              ? ExpandedValue.USER_EXPAND
+              : ExpandedValue.USER_COLLAPSE
+          )
+        }
+      >
         {directory.dirName.split("__")[1]}{" "}
         <Icon
           sdsIcon={isExpanded % 2 == 1 ? "chevronDown" : "chevronRight"}
@@ -218,17 +248,23 @@ const Directory = memo(function RenderDirectory({
 }: {
   activeFile: string;
   directory: Directory;
-  isExpanded: 0 | 1 | 2 | 3;
-  setIsExpanded: (isExpanded: 0 | 1 | 2 | 3) => void;
+  isExpanded: ExpandedValue;
+  setIsExpanded: (isExpanded: ExpandedValue) => void;
   isChild?: boolean;
 }) {
+  const initialState = useMemo(() => {
+    return containsActiveFile(directory, activeFile)
+      ? ExpandedValue.DEFAULT_EXPAND
+      : ExpandedValue.DEFAULT_COLLAPSE;
+  }, [directory.files, activeFile]);
+  setIsExpanded(initialState);
+
   const fileComponents: Array<[string, JSX.Element]> = directory.files.map(
     (file) => {
       let href = "/docs/";
       if (directory.slug.length > 0) href += directory.slug.join("/") + "/";
       href += file;
       const isActiveFile = file === activeFile;
-      if (isActiveFile && isExpanded < 2) setIsExpanded(1);
 
       return [
         file,


### PR DESCRIPTION
## Reason for Change

ticket:
https://github.com/chanzuckerberg/single-cell-data-portal/issues/4729

## Changes

- sets the `isExpanded` state to 1 if `directory.files.includes(activeFile)` using the react hook `useMemo`
- after doing some reading + consulting chatGPT, i believe a react hook is necessary because the values `directory.files` and `activeFile` may not be set when the component is first rendered. the `useMemo` hook will ensure that the state is set if the data is updated asynchronously
- i think `useMemo` is preferred over `useEffect` since this component doesn't rely on any external dependencies
- recursively checks the directory as well as any child subdirectories to see if the activeFile is in there, and sets the expansion state as necessary
- i also included some aesthetic changes to declare `ExpandedValue` as an enum, so that it's more clear what the different numerical values mean. this should not affect any functionality (ex: `if isExpanded % 2` should still work)

## Testing steps

- tbh i don't fully understand the product well enough to get to this page from gene expression (lol), but i was able to repro the bug by just opening up a new tab with the following URL and seeing that the navigation outline was expanded: https://localhost:3000/docs/05__Annotate%20and%20Analyze%20Your%20Data/5_0__Get%20Started

https://github.com/chanzuckerberg/single-cell-data-portal/assets/5653616/1c28b02e-76af-4066-824a-84fc25feb99a

## Notes for Reviewer
let me know if there's a better way to do this!