### PR TITLE
feat: allow cxg reprocessing job to run again

### DIFF
--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -238,7 +238,7 @@ resource "aws_sfn_state_machine" "state_machine_cxg_remaster" {
       "Parameters": {
         "JobDefinition": "${var.job_definition_arn}",
         "JobName": "cxg_remaster",
-        "JobQueue": "arn:aws:batch:us-west-2:699936264352:job-queue/dp-dev",
+        "JobQueue": "${var.job_queue_arn}",
         "ContainerOverrides": {
           "Environment": [
             {

--- a/backend/layers/processing/process.py
+++ b/backend/layers/processing/process.py
@@ -100,12 +100,10 @@ class ProcessMain(ProcessingLogic):
         try:
             if step_name == "download-validate":
                 self.process_download_validate.process(dataset_id, dropbox_uri, artifact_bucket, datasets_bucket)
-            elif step_name == "cxg":
+            elif step_name == "cxg" or step_name == "cxg_remaster":
                 self.process_cxg.process(dataset_id, artifact_bucket, cxg_bucket)
             elif step_name == "seurat":
                 self.process_seurat.process(dataset_id, artifact_bucket, datasets_bucket)
-            elif step_name == "cxg_remaster":
-                raise NotImplementedError("cxg remasters are not supported anymore")
             else:
                 self.logger.error(f"Step function configuration error: Unexpected STEP_NAME '{step_name}'")
 
@@ -132,7 +130,7 @@ class ProcessMain(ProcessingLogic):
                 self.update_processing_status(dataset_id, DatasetStatusKey.UPLOAD, DatasetUploadStatus.FAILED)
             elif step_name == "seurat":
                 self.update_processing_status(dataset_id, DatasetStatusKey.RDS, DatasetConversionStatus.FAILED)
-            elif step_name == "cxg":
+            elif step_name == "cxg" or step_name == "cxg_remaster":
                 self.update_processing_status(dataset_id, DatasetStatusKey.CXG, DatasetConversionStatus.FAILED)
             return False
 


### PR DESCRIPTION
## Reason for Change

- #4855

## Changes

- update step function main process to re-allow cxg remastering job, leveraging existing cxg remaster job definition 
- simply re-processes a dataset cxg from its labeled h5ad, necessary to backfill gene feature IDs to our cxg's

## Testing steps
- triggered a cxg remaster in rdev, in-place reprocessing was successful with these changes w/o issue
- will test with a selected subset of cxg's in dev and coordinate with data viz before running a reprocess of the corpus in prod

## Notes for Reviewer
