### PR TITLE
fix(cell-guide): set share URL to version 2 for enriched genes share link

### DIFF
--- a/frontend/src/views/CellCards/components/CellCard/components/EnrichedGenesTable/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/EnrichedGenesTable/index.tsx
@@ -129,7 +129,7 @@ const EnrichedGenesTable = ({ cellTypeId }: Props) => {
                 testId={CELL_CARD_ENRICHED_GENES_TABLE_DROPDOWN}
               />
               <Link
-                url={`${ROUTES.WHERE_IS_MY_GENE}?genes=${genesForShareUrl}`}
+                url={`${ROUTES.WHERE_IS_MY_GENE}?genes=${genesForShareUrl}&ver=2`}
                 label="Open in Gene Expression"
               />
             </TableTitleInnerWrapper>


### PR DESCRIPTION
## Reason for Change

- The version on the share URL wasn't set for the enriched genes Open in Gene Expression link, so the WMG client expected commas that weren't URL encoded.

## Changes

- add ver=2 to the end of the share URL link.

## Testing steps

- Tested locally
