### PR TITLE
chore(cell-guide): rename publication to references for canonical marker gene table

### DIFF
--- a/frontend/src/views/CellCards/components/CellCard/components/CanonicalMarkerGeneTable/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/CanonicalMarkerGeneTable/index.tsx
@@ -25,9 +25,9 @@ export const CELL_CARD_CANONICAL_MARKER_GENES_TABLE_DROPDOWN =
 interface TableRow {
   symbol: string;
   name: string;
-  publications: ReactElement | string;
+  references: ReactElement | string;
 }
-const tableColumns: Array<keyof TableRow> = ["symbol", "name", "publications"];
+const tableColumns: Array<keyof TableRow> = ["symbol", "name", "references"];
 
 interface Props {
   cellTypeId: string;
@@ -95,7 +95,7 @@ const CanonicalMarkerGeneTable = ({ cellTypeId }: Props) => {
       rows.push({
         symbol: markerGene.symbol,
         name: markerGene.name,
-        publications: publicationLinks,
+        references: publicationLinks,
       });
     }
     return rows;

--- a/frontend/tests/features/cellCards/cellCards.test.ts
+++ b/frontend/tests/features/cellCards/cellCards.test.ts
@@ -153,7 +153,7 @@ describe("Cell Cards", () => {
             return await element.textContent();
           })
         );
-        expect(columnHeaders).toEqual(["Symbol", "Name", "Publications"]);
+        expect(columnHeaders).toEqual(["Symbol", "Name", "References"]);
         const rowElements = await page
           .locator(`${tableSelector} tbody tr`)
           .elementHandles();


### PR DESCRIPTION
## Reason for Change

- To be consistent with CCF nomenclature

## Testing steps

- Tested locally