### PR TITLE
chore(cell-guide): update canonical marker gene tooltip to point to latest ASCT+B version

### DIFF
--- a/frontend/src/views/CellCards/components/CellCard/components/CanonicalMarkerGeneTable/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/CanonicalMarkerGeneTable/index.tsx
@@ -128,7 +128,7 @@ const CanonicalMarkerGeneTable = ({ cellTypeId }: Props) => {
                     "Anatomical Structures, Cell Types and Biomarkers (ASCT+B)"
                   }
                   url={
-                    "https://hubmapconsortium.github.io/ccf/pages/ccf-anatomical-structures.html"
+                    "https://humanatlas.io/asctb-tables"
                   }
                 />
                 {

--- a/frontend/src/views/CellCards/components/CellCard/components/CanonicalMarkerGeneTable/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/CanonicalMarkerGeneTable/index.tsx
@@ -127,9 +127,7 @@ const CanonicalMarkerGeneTable = ({ cellTypeId }: Props) => {
                   label={
                     "Anatomical Structures, Cell Types and Biomarkers (ASCT+B)"
                   }
-                  url={
-                    "https://humanatlas.io/asctb-tables"
-                  }
+                  url={"https://humanatlas.io/asctb-tables"}
                 />
                 {
                   " tables. The tables are authored and reviewed by an international team of anatomists, pathologists, physicians, and other experts."


### PR DESCRIPTION

## Reason for Change

- The tooltip was pointing to ASCT+B v1.2 but we are using v1.3.

## Testing steps

- Tested locally