### PR TITLE
chore(cell-guide): update dag tooltip to remove descendent cells for leaf nodes

### DIFF
--- a/frontend/src/views/CellCards/components/CellCard/components/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/OntologyDagView/index.tsx
@@ -338,8 +338,13 @@ export default function OntologyDagView({ cellTypeId, skinnyMode }: TreeProps) {
                 >
                   <div data-testid={CELL_CARD_ONTOLOGY_DAG_VIEW_TOOLTIP}>
                     <b>{tooltipData?.n_cells}</b> cells
-                    <br />
-                    <b>{tooltipData?.n_cells_rollup}</b> descendant cells
+                    {
+                      tooltipData?.n_cells !== tooltipData?.n_cells_rollup && 
+                      <>
+                        <br />
+                        <b>{tooltipData?.n_cells_rollup}</b> descendant cells
+                      </>
+                    }
                   </div>
                 </TooltipInPortal>
               )}

--- a/frontend/src/views/CellCards/components/CellCard/components/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/OntologyDagView/index.tsx
@@ -338,13 +338,12 @@ export default function OntologyDagView({ cellTypeId, skinnyMode }: TreeProps) {
                 >
                   <div data-testid={CELL_CARD_ONTOLOGY_DAG_VIEW_TOOLTIP}>
                     <b>{tooltipData?.n_cells}</b> cells
-                    {
-                      tooltipData?.n_cells !== tooltipData?.n_cells_rollup && 
+                    {tooltipData?.n_cells !== tooltipData?.n_cells_rollup && (
                       <>
                         <br />
                         <b>{tooltipData?.n_cells_rollup}</b> descendant cells
                       </>
-                    }
+                    )}
                   </div>
                 </TooltipInPortal>
               )}


### PR DESCRIPTION
## Reason for Change

- Update the DAG tooltip to remove descendant # cells indicator for leaf nodes
- Leaf nodes have no descendants so this information isn't meaningful.

## Testing steps

- Tested locally