### PR TITLE
chore(cell-guide): increase vertical spacing between nodes in ontology view

### DIFF
--- a/frontend/src/views/CellCards/components/CellCard/components/OntologyDagView/common/constants.ts
+++ b/frontend/src/views/CellCards/components/CellCard/components/OntologyDagView/common/constants.ts
@@ -9,5 +9,5 @@ export const largeSize = 8;
 export const defaultMargin = { top: 50, left: 0, right: 0, bottom: 0 };
 export const DEFAULT_ONTOLOGY_WIDTH = 1000;
 export const DEFAULT_ONTOLOGY_HEIGHT = 500;
-export const NODE_SPACINGS = [15, 200];
+export const NODE_SPACINGS = [18, 200];
 export const TREE_ANIMATION_DURATION = 250;

--- a/frontend/tests/features/cellCards/cellCards.test.ts
+++ b/frontend/tests/features/cellCards/cellCards.test.ts
@@ -332,7 +332,7 @@ describe("Cell Cards", () => {
         const nodesLocator = `[data-testid^='${CELL_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}']`;
         const nodesBefore = await page.locator(nodesLocator).elementHandles();
         const numNodesBefore = nodesBefore.length;
-    
+
         const dummyChildLocator = `[data-testid='${CELL_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}-dummy-child-CL_0000842__0-has-children-isTargetNode=false']`;
         const dummyChild = (
           await page.locator(dummyChildLocator).elementHandles()

--- a/frontend/tests/features/cellCards/cellCards.test.ts
+++ b/frontend/tests/features/cellCards/cellCards.test.ts
@@ -324,7 +324,7 @@ describe("Cell Cards", () => {
       test("Clicking on a collapsed node stub displays hidden cell types", async ({
         page,
       }) => {
-        await goToPage(`${TEST_URL}${ROUTES.CELL_CARDS}/CL_0000540`, page); // Neuron
+        await goToPage(`${TEST_URL}${ROUTES.CELL_CARDS}/CL_0000084`, page); // T cell
         await page
           .getByTestId(CELL_CARD_ONTOLOGY_DAG_VIEW)
           .waitFor({ timeout: 5000 });
@@ -332,11 +332,14 @@ describe("Cell Cards", () => {
         const nodesLocator = `[data-testid^='${CELL_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}']`;
         const nodesBefore = await page.locator(nodesLocator).elementHandles();
         const numNodesBefore = nodesBefore.length;
-
-        const dummyChildLocator = `[data-testid^='${CELL_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}-dummy-child']`;
+    
+        const dummyChildLocator = `[data-testid='${CELL_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}-dummy-child-CL_0000842__0-has-children-isTargetNode=false']`;
         const dummyChild = (
           await page.locator(dummyChildLocator).elementHandles()
         )[0];
+        // check that dummyChild is clickable
+        const isVisible = await dummyChild.isVisible();
+        expect(isVisible).toBe(true);
         await dummyChild.click();
 
         const nodesAfter = await page.locator(nodesLocator).elementHandles();
@@ -377,6 +380,21 @@ describe("Cell Cards", () => {
       });
     });
     describe("CellCard Sidebar", () => {
+      test("Scrolling on CellCard updates the navbar", async ({ page }) => {
+        await goToPage(`${TEST_URL}${ROUTES.CELL_CARDS}/CL_0000540`, page); // Neuron
+        const navbar = page.getByTestId(CELL_CARD_NAVIGATION_SIDEBAR);
+        const section0 = page.getByTestId("section-0");
+        await section0.scrollIntoViewIfNeeded();
+        const section2 = page.getByTestId("section-2");
+        await section2.scrollIntoViewIfNeeded();
+
+        // check that the navbar tab corresponding to section 2 is highlighted
+        const selectedTab = navbar.locator(
+          ".MuiButtonBase-root.MuiTab-root.Mui-selected"
+        );
+        const selectedTabText = await selectedTab.innerText();
+        expect(selectedTabText).toBe("Marker Genes");
+      });
       test("Clicking on the navbar scrolls to the section", async ({
         page,
       }) => {

--- a/frontend/tests/features/cellCards/cellCards.test.ts
+++ b/frontend/tests/features/cellCards/cellCards.test.ts
@@ -380,21 +380,6 @@ describe("Cell Cards", () => {
       });
     });
     describe("CellCard Sidebar", () => {
-      test("Scrolling on CellCard updates the navbar", async ({ page }) => {
-        await goToPage(`${TEST_URL}${ROUTES.CELL_CARDS}/CL_0000540`, page); // Neuron
-        const navbar = page.getByTestId(CELL_CARD_NAVIGATION_SIDEBAR);
-        const section0 = page.getByTestId("section-0");
-        await section0.scrollIntoViewIfNeeded();
-        const section2 = page.getByTestId("section-2");
-        await section2.scrollIntoViewIfNeeded();
-
-        // check that the navbar tab corresponding to section 2 is highlighted
-        const selectedTab = navbar.locator(
-          ".MuiButtonBase-root.MuiTab-root.Mui-selected"
-        );
-        const selectedTabText = await selectedTab.innerText();
-        expect(selectedTabText).toBe("Marker Genes");
-      });
       test("Clicking on the navbar scrolls to the section", async ({
         page,
       }) => {


### PR DESCRIPTION
## Reason for Change

-There was overlap between 2 square nodes:
<img width="259" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/16548075/9dbef0bb-7d99-4290-a389-a01b93497740">


## Changes

- Increase vertical spacing from 15 to 18

## Testing steps

- Tested locally
<img width="312" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/16548075/7c970251-d562-4311-891e-22f939657328">
