### PR TITLE
feat: Unit tests and security for WMG V2 API

### DIFF
--- a/backend/wmg/api/wmg-api-v2.yml
+++ b/backend/wmg/api/wmg-api-v2.yml
@@ -62,6 +62,7 @@ paths:
                   required:
                     - gene_ontology_term_ids
                     - organism_ontology_term_id
+                  additionalProperties: false
                   properties:
                     gene_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
@@ -91,6 +92,7 @@ paths:
                     - disease
               required:
                 - filter
+              additionalProperties: false
       responses:
         "200":
           description: OK
@@ -573,11 +575,13 @@ paths:
           application/json:
             schema:
               type: object
+              #additionalProperties: false
               properties:
                 filter:
                   type: object
                   required:
                     - organism_ontology_term_id
+                  #additionalProperties: false
                   properties:
                     organism_ontology_term_id:
                       type: string
@@ -655,6 +659,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 celltype:
                   type: string

--- a/backend/wmg/api/wmg-api-v2.yml
+++ b/backend/wmg/api/wmg-api-v2.yml
@@ -575,19 +575,21 @@ paths:
           application/json:
             schema:
               type: object
-              #additionalProperties: false
+              additionalProperties: false
               properties:
                 filter:
                   type: object
                   required:
                     - organism_ontology_term_id
-                  #additionalProperties: false
+                  additionalProperties: false
                   properties:
                     organism_ontology_term_id:
                       type: string
                     tissue_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
                     cell_type_ontology_term_ids:
+                      $ref: "#/components/schemas/wmg_ontology_term_id_list"
+                    gene_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
                     dataset_ids:
                       type: array
@@ -598,7 +600,7 @@ paths:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
                     sex_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
-                    development_ontology_stage_term_ids:
+                    development_stage_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
                     self_reported_ethnicity_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"

--- a/backend/wmg/data/query.py
+++ b/backend/wmg/data/query.py
@@ -127,7 +127,9 @@ class WmgQuery:
     # TODO: refactor for readability: https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues
     #  /chanzuckerberg/single-cell-data-portal/2133
     @staticmethod
-    def _query(cube: Array, criteria: Union[WmgQueryCriteria, FmgQueryCriteria], indexed_dims: List[str]) -> DataFrame:
+    def _query(
+        cube: Array, criteria: Union[WmgQueryCriteria, WmgQueryCriteriaV2, FmgQueryCriteria], indexed_dims: List[str]
+    ) -> DataFrame:
         query_cond = ""
         attrs = {}
         for attr_name, vals in criteria.dict(exclude=set(indexed_dims)).items():

--- a/tests/unit/backend/wmg/api/test_v2.py
+++ b/tests/unit/backend/wmg/api/test_v2.py
@@ -496,6 +496,29 @@ class WmgApiV2Tests(unittest.TestCase):
             "'organism_ontology_term_id' is a required property - 'filter'", json.loads(response.data)["detail"]
         )
 
+    def test__filter_request_with_query_key_not_specified_in_api_spec_returns_400(self):
+        filter_dict = dict(
+            # these don't matter for the expected result
+            gene_ontology_term_ids=["gene_ontology_term_id_0"],
+            organism_ontology_term_id="organism_ontology_term_id_0",
+            tissue_ontology_term_ids=["tissue_ontology_term_id_0"],
+            # these matter for the expected result
+            development_stage_ontology_term_ids=["development_stage_ontology_term_id_0"],
+            self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
+        )
+
+        filter_request = dict(
+            filter=filter_dict,
+            is_rollup=True,
+        )
+
+        response = self.app.post("/wmg/v2/filters", json=filter_request)
+
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            "Additional properties are not allowed ('is_rollup' was unexpected)", json.loads(response.data)["detail"]
+        )
+
     @patch("backend.wmg.api.v2.fetch_datasets_metadata")
     @patch("backend.wmg.api.v2.gene_term_label")
     @patch("backend.wmg.api.v2.ontology_term_label")
@@ -522,10 +545,7 @@ class WmgApiV2Tests(unittest.TestCase):
                 self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
             )
 
-            filter_0_request = dict(
-                filter=filter_0,
-                is_rollup=True,
-            )
+            filter_0_request = dict(filter=filter_0)
 
             response = self.app.post("/wmg/v2/filters", json=filter_0_request)
 
@@ -549,7 +569,6 @@ class WmgApiV2Tests(unittest.TestCase):
                 "tissue_terms": [{"tissue_ontology_term_id_0": "tissue_ontology_term_id_0_label"}],
                 "cell_type_terms": [{"cell_type_ontology_term_id_0": "cell_type_ontology_term_id_0_label"}],
             }
-            print(f"PRATHAP SAYS: {json.loads(response.data)}")
             self.assertEqual(json.loads(response.data)["filter_dims"], expected_filters)
 
     @patch("backend.wmg.api.v2.fetch_datasets_metadata")
@@ -587,11 +606,7 @@ class WmgApiV2Tests(unittest.TestCase):
                     self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
                 )
 
-                filter_0_request = dict(
-                    filter=filter_0,
-                    # matters for this test
-                    is_rollup=True,
-                )
+                filter_0_request = dict(filter=filter_0)
 
                 filter_0_no_dev_stage_filter = dict(
                     # these don't matter for the expected result
@@ -602,7 +617,7 @@ class WmgApiV2Tests(unittest.TestCase):
                     development_stage_ontology_term_ids=[],
                     self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_0"],
                 )
-                filter_0_no_dev_stage_request = dict(filter=filter_0_no_dev_stage_filter, is_rollup=True)
+                filter_0_no_dev_stage_request = dict(filter=filter_0_no_dev_stage_filter)
 
                 filter_0_no_ethnicity_filter = dict(
                     # these don't matter for the expected result
@@ -613,7 +628,7 @@ class WmgApiV2Tests(unittest.TestCase):
                     development_stage_ontology_term_ids=["development_stage_ontology_term_id_0"],
                     self_reported_ethnicity_ontology_term_ids=[],
                 )
-                filter_0_no_ethnicity_request = dict(filter=filter_0_no_ethnicity_filter, is_rollup=True)
+                filter_0_no_ethnicity_request = dict(filter=filter_0_no_ethnicity_filter)
                 # the values for dev_stage terms when a dev stage filter is included should match the values returned
                 # if no filter is passed in for dev stage
                 response = self.app.post("/wmg/v2/filters", json=filter_0_request)
@@ -667,7 +682,7 @@ class WmgApiV2Tests(unittest.TestCase):
                     {"self_reported_ethnicity_ontology_term_id_1": "self_reported_ethnicity_ontology_term_id_1_label"},
                     {"self_reported_ethnicity_ontology_term_id_2": "self_reported_ethnicity_ontology_term_id_2_label"},
                 ]
-                self_reported_ethnicity_0_request = dict(filter=self_reported_ethnicity_0_filter, is_rollup=True)
+                self_reported_ethnicity_0_request = dict(filter=self_reported_ethnicity_0_filter)
                 response = self.app.post("/wmg/v2/filters", json=self_reported_ethnicity_0_request)
                 dev_stage_terms = _sort_list_by_dictionary_keys(
                     json.loads(response.data)["filter_dims"]["development_stage_terms"]
@@ -696,7 +711,7 @@ class WmgApiV2Tests(unittest.TestCase):
                 expected_self_reported_ethnicity_term = [
                     {"self_reported_ethnicity_ontology_term_id_0": "self_reported_ethnicity_ontology_term_id_0_label"}
                 ]
-                self_reported_ethnicity_1_request = dict(filter=self_reported_ethnicity_1_filter, is_rollup=True)
+                self_reported_ethnicity_1_request = dict(filter=self_reported_ethnicity_1_filter)
                 response = self.app.post("/wmg/v2/filters", json=self_reported_ethnicity_1_request)
                 dev_stage_terms_no_dev_filter = _sort_list_by_dictionary_keys(
                     json.loads(response.data)["filter_dims"]["development_stage_terms"]
@@ -716,9 +731,7 @@ class WmgApiV2Tests(unittest.TestCase):
                     development_stage_ontology_term_ids=["development_stage_ontology_term_id_1"],
                     self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_1"],
                 )
-                self_reported_ethnicity_1_dev_1_request = dict(
-                    filter=self_reported_ethnicity_1_dev_1_filter, is_rollup=True
-                )
+                self_reported_ethnicity_1_dev_1_request = dict(filter=self_reported_ethnicity_1_dev_1_filter)
 
                 response = self.app.post("/wmg/v2/filters", json=self_reported_ethnicity_1_dev_1_request)
                 dev_stage_terms_dev_filter = _sort_list_by_dictionary_keys(
@@ -754,8 +767,8 @@ class WmgApiV2Tests(unittest.TestCase):
                     development_stage_ontology_term_ids=["development_stage_ontology_term_id_2"],
                     self_reported_ethnicity_ontology_term_ids=["self_reported_ethnicity_ontology_term_id_2"],
                 )
-                self_reported_ethnicity_2_request = dict(filter=self_reported_ethnicity_2_filter, is_rollup=True)
-                eth_2_dev_2_request = dict(filter=self_reported_ethnicity_2_dev_2_filter, is_rollup=True)
+                self_reported_ethnicity_2_request = dict(filter=self_reported_ethnicity_2_filter)
+                eth_2_dev_2_request = dict(filter=self_reported_ethnicity_2_dev_2_filter)
                 response = self.app.post("/wmg/v2/filters", json=self_reported_ethnicity_2_request)
                 dev_stage_terms_eth_2_no_dev_filter = _sort_list_by_dictionary_keys(
                     json.loads(response.data)["filter_dims"]["development_stage_terms"]


### PR DESCRIPTION
## Reason for Change

- #4863 
- This PR addresses step 5 in the ticket above - specifically creating unit test coverage for the WMG V2 API where the `query` endpoint expects request bodies without `tissue_ontology_term_ids` key.

## Changes

- add unit tests
- Make api more secure by making strict the schema of the request body on `HTTP POST`. Specifically, the openApi spec is modified such that properties not specified in the request body schema are rejected. This prevents potential injection attacks that could lead to a denial of service or worse things.


## Testing steps

- Unit tests

## Notes for Reviewer
