### PR TITLE
fix: revert aws-sdk dependency upgrade

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,7 +61,7 @@
         "sharp": "^0.30.6"
       },
       "devDependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.8.1",
+        "@aws-sdk/client-secrets-manager": "3.183.0",
         "@babel/core": "^7.16.0",
         "@babel/preset-react": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
       "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
@@ -140,16 +140,16 @@
       "dev": true
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -162,13 +162,13 @@
       "dev": true
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
         "tslib": "^1.11.1"
       }
     },
@@ -179,9 +179,9 @@
       "dev": true
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
@@ -194,12 +194,12 @@
       "dev": true
     },
     "node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
@@ -211,835 +211,745 @@
       "dev": true
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.338.0.tgz",
-      "integrity": "sha512-/yLI32+HwFNBRJ39jMXw+/cn3AnlCuJpQd7Ax4887g32Dgte5eyrfY8sJUOL6902BUmAq4oSRI5QeBXNplO0Xw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.183.0.tgz",
+      "integrity": "sha512-iRhdCoC/QyyB6iRCytb12T0XtfmQRn849vnbcUd8BprXvkQ/YwmFS//4Lj02uxS+myqXCntoAj1nKvZZwcFmbg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.338.0.tgz",
-      "integrity": "sha512-Kh8LGEXJMte4WxCretFxUcutp4RrWxqiG6eawaIaMgLY5GtWdhOS2rv7JMjHIcv83bgr52pOa1ifBY2VUPrFkQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.183.0.tgz",
+      "integrity": "sha512-P2WxRE6LZLaWzSg9pu3IpCWp5FcToH40U/o+TfMlbcELQVIhzLPmyrYAnJJx1hSQaud328N2KZTyVGhX1ef9OQ==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.338.0",
-        "@aws-sdk/config-resolver": "3.338.0",
-        "@aws-sdk/credential-provider-node": "3.338.0",
-        "@aws-sdk/fetch-http-handler": "3.338.0",
-        "@aws-sdk/hash-node": "3.338.0",
-        "@aws-sdk/invalid-dependency": "3.338.0",
-        "@aws-sdk/middleware-content-length": "3.338.0",
-        "@aws-sdk/middleware-endpoint": "3.338.0",
-        "@aws-sdk/middleware-host-header": "3.338.0",
-        "@aws-sdk/middleware-logger": "3.338.0",
-        "@aws-sdk/middleware-recursion-detection": "3.338.0",
-        "@aws-sdk/middleware-retry": "3.338.0",
-        "@aws-sdk/middleware-serde": "3.338.0",
-        "@aws-sdk/middleware-signing": "3.338.0",
-        "@aws-sdk/middleware-stack": "3.338.0",
-        "@aws-sdk/middleware-user-agent": "3.338.0",
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/node-http-handler": "3.338.0",
-        "@aws-sdk/smithy-client": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.338.0",
-        "@aws-sdk/util-defaults-mode-node": "3.338.0",
-        "@aws-sdk/util-endpoints": "3.338.0",
-        "@aws-sdk/util-retry": "3.338.0",
-        "@aws-sdk/util-user-agent-browser": "3.338.0",
-        "@aws-sdk/util-user-agent-node": "3.338.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.183.0",
+        "@aws-sdk/config-resolver": "3.183.0",
+        "@aws-sdk/credential-provider-node": "3.183.0",
+        "@aws-sdk/fetch-http-handler": "3.183.0",
+        "@aws-sdk/hash-node": "3.183.0",
+        "@aws-sdk/invalid-dependency": "3.183.0",
+        "@aws-sdk/middleware-content-length": "3.183.0",
+        "@aws-sdk/middleware-host-header": "3.183.0",
+        "@aws-sdk/middleware-logger": "3.183.0",
+        "@aws-sdk/middleware-recursion-detection": "3.183.0",
+        "@aws-sdk/middleware-retry": "3.183.0",
+        "@aws-sdk/middleware-serde": "3.183.0",
+        "@aws-sdk/middleware-signing": "3.183.0",
+        "@aws-sdk/middleware-stack": "3.183.0",
+        "@aws-sdk/middleware-user-agent": "3.183.0",
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/node-http-handler": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/smithy-client": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/url-parser": "3.183.0",
+        "@aws-sdk/util-base64-browser": "3.183.0",
+        "@aws-sdk/util-base64-node": "3.183.0",
+        "@aws-sdk/util-body-length-browser": "3.183.0",
+        "@aws-sdk/util-body-length-node": "3.183.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.183.0",
+        "@aws-sdk/util-defaults-mode-node": "3.183.0",
+        "@aws-sdk/util-user-agent-browser": "3.183.0",
+        "@aws-sdk/util-user-agent-node": "3.183.0",
+        "@aws-sdk/util-utf8-browser": "3.183.0",
+        "@aws-sdk/util-utf8-node": "3.183.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.338.0.tgz",
-      "integrity": "sha512-EglKsGlVph65PuFPKq1nGlxsY99XM2xHJaB1uX0bQEC94qrmS/M4a5kno5tiUnTWO1K+K4JBQiOxdGJs0GUS+w==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.183.0.tgz",
+      "integrity": "sha512-Dw2objS0rxlziFL0Jahzy8H1OlyrRCnmVH7f1pBrmU7RSzztBpU2Z8OPaE5m1MwUISzpOWQlo8zEVUMYuT/Rww==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.338.0",
-        "@aws-sdk/fetch-http-handler": "3.338.0",
-        "@aws-sdk/hash-node": "3.338.0",
-        "@aws-sdk/invalid-dependency": "3.338.0",
-        "@aws-sdk/middleware-content-length": "3.338.0",
-        "@aws-sdk/middleware-endpoint": "3.338.0",
-        "@aws-sdk/middleware-host-header": "3.338.0",
-        "@aws-sdk/middleware-logger": "3.338.0",
-        "@aws-sdk/middleware-recursion-detection": "3.338.0",
-        "@aws-sdk/middleware-retry": "3.338.0",
-        "@aws-sdk/middleware-serde": "3.338.0",
-        "@aws-sdk/middleware-stack": "3.338.0",
-        "@aws-sdk/middleware-user-agent": "3.338.0",
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/node-http-handler": "3.338.0",
-        "@aws-sdk/smithy-client": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.338.0",
-        "@aws-sdk/util-defaults-mode-node": "3.338.0",
-        "@aws-sdk/util-endpoints": "3.338.0",
-        "@aws-sdk/util-retry": "3.338.0",
-        "@aws-sdk/util-user-agent-browser": "3.338.0",
-        "@aws-sdk/util-user-agent-node": "3.338.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.183.0",
+        "@aws-sdk/fetch-http-handler": "3.183.0",
+        "@aws-sdk/hash-node": "3.183.0",
+        "@aws-sdk/invalid-dependency": "3.183.0",
+        "@aws-sdk/middleware-content-length": "3.183.0",
+        "@aws-sdk/middleware-host-header": "3.183.0",
+        "@aws-sdk/middleware-logger": "3.183.0",
+        "@aws-sdk/middleware-recursion-detection": "3.183.0",
+        "@aws-sdk/middleware-retry": "3.183.0",
+        "@aws-sdk/middleware-serde": "3.183.0",
+        "@aws-sdk/middleware-stack": "3.183.0",
+        "@aws-sdk/middleware-user-agent": "3.183.0",
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/node-http-handler": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/smithy-client": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/url-parser": "3.183.0",
+        "@aws-sdk/util-base64-browser": "3.183.0",
+        "@aws-sdk/util-base64-node": "3.183.0",
+        "@aws-sdk/util-body-length-browser": "3.183.0",
+        "@aws-sdk/util-body-length-node": "3.183.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.183.0",
+        "@aws-sdk/util-defaults-mode-node": "3.183.0",
+        "@aws-sdk/util-user-agent-browser": "3.183.0",
+        "@aws-sdk/util-user-agent-node": "3.183.0",
+        "@aws-sdk/util-utf8-browser": "3.183.0",
+        "@aws-sdk/util-utf8-node": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.338.0.tgz",
-      "integrity": "sha512-mny5Q3LWKTcMMFS8WxeOCTinl193z7vS3b+eQz09K4jb1Lq04Bpjw25cySgBnhMGZ7QHQiYBscNLyu/TfOKiHA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.338.0",
-        "@aws-sdk/fetch-http-handler": "3.338.0",
-        "@aws-sdk/hash-node": "3.338.0",
-        "@aws-sdk/invalid-dependency": "3.338.0",
-        "@aws-sdk/middleware-content-length": "3.338.0",
-        "@aws-sdk/middleware-endpoint": "3.338.0",
-        "@aws-sdk/middleware-host-header": "3.338.0",
-        "@aws-sdk/middleware-logger": "3.338.0",
-        "@aws-sdk/middleware-recursion-detection": "3.338.0",
-        "@aws-sdk/middleware-retry": "3.338.0",
-        "@aws-sdk/middleware-serde": "3.338.0",
-        "@aws-sdk/middleware-stack": "3.338.0",
-        "@aws-sdk/middleware-user-agent": "3.338.0",
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/node-http-handler": "3.338.0",
-        "@aws-sdk/smithy-client": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.338.0",
-        "@aws-sdk/util-defaults-mode-node": "3.338.0",
-        "@aws-sdk/util-endpoints": "3.338.0",
-        "@aws-sdk/util-retry": "3.338.0",
-        "@aws-sdk/util-user-agent-browser": "3.338.0",
-        "@aws-sdk/util-user-agent-node": "3.338.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.338.0.tgz",
-      "integrity": "sha512-FBHy/G7BAPX0CdEeeGYpoAnKXVCSIIkESLU2wF6x880z+U2IqiL48Fzoa5qoLaLPQaK/30P7ytznkqm4vd1OFw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.183.0.tgz",
+      "integrity": "sha512-xl7CDncgUmcSJ5Nq3zDylyCzdJhfWzu3GUHXFv5HszcmSwrVZOtmm+j0XQfnqO3XdN8o/1CtsAkiUC7hQV8iDg==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.338.0",
-        "@aws-sdk/credential-provider-node": "3.338.0",
-        "@aws-sdk/fetch-http-handler": "3.338.0",
-        "@aws-sdk/hash-node": "3.338.0",
-        "@aws-sdk/invalid-dependency": "3.338.0",
-        "@aws-sdk/middleware-content-length": "3.338.0",
-        "@aws-sdk/middleware-endpoint": "3.338.0",
-        "@aws-sdk/middleware-host-header": "3.338.0",
-        "@aws-sdk/middleware-logger": "3.338.0",
-        "@aws-sdk/middleware-recursion-detection": "3.338.0",
-        "@aws-sdk/middleware-retry": "3.338.0",
-        "@aws-sdk/middleware-sdk-sts": "3.338.0",
-        "@aws-sdk/middleware-serde": "3.338.0",
-        "@aws-sdk/middleware-signing": "3.338.0",
-        "@aws-sdk/middleware-stack": "3.338.0",
-        "@aws-sdk/middleware-user-agent": "3.338.0",
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/node-http-handler": "3.338.0",
-        "@aws-sdk/smithy-client": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.338.0",
-        "@aws-sdk/util-defaults-mode-node": "3.338.0",
-        "@aws-sdk/util-endpoints": "3.338.0",
-        "@aws-sdk/util-retry": "3.338.0",
-        "@aws-sdk/util-user-agent-browser": "3.338.0",
-        "@aws-sdk/util-user-agent-node": "3.338.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.183.0",
+        "@aws-sdk/credential-provider-node": "3.183.0",
+        "@aws-sdk/fetch-http-handler": "3.183.0",
+        "@aws-sdk/hash-node": "3.183.0",
+        "@aws-sdk/invalid-dependency": "3.183.0",
+        "@aws-sdk/middleware-content-length": "3.183.0",
+        "@aws-sdk/middleware-host-header": "3.183.0",
+        "@aws-sdk/middleware-logger": "3.183.0",
+        "@aws-sdk/middleware-recursion-detection": "3.183.0",
+        "@aws-sdk/middleware-retry": "3.183.0",
+        "@aws-sdk/middleware-sdk-sts": "3.183.0",
+        "@aws-sdk/middleware-serde": "3.183.0",
+        "@aws-sdk/middleware-signing": "3.183.0",
+        "@aws-sdk/middleware-stack": "3.183.0",
+        "@aws-sdk/middleware-user-agent": "3.183.0",
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/node-http-handler": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/smithy-client": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/url-parser": "3.183.0",
+        "@aws-sdk/util-base64-browser": "3.183.0",
+        "@aws-sdk/util-base64-node": "3.183.0",
+        "@aws-sdk/util-body-length-browser": "3.183.0",
+        "@aws-sdk/util-body-length-node": "3.183.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.183.0",
+        "@aws-sdk/util-defaults-mode-node": "3.183.0",
+        "@aws-sdk/util-user-agent-browser": "3.183.0",
+        "@aws-sdk/util-user-agent-node": "3.183.0",
+        "@aws-sdk/util-utf8-browser": "3.183.0",
+        "@aws-sdk/util-utf8-node": "3.183.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.338.0.tgz",
-      "integrity": "sha512-rB9WUaMfTB74Hd2mOiyPFR7Q1viT+w6SaDSR9SA1P8EeIg5H13FNdIKb736Z8/6QJhDj7whdyk1CTGV+DmXOOg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.183.0.tgz",
+      "integrity": "sha512-cJBY5g+yJAI0iigketD3rbweyoLOw6SFiJDzRqZq3KgytmnhnrmNbRVTSdq1Qtn+d20NVxT9kSRUu21QyHb1nw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/signature-v4": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-config-provider": "3.183.0",
+        "@aws-sdk/util-middleware": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.338.0.tgz",
-      "integrity": "sha512-j14vApy80tpk87C3x3uBf1caQsuR8RdQ8iOW830H/AOhsa88XaZIB/NQSX7exaIKZa2RU0Vv2wIlGAA8ko7J6g==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.183.0.tgz",
+      "integrity": "sha512-RJ1QZxpfWf3hmjUm1fYCEj3p4Rl61kMFfU6ab3hpDGuSXbuLkAvTOIbssIUDHcgxUSszV5XqpPzBUnTui3cZYA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.338.0.tgz",
-      "integrity": "sha512-qsqeywYfJevg5pgUUUBmm7pK1bckVrl091PZB2IliFdQVnDvI5GFLf4B0oZqjaLAzPG1gVtxRvqIve+tnP/+xA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.183.0.tgz",
+      "integrity": "sha512-RHzciaoW0sPV52VUMd3SrIFrKhXsKbn9okEF+UdR2P3RgxNsguUZsewpDqhjGZBH0E2IiuFrBPjsxQKAI+mFbQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/url-parser": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.338.0.tgz",
-      "integrity": "sha512-UhgYgymT9sJiRm0peqP5EvtR4dXiS2Q2AuFgDUjBvDz8JaZlqafsIS4cfyGwTHV/xY6cdiMu5rCTe8hTyXsukQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.183.0.tgz",
+      "integrity": "sha512-tWiTIeA72L/7nJnDS5GfNmX58Ms9bUQLb7e9PXv5lWAfyiT9po6KMdBGIN7qld1kxBDcwFZPxsxtkHrbU+6d6A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.338.0",
-        "@aws-sdk/credential-provider-imds": "3.338.0",
-        "@aws-sdk/credential-provider-process": "3.338.0",
-        "@aws-sdk/credential-provider-sso": "3.338.0",
-        "@aws-sdk/credential-provider-web-identity": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.183.0",
+        "@aws-sdk/credential-provider-imds": "3.183.0",
+        "@aws-sdk/credential-provider-sso": "3.183.0",
+        "@aws-sdk/credential-provider-web-identity": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/shared-ini-file-loader": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.338.0.tgz",
-      "integrity": "sha512-nZjaMRxJqX0EXMV9LA5IbRQI1pDGGZiPYX2KDfZ1Y9Gc1Y/vIZhHKOHGb1uKMAonlR076CsXlev4/tjC8SGGuw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.183.0.tgz",
+      "integrity": "sha512-APVAOnB/5CWqnLOY4FnZ779jFg7c8EU4zlj1klZRdNLCTjDXkQSrkJ14Zy44NiTWfxalU5BPsCFHDsQo0hkyQQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.338.0",
-        "@aws-sdk/credential-provider-imds": "3.338.0",
-        "@aws-sdk/credential-provider-ini": "3.338.0",
-        "@aws-sdk/credential-provider-process": "3.338.0",
-        "@aws-sdk/credential-provider-sso": "3.338.0",
-        "@aws-sdk/credential-provider-web-identity": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.183.0",
+        "@aws-sdk/credential-provider-imds": "3.183.0",
+        "@aws-sdk/credential-provider-ini": "3.183.0",
+        "@aws-sdk/credential-provider-process": "3.183.0",
+        "@aws-sdk/credential-provider-sso": "3.183.0",
+        "@aws-sdk/credential-provider-web-identity": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/shared-ini-file-loader": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.338.0.tgz",
-      "integrity": "sha512-5I1EgJxFFEg8xel2kInMpkdBKajUut0hR2fBajqCmK7Pflu8s0I2NKDots9a3YJagNrFJq38+EzoDcUvRrd2dg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.183.0.tgz",
+      "integrity": "sha512-JRePfiFPWpyF3iotHx45WyP1qe50BsPdOOFGh3vmyx5L92lnzchlGsOMpcNUiATUuA3Ar0LUt5bS299LTZWeuQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/shared-ini-file-loader": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.338.0.tgz",
-      "integrity": "sha512-fpzYHK17iF/uFkrm4cLg/utDVKSBTWNjAiNlE3GF6CaixBCwc0QBLKHk2nG4d1ZZeMVCbIUMS7eoqfR0LYc/yw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.183.0.tgz",
+      "integrity": "sha512-jddGjwAFbYyZkIiR+ghPPh92MQuljI/tusOEgvvUM/w+Cx4jvulZo8rJuEvlU49cXn76dyNxGeDWeqfskuOMpQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/token-providers": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/shared-ini-file-loader": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.338.0.tgz",
-      "integrity": "sha512-kjT/P18jM1icwjYwr8wfY//T8lv2s81ms7OC7vgiSqckmQOxpVkdsep9d44ymSUXwopmotFP7M9gGnEHS6HwAA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.183.0.tgz",
+      "integrity": "sha512-AZGZ4zrjMgtVk5MhsRGj6glsivls4qWUQ1Vuq9FjlaN+ltW74w3D0juTwpUI/OHuSHhOznOZsO9fI4DlCfUeSw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.338.0.tgz",
-      "integrity": "sha512-NOIQmeSa51J2nFAzl99IjxwQkq27cdNJzF59jQWzpUCGbxXfMD4WWy2NHubabSFuJ4FJU2eyoQHUNUFc6/uxXA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.183.0.tgz",
+      "integrity": "sha512-YaVXUTYnm6ZsT4qVWcAvtjkxsxzGJW1l0o4oXnnz3hhl7AZM/RjL2l24aixSMeoj7R4hA4Yi7sHFm5OlHSTg5A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/querystring-builder": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/querystring-builder": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-base64-browser": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.338.0.tgz",
-      "integrity": "sha512-udveX3ZRO1oUbyBTQH0LJ8Ika7uk0pHuXrqapdi66GGRJB50IhmOg372zUEwZjDB7DZYXfGTCuAj2OoEalgpBA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.183.0.tgz",
+      "integrity": "sha512-XPe1TzupofkypgLw4Y38ruUM4hrrGIGwJGI/KsljDoEDpz24SyMItyCZbF7ddaPkbJGa4oO+HN072SXPB/z/6g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-buffer-from": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.338.0.tgz",
-      "integrity": "sha512-m6r1fTTGSl0V6l8Z+Ii4Ei8VFpDmu0AT6A59ZhJaMZgxf925ywuCPydyDW9ZqTLE0e7CgxhEHEsH1+HzpVuHTw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.183.0.tgz",
+      "integrity": "sha512-ouKWKIFzWEt64Eg+WPjMlG/KzvQ4h3DakjHJ6L1IB/lXDL8TzJwqKdyEyt3V6/jOXLt8Wf6LtG8HA+5OC+jASQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.183.0.tgz",
+      "integrity": "sha512-s0ukhcjX1dUPRFPLyWJw9mg6SB+5YOdV2vHoKez0L7ry97p3C29wtImV2NOdw54fn/lKOtil22lFN7JpoaqU/w==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.338.0.tgz",
-      "integrity": "sha512-m2C+yJaNmbA3ocBp/7ImUUuimymV5JsFdV7yAibpbYMX22g3q83nieOF9x0I66J0+h+/bcriz/T1ZJAPANLz/g==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.183.0.tgz",
+      "integrity": "sha512-dcLMEEa6j3eDH8obsDHZaHgOZIUPDIZdkgtLYB0tyvJEo8HZGEE/Ch1abwlIzXkZ7qRPXysgX7JayJV8N7kxEw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.338.0.tgz",
-      "integrity": "sha512-bzL9Q8lFidg2NTjGVGDKI6yPG/XiPS+VIAMHJeihQmcv1alIy+N3IL4bEN15Fg+cwaGm+P3BevcLIHmcCOVb4w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "@aws-sdk/util-middleware": "3.338.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.338.0.tgz",
-      "integrity": "sha512-k3C7oppkrqeKrAJt9XIl45SdELtnph9BF0QypjyRfT5MNEDnMMsQkc6xy3ZMqG5dWQq6B2l8C+JL7pOvkSQP3w==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.183.0.tgz",
+      "integrity": "sha512-EcInz6QFQ0ljK8QABX/NRcLYGySv+S/mmJYSLIHkU+/FDh+Wh08Awq9OVjJwGp2mmHM1ZHHHI0sTrdBdmBLX3g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.338.0.tgz",
-      "integrity": "sha512-btj9U0Xovq/UAu3Ur4lAfF7Q3DvvwJ/0UUWsI6GgSzzqSOFgKCz7hCP2GZIT8aXEA5hJOpBOEMkNMjWPNa91Hg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.183.0.tgz",
+      "integrity": "sha512-bEjira7lUPtIfOCDAAkWR53gIJG2g8HhYeL0C+fGB4lztf2Cdlqg9quLXXHRVd0Vmio4OR3NMm5aPIwMnUULWQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.338.0.tgz",
-      "integrity": "sha512-fu5KwiHHSqC8KTQH6xdJ9+dua4gQcXSFLE5fVsergqd0uVdsmhiI+IDfW6QNwF/lmCqnoKDkpeasuB98eG2tow==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.183.0.tgz",
+      "integrity": "sha512-RcsFN5Mp10SO9yKRVeFqedxQIhqWi00Kb5EpE1SR7bC/tcrizS2e0ytFkLk2Bv2U6tbT1CYg7EMa76ssRaSk5w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.338.0.tgz",
-      "integrity": "sha512-nw1oPFkB7TdDG4Vlz2Td47ft/2Gmx1bA18QfE9K1mMWZ4nnoAL8xnHbowlTfHo62+BbFCAPu53PzDUCncBL0iw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.183.0.tgz",
+      "integrity": "sha512-TV3yKWd5g+18/0XjqVeG4/IrksAvBBqSuBVaaNFUACBhwZGZy6IV0sSOlYnWHLTPbPIwrxN9TTt+uIdvCbf+hw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/service-error-classification": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-middleware": "3.338.0",
-        "@aws-sdk/util-retry": "3.338.0",
-        "tslib": "^2.5.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/service-error-classification": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-middleware": "3.183.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.338.0.tgz",
-      "integrity": "sha512-aZ8eFVaot8oYQri1wOesrA3gLizeAHtlA/ELlqxoGDJtO011J4/hTHTn0iJGbktaCvc1L3TF6mgOsgXpudYqMg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.183.0.tgz",
+      "integrity": "sha512-d8zqIDiT1/Zqh0RB/VV4RHz+CIyrMbxEm81rx0pn/9eMVLO4A33j1DaaTcQ0fuCCU7K2rptJC+t2tvkzmXPERg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-signing": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/signature-v4": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.338.0.tgz",
-      "integrity": "sha512-AabRLrE6sk9tqQlQ7z3kn4gTHNN7Anjk/AM0ZEu96WcWjedcpgM1vVpKTBE7vjnxcTRNq0CEM3GLtQqaZ7/HjQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.183.0.tgz",
+      "integrity": "sha512-8VqXmaIbH5E1L7ORXLAhaLKpoUJl7vYCbFpL3NKPlVBPDPAydLhyEltBc3mJTfUo4XWYn6qRqgNwlppXUJZ1xg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.338.0.tgz",
-      "integrity": "sha512-AprhhShMF75mOx80SABujLwrU/w2uHQIvWd6aF3BsE5JRI3uQZRqspfjFCaK52HNLQPj3sCQUw1GeiZJ8GyWCw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.183.0.tgz",
+      "integrity": "sha512-ABb8aSs6649pOZg2Ck3EyeMJo03eYBIqUw7vOhBR6IhQA/XHCFzFX8vEhWjhEWfQcUQBIzNlgoY+0uXK0wVEYQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/signature-v4": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-middleware": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/signature-v4": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-middleware": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.338.0.tgz",
-      "integrity": "sha512-9zXyiklX9AK9ZIXuIPzWzz2vevBEcnBs9UNIxiHl4NBZ8d8oyTvaES1PtFuwL6f7ANSZ9EGVQ2rdTTnMNxMI1A==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.183.0.tgz",
+      "integrity": "sha512-xNvGdj5qgSiC0WETkDOk1Rr7goR7smjbRc/vcYzO4HLwfw2JX/QxtZ2iNAdBMwW1M8O4JfVqS3ynqlE6Ssd7YQ==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.338.0.tgz",
-      "integrity": "sha512-DMqODOsDMFMPcDw2Ya6a0i34AhaBDRpp3vJ+FK3zPxUIsv6iHA+XqEcXLOxROLLoydoyxus7k2U+EWibLZrFbQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.183.0.tgz",
+      "integrity": "sha512-XPX6LKS+zD11yB7nMSQHnW749+2RcFDjr0l2Eb+X0Tffr70JrWpiSx8wYAWUcuTg5Zv4aJAdzYCCaJKZt61Wqg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-endpoints": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.338.0.tgz",
-      "integrity": "sha512-YO7yWg3ipnUI5u6D+Zn2NUpjj5krwc8zNWeY79ULVIp9g7faqGX3xMSjeRSrpZ83s5jg1dOm/+bB0gw7mCrRCw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.183.0.tgz",
+      "integrity": "sha512-Y15Byu7uJxkpHes4PxLBfJEgvxXS5ovyfDGJKJYISwBqJFkDP9gp8/5hg/uHxlJuVWEgFDSTi5kOUjnOhaCZ/A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/shared-ini-file-loader": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.338.0.tgz",
-      "integrity": "sha512-V1BLzCruiv45tJ0vXjiamY8LncIsUFsXYJGDupomFYhWRN8L1MUB9f2vdKn5X3wXn/yKrluwTmNaryrIqd9akA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.183.0.tgz",
+      "integrity": "sha512-mwxwcDW03qZDk/XHr+MJrFUIAaCSIOPYemiM24gOhEqv6/B0ikxAzZIrggd8jKFlnPxPHME0FCFuIQ6tmokEyA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.338.0",
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/querystring-builder": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/abort-controller": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/querystring-builder": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.338.0.tgz",
-      "integrity": "sha512-mC+ZJ738ipif6ZkH59gcipozYj1FOfpXr9pGVCA2hJGLDdaBwI2Jfpb2qCqbsTNtoCjBuIy+sQHGmUHyclgYHg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.183.0.tgz",
+      "integrity": "sha512-IYZNJX/S2wQsDKx+Pm+gwCKFR037/T+K85YW7j8be7aItqZqwOo7yRNXhJSOJPMANxhz4KmHH3n1oXhmCBvyug==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.338.0.tgz",
-      "integrity": "sha512-JX03Q2gshdzOWtA/07kdpk0hqeOrOfwuF8TB97g66VCcIopYQkCeNH1zzkWu+RsGxfSlzQ7up+ZM6sclYXyB1A==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.183.0.tgz",
+      "integrity": "sha512-uFxp2YDRQgvHvGWY91CqZjqhDFoiPx9dr45ZIq/jZ4bOQ9rY619PAIBQ15eh54v7DI1zm4pLlXXvytA0LJF3jg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.338.0.tgz",
-      "integrity": "sha512-IB3YhO93Htwt2SxJx4VWsN57Rt1KEsvZ6PbneO4bcS96E04BlfBujYMZ+QxEM3EJxorhpkwbI2QnI12IjD8FhA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.183.0.tgz",
+      "integrity": "sha512-12IFkuyPyJk8MZ1CKxiFo0GCTmqTwlJ3rMRk7L1wk44yObdKpQK/MSkUl0QgZHSjsS84zfqdeOXQJqLGGaIETg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-uri-escape": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.338.0.tgz",
-      "integrity": "sha512-vtI8Gqx4yj0BZlWonRMgLz68sHt5H48HN+ClnY+fDDB/8KLnCuwZ3TGKmYIbYbshL9wjJz0A9aLzuC6nPQ5JKw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.183.0.tgz",
+      "integrity": "sha512-0yB48bevrHMzXf2afYIAAqYfqCea3aeTyGLa+7IeWZbgP481JbGQyMMNtQBA8VgOB3k7vDEqIYT+QuVxbVhKCA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.338.0.tgz",
-      "integrity": "sha512-BJFr2mx/N3NbycGTlMMGRBc0tGcHXHEbMPy1H2RbejzL23zh27MchaL1WAK9SvwVMKS29hSDbhkuVR2ABRjerA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.183.0.tgz",
+      "integrity": "sha512-WCQzfRgCHdSXT6spTpGNV2zjBWN1QMxwA3L7sdmXvGDYR1USZlyNRwvYOc7g6Px2ZmMI5DnzjIKu60eSyVsH+w==",
       "dev": true,
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.338.0.tgz",
-      "integrity": "sha512-MA1Sp97LFlOXcUaXgo47j86IsPRWYq1V/JqR+uu0zofZw4Xlt7Y6F+mmnDHvuuMy6R2ltzjXSwgrrW3k0bxFPA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.183.0.tgz",
+      "integrity": "sha512-QqLdLthJP73m+h9FhCPsRUsF0AAtHVLivOvtH9ZRoph7C2bqSvfm8LHQO20R61acN9o72mgMiVDVBp/XhiGpkA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.338.0.tgz",
-      "integrity": "sha512-EwKTe/8Iwab/v0eo27w7DRYlqp9wEZEhuRfOMwTikUVH6iuTnW6AXjcIUfcRYBRbx2zqnRSiMAZkjN6ZFYm0bQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.183.0.tgz",
+      "integrity": "sha512-XlYaSVbC6acTdc7FI5hmfZqOLPBwNCbnutmoElTdJQKwhSS6LvwwUngM4L5tm3etlPkKVFSsWllG68Au/vFF4w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.338.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/is-array-buffer": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-hex-encoding": "3.183.0",
+        "@aws-sdk/util-middleware": "3.183.0",
+        "@aws-sdk/util-uri-escape": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.338.0.tgz",
-      "integrity": "sha512-IpFLdLG8GwaiFdqVXf+WyU47Hfa2BMIupAU6iSkE2ZO0lBdg+efn/BBwis5WbBNTDCaaU0xH9y68SmnqqtD7pA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.183.0.tgz",
+      "integrity": "sha512-HesHCNI09yCGh/QaLWyiMia0I3i6xs9v7ghksGXNhpNNrTIshFu5AUh2uJTdlaHiUN9zlED3ulkPo2FrE7Lxww==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-stack": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.338.0.tgz",
-      "integrity": "sha512-wuiEGcWiMeq5N68M489i2iGYcCad9p1btNEOFgus+JO3DRSA6HZXizLI1wqfbUm5Ei8512AvUKB6N8PMzahQsg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.338.0.tgz",
-      "integrity": "sha512-hrNK15o+EObLrl9oWOyxJN2dwjgbdBMGolLEVP/wR/+M9ojHgk/x1kMsCVcV82a8Vgdtqx1TyOC3UugUPT0+NA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.183.0.tgz",
+      "integrity": "sha512-V5IU7q7Y2ADIFzvUxoGfpVahhVnGjCABTv9jZYUSyJW7/OwSB+eA2C1B8ZsKAYLWtc9xKxYpRl5FI5e7FBGUIQ==",
       "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.338.0.tgz",
-      "integrity": "sha512-x8a5swfZ6iWJZEA8rm99OKQ1A6xhWPP1taQUzoPavGCzPAOqyc8cd0FcXYMxvtXb3FeBhGaI8tiGKvelJro0+A==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.183.0.tgz",
+      "integrity": "sha512-hrgeIDyAIJfGYbfGfQJD41iUwncfdhObyQ+aPfjZjAzqNSmNCV1jF9+k/BXdMnjCAM6n8rX6ZNko9PhtGz9uKw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/querystring-parser": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
-    "node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.183.0.tgz",
+      "integrity": "sha512-rDTgkDHQbQtg/2RGbBb1ztZCRF8ELAXyhVQ7CqEqZSirdpQyIdOOVi8ucr4sjVyUQIq92irfJO1SEcANsaFhWQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.183.0.tgz",
+      "integrity": "sha512-FqgzW17oMvv41eB6Lsq2q32HGch5pSmUtXdcVjvXkPKc5CGtNIB49pRx4re4SOGKexkBabB9gdmubs3jH8BB5Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.183.0.tgz",
+      "integrity": "sha512-HniybeERXdHnN+NceOOlaeWgqfDgfWhtFmdOxJYWaxUW21RX+GQiObXtjnU7Nb0DtzTkAv/PWfkZ5lS8WLGQ2Q==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.183.0.tgz",
+      "integrity": "sha512-BBaGaQtSQFXtKB9hXnGog5osNTasAe1GlvQCRqvBEvF2LwM54M+Hsr5HisJKnCybUgQGi0R2Al3CohjMy+mczQ==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.183.0.tgz",
+      "integrity": "sha512-y/GPvo7kqM7taj6+Iq2uUxdrdDcUAtmQEX1l24qjl7MYEnZMncfxWjFdBhIvq4HBJjN3Oq8OIvTc/ZDB2obBJA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/is-array-buffer": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.183.0.tgz",
+      "integrity": "sha512-F6QaY3giXX4kSJk1VIkw9n9I4heTNgv5RmAgY5xlCNU5BqoWyIbWG9B8r/P7metlPhACZ1M8dMp5RwQi8Ae1Jw==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.338.0.tgz",
-      "integrity": "sha512-Zfr5c7JKMJTfb7z+hgd0ioU5iw+wId6Cppc5V1HpZuS2YY4Mn3aJIixzyzhIoCzbmk/yIkf96981epM9eo3/TA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.183.0.tgz",
+      "integrity": "sha512-YWKb4Y0bo/hpAVvf27wAQ3vj8OSVHkyHeoZC6ni9alkK41SAlv3RjodfTAhN0039QD+DirTa3EkLQj9ag1Igdg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.338.0.tgz",
-      "integrity": "sha512-DFM3BSpSetshZTgTjueCkAYZWS0tn5zl7SjkSpFhWQZ8Tt/Df3/DEjcPvxzmC/5vgYSUXNsqcI7lLAJk9aGZAA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.183.0.tgz",
+      "integrity": "sha512-zuNFv2nSgtK6yTEMiEZW2vNxtC6vcKlt6vv0QtIEZZGGhjxEx2dK28jKr9GHlDLIt99mjvJaqiP4tiyfNE5Xpg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.338.0",
-        "@aws-sdk/credential-provider-imds": "3.338.0",
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/config-resolver": "3.183.0",
+        "@aws-sdk/credential-provider-imds": "3.183.0",
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.338.0.tgz",
-      "integrity": "sha512-0gBQcohbNcBsBR7oyaD0Dg2m6qOmfp0G1iN/NM23gwAr2H3ni8tUXfs1HsZzxikOwUr6dSLASokc30vQXBF44A==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.183.0.tgz",
+      "integrity": "sha512-pcvgpSID2mFnkaWPd/cpP4H7Lpu9w9Sc2QcMc2kvkOgkNb7mNres+guybqIMIlsOfuVuFK6291KwtYEgYIWHjQ==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
@@ -1055,65 +965,52 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.338.0.tgz",
-      "integrity": "sha512-oQuAmhi16HWEqVa+Nq4VD4Ymet9vS+uiW92reaagQrW2QFjAgJW9A6pU0PcIHF9sWY1iDKeNdV5b9odQ45PDJA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.183.0.tgz",
+      "integrity": "sha512-zbAFH5SkJ1kTFWPZVg4JdQEhfnJAyL/BDDtGPublVCbplXHAFxoYsneL0he4OEyJbf9KQyITOlzOcthB1kS9Qg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.338.0.tgz",
-      "integrity": "sha512-diR6M3gJgSgBg/87L2e8iF8urG+LOW9ZGWxhntYpYX4uhiIjwNgUPUa993553C8GIOZDHez5X9ExU4asYGQ71Q==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.338.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.183.0.tgz",
+      "integrity": "sha512-pBTwFR/s3ITNHDbsnjhGu6g47PUb5NFbAOWRMFukJME5glOTkFViGlSrEbq0xZB/A0jKFZBQWXLDtgR2G0N8TA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.338.0.tgz",
-      "integrity": "sha512-3e8D+SOtOQEtRtksOEF7EC26xPkuY6YK6biLgdtvR9JspK96rHk5eX1HEJeBJJqbxhyPaxpIw+OhWhnsrUS3hA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.183.0.tgz",
+      "integrity": "sha512-uLUFxHFzh/ivcEeocpvMZBnpEDA793lAtsReaG7QRA1PheRgAQQHeugrTOkQ7doGCz0YBbocXAMcNDrmN1EdNA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.338.0",
+        "@aws-sdk/types": "3.183.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.338.0.tgz",
-      "integrity": "sha512-rc+bC5KM9h25urRc+MXuViJkJ+qYG2NlCRw6xm2lSIvHFJTUjH1ZMO3mqNDYkGnQRbj0mmrVe+N77TJZGf3Q2Q==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.183.0.tgz",
+      "integrity": "sha512-EsyNWuW4ZhLoo5sDs/rMuL5BwGgyyO5bJxI4GzXhDcPPJerQvDZ3ZD3aB55IzAWd4EMHft3Man2uB2bCSWavjA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -1124,26 +1021,26 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.183.0.tgz",
+      "integrity": "sha512-6JHlQ5VkF2XdUfyK1pjpR1A8I+hVdyV0yGiyOB3Vge2zIkcc6oZQYIsSePFmqujJspz29GK0InbQhJXKuLDekg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.183.0.tgz",
+      "integrity": "sha512-5oIc0Bco765sMd0X4jOpwidBxPOXocGXuaTM5LxfFlw+KZjgh609VQHii9pUlere23kCXF3cZzup++oSQBSrTg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.183.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3375,31 +3272,6 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@stylelint/postcss-css-in-js": {
       "version": "0.37.3",
@@ -7455,15 +7327,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
       "dev": true,
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
       "bin": {
-        "fxparser": "src/cli/cli.js"
+        "xml2js": "cli.js"
       },
       "funding": {
         "type": "paypal",
@@ -14067,12 +13936,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "dev": true
-    },
     "node_modules/style-search": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
@@ -15957,9 +15820,9 @@
       }
     },
     "@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
       "dev": true,
       "requires": {
         "tslib": "^1.11.1"
@@ -15974,16 +15837,16 @@
       }
     },
     "@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
       "dev": true,
       "requires": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -15998,13 +15861,13 @@
       }
     },
     "@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
       "dev": true,
       "requires": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -16017,9 +15880,9 @@
       }
     },
     "@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.11.1"
@@ -16034,12 +15897,12 @@
       }
     },
     "@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
@@ -16053,697 +15916,619 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.338.0.tgz",
-      "integrity": "sha512-/yLI32+HwFNBRJ39jMXw+/cn3AnlCuJpQd7Ax4887g32Dgte5eyrfY8sJUOL6902BUmAq4oSRI5QeBXNplO0Xw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.183.0.tgz",
+      "integrity": "sha512-iRhdCoC/QyyB6iRCytb12T0XtfmQRn849vnbcUd8BprXvkQ/YwmFS//4Lj02uxS+myqXCntoAj1nKvZZwcFmbg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-secrets-manager": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.338.0.tgz",
-      "integrity": "sha512-Kh8LGEXJMte4WxCretFxUcutp4RrWxqiG6eawaIaMgLY5GtWdhOS2rv7JMjHIcv83bgr52pOa1ifBY2VUPrFkQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.183.0.tgz",
+      "integrity": "sha512-P2WxRE6LZLaWzSg9pu3IpCWp5FcToH40U/o+TfMlbcELQVIhzLPmyrYAnJJx1hSQaud328N2KZTyVGhX1ef9OQ==",
       "dev": true,
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.338.0",
-        "@aws-sdk/config-resolver": "3.338.0",
-        "@aws-sdk/credential-provider-node": "3.338.0",
-        "@aws-sdk/fetch-http-handler": "3.338.0",
-        "@aws-sdk/hash-node": "3.338.0",
-        "@aws-sdk/invalid-dependency": "3.338.0",
-        "@aws-sdk/middleware-content-length": "3.338.0",
-        "@aws-sdk/middleware-endpoint": "3.338.0",
-        "@aws-sdk/middleware-host-header": "3.338.0",
-        "@aws-sdk/middleware-logger": "3.338.0",
-        "@aws-sdk/middleware-recursion-detection": "3.338.0",
-        "@aws-sdk/middleware-retry": "3.338.0",
-        "@aws-sdk/middleware-serde": "3.338.0",
-        "@aws-sdk/middleware-signing": "3.338.0",
-        "@aws-sdk/middleware-stack": "3.338.0",
-        "@aws-sdk/middleware-user-agent": "3.338.0",
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/node-http-handler": "3.338.0",
-        "@aws-sdk/smithy-client": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.338.0",
-        "@aws-sdk/util-defaults-mode-node": "3.338.0",
-        "@aws-sdk/util-endpoints": "3.338.0",
-        "@aws-sdk/util-retry": "3.338.0",
-        "@aws-sdk/util-user-agent-browser": "3.338.0",
-        "@aws-sdk/util-user-agent-node": "3.338.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.183.0",
+        "@aws-sdk/config-resolver": "3.183.0",
+        "@aws-sdk/credential-provider-node": "3.183.0",
+        "@aws-sdk/fetch-http-handler": "3.183.0",
+        "@aws-sdk/hash-node": "3.183.0",
+        "@aws-sdk/invalid-dependency": "3.183.0",
+        "@aws-sdk/middleware-content-length": "3.183.0",
+        "@aws-sdk/middleware-host-header": "3.183.0",
+        "@aws-sdk/middleware-logger": "3.183.0",
+        "@aws-sdk/middleware-recursion-detection": "3.183.0",
+        "@aws-sdk/middleware-retry": "3.183.0",
+        "@aws-sdk/middleware-serde": "3.183.0",
+        "@aws-sdk/middleware-signing": "3.183.0",
+        "@aws-sdk/middleware-stack": "3.183.0",
+        "@aws-sdk/middleware-user-agent": "3.183.0",
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/node-http-handler": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/smithy-client": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/url-parser": "3.183.0",
+        "@aws-sdk/util-base64-browser": "3.183.0",
+        "@aws-sdk/util-base64-node": "3.183.0",
+        "@aws-sdk/util-body-length-browser": "3.183.0",
+        "@aws-sdk/util-body-length-node": "3.183.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.183.0",
+        "@aws-sdk/util-defaults-mode-node": "3.183.0",
+        "@aws-sdk/util-user-agent-browser": "3.183.0",
+        "@aws-sdk/util-user-agent-node": "3.183.0",
+        "@aws-sdk/util-utf8-browser": "3.183.0",
+        "@aws-sdk/util-utf8-node": "3.183.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.338.0.tgz",
-      "integrity": "sha512-EglKsGlVph65PuFPKq1nGlxsY99XM2xHJaB1uX0bQEC94qrmS/M4a5kno5tiUnTWO1K+K4JBQiOxdGJs0GUS+w==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.183.0.tgz",
+      "integrity": "sha512-Dw2objS0rxlziFL0Jahzy8H1OlyrRCnmVH7f1pBrmU7RSzztBpU2Z8OPaE5m1MwUISzpOWQlo8zEVUMYuT/Rww==",
       "dev": true,
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.338.0",
-        "@aws-sdk/fetch-http-handler": "3.338.0",
-        "@aws-sdk/hash-node": "3.338.0",
-        "@aws-sdk/invalid-dependency": "3.338.0",
-        "@aws-sdk/middleware-content-length": "3.338.0",
-        "@aws-sdk/middleware-endpoint": "3.338.0",
-        "@aws-sdk/middleware-host-header": "3.338.0",
-        "@aws-sdk/middleware-logger": "3.338.0",
-        "@aws-sdk/middleware-recursion-detection": "3.338.0",
-        "@aws-sdk/middleware-retry": "3.338.0",
-        "@aws-sdk/middleware-serde": "3.338.0",
-        "@aws-sdk/middleware-stack": "3.338.0",
-        "@aws-sdk/middleware-user-agent": "3.338.0",
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/node-http-handler": "3.338.0",
-        "@aws-sdk/smithy-client": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.338.0",
-        "@aws-sdk/util-defaults-mode-node": "3.338.0",
-        "@aws-sdk/util-endpoints": "3.338.0",
-        "@aws-sdk/util-retry": "3.338.0",
-        "@aws-sdk/util-user-agent-browser": "3.338.0",
-        "@aws-sdk/util-user-agent-node": "3.338.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/client-sso-oidc": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.338.0.tgz",
-      "integrity": "sha512-mny5Q3LWKTcMMFS8WxeOCTinl193z7vS3b+eQz09K4jb1Lq04Bpjw25cySgBnhMGZ7QHQiYBscNLyu/TfOKiHA==",
-      "dev": true,
-      "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.338.0",
-        "@aws-sdk/fetch-http-handler": "3.338.0",
-        "@aws-sdk/hash-node": "3.338.0",
-        "@aws-sdk/invalid-dependency": "3.338.0",
-        "@aws-sdk/middleware-content-length": "3.338.0",
-        "@aws-sdk/middleware-endpoint": "3.338.0",
-        "@aws-sdk/middleware-host-header": "3.338.0",
-        "@aws-sdk/middleware-logger": "3.338.0",
-        "@aws-sdk/middleware-recursion-detection": "3.338.0",
-        "@aws-sdk/middleware-retry": "3.338.0",
-        "@aws-sdk/middleware-serde": "3.338.0",
-        "@aws-sdk/middleware-stack": "3.338.0",
-        "@aws-sdk/middleware-user-agent": "3.338.0",
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/node-http-handler": "3.338.0",
-        "@aws-sdk/smithy-client": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.338.0",
-        "@aws-sdk/util-defaults-mode-node": "3.338.0",
-        "@aws-sdk/util-endpoints": "3.338.0",
-        "@aws-sdk/util-retry": "3.338.0",
-        "@aws-sdk/util-user-agent-browser": "3.338.0",
-        "@aws-sdk/util-user-agent-node": "3.338.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.183.0",
+        "@aws-sdk/fetch-http-handler": "3.183.0",
+        "@aws-sdk/hash-node": "3.183.0",
+        "@aws-sdk/invalid-dependency": "3.183.0",
+        "@aws-sdk/middleware-content-length": "3.183.0",
+        "@aws-sdk/middleware-host-header": "3.183.0",
+        "@aws-sdk/middleware-logger": "3.183.0",
+        "@aws-sdk/middleware-recursion-detection": "3.183.0",
+        "@aws-sdk/middleware-retry": "3.183.0",
+        "@aws-sdk/middleware-serde": "3.183.0",
+        "@aws-sdk/middleware-stack": "3.183.0",
+        "@aws-sdk/middleware-user-agent": "3.183.0",
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/node-http-handler": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/smithy-client": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/url-parser": "3.183.0",
+        "@aws-sdk/util-base64-browser": "3.183.0",
+        "@aws-sdk/util-base64-node": "3.183.0",
+        "@aws-sdk/util-body-length-browser": "3.183.0",
+        "@aws-sdk/util-body-length-node": "3.183.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.183.0",
+        "@aws-sdk/util-defaults-mode-node": "3.183.0",
+        "@aws-sdk/util-user-agent-browser": "3.183.0",
+        "@aws-sdk/util-user-agent-node": "3.183.0",
+        "@aws-sdk/util-utf8-browser": "3.183.0",
+        "@aws-sdk/util-utf8-node": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.338.0.tgz",
-      "integrity": "sha512-FBHy/G7BAPX0CdEeeGYpoAnKXVCSIIkESLU2wF6x880z+U2IqiL48Fzoa5qoLaLPQaK/30P7ytznkqm4vd1OFw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.183.0.tgz",
+      "integrity": "sha512-xl7CDncgUmcSJ5Nq3zDylyCzdJhfWzu3GUHXFv5HszcmSwrVZOtmm+j0XQfnqO3XdN8o/1CtsAkiUC7hQV8iDg==",
       "dev": true,
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.338.0",
-        "@aws-sdk/credential-provider-node": "3.338.0",
-        "@aws-sdk/fetch-http-handler": "3.338.0",
-        "@aws-sdk/hash-node": "3.338.0",
-        "@aws-sdk/invalid-dependency": "3.338.0",
-        "@aws-sdk/middleware-content-length": "3.338.0",
-        "@aws-sdk/middleware-endpoint": "3.338.0",
-        "@aws-sdk/middleware-host-header": "3.338.0",
-        "@aws-sdk/middleware-logger": "3.338.0",
-        "@aws-sdk/middleware-recursion-detection": "3.338.0",
-        "@aws-sdk/middleware-retry": "3.338.0",
-        "@aws-sdk/middleware-sdk-sts": "3.338.0",
-        "@aws-sdk/middleware-serde": "3.338.0",
-        "@aws-sdk/middleware-signing": "3.338.0",
-        "@aws-sdk/middleware-stack": "3.338.0",
-        "@aws-sdk/middleware-user-agent": "3.338.0",
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/node-http-handler": "3.338.0",
-        "@aws-sdk/smithy-client": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.338.0",
-        "@aws-sdk/util-defaults-mode-node": "3.338.0",
-        "@aws-sdk/util-endpoints": "3.338.0",
-        "@aws-sdk/util-retry": "3.338.0",
-        "@aws-sdk/util-user-agent-browser": "3.338.0",
-        "@aws-sdk/util-user-agent-node": "3.338.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.183.0",
+        "@aws-sdk/credential-provider-node": "3.183.0",
+        "@aws-sdk/fetch-http-handler": "3.183.0",
+        "@aws-sdk/hash-node": "3.183.0",
+        "@aws-sdk/invalid-dependency": "3.183.0",
+        "@aws-sdk/middleware-content-length": "3.183.0",
+        "@aws-sdk/middleware-host-header": "3.183.0",
+        "@aws-sdk/middleware-logger": "3.183.0",
+        "@aws-sdk/middleware-recursion-detection": "3.183.0",
+        "@aws-sdk/middleware-retry": "3.183.0",
+        "@aws-sdk/middleware-sdk-sts": "3.183.0",
+        "@aws-sdk/middleware-serde": "3.183.0",
+        "@aws-sdk/middleware-signing": "3.183.0",
+        "@aws-sdk/middleware-stack": "3.183.0",
+        "@aws-sdk/middleware-user-agent": "3.183.0",
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/node-http-handler": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/smithy-client": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/url-parser": "3.183.0",
+        "@aws-sdk/util-base64-browser": "3.183.0",
+        "@aws-sdk/util-base64-node": "3.183.0",
+        "@aws-sdk/util-body-length-browser": "3.183.0",
+        "@aws-sdk/util-body-length-node": "3.183.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.183.0",
+        "@aws-sdk/util-defaults-mode-node": "3.183.0",
+        "@aws-sdk/util-user-agent-browser": "3.183.0",
+        "@aws-sdk/util-user-agent-node": "3.183.0",
+        "@aws-sdk/util-utf8-browser": "3.183.0",
+        "@aws-sdk/util-utf8-node": "3.183.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.338.0.tgz",
-      "integrity": "sha512-rB9WUaMfTB74Hd2mOiyPFR7Q1viT+w6SaDSR9SA1P8EeIg5H13FNdIKb736Z8/6QJhDj7whdyk1CTGV+DmXOOg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.183.0.tgz",
+      "integrity": "sha512-cJBY5g+yJAI0iigketD3rbweyoLOw6SFiJDzRqZq3KgytmnhnrmNbRVTSdq1Qtn+d20NVxT9kSRUu21QyHb1nw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/signature-v4": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-config-provider": "3.183.0",
+        "@aws-sdk/util-middleware": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.338.0.tgz",
-      "integrity": "sha512-j14vApy80tpk87C3x3uBf1caQsuR8RdQ8iOW830H/AOhsa88XaZIB/NQSX7exaIKZa2RU0Vv2wIlGAA8ko7J6g==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.183.0.tgz",
+      "integrity": "sha512-RJ1QZxpfWf3hmjUm1fYCEj3p4Rl61kMFfU6ab3hpDGuSXbuLkAvTOIbssIUDHcgxUSszV5XqpPzBUnTui3cZYA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.338.0.tgz",
-      "integrity": "sha512-qsqeywYfJevg5pgUUUBmm7pK1bckVrl091PZB2IliFdQVnDvI5GFLf4B0oZqjaLAzPG1gVtxRvqIve+tnP/+xA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.183.0.tgz",
+      "integrity": "sha512-RHzciaoW0sPV52VUMd3SrIFrKhXsKbn9okEF+UdR2P3RgxNsguUZsewpDqhjGZBH0E2IiuFrBPjsxQKAI+mFbQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/url-parser": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.338.0.tgz",
-      "integrity": "sha512-UhgYgymT9sJiRm0peqP5EvtR4dXiS2Q2AuFgDUjBvDz8JaZlqafsIS4cfyGwTHV/xY6cdiMu5rCTe8hTyXsukQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.183.0.tgz",
+      "integrity": "sha512-tWiTIeA72L/7nJnDS5GfNmX58Ms9bUQLb7e9PXv5lWAfyiT9po6KMdBGIN7qld1kxBDcwFZPxsxtkHrbU+6d6A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.338.0",
-        "@aws-sdk/credential-provider-imds": "3.338.0",
-        "@aws-sdk/credential-provider-process": "3.338.0",
-        "@aws-sdk/credential-provider-sso": "3.338.0",
-        "@aws-sdk/credential-provider-web-identity": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.183.0",
+        "@aws-sdk/credential-provider-imds": "3.183.0",
+        "@aws-sdk/credential-provider-sso": "3.183.0",
+        "@aws-sdk/credential-provider-web-identity": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/shared-ini-file-loader": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.338.0.tgz",
-      "integrity": "sha512-nZjaMRxJqX0EXMV9LA5IbRQI1pDGGZiPYX2KDfZ1Y9Gc1Y/vIZhHKOHGb1uKMAonlR076CsXlev4/tjC8SGGuw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.183.0.tgz",
+      "integrity": "sha512-APVAOnB/5CWqnLOY4FnZ779jFg7c8EU4zlj1klZRdNLCTjDXkQSrkJ14Zy44NiTWfxalU5BPsCFHDsQo0hkyQQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.338.0",
-        "@aws-sdk/credential-provider-imds": "3.338.0",
-        "@aws-sdk/credential-provider-ini": "3.338.0",
-        "@aws-sdk/credential-provider-process": "3.338.0",
-        "@aws-sdk/credential-provider-sso": "3.338.0",
-        "@aws-sdk/credential-provider-web-identity": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.183.0",
+        "@aws-sdk/credential-provider-imds": "3.183.0",
+        "@aws-sdk/credential-provider-ini": "3.183.0",
+        "@aws-sdk/credential-provider-process": "3.183.0",
+        "@aws-sdk/credential-provider-sso": "3.183.0",
+        "@aws-sdk/credential-provider-web-identity": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/shared-ini-file-loader": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.338.0.tgz",
-      "integrity": "sha512-5I1EgJxFFEg8xel2kInMpkdBKajUut0hR2fBajqCmK7Pflu8s0I2NKDots9a3YJagNrFJq38+EzoDcUvRrd2dg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.183.0.tgz",
+      "integrity": "sha512-JRePfiFPWpyF3iotHx45WyP1qe50BsPdOOFGh3vmyx5L92lnzchlGsOMpcNUiATUuA3Ar0LUt5bS299LTZWeuQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/shared-ini-file-loader": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.338.0.tgz",
-      "integrity": "sha512-fpzYHK17iF/uFkrm4cLg/utDVKSBTWNjAiNlE3GF6CaixBCwc0QBLKHk2nG4d1ZZeMVCbIUMS7eoqfR0LYc/yw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.183.0.tgz",
+      "integrity": "sha512-jddGjwAFbYyZkIiR+ghPPh92MQuljI/tusOEgvvUM/w+Cx4jvulZo8rJuEvlU49cXn76dyNxGeDWeqfskuOMpQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-sso": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/token-providers": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/shared-ini-file-loader": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.338.0.tgz",
-      "integrity": "sha512-kjT/P18jM1icwjYwr8wfY//T8lv2s81ms7OC7vgiSqckmQOxpVkdsep9d44ymSUXwopmotFP7M9gGnEHS6HwAA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.183.0.tgz",
+      "integrity": "sha512-AZGZ4zrjMgtVk5MhsRGj6glsivls4qWUQ1Vuq9FjlaN+ltW74w3D0juTwpUI/OHuSHhOznOZsO9fI4DlCfUeSw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.338.0.tgz",
-      "integrity": "sha512-NOIQmeSa51J2nFAzl99IjxwQkq27cdNJzF59jQWzpUCGbxXfMD4WWy2NHubabSFuJ4FJU2eyoQHUNUFc6/uxXA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.183.0.tgz",
+      "integrity": "sha512-YaVXUTYnm6ZsT4qVWcAvtjkxsxzGJW1l0o4oXnnz3hhl7AZM/RjL2l24aixSMeoj7R4hA4Yi7sHFm5OlHSTg5A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/querystring-builder": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/querystring-builder": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-base64-browser": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.338.0.tgz",
-      "integrity": "sha512-udveX3ZRO1oUbyBTQH0LJ8Ika7uk0pHuXrqapdi66GGRJB50IhmOg372zUEwZjDB7DZYXfGTCuAj2OoEalgpBA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.183.0.tgz",
+      "integrity": "sha512-XPe1TzupofkypgLw4Y38ruUM4hrrGIGwJGI/KsljDoEDpz24SyMItyCZbF7ddaPkbJGa4oO+HN072SXPB/z/6g==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-buffer-from": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.338.0.tgz",
-      "integrity": "sha512-m6r1fTTGSl0V6l8Z+Ii4Ei8VFpDmu0AT6A59ZhJaMZgxf925ywuCPydyDW9ZqTLE0e7CgxhEHEsH1+HzpVuHTw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.183.0.tgz",
+      "integrity": "sha512-ouKWKIFzWEt64Eg+WPjMlG/KzvQ4h3DakjHJ6L1IB/lXDL8TzJwqKdyEyt3V6/jOXLt8Wf6LtG8HA+5OC+jASQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.183.0.tgz",
+      "integrity": "sha512-s0ukhcjX1dUPRFPLyWJw9mg6SB+5YOdV2vHoKez0L7ry97p3C29wtImV2NOdw54fn/lKOtil22lFN7JpoaqU/w==",
       "dev": true,
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.338.0.tgz",
-      "integrity": "sha512-m2C+yJaNmbA3ocBp/7ImUUuimymV5JsFdV7yAibpbYMX22g3q83nieOF9x0I66J0+h+/bcriz/T1ZJAPANLz/g==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.183.0.tgz",
+      "integrity": "sha512-dcLMEEa6j3eDH8obsDHZaHgOZIUPDIZdkgtLYB0tyvJEo8HZGEE/Ch1abwlIzXkZ7qRPXysgX7JayJV8N7kxEw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-endpoint": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.338.0.tgz",
-      "integrity": "sha512-bzL9Q8lFidg2NTjGVGDKI6yPG/XiPS+VIAMHJeihQmcv1alIy+N3IL4bEN15Fg+cwaGm+P3BevcLIHmcCOVb4w==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/middleware-serde": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/url-parser": "3.338.0",
-        "@aws-sdk/util-middleware": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.338.0.tgz",
-      "integrity": "sha512-k3C7oppkrqeKrAJt9XIl45SdELtnph9BF0QypjyRfT5MNEDnMMsQkc6xy3ZMqG5dWQq6B2l8C+JL7pOvkSQP3w==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.183.0.tgz",
+      "integrity": "sha512-EcInz6QFQ0ljK8QABX/NRcLYGySv+S/mmJYSLIHkU+/FDh+Wh08Awq9OVjJwGp2mmHM1ZHHHI0sTrdBdmBLX3g==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.338.0.tgz",
-      "integrity": "sha512-btj9U0Xovq/UAu3Ur4lAfF7Q3DvvwJ/0UUWsI6GgSzzqSOFgKCz7hCP2GZIT8aXEA5hJOpBOEMkNMjWPNa91Hg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.183.0.tgz",
+      "integrity": "sha512-bEjira7lUPtIfOCDAAkWR53gIJG2g8HhYeL0C+fGB4lztf2Cdlqg9quLXXHRVd0Vmio4OR3NMm5aPIwMnUULWQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.338.0.tgz",
-      "integrity": "sha512-fu5KwiHHSqC8KTQH6xdJ9+dua4gQcXSFLE5fVsergqd0uVdsmhiI+IDfW6QNwF/lmCqnoKDkpeasuB98eG2tow==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.183.0.tgz",
+      "integrity": "sha512-RcsFN5Mp10SO9yKRVeFqedxQIhqWi00Kb5EpE1SR7bC/tcrizS2e0ytFkLk2Bv2U6tbT1CYg7EMa76ssRaSk5w==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.338.0.tgz",
-      "integrity": "sha512-nw1oPFkB7TdDG4Vlz2Td47ft/2Gmx1bA18QfE9K1mMWZ4nnoAL8xnHbowlTfHo62+BbFCAPu53PzDUCncBL0iw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.183.0.tgz",
+      "integrity": "sha512-TV3yKWd5g+18/0XjqVeG4/IrksAvBBqSuBVaaNFUACBhwZGZy6IV0sSOlYnWHLTPbPIwrxN9TTt+uIdvCbf+hw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/service-error-classification": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-middleware": "3.338.0",
-        "@aws-sdk/util-retry": "3.338.0",
-        "tslib": "^2.5.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/service-error-classification": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-middleware": "3.183.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.338.0.tgz",
-      "integrity": "sha512-aZ8eFVaot8oYQri1wOesrA3gLizeAHtlA/ELlqxoGDJtO011J4/hTHTn0iJGbktaCvc1L3TF6mgOsgXpudYqMg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.183.0.tgz",
+      "integrity": "sha512-d8zqIDiT1/Zqh0RB/VV4RHz+CIyrMbxEm81rx0pn/9eMVLO4A33j1DaaTcQ0fuCCU7K2rptJC+t2tvkzmXPERg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-signing": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-signing": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/signature-v4": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.338.0.tgz",
-      "integrity": "sha512-AabRLrE6sk9tqQlQ7z3kn4gTHNN7Anjk/AM0ZEu96WcWjedcpgM1vVpKTBE7vjnxcTRNq0CEM3GLtQqaZ7/HjQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.183.0.tgz",
+      "integrity": "sha512-8VqXmaIbH5E1L7ORXLAhaLKpoUJl7vYCbFpL3NKPlVBPDPAydLhyEltBc3mJTfUo4XWYn6qRqgNwlppXUJZ1xg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.338.0.tgz",
-      "integrity": "sha512-AprhhShMF75mOx80SABujLwrU/w2uHQIvWd6aF3BsE5JRI3uQZRqspfjFCaK52HNLQPj3sCQUw1GeiZJ8GyWCw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.183.0.tgz",
+      "integrity": "sha512-ABb8aSs6649pOZg2Ck3EyeMJo03eYBIqUw7vOhBR6IhQA/XHCFzFX8vEhWjhEWfQcUQBIzNlgoY+0uXK0wVEYQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/signature-v4": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-middleware": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/signature-v4": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-middleware": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.338.0.tgz",
-      "integrity": "sha512-9zXyiklX9AK9ZIXuIPzWzz2vevBEcnBs9UNIxiHl4NBZ8d8oyTvaES1PtFuwL6f7ANSZ9EGVQ2rdTTnMNxMI1A==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.183.0.tgz",
+      "integrity": "sha512-xNvGdj5qgSiC0WETkDOk1Rr7goR7smjbRc/vcYzO4HLwfw2JX/QxtZ2iNAdBMwW1M8O4JfVqS3ynqlE6Ssd7YQ==",
       "dev": true,
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.338.0.tgz",
-      "integrity": "sha512-DMqODOsDMFMPcDw2Ya6a0i34AhaBDRpp3vJ+FK3zPxUIsv6iHA+XqEcXLOxROLLoydoyxus7k2U+EWibLZrFbQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.183.0.tgz",
+      "integrity": "sha512-XPX6LKS+zD11yB7nMSQHnW749+2RcFDjr0l2Eb+X0Tffr70JrWpiSx8wYAWUcuTg5Zv4aJAdzYCCaJKZt61Wqg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-endpoints": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.338.0.tgz",
-      "integrity": "sha512-YO7yWg3ipnUI5u6D+Zn2NUpjj5krwc8zNWeY79ULVIp9g7faqGX3xMSjeRSrpZ83s5jg1dOm/+bB0gw7mCrRCw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.183.0.tgz",
+      "integrity": "sha512-Y15Byu7uJxkpHes4PxLBfJEgvxXS5ovyfDGJKJYISwBqJFkDP9gp8/5hg/uHxlJuVWEgFDSTi5kOUjnOhaCZ/A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/shared-ini-file-loader": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.338.0.tgz",
-      "integrity": "sha512-V1BLzCruiv45tJ0vXjiamY8LncIsUFsXYJGDupomFYhWRN8L1MUB9f2vdKn5X3wXn/yKrluwTmNaryrIqd9akA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.183.0.tgz",
+      "integrity": "sha512-mwxwcDW03qZDk/XHr+MJrFUIAaCSIOPYemiM24gOhEqv6/B0ikxAzZIrggd8jKFlnPxPHME0FCFuIQ6tmokEyA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/abort-controller": "3.338.0",
-        "@aws-sdk/protocol-http": "3.338.0",
-        "@aws-sdk/querystring-builder": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/abort-controller": "3.183.0",
+        "@aws-sdk/protocol-http": "3.183.0",
+        "@aws-sdk/querystring-builder": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.338.0.tgz",
-      "integrity": "sha512-mC+ZJ738ipif6ZkH59gcipozYj1FOfpXr9pGVCA2hJGLDdaBwI2Jfpb2qCqbsTNtoCjBuIy+sQHGmUHyclgYHg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.183.0.tgz",
+      "integrity": "sha512-IYZNJX/S2wQsDKx+Pm+gwCKFR037/T+K85YW7j8be7aItqZqwOo7yRNXhJSOJPMANxhz4KmHH3n1oXhmCBvyug==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.338.0.tgz",
-      "integrity": "sha512-JX03Q2gshdzOWtA/07kdpk0hqeOrOfwuF8TB97g66VCcIopYQkCeNH1zzkWu+RsGxfSlzQ7up+ZM6sclYXyB1A==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.183.0.tgz",
+      "integrity": "sha512-uFxp2YDRQgvHvGWY91CqZjqhDFoiPx9dr45ZIq/jZ4bOQ9rY619PAIBQ15eh54v7DI1zm4pLlXXvytA0LJF3jg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.338.0.tgz",
-      "integrity": "sha512-IB3YhO93Htwt2SxJx4VWsN57Rt1KEsvZ6PbneO4bcS96E04BlfBujYMZ+QxEM3EJxorhpkwbI2QnI12IjD8FhA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.183.0.tgz",
+      "integrity": "sha512-12IFkuyPyJk8MZ1CKxiFo0GCTmqTwlJ3rMRk7L1wk44yObdKpQK/MSkUl0QgZHSjsS84zfqdeOXQJqLGGaIETg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-uri-escape": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.338.0.tgz",
-      "integrity": "sha512-vtI8Gqx4yj0BZlWonRMgLz68sHt5H48HN+ClnY+fDDB/8KLnCuwZ3TGKmYIbYbshL9wjJz0A9aLzuC6nPQ5JKw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.183.0.tgz",
+      "integrity": "sha512-0yB48bevrHMzXf2afYIAAqYfqCea3aeTyGLa+7IeWZbgP481JbGQyMMNtQBA8VgOB3k7vDEqIYT+QuVxbVhKCA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.338.0.tgz",
-      "integrity": "sha512-BJFr2mx/N3NbycGTlMMGRBc0tGcHXHEbMPy1H2RbejzL23zh27MchaL1WAK9SvwVMKS29hSDbhkuVR2ABRjerA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.183.0.tgz",
+      "integrity": "sha512-WCQzfRgCHdSXT6spTpGNV2zjBWN1QMxwA3L7sdmXvGDYR1USZlyNRwvYOc7g6Px2ZmMI5DnzjIKu60eSyVsH+w==",
       "dev": true
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.338.0.tgz",
-      "integrity": "sha512-MA1Sp97LFlOXcUaXgo47j86IsPRWYq1V/JqR+uu0zofZw4Xlt7Y6F+mmnDHvuuMy6R2ltzjXSwgrrW3k0bxFPA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.183.0.tgz",
+      "integrity": "sha512-QqLdLthJP73m+h9FhCPsRUsF0AAtHVLivOvtH9ZRoph7C2bqSvfm8LHQO20R61acN9o72mgMiVDVBp/XhiGpkA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.338.0.tgz",
-      "integrity": "sha512-EwKTe/8Iwab/v0eo27w7DRYlqp9wEZEhuRfOMwTikUVH6iuTnW6AXjcIUfcRYBRbx2zqnRSiMAZkjN6ZFYm0bQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.183.0.tgz",
+      "integrity": "sha512-XlYaSVbC6acTdc7FI5hmfZqOLPBwNCbnutmoElTdJQKwhSS6LvwwUngM4L5tm3etlPkKVFSsWllG68Au/vFF4w==",
       "dev": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.338.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.338.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/is-array-buffer": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "@aws-sdk/util-hex-encoding": "3.183.0",
+        "@aws-sdk/util-middleware": "3.183.0",
+        "@aws-sdk/util-uri-escape": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.338.0.tgz",
-      "integrity": "sha512-IpFLdLG8GwaiFdqVXf+WyU47Hfa2BMIupAU6iSkE2ZO0lBdg+efn/BBwis5WbBNTDCaaU0xH9y68SmnqqtD7pA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.183.0.tgz",
+      "integrity": "sha512-HesHCNI09yCGh/QaLWyiMia0I3i6xs9v7ghksGXNhpNNrTIshFu5AUh2uJTdlaHiUN9zlED3ulkPo2FrE7Lxww==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-stack": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/token-providers": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.338.0.tgz",
-      "integrity": "sha512-wuiEGcWiMeq5N68M489i2iGYcCad9p1btNEOFgus+JO3DRSA6HZXizLI1wqfbUm5Ei8512AvUKB6N8PMzahQsg==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/client-sso-oidc": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/shared-ini-file-loader": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-stack": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.338.0.tgz",
-      "integrity": "sha512-hrNK15o+EObLrl9oWOyxJN2dwjgbdBMGolLEVP/wR/+M9ojHgk/x1kMsCVcV82a8Vgdtqx1TyOC3UugUPT0+NA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.0"
-      }
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.183.0.tgz",
+      "integrity": "sha512-V5IU7q7Y2ADIFzvUxoGfpVahhVnGjCABTv9jZYUSyJW7/OwSB+eA2C1B8ZsKAYLWtc9xKxYpRl5FI5e7FBGUIQ==",
+      "dev": true
     },
     "@aws-sdk/url-parser": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.338.0.tgz",
-      "integrity": "sha512-x8a5swfZ6iWJZEA8rm99OKQ1A6xhWPP1taQUzoPavGCzPAOqyc8cd0FcXYMxvtXb3FeBhGaI8tiGKvelJro0+A==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.183.0.tgz",
+      "integrity": "sha512-hrgeIDyAIJfGYbfGfQJD41iUwncfdhObyQ+aPfjZjAzqNSmNCV1jF9+k/BXdMnjCAM6n8rX6ZNko9PhtGz9uKw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/querystring-parser": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/querystring-parser": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.183.0.tgz",
+      "integrity": "sha512-rDTgkDHQbQtg/2RGbBb1ztZCRF8ELAXyhVQ7CqEqZSirdpQyIdOOVi8ucr4sjVyUQIq92irfJO1SEcANsaFhWQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.183.0.tgz",
+      "integrity": "sha512-FqgzW17oMvv41eB6Lsq2q32HGch5pSmUtXdcVjvXkPKc5CGtNIB49pRx4re4SOGKexkBabB9gdmubs3jH8BB5Q==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.183.0.tgz",
+      "integrity": "sha512-HniybeERXdHnN+NceOOlaeWgqfDgfWhtFmdOxJYWaxUW21RX+GQiObXtjnU7Nb0DtzTkAv/PWfkZ5lS8WLGQ2Q==",
       "dev": true,
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.183.0.tgz",
+      "integrity": "sha512-BBaGaQtSQFXtKB9hXnGog5osNTasAe1GlvQCRqvBEvF2LwM54M+Hsr5HisJKnCybUgQGi0R2Al3CohjMy+mczQ==",
       "dev": true,
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.183.0.tgz",
+      "integrity": "sha512-y/GPvo7kqM7taj6+Iq2uUxdrdDcUAtmQEX1l24qjl7MYEnZMncfxWjFdBhIvq4HBJjN3Oq8OIvTc/ZDB2obBJA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/is-array-buffer": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.183.0.tgz",
+      "integrity": "sha512-F6QaY3giXX4kSJk1VIkw9n9I4heTNgv5RmAgY5xlCNU5BqoWyIbWG9B8r/P7metlPhACZ1M8dMp5RwQi8Ae1Jw==",
       "dev": true,
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.338.0.tgz",
-      "integrity": "sha512-Zfr5c7JKMJTfb7z+hgd0ioU5iw+wId6Cppc5V1HpZuS2YY4Mn3aJIixzyzhIoCzbmk/yIkf96981epM9eo3/TA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.183.0.tgz",
+      "integrity": "sha512-YWKb4Y0bo/hpAVvf27wAQ3vj8OSVHkyHeoZC6ni9alkK41SAlv3RjodfTAhN0039QD+DirTa3EkLQj9ag1Igdg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.338.0.tgz",
-      "integrity": "sha512-DFM3BSpSetshZTgTjueCkAYZWS0tn5zl7SjkSpFhWQZ8Tt/Df3/DEjcPvxzmC/5vgYSUXNsqcI7lLAJk9aGZAA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.183.0.tgz",
+      "integrity": "sha512-zuNFv2nSgtK6yTEMiEZW2vNxtC6vcKlt6vv0QtIEZZGGhjxEx2dK28jKr9GHlDLIt99mjvJaqiP4tiyfNE5Xpg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.338.0",
-        "@aws-sdk/credential-provider-imds": "3.338.0",
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/property-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-endpoints": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.338.0.tgz",
-      "integrity": "sha512-0gBQcohbNcBsBR7oyaD0Dg2m6qOmfp0G1iN/NM23gwAr2H3ni8tUXfs1HsZzxikOwUr6dSLASokc30vQXBF44A==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/config-resolver": "3.183.0",
+        "@aws-sdk/credential-provider-imds": "3.183.0",
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/property-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.183.0.tgz",
+      "integrity": "sha512-pcvgpSID2mFnkaWPd/cpP4H7Lpu9w9Sc2QcMc2kvkOgkNb7mNres+guybqIMIlsOfuVuFK6291KwtYEgYIWHjQ==",
       "dev": true,
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -16756,71 +16541,61 @@
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.338.0.tgz",
-      "integrity": "sha512-oQuAmhi16HWEqVa+Nq4VD4Ymet9vS+uiW92reaagQrW2QFjAgJW9A6pU0PcIHF9sWY1iDKeNdV5b9odQ45PDJA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.183.0.tgz",
+      "integrity": "sha512-zbAFH5SkJ1kTFWPZVg4JdQEhfnJAyL/BDDtGPublVCbplXHAFxoYsneL0he4OEyJbf9KQyITOlzOcthB1kS9Qg==",
       "dev": true,
       "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-retry": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.338.0.tgz",
-      "integrity": "sha512-diR6M3gJgSgBg/87L2e8iF8urG+LOW9ZGWxhntYpYX4uhiIjwNgUPUa993553C8GIOZDHez5X9ExU4asYGQ71Q==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/service-error-classification": "3.338.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.183.0.tgz",
+      "integrity": "sha512-pBTwFR/s3ITNHDbsnjhGu6g47PUb5NFbAOWRMFukJME5glOTkFViGlSrEbq0xZB/A0jKFZBQWXLDtgR2G0N8TA==",
       "dev": true,
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.338.0.tgz",
-      "integrity": "sha512-3e8D+SOtOQEtRtksOEF7EC26xPkuY6YK6biLgdtvR9JspK96rHk5eX1HEJeBJJqbxhyPaxpIw+OhWhnsrUS3hA==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.183.0.tgz",
+      "integrity": "sha512-uLUFxHFzh/ivcEeocpvMZBnpEDA793lAtsReaG7QRA1PheRgAQQHeugrTOkQ7doGCz0YBbocXAMcNDrmN1EdNA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.338.0",
+        "@aws-sdk/types": "3.183.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.338.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.338.0.tgz",
-      "integrity": "sha512-rc+bC5KM9h25urRc+MXuViJkJ+qYG2NlCRw6xm2lSIvHFJTUjH1ZMO3mqNDYkGnQRbj0mmrVe+N77TJZGf3Q2Q==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.183.0.tgz",
+      "integrity": "sha512-EsyNWuW4ZhLoo5sDs/rMuL5BwGgyyO5bJxI4GzXhDcPPJerQvDZ3ZD3aB55IzAWd4EMHft3Man2uB2bCSWavjA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.338.0",
-        "@aws-sdk/types": "3.338.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/node-config-provider": "3.183.0",
+        "@aws-sdk/types": "3.183.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.183.0.tgz",
+      "integrity": "sha512-6JHlQ5VkF2XdUfyK1pjpR1A8I+hVdyV0yGiyOB3Vge2zIkcc6oZQYIsSePFmqujJspz29GK0InbQhJXKuLDekg==",
       "dev": true,
       "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.183.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.183.0.tgz",
+      "integrity": "sha512-5oIc0Bco765sMd0X4jOpwidBxPOXocGXuaTM5LxfFlw+KZjgh609VQHii9pUlere23kCXF3cZzup++oSQBSrTg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.183.0",
         "tslib": "^2.3.1"
       }
     },
@@ -18289,25 +18064,6 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
-    },
-    "@smithy/protocol-http": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
-      "dev": true,
-      "requires": {
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@smithy/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.0"
-      }
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.3",
@@ -21388,13 +21144,10 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
-      "dev": true,
-      "requires": {
-        "strnum": "^1.0.5"
-      }
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "dev": true
     },
     "fastest-levenshtein": {
       "version": "1.0.16",
@@ -26116,12 +25869,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
-    },
-    "strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "dev": true
     },
     "style-search": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
     "sharp": "^0.30.6"
   },
   "devDependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.8.1",
+    "@aws-sdk/client-secrets-manager": "3.183.0",
     "@babel/core": "^7.16.0",
     "@babel/preset-react": "^7.16.0",
     "@babel/preset-typescript": "^7.16.0",


### PR DESCRIPTION
## Reason for Change

- The AWS SDK version was uncapped and `npm i` automatically installed a backwards-incompatible version, which prevented the testrunner from being able to log in.
-
## Notes for Reviewer
