### PR TITLE
Revert "fix: set action timeout to 10s"

### DIFF
--- a/frontend/tests/common/context.ts
+++ b/frontend/tests/common/context.ts
@@ -15,7 +15,7 @@ const VIEWPORT = {
 export const COMMON_PLAYWRIGHT_CONTEXT: Config["use"] = {
   acceptDownloads: true,
   /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-  actionTimeout: 10000,
+  actionTimeout: 0,
   headless: !isHeadful,
   ignoreHTTPSErrors: true,
   screenshot: "only-on-failure",


### PR DESCRIPTION
Reverts chanzuckerberg/single-cell-data-portal#4917

The action timeout being set to 10s triggered errors when waiting for a button for longer than 10s because the page was taking long to navigate to the desired URL. Errors were also being triggered because waiting for a download took longer than 10s.