### PR TITLE
fix: Fix typo in request body schema for WMG V2 API

### DIFF
--- a/backend/wmg/api/wmg-api-v2.yml
+++ b/backend/wmg/api/wmg-api-v2.yml
@@ -77,7 +77,7 @@ paths:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
                     sex_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
-                    development_ontology_stage_term_ids:
+                    development_stage_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
                     self_reported_ethnicity_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"


### PR DESCRIPTION
`development_stage_ontology_term_ids` key was misspelled causing WMG V2 API to break.

## Reason for Change

- `development_stage_ontology_term_id` key in the WMG V2 API was misspelled as `development_ontology_stage_term_id` causing the WMG V2 API to fail while parsing the request body.

## Changes

- Change `development_ontology_stage_term_id` key to `development_stage_ontology_term_id` in the openapi spec file.

## Testing steps

- unit tests

## Notes for Reviewer
