### PR TITLE
feat: UI Updates to sortable column headers (#4905)

### DIFF
--- a/frontend/src/components/common/Grid/components/HeaderCell/index.tsx
+++ b/frontend/src/components/common/Grid/components/HeaderCell/index.tsx
@@ -36,7 +36,7 @@ export default function HeaderCell({
           <SortIcon>
             <Icon
               sdsIcon={isSortedDesc === false ? "chevronUp" : "chevronDown"} // Show chevron down when isSortedDesc is true or undefined.
-              sdsSize="xs"
+              sdsSize="s"
               sdsType="interactive"
             />
           </SortIcon>

--- a/frontend/src/components/common/Grid/components/HeaderCell/style.ts
+++ b/frontend/src/components/common/Grid/components/HeaderCell/style.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { ALIGNMENT } from "src/components/common/Grid/common/entities";
-import { CommonThemeProps, getSpaces, getColors } from "@czi-sds/components";
+import { CommonThemeProps, getColors, getSpaces } from "@czi-sds/components";
 import { css } from "@emotion/react";
 
 const grey400 = (props: CommonThemeProps) => getColors(props)?.gray[400];
@@ -33,8 +33,6 @@ export const SortIcon = styled.span`
 
   .MuiSvgIcon-root {
     color: ${grey400};
-    height: 10px;
-    width: 10px;
   }
 `;
 
@@ -54,18 +52,22 @@ const sortableHeaderCss = css`
 
 const sortedHeaderCss = (props: Props) => css`
   ${Header} {
-    color: ${primary400(props)};
+    color: #000000;
+
+    ${SortIcon} .MuiSvgIcon-root {
+      color: ${primary400(props)};
+    }
 
     &:hover {
-      color: ${primary500(props)};
+      ${SortIcon} .MuiSvgIcon-root {
+        color: ${primary500(props)};
+      }
     }
 
     &:active {
-      color: ${primary600(props)};
-    }
-
-    ${SortIcon} .MuiSvgIcon-root {
-      color: inherit;
+      ${SortIcon} .MuiSvgIcon-root {
+        color: ${primary600(props)};
+      }
     }
   }
 `;


### PR DESCRIPTION
## Reason for Change

- #4905 

## Changes

- Modified column header sort ui as per [mocks](https://www.figma.com/file/18a4QULVIfpFQhTn1FGh8a/Filtering?type=design&node-id=4846-40544&t=FWVYJSodTiqZD6vk-4).

## Testing steps

- Log in as a curator and on the Collections page, click on the "Status" header.
