### PR TITLE
chore: update constants in validation file

### DIFF
--- a/backend/wmg/data/validation/validation.py
+++ b/backend/wmg/data/validation/validation.py
@@ -21,10 +21,10 @@ class Validation:
         self.cell_count_path = f"{corpus_path}/{CELL_COUNTS_CUBE_NAME}"
         self.env = os.getenv("DEPLOYMENT_STAGE")
         self.validation_dataset_id = "3de0ad6d-4378-4f62-b37b-ec0b75a50d94"
-        self.MIN_CUBE_SIZE_GB = 1
-        self.MIN_TISSUE_COUNT = 15
-        self.MIN_SPECIES_COUNT = 2
-        self.MIN_DATASET_COUNT = 50
+        self.MIN_CUBE_SIZE_GB = 2.3
+        self.MIN_TISSUE_COUNT = 53
+        self.MIN_SPECIES_COUNT = 4
+        self.MIN_DATASET_COUNT = 254
         self.MIN_MALAT1_GENE_EXPRESSION_CELL_COUNT_PERCENT = 80
         self.MIN_ACTB_GENE_EXPRESSION_CELL_COUNT_PERCENT = 60
         self.MIN_MALAT1_RANKIT_EXPRESSION = 4


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/4529

## Changes

i pulled the cell counts data frame in locally, and ran the following commands
```
In [3]: cell_counts_df["dataset_id"].nunique()
Out[3]: 283

# ignoring this because i believe this is the original tissue types, which contain some duplicates that are later consolidated
In [5]: cell_counts_df["tissue_original_ontology_term_id"].nunique()
Out[5]: 190

# and i think this is deduped tissue id
In [4]: cell_counts_df["tissue_ontology_term_id"].nunique()
Out[4]: 61

In [6]: cell_counts_df["organism_ontology_term_id"].nunique()
Out[6]: 4
```

i also found the total size of the expression summary cube by running this command from the `snapshot/expression_summary` directory:
```
find . -type f -name '*.tdb' -exec du -ch {} + | grep total$
2.6G	total
```

the constants were then set as roughly 90% of what the current values are in the expression summary cube.

## Testing steps

- i did not test anything locally, only because i don't know how :P

## Notes for Reviewer
