### PR TITLE
fix: refactor cxg reprocessing such that original cxg uri is retained and updated in-place

### DIFF
--- a/tests/unit/processing/test_processing.py
+++ b/tests/unit/processing/test_processing.py
@@ -129,11 +129,11 @@ class ProcessingTest(BaseProcessingTest):
             status = self.business_logic.get_dataset_status(dataset_version_id)
             self.assertEqual(status.cxg_status, DatasetConversionStatus.UPLOADED)
 
-            self.assertTrue(self.s3_provider.uri_exists(f"s3://diff_cxg_bucket/{dataset_version_id.id}.cxg/"))
+            self.assertTrue(self.s3_provider.uri_exists(f"s3://fake_cxg_bucket/{dataset_version_id.id}.cxg/"))
 
             artifacts = list(self.business_logic.get_dataset_artifacts(dataset_version_id))
             cxg_artifact = [artifact for artifact in artifacts if artifact.type == "cxg"][0]
-            self.assertTrue(cxg_artifact, f"s3://diff_cxg_bucket/{dataset_version_id.id}.cxg/")
+            self.assertTrue(cxg_artifact, f"s3://fake_cxg_bucket/{dataset_version_id.id}.cxg/")
 
     @patch("backend.layers.processing.process_download_validate.ProcessDownloadValidate.extract_metadata")
     @patch("backend.layers.processing.process_seurat.ProcessSeurat.make_seurat")


### PR DESCRIPTION
## Reason for Change

- #4855
- Necessary because local h5ad / cxg filename do not have a consistent s3_uri naming convention across all datasets, meaning it's easiest to fetch the old path + update in-place when re-processing rather than try to reverse engineer how each dataset at different points in time mapped from dataset ID -> labeled h5ad s3_uri -> cxg s3_uri 

## Changes

- when reprocessing cxgs, updates cxg artifact in-place based on reprocessing previous labeled h5ad

## Testing steps

- rdev + unit tests

## Notes for Reviewer
