### PR TITLE
Rebuild + push processing image upon webhook POST triggered by single-cell-curation

### DIFF
--- a/.github/workflows/rebuild-processing-image.yml
+++ b/.github/workflows/rebuild-processing-image.yml
@@ -1,0 +1,96 @@
+name: Rebuild and Push Processing Image
+
+env:
+  DEPLOYMENT_STAGE: test
+  # Force using BuildKit instead of normal Docker, required so that metadata
+  # is written/read to allow us to use layers of previous builds as cache.
+  DOCKER_BUILDKIT: 1
+  COMPOSE_DOCKER_CLI_BUILD: 1
+  DOCKER_REPO: ${{ secrets.ECR_REPO }}/
+
+permissions:
+  id-token: write
+  contents: read
+  deployments: write
+
+on:
+  repository_dispatch:
+    types: [rebuild-processing]
+  push: # TODO: remove, just for testing workflow
+    branches:
+      - nayib/rebuild-processing-image
+
+jobs:
+  rebuild-and-push-processing-image-dev:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Login to ECR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.ECR_REPO }}
+      - name: Checkout Dev (main)
+        uses: actions/checkout@v2
+      - name: Install happy
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+        with:
+          happy_version: "0.59.0"
+      - name: Docker build, push, and tag
+        shell: bash
+        run: |
+          happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} processing
+  rebuild-and-push-processing-image-staging:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Login to ECR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.ECR_REPO }}
+      - name: Checkout Staging
+        uses: actions/checkout@v2
+        with:
+          ref: staging
+      - name: Install happy
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+        with:
+          happy_version: "0.59.0"
+      - name: Docker build, push, and tag
+        shell: bash
+        run: |
+          happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} processing
+  rebuild-and-push-processing-image-prod:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Login to ECR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.ECR_REPO }}
+      - name: Checkout Prod
+        uses: actions/checkout@v2
+        with:
+          ref: prod
+      - name: Install happy
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+        with:
+          happy_version: "0.59.0"
+      - name: Docker build, push, and tag
+        shell: bash
+        run: |
+          happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} processing

--- a/.github/workflows/rebuild-processing-image.yml
+++ b/.github/workflows/rebuild-processing-image.yml
@@ -69,28 +69,29 @@ jobs:
         shell: bash
         run: |
           happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} processing
-  rebuild-and-push-processing-image-prod:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1800
-      - name: Login to ECR
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ secrets.ECR_REPO }}
-      - name: Checkout Prod
-        uses: actions/checkout@v2
-        with:
-          ref: prod
-      - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
-        with:
-          happy_version: "0.59.0"
-      - name: Docker build, push, and tag
-        shell: bash
-        run: |
-          happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} processing
+
+#  rebuild-and-push-processing-image-prod:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v2
+#        with:
+#          aws-region: us-west-2
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          role-duration-seconds: 1800
+#      - name: Login to ECR
+#        uses: docker/login-action@v1
+#        with:
+#          registry: ${{ secrets.ECR_REPO }}
+#      - name: Checkout Prod
+#        uses: actions/checkout@v2
+#        with:
+#          ref: prod
+#      - name: Install happy
+#        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+#        with:
+#          happy_version: "0.59.0"
+#      - name: Docker build, push, and tag
+#        shell: bash
+#        run: |
+#          happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} processing

--- a/.github/workflows/rebuild-processing-image.yml
+++ b/.github/workflows/rebuild-processing-image.yml
@@ -16,9 +16,9 @@ permissions:
 on:
   repository_dispatch:
     types: [rebuild-processing]
-  push: # TODO: remove, just for testing workflow
-    branches:
-      - nayib/rebuild-processing-image
+#  push: # TODO: remove, just for testing workflow
+#    branches:
+#      - nayib/rebuild-processing-image
 
 jobs:
   rebuild-and-push-processing-image-dev:
@@ -68,7 +68,7 @@ jobs:
       - name: Docker build, push, and tag
         shell: bash
         run: |
-          happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} processing
+          happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} --slice processing
 
 #  rebuild-and-push-processing-image-prod:
 #    runs-on: ubuntu-20.04

--- a/.happy/config.json
+++ b/.happy/config.json
@@ -5,6 +5,50 @@
   "app": "data-portal",
   "default_compose_env_file": ".env.ecr",
   "services": ["frontend", "backend"],
+  "slices": {
+    "frontend": {
+        "build_images": [
+            "corpora-frontend"
+        ],
+        "profile": "frontend"
+    },
+    "backend": {
+        "build_images": [
+            "corpora-backend"
+        ],
+        "profile": "backend"
+    },
+    "processing": {
+        "build_images": [
+            "corpora-upload"
+        ],
+        "profile": "processing"
+    },
+    "wmg_processing": {
+        "build_images": [
+            "wmg-processing"
+        ],
+        "profile": "wmg_processing"
+    },
+    "dataset_submissions": {
+        "build_images": [
+            "dataset-submissions"
+        ],
+        "profile": "dataset_submissions"
+    },
+    "upload_failures": {
+        "build_images": [
+            "corpora-upload-failures"
+        ],
+        "profile": "upload_failures"
+    },
+    "upload_success": {
+        "build_images": [
+            "corpora-upload-success"
+        ],
+        "profile": "upload_success"
+    },
+  },
   "environments": {
     "rdev": {
       "aws_profile": "single-cell-dev",

--- a/backend/layers/processing/requirements.txt
+++ b/backend/layers/processing/requirements.txt
@@ -1,4 +1,4 @@
-cellxgene-schema==3.0.2
+cellxgene-schema
 dataclasses-json
 matplotlib==3.6.3 # 3.7.0 isn't compatible with scanpy: https://github.com/scverse/scanpy/issues/2411
 numba==0.56.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.8"
 services:
   database:
     image: postgres:13.0
-    platform: linux/amd64
     ports:
       - "5432:5432"
     environment:
@@ -36,7 +35,6 @@ services:
           - localstack.corporanet.local
   frontend:
     image: "${DOCKER_REPO}corpora-frontend"
-    platform: linux/amd64
     build:
       context: frontend
       cache_from:
@@ -69,7 +67,6 @@ services:
           - frontend.corporanet.local
   upload_failures:
     image: "${DOCKER_REPO}corpora-upload-failures"
-    platform: linux/amd64
     build:
       context: .
       cache_from:
@@ -104,7 +101,6 @@ services:
           - uploadfailures.corporanet.local
   upload_success:
     image: "${DOCKER_REPO}corpora-upload-success"
-    platform: linux/amd64
     build:
       context: .
       cache_from:
@@ -139,7 +135,6 @@ services:
           - uploadsuccess.corporanet.local
   dataset_submissions:
     image: "${DOCKER_REPO}dataset-submissions"
-    platform: linux/amd64
     build:
       context: .
       cache_from:
@@ -173,7 +168,6 @@ services:
           - dataset_submissions.corporanet.local
   processing:
     image: "${DOCKER_REPO}corpora-upload"
-    platform: linux/amd64
     build:
       context: .
       cache_from:
@@ -208,7 +202,6 @@ services:
           - processing.corporanet.local
   wmg_processing:
     image: "${DOCKER_REPO}wmg-processing"
-    platform: linux/amd64
     build:
       context: .
       cache_from:
@@ -241,7 +234,6 @@ services:
           - processing.corporanet.local
   backend:
     image: "${DOCKER_REPO}corpora-backend"
-    platform: linux/amd64
     build:
       context: .
       cache_from:


### PR DESCRIPTION
## Reason for Change

- #4785

## Changes

- Rebuild + push processing image upon webhook POST triggered by single-cell-curation, automated after a release to Test PyPI after the monthly minor schema version bump.
- Update config.json in happy to support slicing for our containers

## Testing steps

## Notes for Reviewer
- happy 'slice' not working as expected; currently rebuilds and pushes all containers to docker ECR instead of just the slice. Waiting on team-happy to [resolve](https://czi-tech.atlassian.net/browse/CCIE-1511?atlOrigin=eyJpIjoiZjE4YWJiYTMxMzQ4NGJhM2IzMTljY2QzOGQ5NWQyMzciLCJwIjoiamlyYS1zbGFjay1pbnQifQ)
