### PR TITLE
chore: rename test files

### DIFF
--- a/tests/unit/backend/wmg/api/test_v1.py
+++ b/tests/unit/backend/wmg/api/test_v1.py
@@ -544,7 +544,7 @@ class WmgApiV1Tests(unittest.TestCase):
     @patch("backend.wmg.api.v1.gene_term_label")
     @patch("backend.wmg.api.v1.ontology_term_label")
     @patch("backend.wmg.api.v1.load_snapshot")
-    def test__query_request_with_filter_dims__returns_valid_filter_dims__base_case(
+    def test__filter_request_with_filter_dims__returns_valid_filter_dims__base_case(
         self, load_snapshot, ontology_term_label, gene_term_label, fetch_datasets_metadata
     ):
         # mock the functions in the ontology_labels module, so we can assert deterministic values in the
@@ -599,7 +599,7 @@ class WmgApiV1Tests(unittest.TestCase):
     @patch("backend.wmg.api.v1.gene_term_label")
     @patch("backend.wmg.api.v1.ontology_term_label")
     @patch("backend.wmg.api.v1.load_snapshot")
-    def test__query_request_with_filter_dims__returns_valid_filter_dims(
+    def test__filter_request_with_filter_dims__returns_valid_filter_dims(
         self, load_snapshot, ontology_term_label, gene_term_label, fetch_datasets_metadata
     ):
         # mock the functions in the ontology_labels module, so we can assert deterministic values in the

--- a/tests/unit/backend/wmg/api/test_v2.py
+++ b/tests/unit/backend/wmg/api/test_v2.py
@@ -523,7 +523,7 @@ class WmgApiV2Tests(unittest.TestCase):
     @patch("backend.wmg.api.v2.gene_term_label")
     @patch("backend.wmg.api.v2.ontology_term_label")
     @patch("backend.wmg.api.v2.load_snapshot")
-    def test__query_request_with_filter_dims__returns_valid_filter_dims__base_case(
+    def test__filter_request_with_filter_dims__returns_valid_filter_dims__base_case(
         self, load_snapshot, ontology_term_label, gene_term_label, fetch_datasets_metadata
     ):
         # mock the functions in the ontology_labels module, so we can assert deterministic values in the
@@ -575,7 +575,7 @@ class WmgApiV2Tests(unittest.TestCase):
     @patch("backend.wmg.api.v2.gene_term_label")
     @patch("backend.wmg.api.v2.ontology_term_label")
     @patch("backend.wmg.api.v2.load_snapshot")
-    def test__query_request_with_filter_dims__returns_valid_filter_dims(
+    def test__filter_request_with_filter_dims__returns_valid_filter_dims(
         self, load_snapshot, ontology_term_label, gene_term_label, fetch_datasets_metadata
     ):
         # mock the functions in the ontology_labels module, so we can assert deterministic values in the


### PR DESCRIPTION
## Reason for Change

[ticket](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/4528)

## Changes

renames the test files as specified in that ^ ticket. i also updated the method names in `test_v2.py`

## Testing steps

n/a

## Notes for Reviewer
