### PR TITLE
fix: reprocess needs to fetch current local h5ad s3_uri

### DIFF
--- a/backend/layers/processing/process_cxg.py
+++ b/backend/layers/processing/process_cxg.py
@@ -49,12 +49,20 @@ class ProcessCxg(ProcessingLogic):
         labeled_h5ad_filename = "local.h5ad"
 
         # Download the labeled dataset from the artifact bucket
-        key_prefix = self.get_key_prefix(dataset_id.id)
-        object_key = f"{key_prefix}/{labeled_h5ad_filename}"
+        object_key = None
+        current_artifacts = None
+        if is_reprocess:
+            current_artifacts = self.business_logic.get_dataset_artifacts(dataset_id)
+            existing_h5ad = [artifact for artifact in current_artifacts if artifact.type == DatasetArtifactType.H5AD][0]
+            if existing_h5ad:
+                _, object_key = self.s3_provider.parse_s3_uri(existing_h5ad.uri)
+        if object_key is None:
+            key_prefix = self.get_key_prefix(dataset_id.id)
+            object_key = f"{key_prefix}/{labeled_h5ad_filename}"
         self.download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
 
         # Convert the labeled dataset to CXG and upload it to the cellxgene bucket
-        self.process_cxg(labeled_h5ad_filename, dataset_id, cellxgene_bucket, is_reprocess)
+        self.process_cxg(labeled_h5ad_filename, dataset_id, cellxgene_bucket, current_artifacts)
 
     @logit
     def make_cxg(self, local_filename):
@@ -80,14 +88,13 @@ class ProcessCxg(ProcessingLogic):
         """
         self.s3_provider.upload_directory(cxg_dir, s3_uri)
 
-    def process_cxg(self, local_filename, dataset_id, cellxgene_bucket, is_reprocess):
+    def process_cxg(self, local_filename, dataset_id, cellxgene_bucket, current_artifacts=None):
         cxg_dir = self.convert_file(
             self.make_cxg, local_filename, "Issue creating cxg.", dataset_id, DatasetStatusKey.CXG
         )
         s3_uri = None
-        if is_reprocess:
-            existing_artifacts = self.business_logic.get_dataset_artifacts(dataset_id)
-            existing_cxg = [artifact for artifact in existing_artifacts if artifact.type == DatasetArtifactType.CXG][0]
+        if current_artifacts:
+            existing_cxg = [artifact for artifact in current_artifacts if artifact.type == DatasetArtifactType.CXG][0]
             if existing_cxg:
                 s3_uri = existing_cxg.uri
 
@@ -98,7 +105,8 @@ class ProcessCxg(ProcessingLogic):
         self.update_processing_status(dataset_id, DatasetStatusKey.CXG, DatasetConversionStatus.UPLOADING)
         self.copy_cxg_files_to_cxg_bucket(cxg_dir, s3_uri)
         self.logger.info(f"Updating database with cxg artifact for dataset {dataset_id}. s3_uri is {s3_uri}")
-        if not is_reprocess:
+
+        if not current_artifacts:
             self.business_logic.add_dataset_artifact(dataset_id, DatasetArtifactType.CXG, s3_uri)
 
         self.update_processing_status(dataset_id, DatasetStatusKey.CXG, DatasetConversionStatus.UPLOADED)

--- a/backend/layers/thirdparty/s3_provider.py
+++ b/backend/layers/thirdparty/s3_provider.py
@@ -18,7 +18,7 @@ class S3Provider(S3ProviderInterface):
     def __init__(self) -> None:
         self.client = boto3.client("s3")
 
-    def _parse_s3_uri(self, s3_uri: str) -> Tuple[str, str]:
+    def parse_s3_uri(self, s3_uri: str) -> Tuple[str, str]:
         parsed_url = urlparse(s3_uri)
         return parsed_url.netloc, parsed_url.path[1:]
 
@@ -26,7 +26,7 @@ class S3Provider(S3ProviderInterface):
         """
         Returns the file size of an S3 object located at `path`
         """
-        bucket, key = self._parse_s3_uri(path)
+        bucket, key = self.parse_s3_uri(path)
         try:
             response = self.client.head_object(Bucket=bucket, Key=key)
         except Exception:
@@ -37,7 +37,7 @@ class S3Provider(S3ProviderInterface):
         """
         Generates a presigned url that can be used to download the S3 object located at `path`
         """
-        bucket, key = self._parse_s3_uri(path)
+        bucket, key = self.parse_s3_uri(path)
         return self.client.generate_presigned_url(
             "get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=expiration
         )

--- a/backend/layers/thirdparty/s3_provider_mock.py
+++ b/backend/layers/thirdparty/s3_provider_mock.py
@@ -1,5 +1,6 @@
 import contextlib
 from typing import List
+from urllib.parse import urlparse
 
 from backend.layers.thirdparty.s3_provider_interface import S3ProviderInterface
 
@@ -11,6 +12,10 @@ class MockS3Provider(S3ProviderInterface):
 
     def __init__(self) -> None:
         self.mock_s3_fs = []
+
+    def parse_s3_uri(self, s3_uri: str):
+        parsed_url = urlparse(s3_uri)
+        return parsed_url.netloc, parsed_url.path[1:]
 
     def upload_file(self, src_file: str, bucket_name: str, dst_file: str, extra_args: dict):
         url = f"s3://{bucket_name}/{dst_file}"

--- a/tests/unit/processing/test_processing.py
+++ b/tests/unit/processing/test_processing.py
@@ -117,6 +117,9 @@ class ProcessingTest(BaseProcessingTest):
         with patch("backend.layers.processing.process_cxg.ProcessCxg.make_cxg") as mock:
             mock.return_value = "local.cxg"
             ps = ProcessCxg(self.business_logic, self.uri_provider, self.s3_provider)
+            self.business_logic.add_dataset_artifact(
+                dataset_version_id, "h5ad", f"s3://fake_bucket_name/{dataset_id}/local.h5ad"
+            )
             ps.process(dataset_version_id, "fake_bucket_name", "fake_cxg_bucket")
 
             status = self.business_logic.get_dataset_status(dataset_version_id)


### PR DESCRIPTION
## Reason for Change

- #4856

## Changes

- refactor cxg reprocessing path to fetch current local h5ad s3_uri rather than assume ID (issue: inconsistent whether local.h5ad location uses dataset ID or dataset version ID)

## Testing steps

- rdev

## Notes for Reviewer
