### PR TITLE
chore: upgrade tiledb to 0.21.4

### DIFF
--- a/backend/wmg/data/query.py
+++ b/backend/wmg/data/query.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Union
 
-import tiledb
 from pandas import DataFrame
 from pydantic import BaseModel, Field
 from tiledb import Array

--- a/backend/wmg/data/query.py
+++ b/backend/wmg/data/query.py
@@ -143,8 +143,6 @@ class WmgQuery:
                 attrs[attr] = vals
                 query_cond += f"{attr} in {vals}"
 
-        attr_cond = tiledb.QueryCondition(query_cond) if query_cond else None
-
         tiledb_dims_query = []
         for dim_name in indexed_dims:
             if criteria.dict()[dim_name]:
@@ -156,7 +154,7 @@ class WmgQuery:
 
         tiledb_dims_query = tuple(tiledb_dims_query)
 
-        query_result_df = cube.query(attr_cond=attr_cond, use_arrow=True).df[tiledb_dims_query]
+        query_result_df = cube.query(cond=query_cond or None, use_arrow=True).df[tiledb_dims_query]
         return query_result_df
 
     def list_primary_filter_dimension_term_ids(self, primary_dim_name: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ s3fs==0.4.2
 SQLAlchemy-Utils>=0.36.8
 SQLAlchemy>=1.4.0,<1.5
 tenacity
-tiledb==0.21.1  # Portal's tiledb version should always be the same or older than Explorer's
+tiledb==0.21.4  # Portal's tiledb version should always be the same or older than Explorer's

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ s3fs==0.4.2
 SQLAlchemy-Utils>=0.36.8
 SQLAlchemy>=1.4.0,<1.5
 tenacity
-tiledb==0.16.5  # Portal's tiledb version should always be the same or older than Explorer's
+tiledb==0.21.1  # Portal's tiledb version should always be the same or older than Explorer's


### PR DESCRIPTION
## Reason for Change

- Fixes #4893 

## Changes

- Upgrades tiledb to 0.21.1, which is the version pinned in Explorer.

## Testing steps

- Run tests in GHA, see if they pass
- Run this in rdev, upload a dataset, see if it can be opened by the Explorer
- For WMG, need to figure out a testing strategy w/ data-vis team
