### PR TITLE
fix: update ontology file location in tissue_mapper

### DIFF
--- a/backend/wmg/data/tissue_mapper.py
+++ b/backend/wmg/data/tissue_mapper.py
@@ -106,7 +106,9 @@ class TissueMapper:
         "UBERON_0001062",  # anatomical entity
     ]
 
-    def __init__(self, uberon_ontology: str = "https://github.com/obophenotype/uberon/releases/latest/download/uberon.owl"):
+    def __init__(
+        self, uberon_ontology: str = "https://github.com/obophenotype/uberon/releases/latest/download/uberon.owl"
+    ):
         # TODO: use the pinned ontology at `single-cell-curation`
         self._uberon = owlready2.get_ontology(uberon_ontology)
         self._uberon.load()

--- a/backend/wmg/data/tissue_mapper.py
+++ b/backend/wmg/data/tissue_mapper.py
@@ -106,7 +106,7 @@ class TissueMapper:
         "UBERON_0001062",  # anatomical entity
     ]
 
-    def __init__(self, uberon_ontology: str = "http://purl.obolibrary.org/obo/uberon.owl"):
+    def __init__(self, uberon_ontology: str = "https://github.com/obophenotype/uberon/releases/latest/download/uberon.owl"):
         # TODO: use the pinned ontology at `single-cell-curation`
         self._uberon = owlready2.get_ontology(uberon_ontology)
         self._uberon.load()


### PR DESCRIPTION
## Reason for Change

Fixes an issue where the tissue mapper is unable to download the UBERON ontology file.

## Changes

- Updates the uberon.owl file to a different location (which is the redirect target for the old URI).

## Testing steps

- Unit tests should cover the update.