### PR TITLE
feat: Add aggregate gene expression and cell counts for WMG V2 response

### DIFF
--- a/backend/wmg/api/wmg-api-v2.yml
+++ b/backend/wmg/api/wmg-api-v2.yml
@@ -62,7 +62,6 @@ paths:
                   required:
                     - gene_ontology_term_ids
                     - organism_ontology_term_id
-                  additionalProperties: false
                   properties:
                     gene_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
@@ -81,6 +80,7 @@ paths:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
                     self_reported_ethnicity_ontology_term_ids:
                       $ref: "#/components/schemas/wmg_ontology_term_id_list"
+                  additionalProperties: false
                 is_rollup:
                   type: boolean
                   default: true
@@ -100,41 +100,15 @@ paths:
             application/json:
               example:
                 {
-                  "snapshot_id": "8ce15034-162a-4e2e-9987-eb1af08bd4d4",
+                  "snapshot_id": "1681668176",
                   "expression_summary":
                     {
                       "gene1":
                         {
                           "tissuetype1":
                             {
-                              "CL00000":
-                                {
-                                  "aggregated":
-                                    {
-                                      "id": "CL00000",
-                                      "me": 0.0,
-                                      "n": 0,
-                                      "pc": 0.0,
-                                      "tpc": 0.0,
-                                    },
-                                  "male":
-                                    {
-                                      "id": "CL00001",
-                                      "me": 0.0,
-                                      "n": 0,
-                                      "pc": 0.0,
-                                      "tpc": 0.0,
-                                    },
-                                  "female":
-                                    {
-                                      "id": "CL00002",
-                                      "me": 0.0,
-                                      "n": 0,
-                                      "pc": 0.0,
-                                      "tpc": 0.0,
-                                    },
-                                },
-                              "CL00001":
+                              "aggregated": { "me": 0.0, "n": 0, "tpc": 0.0 },
+                              "celltype1":
                                 {
                                   "aggregated":
                                     {
@@ -158,7 +132,31 @@ paths:
                                       "tpc": 0.0,
                                     },
                                 },
-                              "CL00002":
+                              "celltype2":
+                                {
+                                  "aggregated":
+                                    {
+                                      "me": 0.0,
+                                      "n": 0,
+                                      "pc": 0.0,
+                                      "tpc": 0.0,
+                                    },
+                                  "male":
+                                    {
+                                      "me": 0.0,
+                                      "n": 0,
+                                      "pc": 0.0,
+                                      "tpc": 0.0,
+                                    },
+                                  "female":
+                                    {
+                                      "me": 0.0,
+                                      "n": 0,
+                                      "pc": 0.0,
+                                      "tpc": 0.0,
+                                    },
+                                },
+                              "celltype3":
                                 {
                                   "aggregated":
                                     {
@@ -185,34 +183,8 @@ paths:
                             },
                           "tissuetype2":
                             {
-                              "CL00000":
-                                {
-                                  "aggregated":
-                                    {
-                                      "id": "CL00000",
-                                      "me": 0.0,
-                                      "n": 0,
-                                      "pc": 0.0,
-                                      "tpc": 0.0,
-                                    },
-                                  "male":
-                                    {
-                                      "id": "CL00001",
-                                      "me": 0.0,
-                                      "n": 0,
-                                      "pc": 0.0,
-                                      "tpc": 0.0,
-                                    },
-                                  "female":
-                                    {
-                                      "id": "CL00002",
-                                      "me": 0.0,
-                                      "n": 0,
-                                      "pc": 0.0,
-                                      "tpc": 0.0,
-                                    },
-                                },
-                              "CL00001":
+                              "aggregated": { "me": 0.0, "n": 0, "tpc": 0.0 },
+                              "celltype1":
                                 {
                                   "aggregated":
                                     {
@@ -236,7 +208,31 @@ paths:
                                       "tpc": 0.0,
                                     },
                                 },
-                              "CL00002":
+                              "celltype2":
+                                {
+                                  "aggregated":
+                                    {
+                                      "me": 0.0,
+                                      "n": 0,
+                                      "pc": 0.0,
+                                      "tpc": 0.0,
+                                    },
+                                  "male":
+                                    {
+                                      "me": 0.0,
+                                      "n": 0,
+                                      "pc": 0.0,
+                                      "tpc": 0.0,
+                                    },
+                                  "female":
+                                    {
+                                      "me": 0.0,
+                                      "n": 0,
+                                      "pc": 0.0,
+                                      "tpc": 0.0,
+                                    },
+                                },
+                              "celltype3":
                                 {
                                   "aggregated":
                                     {
@@ -266,11 +262,11 @@ paths:
                         {
                           "tissuetype1":
                             {
-                              "CL00000":
+                              "aggregated": { "me": 0.0, "n": 0, "tpc": 0.0 },
+                              "celltype1":
                                 {
                                   "aggregated":
                                     {
-                                      "id": "CL00000",
                                       "me": 0.0,
                                       "n": 0,
                                       "pc": 0.0,
@@ -293,7 +289,7 @@ paths:
                                       "tpc": 0.0,
                                     },
                                 },
-                              "CL00001":
+                              "celltype2":
                                 {
                                   "aggregated":
                                     {
@@ -317,7 +313,7 @@ paths:
                                       "tpc": 0.0,
                                     },
                                 },
-                              "CL00002":
+                              "celltype3":
                                 {
                                   "aggregated":
                                     {
@@ -344,34 +340,8 @@ paths:
                             },
                           "tissuetype2":
                             {
-                              "CL00000":
-                                {
-                                  "aggregated":
-                                    {
-                                      "id": "CL00000",
-                                      "me": 0.0,
-                                      "n": 0,
-                                      "pc": 0.0,
-                                      "tpc": 0.0,
-                                    },
-                                  "male":
-                                    {
-                                      "id": "CL00001",
-                                      "me": 0.0,
-                                      "n": 0,
-                                      "pc": 0.0,
-                                      "tpc": 0.0,
-                                    },
-                                  "female":
-                                    {
-                                      "id": "CL00002",
-                                      "me": 0.0,
-                                      "n": 0,
-                                      "pc": 0.0,
-                                      "tpc": 0.0,
-                                    },
-                                },
-                              "CL00001":
+                              "aggregated": { "me": 0.0, "n": 0, "tpc": 0.0 },
+                              "celltype1":
                                 {
                                   "aggregated":
                                     {
@@ -395,7 +365,31 @@ paths:
                                       "tpc": 0.0,
                                     },
                                 },
-                              "CL00002":
+                              "celltype2":
+                                {
+                                  "aggregated":
+                                    {
+                                      "me": 0.0,
+                                      "n": 0,
+                                      "pc": 0.0,
+                                      "tpc": 0.0,
+                                    },
+                                  "male":
+                                    {
+                                      "me": 0.0,
+                                      "n": 0,
+                                      "pc": 0.0,
+                                      "tpc": 0.0,
+                                    },
+                                  "female":
+                                    {
+                                      "me": 0.0,
+                                      "n": 0,
+                                      "pc": 0.0,
+                                      "tpc": 0.0,
+                                    },
+                                },
+                              "celltype3":
                                 {
                                   "aggregated":
                                     {
@@ -426,34 +420,40 @@ paths:
                     {
                       "cell_types":
                         {
-                          "gene1":
+                          "tissuetype1":
                             {
-                              "cell_type1":
+                              "aggregated":
+                                {
+                                  "name": "tissue type 1",
+                                  "tissue_ontology_term_id": "tissuetype1",
+                                  "total_count": 4,
+                                },
+                              "celltype1":
                                 {
                                   "aggregated":
                                     {
-                                      "cell_type": "cell type 1",
-                                      "cell_type_ontology_term_id": "CL:0000001",
+                                      "name": "cell type 1",
+                                      "cell_type_ontology_term_id": "celltype1",
                                       "order": 1,
                                       "total_count": 1,
                                     },
                                 },
-                              "cell_type2":
+                              "celltype2":
                                 {
                                   "aggregated":
                                     {
-                                      "cell_type": "cell type 2",
-                                      "cell_type_ontology_term_id": "CL:0000002",
+                                      "name": "cell type 2",
+                                      "cell_type_ontology_term_id": "celltype2",
                                       "order": 0,
-                                      "total_count": 0,
+                                      "total_count": 1,
                                     },
                                 },
-                              "cell_type3":
+                              "celltype3":
                                 {
                                   "aggregated":
                                     {
-                                      "cell_type": "cell type 3",
-                                      "cell_type_ontology_term_id": "CL:0000003",
+                                      "name": "cell type 3",
+                                      "cell_type_ontology_term_id": "celltype3",
                                       "order": 2,
                                       "total_count": 2,
                                     },

--- a/tests/unit/backend/wmg/api/test_v2.py
+++ b/tests/unit/backend/wmg/api/test_v2.py
@@ -2,6 +2,8 @@ import json
 import unittest
 from unittest.mock import patch
 
+from pytest import approx
+
 from backend.api_server.app import app
 from backend.wmg.api.v2 import find_dimension_id_from_compare
 from backend.wmg.data.query import MarkerGeneQueryCriteria
@@ -29,7 +31,39 @@ TEST_SNAPSHOT = "realistic-test-snapshot"
 
 
 # this should only be used for generating expected outputs when using the test snapshot (see test_snapshot.py)
-def generate_expected_term_id_labels_dictionary(genes, tissues, cell_types, total_count, compare_terms=None):
+def generate_expected_term_id_labels_dictionary(
+    *,
+    genes: list[str],
+    tissues: list[str],
+    cell_types: list[str],
+    cell_count_tissue_cell_type: int,
+    compare_terms: list[str],
+    cell_counts_tissue_cell_type_compare_dim: int,
+) -> dict:
+    """
+    Generates aggregated cell counts and cell ordering expected to be returned by /wmg/v2/query endpoint.
+
+    Arguments
+    ---------
+    genes: list of gene ontology term IDs
+
+    tissues: list of tissue ontology term IDs
+
+    cell_types: list of cell_type ontology term IDs
+
+    cell_count_tissue_cell_type: total number of cells for each (tissue, cell_type) combination (scalar)
+
+    compare_terms: list of ontology term IDs form the compare dimension (optional)
+
+    cell_counts_tissue_cell_type_compare_dim: total number of cells for each
+    (tissue, cell_type, <compare_dim>) combination (scalar)
+
+    Returns
+    -------
+    result: A dictionary containing aggregate cell counts and cell type ordering info that is indexable by
+            ["cell_types"][<tissue_ontology_term_id>][<cell_type_ontology_term_id>][<compare_dimension>]
+    """
+
     result = {}
     result["cell_types"] = {}
     # assume tissues are sorted, and cell types are sorted within each tissue
@@ -39,23 +73,34 @@ def generate_expected_term_id_labels_dictionary(genes, tissues, cell_types, tota
     orders = [int(tissue.split("_")[-1]) * len(cell_types) for tissue in tissues]
     for tissue, order in zip(tissues, orders):
         result["cell_types"][tissue] = {}
+
         for cell_type in cell_types:
             result["cell_types"][tissue][cell_type] = {}
             result["cell_types"][tissue][cell_type]["aggregated"] = {
                 "cell_type_ontology_term_id": cell_type,
                 "name": f"{cell_type}_label",
-                "total_count": total_count,
+                "total_count": cell_count_tissue_cell_type,
                 "order": order,
             }
-            if compare_terms:
-                for term in compare_terms:
-                    result["cell_types"][tissue][cell_type][term] = {
-                        "cell_type_ontology_term_id": cell_type,
-                        "name": f"{term}_label",
-                        "total_count": total_count // len(compare_terms),
-                        "order": order,
-                    }
+
+            for term in compare_terms:
+                result["cell_types"][tissue][cell_type][term] = {
+                    "cell_type_ontology_term_id": cell_type,
+                    "name": f"{term}_label",
+                    "total_count": cell_counts_tissue_cell_type_compare_dim,
+                    "order": order,
+                }
             order += 1
+
+        tissue_cell_counts = {
+            "tissue_ontology_term_id": tissue,
+            "name": f"{tissue}_label",
+            "total_count": sum(
+                [agg_dict["aggregated"]["total_count"] for _, agg_dict in result["cell_types"][tissue].items()]
+            ),
+        }
+
+        result["cell_types"][tissue]["aggregated"] = tissue_cell_counts
 
     result["genes"] = []
     for gene in genes:
@@ -64,7 +109,50 @@ def generate_expected_term_id_labels_dictionary(genes, tissues, cell_types, tota
     return result
 
 
-def generate_expected_expression_summary_dictionary(genes, tissues, cell_types, n, me, pc, tpc, compare_terms=None):
+def generate_expected_expression_summary_dictionary(
+    *,
+    genes: list[str],
+    tissues: list[str],
+    cell_count_tissue: int,
+    cell_types: list[str],
+    cell_count_tissue_cell_type: int,
+    nnz_gene_tissue_cell_type: int,
+    compare_terms: list[str],
+    cell_counts_tissue_cell_type_compare_dim: int,
+    nnz_gene_tissue_cell_type_compare_dim: int,
+    me: float,
+) -> dict:
+    """
+    Generates expression summary stats expected to be returned by /wmg/v2/query endpoint.
+
+    Arguments
+    ---------
+    genes: list of gene ontology term IDs
+
+    tissues: list of tissue ontology term IDs
+
+    cell_count_tissue: total number of cells for each tissue combination (scalar)
+
+    cell_types: list of cell_type ontology term IDs
+
+    cell_count_tissue_cell_type: total number of cells for each (tissue, cell_type) combination (scalar)
+
+    nnz_gene_tissue_cell_type: the nnz value for each (gene, tissue, cell_type) combination (scalar)
+
+    compare_terms: list of ontology term IDs form the compare dimension (optional)
+
+    cell_counts_tissue_cell_type_compare_dim: total number of cells for each
+    (tissue, cell_type, <compare_dim>) combination (scalar)
+
+    nnz_gene_tissue_cell_type_compare_dim: the nnz value for each (gene, tissue, cell_type, <compare_dim>) combination (scalar)
+
+    me: mean expression value to use for each (gene, tissue, cell_type) combination (scalar)
+
+    Returns
+    -------
+    result: A dictionary containing gene expression stats that is indexable by
+            [<gene_ontology_term_id>][<tissue_ontology_term_id>][<cell_type_ontology_term_id>][<compare_dimension>]
+    """
     result = {}
     for gene in genes:
         if gene != ".":
@@ -73,42 +161,78 @@ def generate_expected_expression_summary_dictionary(genes, tissues, cell_types, 
                 result[gene][tissue] = {}
                 for cell_type in cell_types:
                     result[gene][tissue][cell_type] = {}
+
+                    pc_gene_tissue_cell_type = nnz_gene_tissue_cell_type / cell_count_tissue_cell_type
+                    tpc_gene_tissue_cell_type = nnz_gene_tissue_cell_type / cell_count_tissue
+
                     result[gene][tissue][cell_type]["aggregated"] = {
-                        "n": n,
+                        "n": nnz_gene_tissue_cell_type,
                         "me": me,
-                        "pc": pc,
-                        "tpc": tpc,
+                        "pc": pc_gene_tissue_cell_type,
+                        "tpc": tpc_gene_tissue_cell_type,
                     }
-                    if compare_terms:
-                        for term in compare_terms:
-                            result[gene][tissue][cell_type][term] = {
-                                "n": n // len(compare_terms),
-                                "me": me,
-                                "pc": pc,
-                                "tpc": tpc / len(compare_terms),
-                            }
+
+                    for term in compare_terms:
+                        pc_gene_tissue_cell_type_compare_dim = (
+                            nnz_gene_tissue_cell_type_compare_dim / cell_counts_tissue_cell_type_compare_dim
+                        )
+                        tpc_gene_tissue_cell_type_compare_dim = (
+                            nnz_gene_tissue_cell_type_compare_dim / cell_count_tissue
+                        )
+
+                        result[gene][tissue][cell_type][term] = {
+                            "n": nnz_gene_tissue_cell_type_compare_dim,
+                            "me": me,
+                            "pc": pc_gene_tissue_cell_type_compare_dim,
+                            "tpc": tpc_gene_tissue_cell_type_compare_dim,
+                        }
+
+                nnz_gene_tissue = sum([agg_dict["aggregated"]["n"] for _, agg_dict in result[gene][tissue].items()])
+                tpc_gene_tissue = nnz_gene_tissue / cell_count_tissue
+                gene_tissue_expr_stats = {
+                    "n": nnz_gene_tissue,
+                    "me": me,
+                    "tpc": tpc_gene_tissue,
+                }
+
+                result[gene][tissue]["aggregated"] = gene_tissue_expr_stats
 
     return result
 
 
-def generate_test_inputs_and_expected_outputs(genes, organism, dim_size, me, expected_count, compare_dim=None):
+def generate_test_inputs_and_expected_outputs(
+    genes: list[str],
+    organism: str,
+    dim_size: int,
+    me: float,
+    cell_count_per_row_cell_counts_cube: int,
+    compare_dim=None,
+) -> tuple:
     """
     Generates test inputs and expected outputs for the /wmg/v2/query endpoint.
 
     Arguments
     ---------
     genes: list of gene ontology term IDs
+
     organism: organism ontology term ID
+
     dim_size: size of each dimension of the test cube
-    me: mean expression value to use for each gene/tissue/cell_type combination (scalar)
-    expected_count: expected number of cells for each gene/tissue/cell_type combination (scalar)
+
+    me: mean expression value to use for each (gene, tissue, cell_type) combination (scalar)
+
+    cell_count_per_row_cell_counts_cube: num of cells per row in cell_counts cube (scalar)
+
     compare_dim: dimension to use for compare feature (optional). None if compare isn't used.
 
     Returns
     -------
     tuple of (request, expected_expression_summary, expected_term_id_labels)
+
     request: dictionary containing the request body to send to the /wmg/v2/query endpoint
+
     expected_expression_summary: dictionary containing the expected expression summary values
+
     expected_term_id_labels: dictionary containing the expected term ID labels
     """
     cell_types = [f"cell_type_ontology_term_id_{i}" for i in range(dim_size)]
@@ -117,29 +241,43 @@ def generate_test_inputs_and_expected_outputs(genes, organism, dim_size, me, exp
     # includes all tissues
     all_tissues = [f"tissue_ontology_term_id_{i}" for i in range(dim_size)]
 
+    expected_combinations_per_tissue = dim_size ** len(expression_summary_non_indexed_dims)
+    cell_count_tissue = cell_count_per_row_cell_counts_cube * expected_combinations_per_tissue
+
     expected_combinations_per_cell_type = dim_size ** len(
         set(expression_summary_non_indexed_dims).difference({"cell_type_ontology_term_id"})
     )
-    compare_terms = (
-        [f"{find_dimension_id_from_compare(compare_dim)}_{i}" for i in range(dim_size)] if compare_dim else None
-    )
+    nnz_gene_tissue_cell_type = expected_combinations_per_cell_type
+    cell_count_tissue_cell_type = expected_combinations_per_cell_type * cell_count_per_row_cell_counts_cube
+
+    compare_terms = []
+    cell_counts_tissue_cell_type_compare_dim = 0
+    nnz_gene_tissue_cell_type_compare_dim = 0
+
+    if compare_dim:
+        compare_terms = [f"{find_dimension_id_from_compare(compare_dim)}_{i}" for i in range(dim_size)]
+        cell_counts_tissue_cell_type_compare_dim = cell_count_tissue_cell_type // len(compare_terms)
+        nnz_gene_tissue_cell_type_compare_dim = nnz_gene_tissue_cell_type // len(compare_terms)
 
     expected_term_id_labels = generate_expected_term_id_labels_dictionary(
-        genes,
-        all_tissues,
-        cell_types,
-        expected_combinations_per_cell_type * expected_count,
+        genes=genes,
+        tissues=all_tissues,
+        cell_types=cell_types,
+        cell_count_tissue_cell_type=cell_count_tissue_cell_type,
         compare_terms=compare_terms,
+        cell_counts_tissue_cell_type_compare_dim=cell_counts_tissue_cell_type_compare_dim,
     )
     expected_expression_summary = generate_expected_expression_summary_dictionary(
-        genes,
-        all_tissues,
-        cell_types,
-        expected_combinations_per_cell_type,
-        me,
-        1 / expected_count,
-        expected_combinations_per_cell_type / (expected_count * (dim_size ** len(expression_summary_non_indexed_dims))),
+        genes=genes,
+        tissues=all_tissues,
+        cell_count_tissue=cell_count_tissue,
+        cell_types=cell_types,
+        cell_count_tissue_cell_type=cell_count_tissue_cell_type,
+        nnz_gene_tissue_cell_type=expected_combinations_per_cell_type,
         compare_terms=compare_terms,
+        cell_counts_tissue_cell_type_compare_dim=cell_counts_tissue_cell_type_compare_dim,
+        nnz_gene_tissue_cell_type_compare_dim=nnz_gene_tissue_cell_type_compare_dim,
+        me=me,
     )
 
     request = dict(filter=dict(gene_ontology_term_ids=genes, organism_ontology_term_id=organism))
@@ -158,6 +296,33 @@ class WmgApiV2Tests(unittest.TestCase):
     Tests WMG API endpoints. Tests the flask app only, and not other stack dependencies, such as S3. Builds and uses a
     temporary WMG cube on local filesystem to avoid dependency on localstack S3.
     """
+
+    # TODO(prathap): Write a generalized utility function that extends the
+    # comparison capability of sequences to also compare floating point
+    # values: https://docs.python.org/3/library/collections.abc.html#module-collections.abc
+    def assert_equality_nested_dict_with_floats(self, *, expected, actual, key_path):
+        self.assertEqual(expected.keys(), actual.keys(), f"Assertion failure in key path: {key_path}")
+
+        for k, expected_value in expected.items():
+            key_path.append(k)
+
+            actual_value = actual[k]
+
+            if isinstance(expected_value, (float, int)) and isinstance(actual_value, (float, int)):
+                self.assertEqual(expected_value, approx(actual_value), f"Assertion failure in key path: {key_path}")
+            else:
+                self.assertIs(type(expected_value), type(actual_value), f"Assertion failure in key path: {key_path}")
+
+                if isinstance(expected_value, dict):
+                    self.assert_equality_nested_dict_with_floats(
+                        expected=expected_value, actual=actual_value, key_path=key_path
+                    )
+                else:
+                    self.assertEqual(expected_value, actual_value, f"Assertion failure in key path: {key_path}")
+
+            key_path.pop()
+
+        self.assertTrue(True, f"Assertion failure in key path: {key_path}")
 
     def setUp(self):
         super().setUp()
@@ -247,7 +412,9 @@ class WmgApiV2Tests(unittest.TestCase):
                 "expression_summary": expected_expression_summary,
                 "term_id_labels": expected_term_id_labels,
             }
-            self.assertEqual(expected_response, json.loads(response.data))
+            self.assert_equality_nested_dict_with_floats(
+                expected=expected_response, actual=json.loads(response.data), key_path=[]
+            )
 
     @patch("backend.wmg.api.v2.gene_term_label")
     @patch("backend.wmg.api.v2.ontology_term_label")
@@ -290,7 +457,10 @@ class WmgApiV2Tests(unittest.TestCase):
                 "expression_summary": expected_expression_summary,
                 "term_id_labels": expected_term_id_labels,
             }
-            self.assertEqual(expected_response, json.loads(response.data))
+
+            self.assert_equality_nested_dict_with_floats(
+                expected=expected_response, actual=json.loads(response.data), key_path=[]
+            )
 
     @patch("backend.wmg.api.v2.gene_term_label")
     @patch("backend.wmg.api.v2.ontology_term_label")
@@ -330,7 +500,10 @@ class WmgApiV2Tests(unittest.TestCase):
                 "expression_summary": expected_expression_summary,
                 "term_id_labels": expected_term_id_labels,
             }
-            self.assertEqual(expected, json.loads(response.data))
+
+            self.assert_equality_nested_dict_with_floats(
+                expected=expected, actual=json.loads(response.data), key_path=[]
+            )
 
     @patch("backend.wmg.api.v2.gene_term_label")
     @patch("backend.wmg.api.v2.ontology_term_label")
@@ -370,7 +543,10 @@ class WmgApiV2Tests(unittest.TestCase):
                 "expression_summary": expected_expression_summary,
                 "term_id_labels": expected_term_id_labels,
             }
-            self.assertEqual(expected, json.loads(response.data))
+
+            self.assert_equality_nested_dict_with_floats(
+                expected=expected, actual=json.loads(response.data), key_path=[]
+            )
 
     @patch("backend.wmg.api.v2.gene_term_label")
     @patch("backend.wmg.api.v2.ontology_term_label")


### PR DESCRIPTION
## Reason for Change

- #4863 
- This PR addresses *step 6* in the ticket referenced. This PR concludes the work needed to make `\query` endpoint for WMG V2 functional (but not necessarily performant)

## Changes

- add aggregate gene expression stats to the response object returned by `\query` endpoint
- add aggregate cell counts stats to the response object returned by `\query` endpoint
- add unit tests to cover changes to the response object returned by `\query` endpoint

## Testing steps

- Unit tests

### Manual Tests on Rdev

1. Go to rdev for `/wmg/v2/query` endpoint: https://rdev-ps-wmg-v2-query-backend.rdev.single-cell.czi.technology/wmg/v2/ui/#/wmg/backend.wmg.api.v2.query
2. Paste in the following request body to the end point:

```
{"filter":{"dataset_ids":[],"development_stage_ontology_term_ids":[],"disease_ontology_term_ids":[],"gene_ontology_term_ids":["ENSG00000156738"], "organism_ontology_term_id":"NCBITaxon:9606","self_reported_ethnicity_ontology_term_ids":[],"sex_ontology_term_ids":[]},"is_rollup":true}
```

3. Verified that response contains aggregated gene expression for each `(gene_ontology_term_id, tissue_ontology_term_id)` combo like this:

```
        "aggregated": {
          "me": 1.953426840087639,
          "n": 570929,
          "tpc": 1.8715915423701033
        }
```

4. Verified that the response contains aggregated cell counts for each `tissue_ontology_term_id` like this:

```
        "aggregated": {
          "name": "respiratory basal cell (cell culture)",
          "tissue_ontology_term_id": "CL:0002633 (cell culture)",
          "total_count": 38665
        }
```

## Notes for Reviewer
