### PR TITLE
fix: WMG slack notifications

### DIFF
--- a/backend/common/utils/result_notification.py
+++ b/backend/common/utils/result_notification.py
@@ -53,17 +53,17 @@ def gen_wmg_pipeline_failure_message(failure_info: str) -> dict:
                 "type": "header",
                 "text": {
                     "type": "plain_text",
-                    "text": f"WMG Snapshot Generation Pipeline FAILED:fire:",
+                    "text": "WMG Snapshot Generation Pipeline FAILED:fire:",
                     "emoji": True,
-                }
+                },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"WMG Snapshot Generation Pipeline failure @sc-oncall-eng \n{failure_info}"
-                }
-            }
+                    "text": f"WMG Snapshot Generation Pipeline failure @sc-oncall-eng \n{failure_info}",
+                },
+            },
         ]
     }
 
@@ -75,8 +75,8 @@ def gen_wmg_pipeline_success_message(snapshot_path: str, dataset_count: int, cel
                 "type": "header",
                 "text": {
                     "type": "plain_text",
-                    "text": f"WMG Snapshot Generation Pipeline Succeeded:tada: ",
-                    "emoji": True
+                    "text": "WMG Snapshot Generation Pipeline Succeeded:tada: ",
+                    "emoji": True,
                 },
             },
             {
@@ -85,8 +85,8 @@ def gen_wmg_pipeline_success_message(snapshot_path: str, dataset_count: int, cel
                     "type": "mrkdwn",
                     "text": f"\n* WMG snapshot stored in {snapshot_path}"
                     f"\n* The cube contains {cell_count} cells from {dataset_count} "
-                    f"\n  datasets, with expression scores across {gene_count} genes."
-                }
-            }
+                    f"\n  datasets, with expression scores across {gene_count} genes.",
+                },
+            },
         ]
     }

--- a/backend/common/utils/result_notification.py
+++ b/backend/common/utils/result_notification.py
@@ -53,9 +53,16 @@ def gen_wmg_pipeline_failure_message(failure_info: str) -> dict:
                 "type": "header",
                 "text": {
                     "type": "plain_text",
-                    "text": f"WMG Snapshot Generation Pipeline FAILED:fire: @sc-oncall-eng \n{failure_info}",
+                    "text": f"WMG Snapshot Generation Pipeline FAILED:fire:",
                     "emoji": True,
-                },
+                }
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"WMG Snapshot Generation Pipeline failure @sc-oncall-eng \n{failure_info}"
+                }
             }
         ]
     }
@@ -68,12 +75,18 @@ def gen_wmg_pipeline_success_message(snapshot_path: str, dataset_count: int, cel
                 "type": "header",
                 "text": {
                     "type": "plain_text",
-                    "text": f"WMG Snapshot Generation Pipeline Succeeded:tada: "
-                    f"\n* WMG snapshot stored in {snapshot_path}"
-                    f"\n* The cube contains {cell_count} cells from {dataset_count} "
-                    f"\n  datasets, with expression scores across {gene_count} genes.",
-                    "emoji": True,
+                    "text": f"WMG Snapshot Generation Pipeline Succeeded:tada: ",
+                    "emoji": True
                 },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"\n* WMG snapshot stored in {snapshot_path}"
+                    f"\n* The cube contains {cell_count} cells from {dataset_count} "
+                    f"\n  datasets, with expression scores across {gene_count} genes."
+                }
             }
         ]
     }


### PR DESCRIPTION
## Reason for Change

- Fixes #4959 
- Fixes WMG pipeline slack notifications. Those were broken because Slack only accepts up to 150 characters in a `header` block. I changed this to that the header is now a fixed size.

## Changes

- Modifies the wmg slack messages.

## Testing steps

-  Testing the pipeline success is easy - we'll do a test run in dev anyway
- Testing failures is more difficult. I will try to do that using rdev.

## Notes for Reviewer
