### PR TITLE
update to api

### DIFF
--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -194,6 +194,7 @@ def _dataset_to_response(
             "created_at": dataset.created_at,
             "dataset_assets": [_dataset_asset_to_response(a, dataset.version_id.id) for a in dataset.artifacts],
             "dataset_deployments": dataset_deployments,
+            "dataset_id": dataset.dataset_id.id,
             "development_stage": None
             if dataset.metadata is None
             else _ontology_term_ids_to_response(dataset.metadata.development_stage),


### PR DESCRIPTION
## Adding field to portal API

- #4730 (?)
- Currently the id field returns the dataset _version_ ids, not the actual dataset ids, which complicates the code for the publication filter. This code adds a new field that returns the actual dataset id. 

## Changes

- add field to portal API file's dataset_to_response function

## Testing steps
??

## Notes for Reviewer
