### PR TITLE
fix: Fix response object structure for /wmg/v2/query endpoint

### DIFF
--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -195,10 +195,10 @@ def build_expression_summary(query_result: DataFrame, compare: str) -> dict:
 
     for i in range(query_result_agg.shape[0]):
         row = query_result_agg.iloc[i]
-        structured_result[row.gene_ontology_term_id][row.tissue_ontology_term_id]["aggregated"] = dict(
+        structured_result[row.gene_ontology_term_id][row.tissue_ontology_term_id]["tissue_stats"]["aggregated"] = dict(
             n=int(row["nnz"]),
-            me=float(row["sum"] / row["nnz"]),
-            tpc=float(row["nnz"] / row["n_cells_tissue"]),
+            me=(float(row["sum"] / row["nnz"]) if row["nnz"] else 0.0),
+            tpc=(float(row["nnz"] / row["n_cells_tissue"]) if row["n_cells_tissue"] else 0.0),
         )
 
     # Populate gene expressions stats for each (gene, tissue, cell_type) combination
@@ -212,9 +212,9 @@ def build_expression_summary(query_result: DataFrame, compare: str) -> dict:
             "aggregated"
         ] = dict(
             n=int(row["nnz"]),
-            me=float(row["sum"] / row["nnz"]),
-            pc=float(row["nnz"] / row["n_cells_cell_type"]),
-            tpc=float(row["nnz"] / row["n_cells_tissue"]),
+            me=(float(row["sum"] / row["nnz"]) if row["nnz"] else 0.0),
+            pc=(float(row["nnz"] / row["n_cells_cell_type"]) if row["n_cells_cell_type"] else 0.0),
+            tpc=(float(row["nnz"] / row["n_cells_tissue"]) if row["n_cells_tissue"] else 0.0),
         )
 
     # Populate gene expression stats for each (gene, tissue, cell_type, <compare_dimension>) combination
@@ -225,9 +225,9 @@ def build_expression_summary(query_result: DataFrame, compare: str) -> dict:
                 row[compare]
             ] = dict(
                 n=int(row["nnz"]),
-                me=float(row["sum"] / row["nnz"]),
-                pc=float(row["nnz"] / row["n_cells_cell_type"]),
-                tpc=float(row["nnz"] / row["n_cells_tissue"]),
+                me=(float(row["sum"] / row["nnz"]) if row["nnz"] else 0.0),
+                pc=(float(row["nnz"] / row["n_cells_cell_type"]) if row["n_cells_cell_type"] else 0.0),
+                tpc=(float(row["nnz"] / row["n_cells_tissue"]) if row["n_cells_tissue"] else 0.0),
             )
 
     return structured_result
@@ -290,10 +290,11 @@ def build_ordered_cell_types_by_tissue(
 
     for i in range(joined_agg.shape[0]):
         row = joined_agg.iloc[i]
-        structured_result[row.tissue_ontology_term_id]["aggregated"] = {
+        structured_result[row.tissue_ontology_term_id]["tissue_stats"]["aggregated"] = {
             "tissue_ontology_term_id": row.tissue_ontology_term_id,
             "name": ontology_term_label(row.tissue_ontology_term_id),
             "total_count": int(row.n_total_cells),
+            "order": -1,
         }
 
     # Populate aggregated cell counts for each (tissue, cell_type) combination

--- a/backend/wmg/api/wmg-api-v2.yml
+++ b/backend/wmg/api/wmg-api-v2.yml
@@ -107,7 +107,11 @@ paths:
                         {
                           "tissuetype1":
                             {
-                              "aggregated": { "me": 0.0, "n": 0, "tpc": 0.0 },
+                              "tissue_stats":
+                                {
+                                  "aggregated":
+                                    { "me": 0.0, "n": 0, "tpc": 0.0 },
+                                },
                               "celltype1":
                                 {
                                   "aggregated":
@@ -183,7 +187,11 @@ paths:
                             },
                           "tissuetype2":
                             {
-                              "aggregated": { "me": 0.0, "n": 0, "tpc": 0.0 },
+                              "tissue_stats":
+                                {
+                                  "aggregated":
+                                    { "me": 0.0, "n": 0, "tpc": 0.0 },
+                                },
                               "celltype1":
                                 {
                                   "aggregated":
@@ -262,7 +270,11 @@ paths:
                         {
                           "tissuetype1":
                             {
-                              "aggregated": { "me": 0.0, "n": 0, "tpc": 0.0 },
+                              "tissue_stats":
+                                {
+                                  "aggregated":
+                                    { "me": 0.0, "n": 0, "tpc": 0.0 },
+                                },
                               "celltype1":
                                 {
                                   "aggregated":
@@ -340,7 +352,11 @@ paths:
                             },
                           "tissuetype2":
                             {
-                              "aggregated": { "me": 0.0, "n": 0, "tpc": 0.0 },
+                              "tissue_stats":
+                                {
+                                  "aggregated":
+                                    { "me": 0.0, "n": 0, "tpc": 0.0 },
+                                },
                               "celltype1":
                                 {
                                   "aggregated":
@@ -422,11 +438,14 @@ paths:
                         {
                           "tissuetype1":
                             {
-                              "aggregated":
+                              "tissue_stats":
                                 {
-                                  "name": "tissue type 1",
-                                  "tissue_ontology_term_id": "tissuetype1",
-                                  "total_count": 4,
+                                  "aggregated":
+                                    {
+                                      "name": "tissue type 1",
+                                      "tissue_ontology_term_id": "tissuetype1",
+                                      "total_count": 4,
+                                    },
                                 },
                               "celltype1":
                                 {

--- a/tests/unit/backend/wmg/api/test_v2.py
+++ b/tests/unit/backend/wmg/api/test_v2.py
@@ -98,9 +98,11 @@ def generate_expected_term_id_labels_dictionary(
             "total_count": sum(
                 [agg_dict["aggregated"]["total_count"] for _, agg_dict in result["cell_types"][tissue].items()]
             ),
+            "order": -1,
         }
 
-        result["cell_types"][tissue]["aggregated"] = tissue_cell_counts
+        result["cell_types"][tissue]["tissue_stats"] = {}
+        result["cell_types"][tissue]["tissue_stats"]["aggregated"] = tissue_cell_counts
 
     result["genes"] = []
     for gene in genes:
@@ -159,6 +161,7 @@ def generate_expected_expression_summary_dictionary(
             result[gene] = {}
             for tissue in tissues:
                 result[gene][tissue] = {}
+
                 for cell_type in cell_types:
                     result[gene][tissue][cell_type] = {}
 
@@ -195,7 +198,8 @@ def generate_expected_expression_summary_dictionary(
                     "tpc": tpc_gene_tissue,
                 }
 
-                result[gene][tissue]["aggregated"] = gene_tissue_expr_stats
+                result[gene][tissue]["tissue_stats"] = {}
+                result[gene][tissue]["tissue_stats"]["aggregated"] = gene_tissue_expr_stats
 
     return result
 
@@ -273,7 +277,7 @@ def generate_test_inputs_and_expected_outputs(
         cell_count_tissue=cell_count_tissue,
         cell_types=cell_types,
         cell_count_tissue_cell_type=cell_count_tissue_cell_type,
-        nnz_gene_tissue_cell_type=expected_combinations_per_cell_type,
+        nnz_gene_tissue_cell_type=nnz_gene_tissue_cell_type,
         compare_terms=compare_terms,
         cell_counts_tissue_cell_type_compare_dim=cell_counts_tissue_cell_type_compare_dim,
         nnz_gene_tissue_cell_type_compare_dim=nnz_gene_tissue_cell_type_compare_dim,


### PR DESCRIPTION
## Reason for Change

- #4863 
- This is done to minimize the code changes on the frontend since the frontend code that deserializes the response is shared between the components responsible for rendering the heatmap for V1 and V2 respectively.

## Changes

- modify shape of response object for `wmg/v2/query` endpoint

## Testing steps

- Unit tests

## Notes for Reviewer
