### PR TITLE
feat: Deletion of published datasets in the Curation UX must be removed (#3037)

### DIFF
--- a/frontend/src/common/entities.ts
+++ b/frontend/src/common/entities.ts
@@ -147,6 +147,7 @@ export interface Dataset {
   created_at: number;
   original_id?: string;
   published?: boolean;
+  published_at?: number;
   tombstone?: boolean;
   updated?: boolean;
   collection_visibility: Collection["visibility"];

--- a/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/components/MoreDropdown/components/Menu/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/components/MoreDropdown/components/Menu/index.tsx
@@ -39,6 +39,7 @@ const UpdateButton = (props: Partial<IMenuItemProps>) => {
 interface Props {
   collectionId: Collection["id"];
   datasetId?: string;
+  isPublished: boolean;
   revisionsEnabled: boolean;
   onUploadFile: ChooserProps["onUploadFile"];
   isLoading: boolean;
@@ -56,10 +57,14 @@ const StyledMenu = styled(RawMenu)`
 const Menu = ({
   collectionId,
   datasetId = "",
+  isPublished,
   revisionsEnabled,
   onUploadFile,
   isLoading,
 }: Props): JSX.Element => {
+  // A dataset may be deleted if the collection is private, or the dataset has not been previously
+  // published; where the published_at property is used to determine whether the dataset has been previously published.
+  const shouldShowDelete = !revisionsEnabled || !isPublished;
   return (
     <StyledMenu>
       {revisionsEnabled && (
@@ -67,11 +72,13 @@ const Menu = ({
           <UpdateButton disabled={isLoading} />
         </DropboxChooser>
       )}
-      <DeleteDataset
-        Button={DeleteButton}
-        collectionId={collectionId}
-        datasetId={datasetId}
-      />
+      {shouldShowDelete && (
+        <DeleteDataset
+          Button={DeleteButton}
+          collectionId={collectionId}
+          datasetId={datasetId}
+        />
+      )}
     </StyledMenu>
   );
 };

--- a/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/components/MoreDropdown/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/components/MoreDropdown/index.tsx
@@ -8,6 +8,7 @@ import { Collection } from "src/common/entities";
 interface Props {
   collectionId: Collection["id"];
   datasetId?: string;
+  isPublished: boolean;
   revisionsEnabled: boolean;
   onUploadFile: ChooserProps["onUploadFile"];
   isLoading: boolean;
@@ -17,6 +18,7 @@ interface Props {
 const MoreDropdown = ({
   collectionId,
   datasetId = "",
+  isPublished,
   revisionsEnabled,
   onUploadFile,
   isLoading,
@@ -28,6 +30,7 @@ const MoreDropdown = ({
         <Menu
           collectionId={collectionId}
           datasetId={datasetId}
+          isPublished={isPublished}
           revisionsEnabled={revisionsEnabled}
           onUploadFile={onUploadFile}
           isLoading={isLoading}
@@ -39,6 +42,7 @@ const MoreDropdown = ({
   }, [
     collectionId,
     datasetId,
+    isPublished,
     revisionsEnabled,
     isLoading,
     onUploadFile,

--- a/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DatsetRow/index.tsx
@@ -221,6 +221,7 @@ const DatasetRow: FC<Props> = ({
               <MoreDropdown
                 collectionId={collectionId}
                 datasetId={dataset.id}
+                isPublished={!!dataset.published_at} // Dataset has been published.
                 revisionsEnabled={revisionsEnabled}
                 onUploadFile={onUploadFile}
                 isLoading={isLoading}


### PR DESCRIPTION
## Reason for Change

- #3037 

## Changes

- Curators are no longer able to delete a dataset in the private revision of a published collection i.e. if a dataset has been previously published, then it may not be deleted. For clarification see [slack thread](https://clevercanary.slack.com/archives/C02CF7MQPGV/p1685602748854589?thread_ts=1685602175.729339&cid=C02CF7MQPGV).

## Testing steps

- Curator may delete a dataset from a private collection.
- Curator may NOT delete a dataset from a published revision collection.
- Curator may add a new dataset to a published revision collection, and is able to delete the newly added dataset.
