### PR TITLE
fix: prod processing image rebuild job should use same creds as dev/staging

### DIFF
--- a/.github/workflows/rebuild-processing-image.yml
+++ b/.github/workflows/rebuild-processing-image.yml
@@ -75,12 +75,12 @@ jobs:
   rebuild-and-push-processing-image-prod:
     runs-on: ubuntu-20.04
     steps:
-      - name: Configure AWS Prod Credentials
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_PROD_ROLE_TO_ASSUME }}
-          role-duration-seconds: 2700
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
       - name: Login to ECR
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
## Reason for Change

- #4987
- This bug occurs because our ECR for all images, even those used in prod, are in the single-cell-dev AWS account. The equivalent prod role to assume does not have access to the ECR where processing images are tagged/pushed.

## Changes

- change prod processing rebuild workflow job to use same AWS creds as dev/staging jobs

## Testing steps

## Notes for Reviewer
