### PR TITLE
fix: Fix tpc gene expression statistic calculation

### DIFF
--- a/backend/wmg/api/common/expression_dotplot.py
+++ b/backend/wmg/api/common/expression_dotplot.py
@@ -30,7 +30,7 @@ def agg_tissue_counts(cell_counts: DataFrame) -> DataFrame:
 
 
 def build_dot_plot_matrix(
-    query_result: DataFrame,
+    raw_gene_expression: DataFrame,
     cell_counts_cell_type_agg: DataFrame,
     cell_counts_tissue_agg: DataFrame,
     group_by_terms: List[str] = None,
@@ -39,7 +39,7 @@ def build_dot_plot_matrix(
         group_by_terms = DEFAULT_GROUP_BY_TERMS
 
     # Aggregate cube data by gene, tissue, cell type
-    expr_summary_agg = query_result.groupby(["gene_ontology_term_id"] + group_by_terms, as_index=False).sum(
+    expr_summary_agg = raw_gene_expression.groupby(["gene_ontology_term_id"] + group_by_terms, as_index=False).sum(
         numeric_only=True
     )
     return expr_summary_agg.join(cell_counts_cell_type_agg, on=group_by_terms, how="left").join(
@@ -48,7 +48,7 @@ def build_dot_plot_matrix(
 
 
 def get_dot_plot_data(
-    query_result: DataFrame,
+    raw_gene_expression: DataFrame,
     cell_counts: DataFrame,
     group_by_terms: List[str] = None,
 ) -> Tuple[DataFrame, DataFrame]:
@@ -58,6 +58,6 @@ def get_dot_plot_data(
     cell_counts_cell_type_agg = agg_cell_type_counts(cell_counts, group_by_terms)
     cell_counts_tissue_agg = agg_tissue_counts(cell_counts)
     dot_plot_matrix_df = build_dot_plot_matrix(
-        query_result, cell_counts_cell_type_agg, cell_counts_tissue_agg, group_by_terms
+        raw_gene_expression, cell_counts_cell_type_agg, cell_counts_tissue_agg, group_by_terms
     )
     return dot_plot_matrix_df, cell_counts_cell_type_agg

--- a/tests/unit/backend/wmg/api/test_v2.py
+++ b/tests/unit/backend/wmg/api/test_v2.py
@@ -295,6 +295,10 @@ def generate_test_inputs_and_expected_outputs(
     )
 
 
+# TODO(prathap): Write tests that mock backend.wmg.api.v2.get_dot_plot_data() and
+# backend.wmg.api.v2.rollup() so that we can test backend.wmg.api.v2.query() with
+# rollup operations.
+# see: https://github.com/chanzuckerberg/single-cell-data-portal/issues/4997
 class WmgApiV2Tests(unittest.TestCase):
     """
     Tests WMG API endpoints. Tests the flask app only, and not other stack dependencies, such as S3. Builds and uses a


### PR DESCRIPTION
## Reason for Change

- #4971 

Currently, the calculation of tpc involves summing up gene expression values in the rolled-up gene expression dataframe over groups keyed by (gene_ontology_term_id, tissue_ontology_term_id) pairs.

Since rolled-up values are calculated over the cell-type ontology inheritance graph, any aggregation functions grouped by composite keys that DO NOT include `cell_type_ontology_term_id` will aggregate duplicate values.

Since the grouping key (gene_ontology_term_id, tissue_ontology_term_id) does not contain `cell_type_ontology_term_id`, the aggregation CANNOT happen over the rolled-up gene expression dataframe. Instead, the aggregation should be computed over the original gene expression dataframe containing raw gene expression values.

## Changes

See heading above

## Testing steps

- Unit tests
- rdev manual test using the swagger UI to check `wmg/v2/query` responses
   - Go to backend rdev swagger UI for `query` api method: https://rdev-ps-fix-tpc-backend.rdev.single-cell.czi.technology/wmg/v2/ui/#/wmg/backend.wmg.api.v2.query
   - Put in the following query (It might take a long time to run this query - on the order of several tens of seconds):
      ```
      {"compare":"self_reported_ethnicity","filter":{"dataset_ids":[],"development_stage_ontology_term_ids":[],"disease_ontology_term_ids":[],"gene_ontology_term_ids":["ENSG00000156738"], "organism_ontology_term_id":"NCBITaxon:9606","self_reported_ethnicity_ontology_term_ids":[],"sex_ontology_term_ids":[]},"is_rollup":true}
      ```
   - Download the response object and open it in an editor.
   - Search for the word `tissue_stats` (there are many objects keyed by this string) - This is the aggregate stats for the tissue. Check that `tpc` value in _all objects_ are less than `1.0`.  Example:
      ```
      "tissue_stats": {
          "aggregated": {
            "me": 2.935705705122514,
            "n": 11,
            "tpc": 0.0004010061609128358
          }
       ```

## Notes for Reviewer
