### PR TITLE
fix: Bug(curation) Flash of "No Results" when refreshing the collections page / No loading indicator (#4908)

### DIFF
--- a/frontend/src/common/queries/filter.ts
+++ b/frontend/src/common/queries/filter.ts
@@ -56,6 +56,7 @@ const QUERY_ID_DATASETS = "datasetIndex";
 export interface FetchCategoriesRows<T extends Categories> {
   isError: boolean;
   isLoading: boolean;
+  isSuccess: boolean;
   rows: T[];
 }
 
@@ -169,6 +170,7 @@ export function useFetchCollectionRows(
     data: datasets,
     isError: datasetsError,
     isLoading: datasetsLoading,
+    isSuccess: datasetsSuccess,
   } = useFetchDatasets(mode, status);
 
   // Fetch collections.
@@ -176,6 +178,7 @@ export function useFetchCollectionRows(
     data: collectionsById,
     isError: collectionsError,
     isLoading: collectionsLoading,
+    isSuccess: collectionsSuccess,
   } = useFetchCollections(mode, status);
 
   // View model built from join of collections response and aggregated metadata of dataset rows.
@@ -191,6 +194,7 @@ export function useFetchCollectionRows(
   return {
     isError: datasetsError || collectionsError,
     isLoading: datasetsLoading || collectionsLoading,
+    isSuccess: datasetsSuccess && collectionsSuccess,
     rows: collectionRows,
   };
 }
@@ -230,6 +234,7 @@ export function useFetchDatasetRows(
     data: datasets,
     isError: datasetsError,
     isLoading: datasetsLoading,
+    isSuccess: datasetsSuccess,
   } = useFetchDatasets(mode, status);
 
   // Fetch collections.
@@ -237,6 +242,7 @@ export function useFetchDatasetRows(
     data: collectionsById,
     isError: collectionsError,
     isLoading: collectionsLoading,
+    isSuccess: collectionsSuccess,
   } = useFetchCollections(mode, status);
 
   // Build dataset rows once datasets and collections responses have resolved.
@@ -256,6 +262,7 @@ export function useFetchDatasetRows(
   return {
     isError: datasetsError || collectionsError,
     isLoading: datasetsLoading || collectionsLoading,
+    isSuccess: datasetsSuccess && collectionsSuccess,
     rows: datasetRows,
   };
 }

--- a/frontend/src/components/common/Grid/components/Loader/index.tsx
+++ b/frontend/src/components/common/Grid/components/Loader/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { LoadingIndicator } from "@czi-sds/components";
+import { Loader as GridLoader } from "./style";
+
+export default function Loader(): JSX.Element {
+  return (
+    <GridLoader>
+      <LoadingIndicator sdsStyle="tag" />
+    </GridLoader>
+  );
+}

--- a/frontend/src/components/common/Grid/components/Loader/style.ts
+++ b/frontend/src/components/common/Grid/components/Loader/style.ts
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+
+export const Loader = styled.div`
+  align-self: flex-start;
+  grid-area: content;
+  justify-self: center;
+  position: relative;
+  top: 24px;
+`;

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -34,10 +34,11 @@ import DatasetsActionsCell from "src/components/Datasets/components/Grid/compone
 import DatasetNameCell from "src/components/Datasets/components/Grid/components/DatasetNameCell";
 import { DatasetsGrid } from "src/components/Datasets/components/Grid/components/DatasetsGrid/style";
 import SideBar from "src/components/common/SideBar";
-import { View } from "../globalStyle";
 import { ALIGNMENT } from "src/components/common/Grid/common/entities";
 import { CATEGORY_FILTER_DENY_LIST } from "src/views/Datasets/common/constants";
-import { useViewMode } from "src/common/hooks/useViewMode";
+import { useViewMode, VIEW_MODE } from "src/common/hooks/useViewMode";
+import { DatasetsView as View } from "./style";
+import Loader from "src/components/common/Grid/components/Loader";
 
 /**
  * Collection ID object key.
@@ -90,9 +91,15 @@ export default function Datasets(): JSX.Element {
   // Filterable datasets joined from datasets and collections responses.
   const {
     isError,
-    isLoading,
+    isSuccess,
     rows: datasetRows,
   } = useFetchDatasetRows(mode, status);
+
+  // Show datasets list when datasets are successfully loaded.
+  const shouldShowDatasets = !isError && isSuccess;
+
+  // Loading indicator for curator mode, when datasets are not yet successfully loaded.
+  const shouldShowLoader = mode === VIEW_MODE.CURATOR && !shouldShowDatasets;
 
   // Column configuration backing table.
   const columnConfig: Column<DatasetRow>[] = useMemo(
@@ -365,35 +372,39 @@ export default function Datasets(): JSX.Element {
       <Head>
         <title>CELL&times;GENE | Datasets</title>
       </Head>
-      {isError || isLoading ? null : (
-        <>
-          <SideBar
-            label="Filters"
-            isOpen={isSideBarOpen}
-            onToggle={storeIsSideBarOpen}
-          >
-            <Filter {...filterInstance} />
-          </SideBar>
-          <View>
-            {!rows || rows.length === 0 ? (
-              <GridHero>
-                <h3>No Results</h3>
-                <p>There are no datasets matching those filters.</p>
-              </GridHero>
-            ) : (
-              <DatasetsGrid
-                tableCountSummary={buildTableCountSummary(
-                  rows,
-                  preFilteredRows
-                )}
-                // @ts-expect-error -- revisit tableInstance typing
-                tableInstance={tableInstance}
-              />
-            )}
-          </View>
-          {/* May be added in the future after sign off */}
-          {/* <BottomBanner /> */}
-        </>
+      {isError ? null : shouldShowLoader ? (
+        <Loader />
+      ) : (
+        shouldShowDatasets && (
+          <>
+            <SideBar
+              label="Filters"
+              isOpen={isSideBarOpen}
+              onToggle={storeIsSideBarOpen}
+            >
+              <Filter {...filterInstance} />
+            </SideBar>
+            <View>
+              {!rows || rows.length === 0 ? (
+                <GridHero>
+                  <h3>No Results</h3>
+                  <p>There are no datasets matching those filters.</p>
+                </GridHero>
+              ) : (
+                <DatasetsGrid
+                  tableCountSummary={buildTableCountSummary(
+                    rows,
+                    preFilteredRows
+                  )}
+                  // @ts-expect-error -- revisit tableInstance typing
+                  tableInstance={tableInstance}
+                />
+              )}
+            </View>
+            {/* May be added in the future after sign off */}
+            {/* <BottomBanner /> */}
+          </>
+        )
       )}
     </>
   );

--- a/frontend/src/views/Datasets/style.ts
+++ b/frontend/src/views/Datasets/style.ts
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+import { View } from "src/views/globalStyle";
+
+export const DatasetsView = styled(View)`
+  display: grid;
+  gap: 24px;
+  place-content: flex-start stretch;
+`;


### PR DESCRIPTION
## Reason for Change

- #4908 

## Changes

- The Collections and Datasets index has been modified to display only the filter sidebar and list upon successful execution of the collections and datasets query, resolving the issue of unwanted and premature display of "No Results".
- A loading indicator has been implemented specifically for curator mode to provide a visual representation of the pending collections and datasets query.

## Testing steps

- A curator should see on page refresh, *a loading indicator*, followed by the display of the side bar filters and list.
- A non-curator should see on page refresh, *no loading indicator*, followed by the display of the side bar filters and list.
- Both curator and non-curator should not see a flash of "No Results" during loading.
