### PR TITLE
feat: Implement the high-level snapshot creation unit test in TestCorpusLoad

### DIFF
--- a/tests/unit/backend/wmg/fixtures/test_anndata_object.py
+++ b/tests/unit/backend/wmg/fixtures/test_anndata_object.py
@@ -39,7 +39,8 @@ def create_anndata_test_object(num_genes: int = 3, num_cells: int = 5):
     - slow column slicing operations (consider CSC)
     - changes to the sparsity structure are expensive (consider LIL or DOK)
     """
-    # make matrix of gene expression (one value per gene/cell combo)
+    # create sparse matrix of gene expression (one value per gene/cell combo)
+    # values are randomly populated using a poisson distribution
     counts = csr_matrix(np.random.poisson(1, size=(num_cells, num_genes)), dtype=np.float32)
     adata = ad.AnnData(counts)
     adata.obs_names = [f"Cell_{i:d}" for i in range(adata.n_obs)]


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/4519

## Changes

- Implements some basic sanity checks for verifying the snapshot of our cell corpus works as expected. Since I believe the input dataset that is generated for this test includes some amount of randomness (see all usages of `np.random.choice` [here](https://github.com/chanzuckerberg/single-cell-data-portal/blob/main/tests/unit/backend/wmg/fixtures/test_anndata_object.py)), I don't think it would be possible to create this test with a static cube fixture.
- Instead, this does some basic sanity check assertions on mostly the `obs` matrix to verify that the size is roughly correct, the number of unique values is roughly what we expect, and basic assertions when the value for the column is static
- I also noticed that the `var` and `integrated` matrices were both empty Python dataframes. For these two matrices, I just validated the length and the expected column names.

## Testing steps

Ran locally with:
```
DEPLOYMENT_STAGE=test python3 -m unittest tests/unit/wmg_processing/test_load_corpus.py
```

## Notes for Reviewer
