### PR TITLE
feat: Remove 'X' icon from Datasets Download Dialog (#4179)

### DIFF
--- a/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DownloadDataset/index.tsx
+++ b/frontend/src/components/Collection/components/CollectionDatasetsGrid/components/Row/DownloadDataset/index.tsx
@@ -50,6 +50,7 @@ const DownloadDataset: FC<Props> = ({
       />
       <Modal
         title="Download Dataset"
+        isCloseButtonShown={false}
         isOpen={isOpen}
         onClose={toggleOpen}
         className={isLoading || isError ? "modal-loading" : undefined}

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/index.tsx
@@ -37,7 +37,12 @@ const DownloadDataset: FC<Props> = ({
         onClick={toggleOpen}
         data-testid="dataset-download-button"
       />
-      <Modal title="Download Dataset" isOpen={isOpen} onClose={toggleOpen}>
+      <Modal
+        isCloseButtonShown={false}
+        isOpen={isOpen}
+        onClose={toggleOpen}
+        title="Download Dataset"
+      >
         <Content name={name} dataAssets={dataAssets} onClose={toggleOpen} />
       </Modal>
     </>


### PR DESCRIPTION
## Reason for Change

- #4179

## Changes

- Removed `x` button from datasets download dialog (both datasets index and detail pages).
