### PR TITLE
fix: Private collections must not display "No datasets uploaded ... Add Dataset from Dropbox" to submitters (#4491)

### DIFF
--- a/frontend/src/views/Collection/components/DatasetTab/index.tsx
+++ b/frontend/src/views/Collection/components/DatasetTab/index.tsx
@@ -2,7 +2,7 @@ import { Button, Intent, UL } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { FC, useCallback, useState } from "react";
 import { useQueryClient } from "react-query";
-import { Collection, Dataset } from "src/common/entities";
+import { ACCESS_TYPE, Collection, Dataset } from "src/common/entities";
 import {
   USE_COLLECTION,
   useCollection,
@@ -41,6 +41,8 @@ const DatasetTab: FC<Props> = ({
   const queryClient = useQueryClient();
 
   if (isTombstonedCollection(collection)) return null;
+
+  const hasWriteAccess = collection?.access_type === ACCESS_TYPE.WRITE;
 
   const isDatasetPresent =
     datasets?.length > 0 || Object.keys(uploadedFiles).length > 0;
@@ -90,29 +92,33 @@ const DatasetTab: FC<Props> = ({
         <EmptyModal
           title="No datasets uploaded"
           content={
-            <div>
-              Before you begin uploading dataset files:
-              <UL>
-                <li>
-                  You must validate your dataset locally. We provide a local CLI
-                  script to do this.{" "}
-                  <StyledLink href={CLI_README_LINK}>Learn More</StyledLink>
-                </li>
-                <li>
-                  We only support adding datasets in the h5ad format at this
-                  time.
-                </li>
-              </UL>
-            </div>
+            hasWriteAccess ? (
+              <div>
+                Before you begin uploading dataset files:
+                <UL>
+                  <li>
+                    You must validate your dataset locally. We provide a local
+                    CLI script to do this.{" "}
+                    <StyledLink href={CLI_README_LINK}>Learn More</StyledLink>
+                  </li>
+                  <li>
+                    We only support adding datasets in the h5ad format at this
+                    time.
+                  </li>
+                </UL>
+              </div>
+            ) : undefined
           }
           button={
-            <DropboxChooser onUploadFile={addNewFile()}>
-              <Button
-                intent={Intent.PRIMARY}
-                outlined
-                text={"Add Dataset from Dropbox"}
-              />
-            </DropboxChooser>
+            hasWriteAccess ? (
+              <DropboxChooser onUploadFile={addNewFile()}>
+                <Button
+                  intent={Intent.PRIMARY}
+                  outlined
+                  text={"Add Dataset from Dropbox"}
+                />
+              </DropboxChooser>
+            ) : undefined
           }
         />
       )}

--- a/frontend/src/views/Collection/components/EmptyModal/index.tsx
+++ b/frontend/src/views/Collection/components/EmptyModal/index.tsx
@@ -4,8 +4,8 @@ import { Border, CenterAlignedDiv } from "./style";
 
 interface Props {
   title: string;
-  content: ReactChild;
-  button: ReactChild;
+  content?: ReactChild;
+  button?: ReactChild;
 }
 
 const EmptyModal: FC<Props> = ({ title, content, button }) => {


### PR DESCRIPTION
## Reason for Change

- #4491

## Changes

- Modified the private collections "No Datasets Uploaded" modal to optionally render text and button. The uploading of private collection datasets can only be actioned by a curator with write access.
