### PR TITLE
chore: double timeout to 120 seconds

### DIFF
--- a/frontend/tests/utils/helpers.ts
+++ b/frontend/tests/utils/helpers.ts
@@ -57,7 +57,7 @@ const TEST_ENVS_DEV_STAGING = ["dev", "staging"];
 
 export const isDevStaging = TEST_ENVS_DEV_STAGING.includes(TEST_ENV);
 
-const GO_TO_PAGE_TIMEOUT_MS = 60 * 1000;
+const GO_TO_PAGE_TIMEOUT_MS = 120 * 1000;
 
 export async function goToPage(
   url: string = TEST_URL,


### PR DESCRIPTION
## Reason for Change

we're going to try doubling the timeout to see if it helps with e2e tests timing out. currently, about half of recent push tests have failed due to e2e tests timing out

## Changes

doubles timeout from 60 seconds to 120 seconds

## Testing steps

🤷‍♀️ going to see if the push tests for this PR pass

## Notes for Reviewer
