### PR TITLE
feat(cell-cards): Distinguish between canonical and computational marker tables #5035

### DIFF
--- a/frontend/src/views/CellCards/components/CellCard/components/MarkerGeneTables/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/MarkerGeneTables/index.tsx
@@ -421,7 +421,7 @@ const MarkerGeneTables = ({ cellTypeId, setGeneInfoGene }: Props) => {
             setActiveTable(0);
           }}
         >
-          Canonical
+          Canonical (HuBMAP)
         </TableSelectorButton>
         <TableSelectorButton
           data-testid={CELL_CARD_ENRICHED_GENES_TABLE_SELECTOR}
@@ -431,7 +431,7 @@ const MarkerGeneTables = ({ cellTypeId, setGeneInfoGene }: Props) => {
             setActiveTable(1);
           }}
         >
-          Computational
+          Computational (CZI)
         </TableSelectorButton>
       </TableSelectorRow>
       <StyledDivider />


### PR DESCRIPTION
## Reason for Change

- #5035

## Changes

- add
- "HuBMAP" and "CZI" text for marker genes table tabs
- remove
- modify

## Testing steps

1. https://localhost:3000/cell-guide/CL_0000540
2. Scroll down to marker genes section

## Notes for Reviewer
