### PR TITLE
fix(backend): increase number of workers for deployed backend flask app 

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -24,7 +24,10 @@ locals {
   frontend_cmd                 = []
   # TODO: Assess whether this is safe for Portal API as well. Trying 1 worker in rdev portal backend containers, to minimize use of memory by TileDB (allocates multi-GB per process)
   # Note: keep-alive timeout should always be greater than the idle timeout of the load balancer (60 seconds)
-  backend_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "1", "--bind", "0.0.0.0:5000", "backend.api_server.app:app", "--max-requests", "10000", "--timeout", "180", "--keep-alive", "61", "--log-level", "info"]
+  backend_workers              = var.backend_cpus * 2 + 1 # Number of backend workers to run. Using the flask formula 2*cpu+1
+  backend_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "${local.backend_workers}",
+    "--bind", "0.0.0.0:5000", "backend.api_server.app:app", "--max-requests", "10000", "--timeout", "180",
+    "--keep-alive", "61", "--log-level", "info"]
   data_load_path               = "s3://${local.secret["s3_buckets"]["env"]["name"]}/database/seed_data_2023.sql"
 
   vpc_id                          = local.secret["cloud_env"]["vpc_id"]
@@ -131,7 +134,7 @@ module backend_service {
   task_role_arn              = local.ecs_role_arn
   service_port               = 5000
   memory                     = var.backend_memory
-  cpu                        = 2048
+  cpu                        = var.backend_cpus * 1024
   cmd                        = local.backend_cmd
   deployment_stage           = local.deployment_stage
   step_function_arn          = module.upload_sfn.step_function_arn

--- a/.happy/terraform/modules/ecs-stack/variables.tf
+++ b/.happy/terraform/modules/ecs-stack/variables.tf
@@ -112,6 +112,12 @@ variable backend_memory {
   default     = 2048
 }
 
+variable "backend_cpus" {
+  type        = number
+  description = "CPU shares (1cpu=1024) per task"
+  default     = 2
+}
+
 variable frontend_memory {
   type        = number
   description = "Memory reservation for the backend task"

--- a/.happy/terraform/modules/ecs-stack/variables.tf
+++ b/.happy/terraform/modules/ecs-stack/variables.tf
@@ -114,7 +114,7 @@ variable backend_memory {
 
 variable "backend_cpus" {
   type        = number
-  description = "CPU shares (1cpu=1024) per task"
+  description = "CPUs for the backend task"
   default     = 2
 }
 


### PR DESCRIPTION
## Reason for Change

- The container resources are under utilised. These changes make full use of the container as recommended by flask.
- #TICKET_NUMBER

## Changes

- make the number of works match the number recommended by flask.
- make backend vcpus configurable.

## Testing steps


## Notes for Reviewer
