### PR TITLE
fix: change 'datasets' to 'dataset_versions' in GET /collection_versions

### DIFF
--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -148,7 +148,6 @@ def reshape_for_curation_api(
         contact_name=collection_version.metadata.contact_name,
         created_at=collection_version.created_at,
         curator_name=collection_version.curator_name,
-        datasets=response_datasets,
         description=collection_version.metadata.description,
         doi=doi,
         links=links,
@@ -157,7 +156,10 @@ def reshape_for_curation_api(
         publisher_metadata=collection_version.publisher_metadata,
         visibility=get_visibility(collection_version),
     )
-    if not reshape_for_version_endpoint:
+    if reshape_for_version_endpoint:
+        response["dataset_versions"] = response_datasets
+    else:
+        response["datasets"] = response_datasets
         response.update(
             revised_at=collection_version.canonical_collection.revised_at,
             revising_in=revising_in,

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -539,10 +539,10 @@ class TestGetCollectionVersions(BaseAPIPortalTest):
         # Confirm fields are present on Collection version body but ignore equality comparison for timestamps
         self.assertIn("created_at", received_body)
         self.assertIn("published_at", received_body)
-        [self.assertIn("published_at", d) for d in received_body["datasets"]]
+        [self.assertIn("published_at", d) for d in received_body["dataset_versions"]]
         received_body.pop("created_at")
         received_body.pop("published_at")
-        [d.pop("published_at") for d in received_body["datasets"]]
+        [d.pop("published_at") for d in received_body["dataset_versions"]]
 
     def test__get_collection_versions__200(self):
         # Create published collection with 2 published revisions and 1 unpublished revision
@@ -996,7 +996,7 @@ class TestGetCollectionVersionID(BaseAPIPortalTest):
             "contact_email": "john.doe@email.com",
             "contact_name": "john doe",
             "curator_name": "Jane Smith",
-            "datasets": [
+            "dataset_versions": [
                 {
                     "assay": [{"label": "test_assay_label", "ontology_term_id": "test_assay_term_id"}],
                     "assets": [
@@ -1053,8 +1053,8 @@ class TestGetCollectionVersionID(BaseAPIPortalTest):
         received_body.pop("created_at")
         self.assertIn("published_at", received_body)
         received_body.pop("published_at")
-        [self.assertIn("published_at", d) for d in received_body["datasets"]]
-        [d.pop("published_at") for d in received_body["datasets"]]
+        [self.assertIn("published_at", d) for d in received_body["dataset_versions"]]
+        [d.pop("published_at") for d in received_body["dataset_versions"]]
 
         self.assertEqual(received_body, expected_body)
 


### PR DESCRIPTION
## Reason for Change

- #5113 

## Changes

- modify response on `GET /collection_versions/{collection_version_id}` and `GET /collections/{collectIon_id}/versions` such that `.datasets[]` becomes `.dataset_versions[]`

- ## Testing steps

unit tests updated

## Notes for Reviewer
