### PR TITLE
fix: prevent duplicate assets from being returned by Discover API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ local-unit-test: local-unit-test-backend local-unit-test-wmg-backend local-unit-
 .PHONY: local-unit-test-backend
 local-unit-test-backend: 
 	docker-compose run --rm -T backend bash -c \
-	"cd /single-cell-data-portal && coverage run  $(COVERAGE_RUN_ARGS) -m pytest --alluredir=./allure-results tests/unit/backend/layers/";
+	"cd /single-cell-data-portal && coverage run  $(COVERAGE_RUN_ARGS) -m pytest --alluredir=./allure-results tests/unit/backend/layers/ tests/unit/backend/common/";
 
 .PHONY: local-unit-test-wmg-backend
 local-unit-test-wmg-backend: 
@@ -161,7 +161,7 @@ local-unit-test-wmg-backend:
 .PHONY: local-integration-test-backend
 local-integration-test-backend:
 	docker-compose run --rm -e INTEGRATION_TEST=true -e DB_URI=postgresql://corpora:test_pw@database -T backend \
-	bash -c "cd /single-cell-data-portal && coverage run $(COVERAGE_RUN_ARGS) -m pytest tests/unit/backend/layers/";
+	bash -c "cd /single-cell-data-portal && coverage run $(COVERAGE_RUN_ARGS) -m pytest tests/unit/backend/layers/ tests/unit/backend/common/";
 
 .PHONY: local-unit-test-processing
 local-unit-test-processing: # Run processing-unittest target in `processing` Docker container

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -48,7 +48,18 @@ def extract_dataset_assets(dataset_version: DatasetVersion):
             "url": url,
         }
         asset_list.append(result)
-    return asset_list
+    return _with_duplicates_removed(asset_list)  # TODO: de-dupe on DatasetArtifact insertion via unique constraint
+
+
+def _with_duplicates_removed(asset_list: List[dict]) -> List[dict]:
+    asset_types = set()
+    assets = []
+    for asset in asset_list:
+        if asset["filetype"] in asset_types:
+            continue
+        asset_types.add(asset["filetype"])
+        assets.append(asset)
+    return assets
 
 
 def extract_doi_from_links(links: List[Link]) -> Tuple[Optional[str], List[dict]]:

--- a/tests/unit/backend/common/test_common.py
+++ b/tests/unit/backend/common/test_common.py
@@ -1,0 +1,43 @@
+import pytest
+
+from backend.curation.api.v1.curation.collections.common import _with_duplicates_removed
+
+
+@pytest.fixture
+def sample_asset_list():
+    return [
+        {"filetype": "csv", "name": "data.csv"},
+        {"filetype": "json", "name": "data.json"},
+        {"filetype": "csv", "name": "data2.csv"},
+        {"filetype": "txt", "name": "data.txt"},
+        {"filetype": "json", "name": "data2.json"},
+    ]
+
+
+def test_remove_duplicate_dataset_assets(sample_asset_list):
+    expected_result = [
+        {"filetype": "csv", "name": "data.csv"},
+        {"filetype": "json", "name": "data.json"},
+        {"filetype": "txt", "name": "data.txt"},
+    ]
+    result = _with_duplicates_removed(sample_asset_list)
+    assert result == expected_result
+
+
+@pytest.fixture
+def sample_asset_list_without_duplicates():
+    return [
+        {"filetype": "csv", "name": "data.csv"},
+        {"filetype": "json", "name": "data.json"},
+        {"filetype": "txt", "name": "data.txt"},
+    ]
+
+
+def test_remove_duplicate_dataset_assets_no_duplicates(sample_asset_list_without_duplicates):
+    expected_result = [
+        {"filetype": "csv", "name": "data.csv"},
+        {"filetype": "json", "name": "data.json"},
+        {"filetype": "txt", "name": "data.txt"},
+    ]
+    result = _with_duplicates_removed(sample_asset_list_without_duplicates)
+    assert result == expected_result


### PR DESCRIPTION
This temporary fix addresses a more fundamental bug in the pipeline logic which is resulting in occasional instances of duplicate asset rows in the DatasetArtifact table.

## Reason for Change

- #5136 

## Testing steps

- unit tested

## Notes for Reviewer
