### PR TITLE
chore: update rdev seed data dump file

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -28,7 +28,7 @@ locals {
   backend_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "${local.backend_workers}",
     "--bind", "0.0.0.0:5000", "backend.api_server.app:app", "--max-requests", "10000", "--timeout", "180",
     "--keep-alive", "61", "--log-level", "info"]
-  data_load_path               = "s3://${local.secret["s3_buckets"]["env"]["name"]}/database/seed_data_2023.sql"
+  data_load_path               = "s3://${local.secret["s3_buckets"]["env"]["name"]}/database/seed_data_03_98cf7564214f.sql"
 
   vpc_id                          = local.secret["cloud_env"]["vpc_id"]
   subnets                         = local.secret["cloud_env"]["private_subnets"]


### PR DESCRIPTION
This commit updates the rdev seed data dump file to point to a migration hash-titled seed file, in this case the migration that established a `Dataset.tombstone` column.

## Reason for Change

- #5177 
- Rename the (updated) rdev db seed file to indicate the migration with which it is paired.

## Changes

- Rename the (updated) rdev db seed file in the ecs-stack module
- 
## Testing steps

- verified with rdev

## Notes for Reviewer
