### PR TITLE
chore(cell-guide): filter genes with <0.5 marker score and hide irrelevant gene dropdowns

### DIFF
--- a/frontend/src/views/CellCards/components/CellCard/components/Description/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/Description/index.tsx
@@ -91,7 +91,7 @@ export default function Description({
               arrow
               title={
                 <div>
-                  {`This summary on \"${cellTypeName}\" was generated with ChatGPT, powered by the GPT4 model. Keep in mind that ChatGPT may occasionally present information that is not entirely accurate. For transparency, the prompts used to generate this summary are shared below. CZI is currently offering this as a pilot feature and we may update or change this feature in our discretion.`}
+                  {`This summary on \"${cellTypeName}\" was generated with ChatGPT, powered by the GPT4 model. Keep in mind that ChatGPT may occasionally present information that is not entirely accurate. For transparency, the prompts used to generate this summary are shared below. CZI is currently offering this as a pilot feature and we may update or change this feature at our discretion.`}
                   <br />
                   <br />
                   <b>System role</b>

--- a/frontend/src/views/CellCards/components/CellCard/components/MarkerGeneTables/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/MarkerGeneTables/index.tsx
@@ -506,18 +506,22 @@ const MarkerGeneTables = ({ cellTypeId, setGeneInfoGene }: Props) => {
           </TableTitleInnerWrapper>
           {tableRows.length > 0 && (
             <TableTitleInnerWrapper>
-              <DropdownSelect
-                handleChange={handleChangeOrganism}
-                options={uniqueOrganisms}
-                selectedOption={selectedOrganism}
-                testId={CELL_CARD_MARKER_GENES_TABLE_DROPDOWN_ORGANISM}
-              />
-              <DropdownSelect
-                handleChange={handleChangeOrgan}
-                options={uniqueOrgans}
-                selectedOption={selectedOrgan}
-                testId={CELL_CARD_MARKER_GENES_TABLE_DROPDOWN_ORGAN}
-              />
+              {activeTable === 1 && (
+                <DropdownSelect
+                  handleChange={handleChangeOrganism}
+                  options={uniqueOrganisms}
+                  selectedOption={selectedOrganism}
+                  testId={CELL_CARD_MARKER_GENES_TABLE_DROPDOWN_ORGANISM}
+                />
+              )}
+              {activeTable === 0 && (
+                <DropdownSelect
+                  handleChange={handleChangeOrgan}
+                  options={uniqueOrgans}
+                  selectedOption={selectedOrgan}
+                  testId={CELL_CARD_MARKER_GENES_TABLE_DROPDOWN_ORGAN}
+                />
+              )}
               <Link
                 url={`${ROUTES.WHERE_IS_MY_GENE}?genes=${genesForShareUrl}&ver=2`}
                 label="Open in Gene Expression"

--- a/frontend/src/views/CellCards/components/CellCard/components/MarkerGeneTables/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/MarkerGeneTables/index.tsx
@@ -35,6 +35,7 @@ import HelpTooltip from "../common/HelpTooltip";
 import { ROUTES } from "src/common/constants/routes";
 import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
+import { FMG_GENE_STRENGTH_THRESHOLD } from "src/views/WheresMyGene/common/constants";
 
 export const CELL_CARD_MARKER_GENES_TABLE_DROPDOWN_ORGANISM =
   "cell-card-marker-genes-table-dropdown-organism";
@@ -220,6 +221,7 @@ const MarkerGeneTables = ({ cellTypeId, setGeneInfoGene }: Props) => {
       for (const markerGene of genes) {
         const { pc, me, name, symbol, organism, marker_score } = markerGene;
         if (organism !== selectedOrganism) continue;
+        if (marker_score < FMG_GENE_STRENGTH_THRESHOLD) continue;
         rows.push({
           symbolId: symbol,
           symbol: (

--- a/frontend/src/views/CellCards/components/CellCard/components/MarkerGeneTables/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/MarkerGeneTables/index.tsx
@@ -439,7 +439,7 @@ const MarkerGeneTables = ({ cellTypeId, setGeneInfoGene }: Props) => {
       <br />
       <i>
         Quardokus, Ellen, Bruce W. Herr II, Lisel Record, Katy Börner. 2022.
-        HuBMAP ASCT+B Tables. Accessed May 16, 2023.
+        HuBMAP ASCT+B Tables. Accessed July 10, 2023.
       </i>
     </div>
   );

--- a/frontend/tests/features/cellCards/cellCards.test.ts
+++ b/frontend/tests/features/cellCards/cellCards.test.ts
@@ -46,7 +46,7 @@ import {
 
 const { describe } = test;
 
-describe("Cell Cards", () => {
+describe.only("Cell Cards", () => {
   describe("Landing Page", () => {
     test("All LandingPage components are present", async ({ page }) => {
       await goToPage(`${TEST_URL}${ROUTES.CELL_CARDS}`, page);

--- a/frontend/tests/features/cellCards/cellCards.test.ts
+++ b/frontend/tests/features/cellCards/cellCards.test.ts
@@ -46,7 +46,7 @@ import {
 
 const { describe } = test;
 
-describe.only("Cell Cards", () => {
+describe("Cell Cards", () => {
   describe("Landing Page", () => {
     test("All LandingPage components are present", async ({ page }) => {
       await goToPage(`${TEST_URL}${ROUTES.CELL_CARDS}`, page);


### PR DESCRIPTION
## Reason for Change

- This applies the same filtering done for FMG in GE.
- Hide organism dropdown for canonical marker genes and tissue dropdown for computational marker genes
- change typo from "in" to "at"

## Testing
- Tested locally