### PR TITLE
fix(cell-guide): capitalize mouse genes for gene info feature

### DIFF
--- a/frontend/src/views/CellCards/components/CellCard/components/MarkerGeneTables/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/MarkerGeneTables/index.tsx
@@ -232,7 +232,7 @@ const MarkerGeneTables = ({ cellTypeId, setGeneInfoGene }: Props) => {
                 sdsIcon="infoCircle"
                 sdsSize="small"
                 sdsType="secondary"
-                onClick={() => setGeneInfoGene(symbol)}
+                onClick={() => setGeneInfoGene(symbol.toUpperCase())}
               />
             </>
           ),
@@ -366,7 +366,7 @@ const MarkerGeneTables = ({ cellTypeId, setGeneInfoGene }: Props) => {
                 sdsIcon="infoCircle"
                 sdsSize="small"
                 sdsType="secondary"
-                onClick={() => setGeneInfoGene(symbol)}
+                onClick={() => setGeneInfoGene(symbol.toUpperCase())}
               />
             </>
           ),


### PR DESCRIPTION
## Reason for Change

- Gene Info was not working for mouse genes (in computational marker gene table) as the genes are required to be fully capitalized.
- The fix was to simply capitalize the gene symbol prior to setting the gene info gene.

## Testing
 - tested locally