### PR TITLE
fix(cell-guide): fix chatgpt api link

### DIFF
--- a/frontend/src/views/CellCards/components/CellCard/components/Description/index.tsx
+++ b/frontend/src/views/CellCards/components/CellCard/components/Description/index.tsx
@@ -110,7 +110,7 @@ export default function Description({
               }
             >
               <StyledLink
-                href={"https://platform.openai.com/docs/models/gpt-3-5"}
+                href={"https://platform.openai.com/docs/models/gpt-4"}
                 target="_blank"
                 data-testid={CELL_CARD_GPT_TOOLTIP_LINK}
                 onMouseOver={() => {


### PR DESCRIPTION
## Reason for Change

- Link still pointed to GPT3.5
- Now points to GPT4

## Testing
 - tested locally