### PR TITLE
chore: decrease init buffer bytes and use return_incomplete

### DIFF
--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -16,9 +16,10 @@ module stack {
   batch_container_memory_limit = 300000
   wmg_batch_container_memory_limit = 248000
   wmg_desired_vcpus                = 128
-  backend_memory               = 8192
+  backend_memory               = 61440
   frontend_memory              = 4096
   backend_instance_count       = 6
+  backend_cpus                 = 8
 
   wait_for_steady_state        = var.wait_for_steady_state
 }

--- a/backend/wmg/data/query.py
+++ b/backend/wmg/data/query.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Union
 
+import pandas as pd
 from pandas import DataFrame
 from pydantic import BaseModel, Field
 from tiledb import Array
@@ -153,7 +154,10 @@ class WmgQuery:
 
         tiledb_dims_query = tuple(tiledb_dims_query)
 
-        query_result_df = cube.query(cond=query_cond or None, use_arrow=True).df[tiledb_dims_query]
+        query_result_df = pd.concat(
+            cube.query(cond=query_cond or None, use_arrow=True, return_incomplete=True).df[tiledb_dims_query]
+        )
+
         return query_result_df
 
     def list_primary_filter_dimension_term_ids(self, primary_dim_name: str):

--- a/backend/wmg/data/tiledb.py
+++ b/backend/wmg/data/tiledb.py
@@ -10,7 +10,7 @@ from backend.common.utils.tiledb import consolidation_buffer_size, virtual_memor
 def create_ctx(config_overrides: Optional[dict] = None) -> tiledb.Ctx:
     config_overrides = config_overrides or {}
     cfg = {
-        "py.init_buffer_bytes": int(0.5 * GB),
+        "py.init_buffer_bytes": int(0.05 * GB),
         "sm.tile_cache_size": 100 * MB if os.getenv("DEPLOYMENT_STAGE", "test") == "test" else virtual_memory_size(0.5),
         "sm.consolidation.buffer_size": consolidation_buffer_size(0.1),
         "sm.query.sparse_unordered_with_dups.non_overlapping_ranges": "true",


### PR DESCRIPTION
## Reason for Change

- #5213 
- Decreasing buffer by 10x
- Using return_incomplete=True and `pd.concat` to avoid query restarts for queries that exceed buffer size.

## Changes

- add
- remove
- modify

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Notes for Reviewer
