### PR TITLE
fix: make error message more searchable / readable

### DIFF
--- a/backend/wmg/data/validation/validation.py
+++ b/backend/wmg/data/validation/validation.py
@@ -71,9 +71,10 @@ class Validation:
         self.validate_expression_levels_for_particular_gene_dataset()
 
         if len(self.errors) > 0:
-            logger.info(f"Cube Validation Failed with {len(self.errors)} errors")
+            error_message = f"Cube Validation Failed with {len(self.errors)} errors"
             for error in self.errors:
-                logger.info(error)
+                error_message += f"\n{error}"
+            logger.error(error_message)
             return False
         return True
 


### PR DESCRIPTION
## Reason for Change

- this should now allow you to search the aws logs for "Cube Validation Failed" and find all the reasons why cube validation failed
- this also marks these as `error` level logs instead of `info` level

## Testing steps

n/a

## Notes for Reviewer
