### PR TITLE
feat: prevent deletion of published Datasets

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -407,12 +407,19 @@ class BusinessLogic(BusinessLogicInterface):
         return (new_dataset_version.version_id, new_dataset_version.dataset_id)
 
     def remove_dataset_version(
-        self, collection_version_id: CollectionVersionId, dataset_version_id: DatasetVersionId
+        self,
+        collection_version_id: CollectionVersionId,
+        dataset_version_id: DatasetVersionId,
+        delete_published: bool = False,
     ) -> None:
         """
         Removes a dataset version from an existing collection version
         """
         self._assert_collection_version_unpublished(collection_version_id)
+        if not delete_published:
+            dv = self.database_provider.get_dataset_version(dataset_version_id)
+            if dv.canonical_dataset.published_at:
+                raise CollectionUpdateException from None
         self.database_provider.delete_dataset_from_collection_version(collection_version_id, dataset_version_id)
 
     def set_dataset_metadata(self, dataset_version_id: DatasetVersionId, metadata: DatasetMetadata) -> None:

--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -94,7 +94,7 @@ class BusinessLogicInterface:
         pass
 
     def remove_dataset_version(
-        self, collection_version_id: CollectionVersionId, dataset_version_id: DatasetVersionId
+        self, collection_version_id: CollectionVersionId, dataset_version_id: DatasetVersionId, delete_published: bool
     ) -> None:
         pass
 

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1493,6 +1493,22 @@ class TestDeleteDataset(BaseAPIPortalTest):
                 response = self._delete(auth, dataset.collection_id, dataset.dataset_id)
                 self.assertEqual(expected_status_code, response.status_code)
 
+    def test__delete_published_dataset__405(self):
+        """
+        A Dataset that has been published cannot be deleted via the API
+        """
+        for auth_func in (self.make_super_curator_header, self.make_owner_header):
+            with self.subTest("Cannot delete published Dataset in a revision"):
+                collection = self.generate_published_collection()
+                revision = self.generate_revision(collection.collection_id)
+                dataset_id, dataset_version_id = revision.datasets[0].dataset_id, revision.datasets[0].version_id
+                response = self._delete(auth_func, revision.collection_id, dataset_id)
+                self.assertEqual(405, response.status_code)
+            with self.subTest("Cannot delete published Dataset in a revision even after it has been updated"):
+                self.generate_dataset(collection_version=revision, replace_dataset_version_id=dataset_version_id)
+                response = self._delete(auth_func, revision.collection_id, dataset_id)
+                self.assertEqual(405, response.status_code)
+
 
 class TestGetDatasets(BaseAPIPortalTest):
     def test_get_dataset_in_a_collection(self):

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1561,7 +1561,7 @@ class TestGetDatasets(BaseAPIPortalTest):
         response = self.app.get(test_url)
         self.assertEqual(200, response.status_code)
         revision = self.generate_revision(collection.collection_id)
-        self.business_logic.remove_dataset_version(revision.version_id, dataset.version_id)
+        self.business_logic.remove_dataset_version(revision.version_id, dataset.version_id, delete_published=True)
         self.business_logic.publish_collection_version(revision.version_id)
         new_published_version = self.database_provider.get_collection_version(revision.version_id)
         self.assertEqual(1, len(new_published_version.datasets))
@@ -2009,7 +2009,7 @@ class TestGetDatasetIdVersions(BaseAPIPortalTest):
             collection = self.generate_published_collection(add_datasets=2)
             dataset = collection.datasets[0]
             revision = self.generate_revision(collection.collection_id)
-            self.business_logic.remove_dataset_version(revision.version_id, dataset.version_id)
+            self.business_logic.remove_dataset_version(revision.version_id, dataset.version_id, delete_published=True)
             self.business_logic.publish_collection_version(revision.version_id)
             test_url = f"/curation/v1/datasets/{dataset.dataset_id}/versions"
             response = self.app.get(test_url, headers=self.make_owner_header())

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1262,7 +1262,9 @@ class TestCollectionOperations(BaseBusinessLogicTestCase):
         dataset_version_to_remove = new_version.datasets[0]
         dataset_version_to_keep = new_version.datasets[1]
 
-        self.business_logic.remove_dataset_version(new_version.version_id, dataset_version_to_remove.version_id)
+        self.business_logic.remove_dataset_version(
+            new_version.version_id, dataset_version_to_remove.version_id, delete_published=True
+        )
 
         # The new version should have only one dataset (before publishing)
         version_from_db = self.database_provider.get_collection_version(new_version.version_id)

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -880,7 +880,7 @@ class TestDeleteDataset(BaseBusinessLogicTestCase):
         with self.assertRaises(CollectionUpdateException):
             self.business_logic.remove_dataset_version(revision.version_id, revision.datasets[0].version_id)
 
-    def test_delete_published_dataset_success(self):
+    def test_delete_published_dataset_in_revision__success(self):
         collection, revision = self.initialize_collection_with_an_unpublished_revision()
         dataset_version_id_to_delete = revision.datasets[0].version_id
         self.business_logic.remove_dataset_version(

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -853,7 +853,7 @@ class TestUpdateCollectionDatasets(BaseBusinessLogicTestCase):
 
 
 class TestDeleteDataset(BaseBusinessLogicTestCase):
-    def test_delete_dataset_ok(self):
+    def test_delete_dataset_in_private_collection__ok(self):
         collection = self.initialize_unpublished_collection()
         dataset_version_id_to_remove = collection.datasets[0].version_id
         dataset_version_id_strs = [dv.version_id.id for dv in collection.datasets]

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -863,7 +863,7 @@ class TestDeleteDataset(BaseBusinessLogicTestCase):
         dataset_version_id_strs = [dv.version_id.id for dv in updated_collection.datasets]
         self.assertNotIn(dataset_version_id_to_remove.id, dataset_version_id_strs)
 
-    def test_delete_new_dataset_in_revision_ok(self):
+    def test_delete_new_dataset_in_revision__ok(self):
         collection, revision = self.initialize_collection_with_an_unpublished_revision()
         new_dataset_version_id, _ = self.business_logic.create_empty_dataset(revision.version_id)
         revision = self.business_logic.get_collection_version(revision.version_id)
@@ -875,7 +875,7 @@ class TestDeleteDataset(BaseBusinessLogicTestCase):
         # Dataset is removed
         self.assertEqual(len(collection.datasets), len(revision.datasets))
 
-    def test_delete_published_dataset_fail(self):
+    def test_delete_published_dataset__fail(self):
         collection, revision = self.initialize_collection_with_an_unpublished_revision()
         with self.assertRaises(CollectionUpdateException):
             self.business_logic.remove_dataset_version(revision.version_id, revision.datasets[0].version_id)


### PR DESCRIPTION
## Reason for Change

- #3039 

## Changes

- modify `BusinessLogic.remove_dataset_version` to accept a `delete_published` boolean parameter, which defaults to `False`
- prevent a published Dataset from being tombstoned unless `delete_published` is `True`.
- Add business tests per @Bento007 's request

## Testing steps

- unit tested

## Notes for Reviewer

- Parameter approach preferred by eng team to previous implementation with env var - #5226 