### PR TITLE
fix: update requirements for db/remote_migration_init

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -5,7 +5,7 @@ db/migrate:
 .PHONY: db/remote_migration_init
 db/remote_migration_init:
 	# Run utility installation before invoking these commands.
-	pip install awscli -r ../requirements-base.txt
+	pip install awscli -r ../requirements-backend.txt
 	apt-get update && apt-get install -y postgresql-client jq
 
 .PHONY: db/init_remote_dev


### PR DESCRIPTION
fixes
```
[1689971749803][fargate/db/3c25]  =====
[1689971749803][fargate/db/3c25] | starting backend container
[1689971749803][fargate/db/3c25]  =====
[1689971749804][fargate/db/3c25] make: Entering directory '/single-cell-data-portal/backend'
[1689971749806][fargate/db/3c25] /bin/sh: 1: aws: not found
[1689971749838][fargate/db/3c25] # Run utility installation before invoking these commands.
[1689971749839][fargate/db/3c25] pip install awscli -r ../requirements-base.txt
[1689971750244][fargate/db/3c25] ERROR: Could not open requirements file: [Errno 2] No such file or directory: '../requirements-base.txt'
[1689971750303][fargate/db/3c25] make: *** [Makefile:8: db/remote_migration_init] Error 1
[1689971750303][fargate/db/3c25] make: Leaving directory '/single-cell-data-portal/backend'
```

when deploying rdev