### PR TITLE
chore: Pin python package versions for wmg pipeline

### DIFF
--- a/requirements-wmg-pipeline.txt
+++ b/requirements-wmg-pipeline.txt
@@ -1,14 +1,14 @@
-alembic>=1.9, <2
+alembic==1.11.1
 anndata==0.8.0
-allure-pytest<3
+allure-pytest==2.13.2
 black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
-boto3>=1.11.17
-botocore>=1.14.17
+boto3==1.28.7
+botocore>=1.31.7, <1.32.0
 click==8.1.3
-coverage>=6.5.0
+coverage==7.2.7
 dataclasses-json==0.5.7
-furl
-jsonschema
+furl==2.1.3
+jsonschema==4.18.4
 moto==3.1.3
 numba==0.56.2
 numpy==1.23.5
@@ -21,16 +21,16 @@ pyarrow==12.0.0
 pydantic==1.10.7
 pygraphviz==1.11
 PyMySQL==0.9.3
-pytest
-pytest-subtests
-python-json-logger
+pytest==7.4.0
+pytest-subtests==0.11.0
+python-json-logger==2.0.7
 requests>=2.22.0
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
 ruff==0.0.239 # Must be kept in sync with ruff version in .pre-commit-config.yaml
 s3fs==0.4.2
 scanpy==1.9.3
 scipy==1.10.1
-SQLAlchemy>=1.4.0,<1.5
-SQLAlchemy-Utils>=0.36.8
-tenacity
+SQLAlchemy==1.4.49
+SQLAlchemy-Utils==0.41.1
+tenacity==8.2.2
 tiledb==0.21.4  # Portal's tiledb version should always be the same or older than Explorer's


### PR DESCRIPTION
## Reason for Change

- #5075 

## Changes

- modify `requirements-wmg-pipeline.txt` such that package versions are pinned

## Testing steps

- Ensure all unit tests pass locally

## Notes for Reviewer

- `botocore` is not _pinned_ but its version is constrained based on the fact that it is a dependency of `boto3` (which is pinned) and `pipdeptree -packages boto3` requires `botocore` to be within a version range:

```
% pipdeptree --packages boto3    
         
boto3==1.28.7
├── botocore [required: >=1.31.7,<1.32.0, installed: 1.31.7]
│   ├── jmespath [required: >=0.7.1,<2.0.0, installed: 1.0.1]
│   ├── python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.2]
│   │   └── six [required: >=1.5, installed: 1.16.0]
│   └── urllib3 [required: >=1.25.4,<1.27, installed: 1.26.16]
├── jmespath [required: >=0.7.1,<2.0.0, installed: 1.0.1]
└── s3transfer [required: >=0.6.0,<0.7.0, installed: 0.6.1]
    └── botocore [required: >=1.12.36,<2.0a.0, installed: 1.31.7]
        ├── jmespath [required: >=0.7.1,<2.0.0, installed: 1.0.1]
        ├── python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.2]
        │   └── six [required: >=1.5, installed: 1.16.0]
        └── urllib3 [required: >=1.25.4,<1.27, installed: 1.26.16]
```

- `rsa` is not pinned and not required because we rely on `Snyk` to do the pinning
