### PR TITLE
feat: update cube builder to only fetch datasets from pinned CxG schema version

### DIFF
--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -16,7 +16,7 @@ from backend.wmg.data.schemas.corpus_schema import (
     FILTER_RELATIONSHIPS_NAME,
 )
 from backend.wmg.data.tiledb import create_ctx
-from backend.wmg.data.utils import get_collections_from_curation_api, get_datasets_from_curation_api
+from backend.wmg.data.utils import get_datasets_from_curation_api
 
 # Snapshot data artifact file/dir names
 CELL_TYPE_ORDERINGS_FILENAME = "cell_type_orderings.json"
@@ -82,8 +82,6 @@ class WmgSnapshot:
 
     def build_dataset_metadata_dict(self):
         datasets = get_datasets_from_curation_api()
-        collections = get_collections_from_curation_api()
-        collections_dict = {collection["collection_id"]: collection for collection in collections}
         dataset_dict = {}
         for dataset in datasets:
             dataset_id = dataset["dataset_id"]
@@ -91,7 +89,7 @@ class WmgSnapshot:
                 id=dataset_id,
                 label=dataset["title"],
                 collection_id=dataset["collection_id"],
-                collection_label=collections_dict[dataset["collection_id"]]["name"],
+                collection_label=dataset["collection_name"],
             )
         self.dataset_dict = dataset_dict
 

--- a/backend/wmg/data/utils.py
+++ b/backend/wmg/data/utils.py
@@ -160,7 +160,7 @@ def get_datasets_from_curation_api():
         if os.environ.get("DEPLOYMENT_STAGE") in ["test", "rdev"]
         else os.getenv("API_URL")
     )
-    PINNED_SCHEMA_VERSION = "3"
+    PINNED_SCHEMA_VERSION = "3.0.0"
 
     datasets = {}
     if API_URL:

--- a/backend/wmg/data/utils.py
+++ b/backend/wmg/data/utils.py
@@ -160,11 +160,12 @@ def get_datasets_from_curation_api():
         if os.environ.get("DEPLOYMENT_STAGE") in ["test", "rdev"]
         else os.getenv("API_URL")
     )
+    PINNED_SCHEMA_VERSION = "3"
 
     datasets = {}
     if API_URL:
         session = _setup_retry_session()
-        dataset_metadata_url = f"{API_URL}/curation/v1/datasets"
+        dataset_metadata_url = f"{API_URL}/curation/v1/datasets?schema_version={PINNED_SCHEMA_VERSION}"
         response = session.get(dataset_metadata_url)
         if response.status_code == 200:
             datasets = response.json()


### PR DESCRIPTION
## Reason for Change

- #4928

## Changes

- cube builder only fetches the latest published dataset version with pinned major schema version 3 (i.e. 3.X.X) for each canonical dataset
- update build_dataset_metadata_dict function to only make 1 API call (all necessary data is in datasets endpoint)

## Testing steps
- dev cube run

## Notes for Reviewer
