### PR TITLE
test: Skip failing WMG V1 functional tests

### DIFF
--- a/tests/functional/backend/wmg/test_wmg_api.py
+++ b/tests/functional/backend/wmg/test_wmg_api.py
@@ -1,4 +1,5 @@
 import json
+import unittest
 
 import requests
 
@@ -57,6 +58,7 @@ class TestWmgApi(BaseFunctionalTestCase):
         self.assertStatusCode(requests.codes.ok, res)
         self.assertGreater(len(res.content), 10)
 
+    @unittest.skip("Skipping Failing WMG V1 Functional Test. WMG V1 API is deprecated")
     def test_filter_endpoint_common_case(self):
         """
         /v1/filters should support the common case /v1/queries supports
@@ -69,6 +71,7 @@ class TestWmgApi(BaseFunctionalTestCase):
         self.assertStatusCode(requests.codes.ok, res)
         self.assertGreater(len(res.content), 10)
 
+    @unittest.skip("Skipping Failing WMG V1 Functional Test. WMG V1 API is deprecated")
     def test_filter_endpoint_extreme_case(self):
         """
         /v1/filters should support the extreme case /v1/queries supports


### PR DESCRIPTION


## Reason for Change

- A couple of `v1/wmg/api` functional tests are being skipped because the V1 API is deprecated and adds no value. A future PR will clean up the dead code and modify functional tests that target `v2/wmg/api`

## Changes

- add a `@unittest.skip` decorator to the functional tests that should be skipped

## Testing steps

Ran the functional tests _locally_ and check that the appropriate tests are _skipped_ :

```
% AWS_PROFILE=single-cell-dev DEPLOYMENT_STAGE=dev pytest -v tests/functional/backend/wmg/test_wmg_api.py
```

```
================================================================================================================ test session starts ================================================================================================================
platform darwin -- Python 3.10.12, pytest-7.4.0, pluggy-1.2.0 -- /Users/psridharan/miniconda3/envs/test-requirements-reorg/bin/python
cachedir: .pytest_cache
rootdir: /Users/psridharan/code/single-cell-data-portal
plugins: subtests-0.11.0, allure-pytest-2.13.2
collected 8 items                                                                                                                                                                                                                                   

tests/functional/backend/wmg/test_wmg_api.py::TestWmgApi::test_filter_endpoint_common_case SKIPPED (Skipping Failing WMG V1 Functional Test. WMG V1 API is deprecated)                                                                        [ 12%]
tests/functional/backend/wmg/test_wmg_api.py::TestWmgApi::test_filter_endpoint_extreme_case SKIPPED (Skipping Failing WMG V1 Functional Test. WMG V1 API is deprecated)                                                                       [ 25%]
tests/functional/backend/wmg/test_wmg_api.py::TestWmgApi::test_filter_endpoint_supports_ontology_term_ids PASSED                                                                                                                              [ 37%]
tests/functional/backend/wmg/test_wmg_api.py::TestWmgApi::test_markers_happy_path PASSED                                                                                                                                                      [ 50%]
tests/functional/backend/wmg/test_wmg_api.py::TestWmgApi::test_markers_missing_tissue PASSED                                                                                                                                                  [ 62%]
tests/functional/backend/wmg/test_wmg_api.py::TestWmgApi::test_primary_filters PASSED                                                                                                                                                         [ 75%]
tests/functional/backend/wmg/test_wmg_api.py::TestWmgApi::test_query_endpoint_common_case PASSED                                                                                                                                              [ 87%]
tests/functional/backend/wmg/test_wmg_api.py::TestWmgApi::test_query_endpoint_extreme_case PASSED                                                                                                                                             [100%]

=========================================================================================================== 6 passed, 2 skipped in 30.32s ==========================================================================================================
```



## Notes for Reviewer
