### PR TITLE
fix(cellguide): disable full screen when cell type id changes

### DIFF
--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -267,6 +267,7 @@ export default function OntologyDagView({
     return () => {
       setCenteredNodeCoords(false);
       setInitialTransformMatrix(initialTransformMatrixDefault);
+      disableFullScreen();
       hideTooltip();
     };
   }, [cellTypeId, tissueId]);


### PR DESCRIPTION
## Reason for Change

- #5325 

## Changes

- added `disableFullScreen()` to the cleanup hook in the ontology component.

## Testing steps

- Tested locally

## Demo

https://github.com/chanzuckerberg/single-cell-data-portal/assets/16548075/14333085-f2ee-4858-b54d-9639e9eccb0f
