### PR TITLE
test: fix login invalid URL error

### DIFF
--- a/frontend/tests/utils/helpers.ts
+++ b/frontend/tests/utils/helpers.ts
@@ -24,14 +24,14 @@ const DEPLOYED_TEST_USERNAME = "user@example.com";
 let endpoint;
 
 try {
-  endpoint = new URL(process.env["BOTO_ENDPOINT_URL"] as string);
+  endpoint = String(new URL(process.env["BOTO_ENDPOINT_URL"] as string));
 } catch (e) {
   console.log("BOTO_ENDPOINT_URL not assigned, assuming running on deployment");
-  endpoint = "";
 }
 
 const client = new SecretsManagerClient({
-  endpoint: String(endpoint),
+  // (thuang): Do NOT pass empty string to `endpoint` or it will throw `TypeError: Invalid URL`
+  endpoint,
 });
 
 const deployment_stage = process.env.DEPLOYMENT_STAGE || "test";


### PR DESCRIPTION
We're now getting `Invalid URL TypeError` when trying to login, turned out that when I upgraded FE packages last week, a minor version upgrade for `@aws-sdk/client-secrets-manager` actually was a breaking change that it no longer accepts empty string 😮‍💨 

https://github.com/chanzuckerberg/single-cell-data-portal/pull/5222

<img width="438" alt="Screenshot 2023-07-26 at 4 18 36 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/42786737-a07f-4185-8225-5324af1a0bc3">
