### PR TITLE
fix: pull latest schema-migration batch job definition in sfn

### DIFF
--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -1,10 +1,11 @@
-locals {
-  name = "schema-migration"
-}
-
 data aws_region current {}
 
 data aws_caller_identity current {}
+
+locals {
+  name = "schema-migration"
+  job_definition_arn = "arn:aws:batch:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:job-definition/dp-${var.deployment_stage}-${var.custom_stack_name}-schema-migration"
+}
 
 resource aws_cloudwatch_log_group batch_cloud_watch_logs_group {
   retention_in_days = 365
@@ -116,7 +117,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
       "Type": "Task",
       "Resource": "arn:aws:states:::batch:submitJob.sync",
       "Parameters": {
-        "JobDefinition": "${resource.aws_batch_job_definition.schema_migrations.arn}",
+        "JobDefinition": "${local.job_definition_arn}",
         "JobName": "gather_collections",
         "JobQueue": "${var.job_queue_arn}",
         "Timeout": {
@@ -176,7 +177,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
             "Type": "Task",
             "Resource": "arn:aws:states:::batch:submitJob.sync",
             "Parameters": {
-              "JobDefinition": "${resource.aws_batch_job_definition.schema_migrations.arn}",
+              "JobDefinition": "${local.job_definition_arn}",
               "JobName": "collection_migration",
               "JobQueue": "${var.job_queue_arn}",
               "Timeout": {
@@ -241,7 +242,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
             "Type": "Task",
             "Resource": "arn:aws:states:::batch:submitJob.sync",
             "Parameters": {
-            "JobDefinition": "${resource.aws_batch_job_definition.schema_migrations.arn}",
+            "JobDefinition": "${local.job_definition_arn}",
             "JobName": "Collection_publish",
             "JobQueue": "${var.job_queue_arn}",
               "Timeout": {
@@ -299,7 +300,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                   "Type": "Task",
                   "Resource": "arn:aws:states:::batch:submitJob.sync",
                   "Parameters": {
-                    "JobDefinition": "${resource.aws_batch_job_definition.schema_migrations_swap.arn}",
+                    "JobDefinition": "${local.job_definition_arn}",
                     "JobName": "dataset_migration",
                     "JobQueue": "${var.job_queue_arn}",
                     "Timeout": {
@@ -422,7 +423,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
       "Type": "Task",
       "Resource": "arn:aws:states:::batch:submitJob.sync",
       "Parameters": {
-        "JobDefinition": "${resource.aws_batch_job_definition.schema_migrations.arn}",
+        "JobDefinition": "${local.job_definition_arn}",
         "JobName": "report",
         "JobQueue": "${var.job_queue_arn}",
         "Timeout": {

--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -5,6 +5,7 @@ data aws_caller_identity current {}
 locals {
   name = "schema-migration"
   job_definition_arn = "arn:aws:batch:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:job-definition/dp-${var.deployment_stage}-${var.custom_stack_name}-schema-migration"
+  swap_job_definition_arn = "${local.job_definition_arn}-swap"
 }
 
 resource aws_cloudwatch_log_group batch_cloud_watch_logs_group {
@@ -300,7 +301,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                   "Type": "Task",
                   "Resource": "arn:aws:states:::batch:submitJob.sync",
                   "Parameters": {
-                    "JobDefinition": "${local.job_definition_arn}",
+                    "JobDefinition": "${local.swap_job_definition_arn}",
                     "JobName": "dataset_migration",
                     "JobQueue": "${var.job_queue_arn}",
                     "Timeout": {


### PR DESCRIPTION
## Reason for Change

- Previously, we were using an Job Definition ARN for schema-migration that pinned to a particular version. This would cause the step function to start failing during runs if a new version was deployed mid-run (as the pinned version would get marked as inactive). We should use the same model the [upload sfn uses](https://github.com/chanzuckerberg/single-cell-data-portal/blob/main/.happy/terraform/modules/batch/outputs.tf#L6), which is pulling the latest job definition at run-time so that the sfn will persist across deployments, which always trigger new job definitions. 

## Changes

- define job definition arn without the revision number as a local var in schema_migration sfn definition file
- replace in sfn definition 

## Testing steps

- [In-progress] Created an rdev and validated a schema migration works, even after a happy update while running

## Notes for Reviewer
