### PR TITLE
refactor: Remove unused code path

### DIFF
--- a/backend/wmg/config.py
+++ b/backend/wmg/config.py
@@ -9,5 +9,5 @@ class WmgConfig(SecretConfig):
 
     def get_defaults_template(self):
         deployment_stage = os.getenv("DEPLOYMENT_STAGE", "test")
-        defaults_template = {"bucket": f"wmg-{deployment_stage}", "data_path_prefix": "", "tiledb_config_overrides": {}}
+        defaults_template = {"bucket": f"wmg-{deployment_stage}", "tiledb_config_overrides": {}}
         return defaults_template

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -190,14 +190,11 @@ def _update_latest_snapshot_identifier() -> Optional[str]:
 
 
 def _build_data_path_prefix():
-    wmg_config = WmgConfig()
     rdev_prefix = os.environ.get("REMOTE_DEV_PREFIX")
     if rdev_prefix:
         return rdev_prefix.strip("/")
-    elif "data_path_prefix" in wmg_config.config:
-        return wmg_config.data_path_prefix
-    else:
-        return ""
+
+    return ""
 
 
 def _build_snapshot_base_uri(snapshot_identifier: str):


### PR DESCRIPTION
## Reason for Change

- #5353 

## Changes

- Remove an unused code branch in the function that constructs an s3 path prefix of the full path to wmg snapshot.

## Testing steps

- Ensure unit tests for `wmg` API and pipeline pass locally
- Test that the application still works by loading the snapshot in an `rdev` environment
  - https://ps-issue-5353-rdev-frontend.rdev.single-cell.czi.technology/
  - https://ps-issue-5353-rdev-backend.rdev.single-cell.czi.technology/
  
  response from `/query` API in `rdev` has the correct `snapshot_id`:

```
{
  "expression_summary": {},
  "snapshot_id": "1689721444",
  "term_id_labels": {
    "cell_types": {
      "CL:0000082 (cell culture)": {
        "CL:0000010": {
          "aggregated": {
            "cell_type_ontology_term_id": "CL:0000010",
            "name": "cultured cell",
            "order": 0,
            "total_count": 130626
          }
        },
        "tissue_stats": {
          "aggregated": {
            "name": "epithelial cell of lung (cell culture)",
            "order": -1,
            "tissue_ontology_term_id": "CL:0000082 (cell culture)",
            "total_count": 130626
          }
        }
      },
```

## Notes for Reviewer
