### PR TITLE
refactor: Change snapshot loading interface

### DIFF
--- a/backend/wmg/api/__init__.py
+++ b/backend/wmg/api/__init__.py
@@ -1,17 +1,1 @@
-# When the API is set to read a particular
-# snapshot schema version, it will load the
-# latest snapshot for the schema version by
-# default.
-#
-# In the case a specfic snapshot must be loaded
-# WMG_API_FORCE_LOAD_SNAPSHOT_ID should be set.
-WMG_API_SNAPSHOT_SCHEMA_VERSION = "v1"
 
-# In the case we need to rollback or rollforward
-# set this variable to a specific snapshot id
-# that should be loaded.
-#
-# NOTE: The snapshot id that should be force
-# loaded must belong to the schema version set
-# in WMG_API_SNAPSHOT_SCHEMA_VERSION
-WMG_API_FORCE_LOAD_SNAPSHOT_ID = None

--- a/backend/wmg/api/__init__.py
+++ b/backend/wmg/api/__init__.py
@@ -1,0 +1,17 @@
+# When the API is set to read a particular
+# snapshot schema version, it will load the
+# latest snapshot for the schema version by
+# default.
+#
+# In the case a specfic snapshot must be loaded
+# WMG_API_FORCE_LOAD_SNAPSHOT_ID should be set.
+WMG_API_SNAPSHOT_SCHEMA_VERSION = "v1"
+
+# In the case we need to rollback or rollforward
+# set this variable to a specific snapshot id
+# that should be loaded.
+#
+# NOTE: The snapshot id that should be force
+# loaded must belong to the schema version set
+# in WMG_API_SNAPSHOT_SCHEMA_VERSION
+WMG_API_FORCE_LOAD_SNAPSHOT_ID = None

--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -6,6 +6,7 @@ from flask import jsonify
 from pandas import DataFrame
 from server_timing import Timing as ServerTiming
 
+from backend.wmg.api import WMG_API_FORCE_LOAD_SNAPSHOT_ID, WMG_API_SNAPSHOT_SCHEMA_VERSION
 from backend.wmg.api.common.expression_dotplot import get_dot_plot_data
 from backend.wmg.api.common.rollup import rollup
 from backend.wmg.data.ontology_labels import gene_term_label, ontology_term_label
@@ -26,7 +27,11 @@ from backend.wmg.data.utils import depluralize, find_all_dim_option_values, find
 
 
 def primary_filter_dimensions():
-    snapshot: WmgSnapshot = load_snapshot()
+    snapshot: WmgSnapshot = load_snapshot(
+        snapshot_schema_version=WMG_API_SNAPSHOT_SCHEMA_VERSION,
+        specific_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
+    )
+
     return jsonify(snapshot.primary_filter_dimensions)
 
 
@@ -41,7 +46,11 @@ def query():
     criteria = WmgQueryCriteriaV2(**request["filter"])
 
     with ServerTiming.time("query and build response"):
-        snapshot: WmgSnapshot = load_snapshot()
+        snapshot: WmgSnapshot = load_snapshot(
+            snapshot_schema_version=WMG_API_SNAPSHOT_SCHEMA_VERSION,
+            specific_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
+        )
+
         q = WmgQuery(snapshot)
         default = snapshot.expression_summary_default_cube is not None and compare is None
         for dim in criteria.dict():
@@ -89,7 +98,11 @@ def filters():
     criteria = WmgFiltersQueryCriteria(**request["filter"])
 
     with ServerTiming.time("calculate filters and build response"):
-        snapshot: WmgSnapshot = load_snapshot()
+        snapshot: WmgSnapshot = load_snapshot(
+            snapshot_schema_version=WMG_API_SNAPSHOT_SCHEMA_VERSION,
+            specific_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
+        )
+
         response_filter_dims_values = build_filter_dims_values(criteria, snapshot)
         response = jsonify(
             dict(
@@ -107,7 +120,10 @@ def markers():
     organism = request["organism"]
     n_markers = request["n_markers"]
     test = request["test"]
-    snapshot: WmgSnapshot = load_snapshot()
+    snapshot: WmgSnapshot = load_snapshot(
+        snapshot_schema_version=WMG_API_SNAPSHOT_SCHEMA_VERSION,
+        specific_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
+    )
 
     criteria = MarkerGeneQueryCriteria(
         tissue_ontology_term_id=tissue,

--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -6,9 +6,9 @@ from flask import jsonify
 from pandas import DataFrame
 from server_timing import Timing as ServerTiming
 
-from backend.wmg.api import WMG_API_FORCE_LOAD_SNAPSHOT_ID, WMG_API_SNAPSHOT_SCHEMA_VERSION
 from backend.wmg.api.common.expression_dotplot import get_dot_plot_data
 from backend.wmg.api.common.rollup import rollup
+from backend.wmg.api.wmg_api_config import WMG_API_FORCE_LOAD_SNAPSHOT_ID, WMG_API_SNAPSHOT_SCHEMA_VERSION
 from backend.wmg.data.ontology_labels import gene_term_label, ontology_term_label
 from backend.wmg.data.query import (
     MarkerGeneQueryCriteria,

--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -29,7 +29,7 @@ from backend.wmg.data.utils import depluralize, find_all_dim_option_values, find
 def primary_filter_dimensions():
     snapshot: WmgSnapshot = load_snapshot(
         snapshot_schema_version=WMG_API_SNAPSHOT_SCHEMA_VERSION,
-        specific_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
+        explicit_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
     )
 
     return jsonify(snapshot.primary_filter_dimensions)
@@ -48,7 +48,7 @@ def query():
     with ServerTiming.time("query and build response"):
         snapshot: WmgSnapshot = load_snapshot(
             snapshot_schema_version=WMG_API_SNAPSHOT_SCHEMA_VERSION,
-            specific_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
+            explicit_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
         )
 
         q = WmgQuery(snapshot)
@@ -100,7 +100,7 @@ def filters():
     with ServerTiming.time("calculate filters and build response"):
         snapshot: WmgSnapshot = load_snapshot(
             snapshot_schema_version=WMG_API_SNAPSHOT_SCHEMA_VERSION,
-            specific_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
+            explicit_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
         )
 
         response_filter_dims_values = build_filter_dims_values(criteria, snapshot)
@@ -122,7 +122,7 @@ def markers():
     test = request["test"]
     snapshot: WmgSnapshot = load_snapshot(
         snapshot_schema_version=WMG_API_SNAPSHOT_SCHEMA_VERSION,
-        specific_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
+        explicit_snapshot_id_to_load=WMG_API_FORCE_LOAD_SNAPSHOT_ID,
     )
 
     criteria = MarkerGeneQueryCriteria(

--- a/backend/wmg/api/wmg_api_config.py
+++ b/backend/wmg/api/wmg_api_config.py
@@ -1,0 +1,17 @@
+# When the API is set to read a particular
+# snapshot schema version, it will load the
+# latest snapshot for the schema version by
+# default.
+#
+# In the case a specfic snapshot must be loaded
+# WMG_API_FORCE_LOAD_SNAPSHOT_ID should be set.
+WMG_API_SNAPSHOT_SCHEMA_VERSION = "v1"
+
+# In the case we need to rollback or rollforward
+# set this variable to a specific snapshot id
+# that should be loaded.
+#
+# NOTE: The snapshot id that should be force
+# loaded must belong to the schema version set
+# in WMG_API_SNAPSHOT_SCHEMA_VERSION
+WMG_API_FORCE_LOAD_SNAPSHOT_ID = None

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -29,7 +29,14 @@ MARKER_GENES_CUBE_NAME = "marker_genes"
 DATASET_TO_GENE_IDS_FILENAME = f"{DATASET_TO_GENE_IDS_NAME}.json"
 FILTER_RELATIONSHIPS_FILENAME = f"{FILTER_RELATIONSHIPS_NAME}.json"
 
+STACK_NAME = os.environ.get("REMOTE_DEV_PREFIX")
+
+# root directory under which the data artifact exists
+WMG_ROOT_DIR_PATH = STACK_NAME.strip("/") if STACK_NAME else ""
+
 logger = logging.getLogger("wmg")
+
+###################################### PUBLIC INTERFACE #################################
 
 
 @dataclass
@@ -98,33 +105,94 @@ class WmgSnapshot:
 cached_snapshot: Optional[WmgSnapshot] = None
 
 
-def load_snapshot() -> WmgSnapshot:
+def load_snapshot(*, snapshot_schema_version: str, specific_snapshot_id_to_load: Optional[str] = None) -> WmgSnapshot:
     """
-    Loads and caches the WMG snapshot. Reloads the snapshot data if the latest_snapshot_identifier S3 object has
-    been updated.
-    @return: WmgSnapshot object
+    Loads and caches the snapshot identified by the snapshot schema version and a snapshot id.
+
+    By default, this functions loads the latest snapshot id for a given schema version.
+    If a specific snapshot id is given, it will load that snapshot id. Note, that if a specific
+    snapshot id is given, it should be associated with the given schema version.
+
+    The snapshot representation is cached in memory. Therefore, multiple calls to this function
+    will not simply return the cached snapshot if there isn't a newer snapshot id.
     """
     global cached_snapshot
-    if new_snapshot_identifier := _update_latest_snapshot_identifier():
-        cached_snapshot = _load_snapshot(new_snapshot_identifier)
+
+    should_reload, snapshot_id = _should_reload_snapshot(snapshot_schema_version, specific_snapshot_id_to_load)
+
+    if should_reload:
+        cached_snapshot = _load_snapshot(snapshot_schema_version, snapshot_id)
         cached_snapshot.build_dataset_metadata_dict()
+
     return cached_snapshot
 
 
-def _load_snapshot(new_snapshot_identifier) -> WmgSnapshot:
-    cell_type_orderings = _load_cell_type_order(new_snapshot_identifier)
-    primary_filter_dimensions = _load_primary_filter_data(new_snapshot_identifier)
-    dataset_to_gene_ids = _load_dataset_to_gene_ids_data(new_snapshot_identifier)
-    filter_relationships = _load_filter_graph_data(new_snapshot_identifier)
+###################################### PRIVATE INTERFACE #################################
+def _get_latest_snapshot_id(snapshot_schema_version: str) -> str:
+    """
+    Get latest snapshot id for a given snapshot schema version
+    """
+    data_schema_dir_path = _get_wmg_snapshot_schema_dir_path(snapshot_schema_version)
+    file_name = "latest_snapshot_identifier"
 
-    snapshot_base_uri = _build_snapshot_base_uri(new_snapshot_identifier)
+    key_path = f"{data_schema_dir_path}/{file_name}" if data_schema_dir_path else file_name
+
+    latest_snapshot_id = _read_value_at_s3_key(key_path)
+    return latest_snapshot_id
+
+
+def _get_wmg_snapshot_schema_dir_path(snapshot_schema_version: str) -> str:
+    """
+    Get path to a particular snapshot schema version.
+    """
+    data_schema_dir_path = f"snapshots/{snapshot_schema_version}"
+
+    if WMG_ROOT_DIR_PATH:
+        data_schema_dir_path = f"{WMG_ROOT_DIR_PATH}/{data_schema_dir_path}"
+
+    # TODO(prathap) - change to using data_schema_dir_path by uncommenting the below 'return' statement
+    # when working on: https://github.com/chanzuckerberg/single-cell-data-portal/issues/5166
+    # return data_schema_dir_path
+
+    return WMG_ROOT_DIR_PATH
+
+
+def _get_wmg_snapshot_dir_path(snapshot_schema_version: str, snapshot_id: str) -> str:
+    """
+    Get path to the snapshot id directory for a the given snapshot schema version.
+    """
+    data_schema_dir_path = _get_wmg_snapshot_schema_dir_path(snapshot_schema_version)
+
+    snapshot_id_dir_path = f"{data_schema_dir_path}/{snapshot_id}" if data_schema_dir_path else snapshot_id
+    return snapshot_id_dir_path
+
+
+def _get_wmg_snapshot_dir_s3_uri(snapshot_dir_path: str) -> str:
+    """
+    Get the s3 uri of the snapshot directory
+    """
+    wmg_config = WmgConfig()
+
+    return os.path.join("s3://", wmg_config.bucket, snapshot_dir_path)
+
+
+def _load_snapshot(snapshot_schema_version: str, snapshot_id: str) -> WmgSnapshot:
+
+    snapshot_dir_path = _get_wmg_snapshot_dir_path(snapshot_schema_version, snapshot_id)
+
+    cell_type_orderings = _load_cell_type_order(snapshot_dir_path)
+    primary_filter_dimensions = _load_primary_filter_data(snapshot_dir_path)
+    dataset_to_gene_ids = _load_dataset_to_gene_ids_data(snapshot_dir_path)
+    filter_relationships = _load_filter_graph_data(snapshot_dir_path)
+
+    snapshot_base_uri = _get_wmg_snapshot_dir_s3_uri(snapshot_dir_path)
     logger.info(f"Loading WMG snapshot at {snapshot_base_uri}")
 
     # TODO: Okay to keep TileDB arrays open indefinitely? Is it faster than re-opening each request?
     #  https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell
     #  -data-portal/2134
     return WmgSnapshot(
-        snapshot_identifier=new_snapshot_identifier,
+        snapshot_identifier=snapshot_id,
         expression_summary_cube=_open_cube(f"{snapshot_base_uri}/{EXPRESSION_SUMMARY_CUBE_NAME}"),
         expression_summary_default_cube=_open_cube(f"{snapshot_base_uri}/{EXPRESSION_SUMMARY_DEFAULT_CUBE_NAME}"),
         expression_summary_fmg_cube=_open_cube(f"{snapshot_base_uri}/{EXPRESSION_SUMMARY_FMG_CUBE_NAME}"),
@@ -141,71 +209,64 @@ def _open_cube(cube_uri) -> Array:
     return tiledb.open(cube_uri, ctx=create_ctx(json.loads(WmgConfig().tiledb_config_overrides)))
 
 
-def _load_cell_type_order(snapshot_identifier: str) -> DataFrame:
-    return pd.read_json(_read_s3obj(f"{snapshot_identifier}/{CELL_TYPE_ORDERINGS_FILENAME}"))
+def _load_cell_type_order(snapshot_dir_path: str) -> DataFrame:
+    key_path = f"{snapshot_dir_path}/{CELL_TYPE_ORDERINGS_FILENAME}"
+    return pd.read_json(_read_value_at_s3_key(key_path))
 
 
-def _load_primary_filter_data(snapshot_identifier: str) -> Dict:
-    return json.loads(_read_s3obj(f"{snapshot_identifier}/{PRIMARY_FILTER_DIMENSIONS_FILENAME}"))
+def _load_primary_filter_data(snapshot_dir_path: str) -> Dict:
+    key_path = f"{snapshot_dir_path}/{PRIMARY_FILTER_DIMENSIONS_FILENAME}"
+    return json.loads(_read_value_at_s3_key(key_path))
 
 
-def _load_dataset_to_gene_ids_data(snapshot_identifier: str) -> Dict:
-    return json.loads(_read_s3obj(f"{snapshot_identifier}/{DATASET_TO_GENE_IDS_FILENAME}"))
+def _load_dataset_to_gene_ids_data(snapshot_dir_path: str) -> Dict:
+    key_path = f"{snapshot_dir_path}/{DATASET_TO_GENE_IDS_FILENAME}"
+    return json.loads(_read_value_at_s3_key(key_path))
 
 
-def _load_filter_graph_data(snapshot_identifier: str) -> str:
+def _load_filter_graph_data(snapshot_dir_path: str) -> str:
     try:
-        return json.loads(_read_s3obj(f"{snapshot_identifier}/{FILTER_RELATIONSHIPS_FILENAME}"))
+        key_path = f"{snapshot_dir_path}/{FILTER_RELATIONSHIPS_FILENAME}"
+        return json.loads(_read_value_at_s3_key(key_path))
     except Exception:
+        logger.warning(
+            f"{_get_wmg_snapshot_dir_s3_uri(snapshot_dir_path)}/{FILTER_RELATIONSHIPS_FILENAME} could not be loaded"
+        )
         return None
 
 
-def _read_s3obj(relative_path: str) -> str:
+def _read_value_at_s3_key(key_path: str):
+    """
+    Read value at an s3 key
+    """
     s3 = buckets.portal_resource
+
     wmg_config = WmgConfig()
     wmg_config.load()
-    prefixed_relative_path = os.path.join(_build_data_path_prefix(), relative_path or "")
-    s3obj = s3.Object(WmgConfig().bucket, prefixed_relative_path)
+
+    s3obj = s3.Object(wmg_config.bucket, key_path)
     return s3obj.get()["Body"].read().decode("utf-8").strip()
 
 
-# TODO: Worth doing this on a thread, continuously, rather than on-demand, in order to proactively load an updated
-#  snapshot (and maybe warm the TileDB caches?) before a user needs to query the data:
-#  https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data
-#  -portal/2134
-def _update_latest_snapshot_identifier() -> Optional[str]:
-    global cached_snapshot
-
-    new_snapshot_identifier = _read_s3obj("latest_snapshot_identifier")
+def _should_reload_snapshot(
+    snapshot_schema_version: str, specific_snapshot_id_to_load: Optional[str] = None
+) -> tuple[bool, str]:
+    """
+    Returns a pair: (<should_reload>, <snapshot_id>) where <should_reload> is boolean indicating
+    whether then in-memory snapshot should be reloaded and <snapshot_id> is the id of the snapshot that
+    the in-memory data structure represents.
+    """
+    snapshot_id = specific_snapshot_id_to_load or _get_latest_snapshot_id(snapshot_schema_version)
 
     if cached_snapshot is None:
-        logger.info(f"using latest snapshot {new_snapshot_identifier}")
-        return new_snapshot_identifier
-    elif new_snapshot_identifier != cached_snapshot.snapshot_identifier:
-        logger.info(f"detected snapshot update from {cached_snapshot.snapshot_identifier} to {new_snapshot_identifier}")
-        return new_snapshot_identifier
+        logger.info(f"Loading snapshot id: {snapshot_id}")
+        return (True, snapshot_id)
+    elif snapshot_id != cached_snapshot.snapshot_identifier:
+        logger.info(
+            f"Reloading snapshot. Detected snapshot id update from cached "
+            f"snapshot id: {cached_snapshot.snapshot_identifier} to {snapshot_id}"
+        )
+        return (True, snapshot_id)
     else:
-        logger.debug(f"latest snapshot identifier={cached_snapshot.snapshot_identifier}")
-        return None
-
-
-def _build_data_path_prefix():
-    wmg_config = WmgConfig()
-    rdev_prefix = os.environ.get("REMOTE_DEV_PREFIX")
-    if rdev_prefix:
-        return rdev_prefix.strip("/")
-    elif "data_path_prefix" in wmg_config.config:
-        return wmg_config.data_path_prefix
-    else:
-        return ""
-
-
-def _build_snapshot_base_uri(snapshot_identifier: str):
-    wmg_config = WmgConfig()
-    data_path_prefix = _build_data_path_prefix()
-    return os.path.join(
-        "s3://",
-        wmg_config.bucket,
-        data_path_prefix,
-        snapshot_identifier,
-    )
+        logger.debug(f"No need to load snapshot. Using cached snapshot id: {cached_snapshot.snapshot_identifier}")
+        return (False, snapshot_id)

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -105,20 +105,20 @@ class WmgSnapshot:
 cached_snapshot: Optional[WmgSnapshot] = None
 
 
-def load_snapshot(*, snapshot_schema_version: str, specific_snapshot_id_to_load: Optional[str] = None) -> WmgSnapshot:
+def load_snapshot(*, snapshot_schema_version: str, explicit_snapshot_id_to_load: Optional[str] = None) -> WmgSnapshot:
     """
     Loads and caches the snapshot identified by the snapshot schema version and a snapshot id.
 
     By default, this functions loads the latest snapshot id for a given schema version.
-    If a specific snapshot id is given, it will load that snapshot id. Note, that if a specific
+    If an explicit snapshot id is given, it will load that snapshot id. Note, that if an explicit
     snapshot id is given, it should be associated with the given schema version.
 
     The snapshot representation is cached in memory. Therefore, multiple calls to this function
-    will not simply return the cached snapshot if there isn't a newer snapshot id.
+    will simply return the cached snapshot if there isn't a newer snapshot id.
     """
     global cached_snapshot
 
-    should_reload, snapshot_id = _should_reload_snapshot(snapshot_schema_version, specific_snapshot_id_to_load)
+    should_reload, snapshot_id = _should_reload_snapshot(snapshot_schema_version, explicit_snapshot_id_to_load)
 
     if should_reload:
         cached_snapshot = _load_snapshot(snapshot_schema_version, snapshot_id)
@@ -249,14 +249,14 @@ def _read_value_at_s3_key(key_path: str):
 
 
 def _should_reload_snapshot(
-    snapshot_schema_version: str, specific_snapshot_id_to_load: Optional[str] = None
+    snapshot_schema_version: str, explicit_snapshot_id_to_load: Optional[str] = None
 ) -> tuple[bool, str]:
     """
-    Returns a pair: (<should_reload>, <snapshot_id>) where <should_reload> is boolean indicating
+    Returns a pair: (<should_reload>, <snapshot_id>) where <should_reload> is a boolean indicating
     whether then in-memory snapshot should be reloaded and <snapshot_id> is the id of the snapshot that
     the in-memory data structure represents.
     """
-    snapshot_id = specific_snapshot_id_to_load or _get_latest_snapshot_id(snapshot_schema_version)
+    snapshot_id = explicit_snapshot_id_to_load or _get_latest_snapshot_id(snapshot_schema_version)
 
     if cached_snapshot is None:
         logger.info(f"Loading snapshot id: {snapshot_id}")

--- a/backend/wmg/pipeline/summary_cubes/calculate_markers.py
+++ b/backend/wmg/pipeline/summary_cubes/calculate_markers.py
@@ -14,6 +14,7 @@ from backend.wmg.data.rollup import (
     rollup_across_cell_type_descendants,
     rollup_across_cell_type_descendants_array,
 )
+from backend.wmg.data.schemas import WMG_DATA_SCHEMA_VERSION
 from backend.wmg.data.snapshot import (
     CELL_COUNTS_CUBE_NAME,
     DATASET_TO_GENE_IDS_FILENAME,
@@ -83,7 +84,8 @@ def _query_tiledb_context_memoized(
             dataset_to_gene_ids = json.load(fp)
     else:
         if corpus is None:
-            corpus = load_snapshot()
+            corpus = load_snapshot(snapshot_schema_version=WMG_DATA_SCHEMA_VERSION)
+
         assert isinstance(corpus, WmgSnapshot)
         expression_summary_fmg_cube = corpus.expression_summary_fmg_cube
         cell_counts_cube = corpus.cell_counts_cube


### PR DESCRIPTION
## Reason for Change

- #5165 
- The entry point function `load_snapshot()` accepts a snapshot schema version and an optional snapshot id to enable loading snapshots are a particular snapshot schema version.

## Changes

- refactor the interface to `load_snapshot()` and the functions it calls to accept a snapshot schema version to load and an optional snapshot id to force load in the case the latest snapshot at a particular schema version is not needed

- **NOTE**: This change is merely a change to the interface. There are no changes to the behavior (ie output and side effects) of the functions being refactored. That change will come when we address #5166 and #5167 

## Testing steps

- Run unit tests locally and ensure that they all pass
- The following `rdev` functionally shows that the snapshot can be uploaded when you go to the gene expression app: https://ps-wmg-issue-5165-rdev-frontend.rdev.single-cell.czi.technology/gene-expression. The response of `\v2\query` is:

```
{
  "expression_summary": {},
  "snapshot_id": "1689721444",
  "term_id_labels": {
    "cell_types": {
      "CL:0000082 (cell culture)": {
        "CL:0000010": {
          "aggregated": {
            "cell_type_ontology_term_id": "CL:0000010",
            "name": "cultured cell",
            "order": 0,
            "total_count": 130626
          }
        }
```

- [Logs](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fdp$252Frdev$252Fps-wmg-issue-5165-rdev$252Fbackend/log-events/fargate$252Fweb$252F39b8a7c5901549fda8617e4a168b5142$3FfilterPattern$3D$2522Loading+WMG+snapshot$2522) from `cloudwatch` for the rdev prints the snapshot that was loaded:

```
2023-07-31T12:55:20.722-07:00
{
    "levelname": "INFO",
    "asctime": "2023-07-31T19:55:20.031Z",
    "name": "wmg",
    "message": "Loading WMG snapshot at s3://env-rdev-wmg/ps-wmg-issue-5165-rdev/1689721444",
    "lineno": 189,
    "pathname": "/single-cell-data-portal/backend/wmg/data/snapshot.py",
    "request_id": "ba1da4f0-82cd-4ff3-a801-08c992f77050"
}
```

## Notes for Reviewer
