### PR TITLE
feat(schema-migration): unpin cellxgene-schema-cli

### DIFF
--- a/requirements-processing.txt
+++ b/requirements-processing.txt
@@ -4,8 +4,7 @@ allure-pytest<3
 black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
 boto3>=1.11.17
 botocore>=1.14.17
-git+https://github.com/chanzuckerberg/single-cell-curation/@auto/update-convert-py-to-3.1.1#subdirectory=cellxgene_schema_cli # TODO undobeforemerging to main
-# cellxgene-schema TODO restore before merging to main
+cellxgene-schema
 click==8.1.3
 coverage>=6.5.0
 dataclasses-json


### PR DESCRIPTION
unpin before prod deployment. This was original set to test the schema-migration pipeline on the dev data corpus.