### PR TITLE
fix(schema-migration): double the timeout for seurat conversion step

### DIFF
--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -160,7 +160,7 @@ resource "aws_sfn_state_machine" "state_machine" {
                     ]
                   }
                 },
-                "TimeoutSeconds": 36000
+                "TimeoutSeconds": 72000
               }
             }
           }


### PR DESCRIPTION
## Reason for Change

- During a schema migration in dev seurat conversion jobs were timing out. This was likely cause by a number of jobs being ahead of the seurat job in the batch job queue. The lead to the job timing out before being processed.

## Changes

- modify the time for the seurat conversion job from 36000 -> 72000 seconds

## Notes for Reviewer
