### PR TITLE
fix: Make WMG frontend call v2 version of the /markers endpoint

### DIFF
--- a/frontend/src/common/API.ts
+++ b/frontend/src/common/API.ts
@@ -18,6 +18,6 @@ export enum API {
   WMG_PRIMARY_FILTER_DIMENSIONS = "/wmg/v1/primary_filter_dimensions",
   WMG_QUERY = "/wmg/v1/query",
   WMG_FILTERS_QUERY = "/wmg/v1/filters",
-  WMG_MARKER_GENES = "/wmg/v1/markers",
+  WMG_MARKER_GENES = "/wmg/v2/markers",
   WMG_GENE_INFO = "/gene_info/v1/gene_info",
 }

--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -1224,7 +1224,6 @@ export interface FetchMarkerGeneParams {
   tissueID: string;
   organismID: string;
   test?: "ttest" | "binomtest";
-  version?: 1 | 2;
 }
 
 export interface FetchGeneInfoParams {
@@ -1238,9 +1237,8 @@ export async function fetchMarkerGenes({
   organismID,
   tissueID,
   test = "ttest",
-  version = 1,
 }: FetchMarkerGeneParams): Promise<MarkerGeneResponse> {
-  const url = API_URL + replaceV1WithV2(version).WMG_MARKER_GENES;
+  const url = API_URL + API.WMG_MARKER_GENES;
   const body = generateMarkerGeneBody(cellTypeID, tissueID, organismID, test);
   const response = await fetch(url, {
     ...DEFAULT_FETCH_OPTIONS,
@@ -1308,7 +1306,6 @@ export function useMarkerGenes({
   organismID,
   tissueID,
   test,
-  version = 1,
 }: FetchMarkerGeneParams): UseQueryResult<MarkerGeneResponse<MarkerGene>> {
   const { data } = usePrimaryFilterDimensions(2);
   const genesByID = useMemo((): { [name: string]: OntologyTerm } => {
@@ -1342,7 +1339,6 @@ export function useMarkerGenes({
         organismID,
         test,
         tissueID,
-        version,
       });
       const markerGenesIndexedByGeneName = Object.fromEntries(
         filterMarkerGenes(output.marker_genes).reduce(


### PR DESCRIPTION
## Reason for Change

- https://github.com/chanzuckerberg/single-cell-data-portal/pull/5377
- Make the WMG frontend call `/v2/markers` instead of `/v1/markers`

## Changes

- modify call sites on the frontend to call hit `/v2/markers`

## Testing steps

- Manually tested by starting the frontend server locally and checking that adding marker genes calls `/v2/markers` and returns `http 200 OK`

## Notes for Reviewer
