### PR TITLE
fix: cross link relative path

### DIFF
--- a/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/CellInfoSideBar/index.tsx
@@ -100,7 +100,7 @@ function CellInfoSideBar({
     <div>
       <TissueName>{tissueInfo.name}</TissueName>
       <Link
-        href={`https://cellxgene.cziscience.com/cellguide/${cellInfoCellType.cellType.id}`}
+        href={`${ROUTES.CELL_GUIDE}/${cellInfoCellType.cellType.id}`}
         target="_blank"
         rel="noreferrer noopener"
       >


### PR DESCRIPTION
## Reason for Change

1. Use relative path, so the user will get the cell guide from the same domain instead of always from prod

## Changes

- add
- remove
- modify

## Testing steps

1. Open in Cell Guide link should now open a new tab from the same domain. E.g., localhost if open from localhost, staging if open from staging

## Notes for Reviewer
