### PR TITLE
test: Improve e2e tests

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,6 +11,8 @@ import { LOGIN_STATE_FILENAME } from "tests/common/constants";
 import { COMMON_PLAYWRIGHT_CONTEXT } from "tests/common/context";
 import featureFlags from "./tests/common/featureFlags";
 
+const CICD_MAX_FAILURE = 2;
+
 expect.extend(matchers);
 
 /**
@@ -164,6 +166,7 @@ const config: PlaywrightTestConfig = {
   //   command: 'npm run start',
   //   port: 3000,
   // },
+  maxFailures: process.env.CI ? CICD_MAX_FAILURE : undefined,
 };
 
 function getStorageState(): {

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -23,10 +23,12 @@ NOTE. It is advised to run the default `npm run e2e` once PR is ready to ensure 
 
 1. `--ui`: UI Mode lets you explore, run, and debug tests with a time travel experience complete with watch mode. All test files are loaded into the testing sidebar where you can expand each file and describe block to individually run, view, watch and debug each test.
 
+   - ![Image](https://user-images.githubusercontent.com/13063165/234295914-f7ee3d8b-33a7-41b3-bc91-d363baaa7305.png)
    - [Source](https://playwright.dev/docs/test-ui-mode#running-tests-in-ui-mode)
    - Example: `npm run e2e -- --ui -- FILE_PATH`
 
 2. `--debug`: Debug mode launches Playwright Inspector, which lets you play, pause, or step through each action of your test using the toolbar at the top of the Inspector. You can see the current action highlighted in the test code, and matching elements highlighted in the browser window.
+   - ![Image](https://user-images.githubusercontent.com/13063165/212924587-4b84e5f6-b147-40e9-8c75-d7b9ab6b7ca1.png)
    - [Source](https://playwright.dev/docs/debug#playwright-inspector)
    - Example: `npm run e2e -- --debug -- FILE_PATH`
 

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -14,10 +14,21 @@ NOTE. It is advised to run the default `npm run e2e` once PR is ready to ensure 
 
 ## Flags
 
-1. `SKIP_LOGIN`: Add `SKIP_LOGIN=true` to your test command if you don't need Playwright to log into Data Portal
+1. `LOGIN` and `SKIP_LOGIN`: Add `LOGIN=false` or `SKIP_LOGIN=true` to your test command if you don't need Playwright to log into Data Portal
 1. `HEADLESS` and `HEADFUL`: Add `HEADLESS=false` or `HEADFUL=true` to your test command to launch browser
 1. `RETRY`: Add `RETRY=false` if you don't want to retry your test. This is good for failing fast when you're writing tests
 1. `USE_COOKIE`: Manually use your own cookie for authenticated tests. Should only be used locally. The cookie value is set by modifying the `MANUAL_COOKIE` variable in `playwright.config.ts`
+
+## Playwright Cheat Sheet
+
+1. `--ui`: UI Mode lets you explore, run, and debug tests with a time travel experience complete with watch mode. All test files are loaded into the testing sidebar where you can expand each file and describe block to individually run, view, watch and debug each test.
+
+   - [Source](https://playwright.dev/docs/test-ui-mode#running-tests-in-ui-mode)
+   - Example: `npm run e2e -- --ui -- FILE_PATH`
+
+2. `--debug`: Debug mode launches Playwright Inspector, which lets you play, pause, or step through each action of your test using the toolbar at the top of the Inspector. You can see the current action highlighted in the test code, and matching elements highlighted in the browser window.
+   - [Source](https://playwright.dev/docs/debug#playwright-inspector)
+   - Example: `npm run e2e -- --debug -- FILE_PATH`
 
 ### What
 

--- a/frontend/tests/common/constants.ts
+++ b/frontend/tests/common/constants.ts
@@ -23,7 +23,8 @@ export const TEST_URL = TEST_ENV_TO_TEST_URL[TEST_ENV];
 
 export const BLUEPRINT_SAFE_TYPE_OPTIONS = { delay: 50 };
 
-export const SKIP_LOGIN = process.env.SKIP_LOGIN === "true" || false;
+export const SKIP_LOGIN =
+  process.env.SKIP_LOGIN === "true" || process.env.LOGIN === "false" || false;
 
 export const LOGIN_STATE_FILENAME = "loginState.json";
 


### PR DESCRIPTION
## Reason for Change

1. Add e2e test fail fast when there's already 2 tests failing. This should prevent e2e tests from timing out due to too many test failures, so engineers at least get to see the 2 test errors in the GHA report
2. Add a `Playwright Cheat Sheet` section to document efficient ways to debug and write e2e tests ([PREVIEW](https://github.com/chanzuckerberg/single-cell-data-portal/tree/thuang-improve-e2e/frontend/tests#playwright-cheat-sheet))
    
    <img width="799" alt="Screenshot 2023-08-04 at 1 20 43 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/fece240d-f6eb-489b-ab4e-574a7513ba42">

4. Add new test flag `LOGIN=false` to skip login. A complement to `SKIP_LOGIN=true`, which has too many chars to type

## Testing steps

1. `LOGIN=false npm run e2e` should skip login step

## Notes for Reviewer
