### PR TITLE
feat: update load_snapshot to by default read versioned paths

### DIFF
--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -194,7 +194,6 @@ def _get_wmg_snapshot_dir_s3_uri(snapshot_dir_path: str) -> str:
 
 
 def _load_snapshot(*, snapshot_schema_version: str, snapshot_id: str, read_versioned_snapshot: bool) -> WmgSnapshot:
-
     snapshot_dir_path = _get_wmg_snapshot_dir_path(
         snapshot_schema_version=snapshot_schema_version,
         snapshot_id=snapshot_id,
@@ -207,7 +206,7 @@ def _load_snapshot(*, snapshot_schema_version: str, snapshot_id: str, read_versi
     filter_relationships = _load_filter_graph_data(snapshot_dir_path)
 
     snapshot_base_uri = _get_wmg_snapshot_dir_s3_uri(snapshot_dir_path)
-    logger.info(f"Loading WMG snapshot at {snapshot_base_uri}")
+    logger.info(f"Loading WMG snapshot from directory path {snapshot_dir_path} into URI {snapshot_base_uri}")
 
     # TODO: Okay to keep TileDB arrays open indefinitely? Is it faster than re-opening each request?
     #  https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -109,7 +109,7 @@ def load_snapshot(
     *,
     snapshot_schema_version: str,
     explicit_snapshot_id_to_load: Optional[str] = None,
-    read_versioned_snapshot: bool = False,
+    read_versioned_snapshot: bool = True,
 ) -> WmgSnapshot:
     """
     Loads and caches the snapshot identified by the snapshot schema version and a snapshot id.

--- a/tests/unit/wmg_processing/test_cube_pipeline.py
+++ b/tests/unit/wmg_processing/test_cube_pipeline.py
@@ -6,6 +6,8 @@ import unittest
 from unittest import mock
 from unittest.mock import Mock
 
+from backend.wmg.data.load_cube import _get_wmg_snapshot_s3_fullpath
+from backend.wmg.data.snapshot import _get_wmg_snapshot_schema_dir_path
 from backend.wmg.pipeline.cube_pipeline import logger, main
 
 
@@ -44,3 +46,35 @@ class TestCubePipe(unittest.TestCase):
         and correctly uploads files to mock s3
         """
         raise NotImplementedError
+
+    def test_versioned_s3_paths(self):
+        """
+        Tests that the path we use for writing the snapshot is the versioned path, and verifies that the
+        path we read from for API usage respects the read_versioned_snapshot param.
+
+        NOTE: Ideally, we would want this to be a true test of the cube pipeline that actually runs the pipeline,
+        mocks the S3 upload, and then verifies that the API reads are pulling from the correct mocked S3 files.
+        This way, we're testing the high-level functionality of the cube pipeline and the API calls directly.
+        Since our testing infra doesn't currently support S3 mocks well, the past of least resistance is to test
+        the lower level functions that WMG uses to figure out where to write and read snapshots from.
+        """
+
+        wmg_bucket_name = os.environ.get("WMG_BUCKET")
+
+        # Verify that we're writing to the correct path in s3
+        dest_path = _get_wmg_snapshot_s3_fullpath("v1", "snapshot-id", True)
+        self.assertEqual(dest_path, f"s3://{wmg_bucket_name}/snapshots/v1/snapshot-id")
+
+        # Verify that we're reading from the versioned path if we pass in read_versioned_snapshot=True
+        verioned_read_path = _get_wmg_snapshot_schema_dir_path(
+            snapshot_schema_version="v1",
+            read_versioned_snapshot=True,
+        )
+        self.assertEqual(verioned_read_path, "snapshots/v1")
+
+        # Verify that we're reading from the non-versioned path if we pass in read_versioned_snapshot=False
+        root_read_path = _get_wmg_snapshot_schema_dir_path(
+            snapshot_schema_version="v1",
+            read_versioned_snapshot=False,
+        )
+        self.assertEqual(root_read_path, "")


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/5167

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/4691

## Changes

- marker genes is already reading versioned snapshots, this PR will update `load_snapshot` so that all clients (including the WMG API) read versioned snapshot paths
- adds more logging for when we write the snapshots

## Testing steps

- adds a test verifying that we're reading / writing to versioned paths

## Notes for Reviewer
