### PR TITLE
fix: do not assume latest DatasetVersion is active

### DIFF
--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -598,7 +598,7 @@ class DatabaseProvider(DatabaseProviderInterface):
 
     def get_most_recent_active_dataset_version(self, dataset_id: DatasetId) -> Optional[DatasetVersion]:
         """
-        Returns the must recently active Dataset version for a canonical dataset_id
+        Returns the most recently active Dataset version for a canonical dataset_id
         """
         with self._manage_session() as session:
             dataset_versions = session.query(DatasetVersionTable).filter_by(dataset_id=dataset_id.id).all()

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -620,21 +620,11 @@ class DatabaseProvider(DatabaseProviderInterface):
 
     def get_all_versions_for_dataset(self, dataset_id: DatasetId) -> List[DatasetVersion]:
         """
-        Returns all dataset versions for a canonical dataset_id
+        Returns all dataset versions for a canonical dataset_id. ***AT PRESENT THIS FUNCTION IS NOT USED***
         """
-        dataset = self.get_canonical_dataset(dataset_id)
         with self._manage_session() as session:
             dataset_versions = session.query(DatasetVersionTable).filter_by(dataset_id=dataset_id.id).all()
-            artifact_ids = [artifact_id for dv in dataset_versions for artifact_id in dv.artifacts]
-            artifacts = session.query(DatasetArtifactTable).filter(DatasetArtifactTable.id.in_(artifact_ids)).all()
-            artifact_map = {artifact.id: artifact for artifact in artifacts}
-            for i in range(len(dataset_versions)):
-                version = dataset_versions[i]
-                version_artifacts = [
-                    self._row_to_dataset_artifact(artifact_map.get(artifact_id)) for artifact_id in version.artifacts
-                ]
-                dataset_versions[i] = self._row_to_dataset_version(version, dataset, version_artifacts)
-            return dataset_versions
+            return [self._hydrate_dataset_version(dv) for dv in dataset_versions]
 
     def get_all_mapped_datasets_and_collections(self) -> Tuple[List[DatasetVersion], List[CollectionVersion]]:
         """

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -140,7 +140,7 @@ class DatabaseProviderInterface:
 
     def get_most_recent_active_dataset_version(self, dataset_id: DatasetId) -> Optional[DatasetVersion]:
         """
-        Returns the must recent, active Dataset version for a canonical dataset_id
+        Returns the most recent, active Dataset version for a canonical dataset_id
         """
 
     def get_all_versions_for_dataset(self, dataset_id: DatasetId) -> List[DatasetVersion]:

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -138,6 +138,11 @@ class DatabaseProviderInterface:
         Returns a dataset version by id.
         """
 
+    def get_most_recent_active_dataset_version(self, dataset_id: DatasetId) -> Optional[DatasetVersion]:
+        """
+        Returns the must recent, active Dataset version for a canonical dataset_id
+        """
+
     def get_all_versions_for_dataset(self, dataset_id: DatasetId) -> List[DatasetVersion]:
         """
         Returns all dataset versions for a canonical dataset_id

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -324,7 +324,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
 
     def get_most_recent_active_dataset_version(self, dataset_id: DatasetId) -> Optional[DatasetVersion]:
         """
-        Returns the must recent, active Dataset version for a canonical dataset_id
+        Returns the most recent, active Dataset version for a canonical dataset_id
         """
         dataset_versions = list(filter(lambda dv: dv.dataset_id == dataset_id, self.datasets_versions.values()))
         if not dataset_versions:

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -345,6 +345,9 @@ class DatabaseProviderMock(DatabaseProviderInterface):
                     return self._update_dataset_version_with_canonical(dataset_versions_map.get(dv_id))
 
     def get_all_versions_for_dataset(self, dataset_id: DatasetId) -> List[DatasetVersion]:
+        """
+        Returns all dataset versions for a canonical dataset_id. ***AT PRESENT THIS FUNCTION IS NOT USED***
+        """
         versions = []
         for dataset_version in self.datasets_versions.values():
             if dataset_version.dataset_id == dataset_id:

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -322,6 +322,28 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             dataset_versions.append(dataset_version)
         return dataset_versions
 
+    def get_most_recent_active_dataset_version(self, dataset_id: DatasetId) -> Optional[DatasetVersion]:
+        """
+        Returns the must recent, active Dataset version for a canonical dataset_id
+        """
+        dataset_versions = list(filter(lambda dv: dv.dataset_id == dataset_id, self.datasets_versions.values()))
+        if not dataset_versions:
+            return None
+        dataset_versions_map = {str(dv.version_id): dv for dv in dataset_versions}
+        collection_id = dataset_versions[0].collection_id
+        cv_dataset_versions_ids = [
+            cv.datasets
+            for cv in sorted(
+                filter(lambda cv: cv.collection_id == collection_id, self.collections_versions.values()),
+                key=lambda cv: cv.created_at,
+                reverse=True,
+            )
+        ]
+        for cv_dataset_versions in cv_dataset_versions_ids:
+            for dv_id in dataset_versions_map:
+                if DatasetVersionId(dv_id) in cv_dataset_versions:
+                    return self._update_dataset_version_with_canonical(dataset_versions_map.get(dv_id))
+
     def get_all_versions_for_dataset(self, dataset_id: DatasetId) -> List[DatasetVersion]:
         versions = []
         for dataset_version in self.datasets_versions.values():

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -921,7 +921,7 @@ class TestGetDataset(BaseBusinessLogicTestCase):
 
     def test_get_dataset_version_from_canonical(self):
         """
-        Get currently published dataset version using canonical dataset ID, or most recently created unpublished dataset
+        Get currently published dataset version using canonical dataset ID, or most recent active unpublished dataset
         if none are published.
         """
         with self.subTest("Dataset is published with a revision open, get published dataset version"):
@@ -943,6 +943,17 @@ class TestGetDataset(BaseBusinessLogicTestCase):
         with self.subTest("Dataset does not exist"):
             dataset_version = self.business_logic.get_dataset_version_from_canonical(DatasetId(str(uuid.uuid4())))
             self.assertIsNone(dataset_version)
+        with self.subTest("DatasetVersion has been rolled back from most recently-created"):
+            unpublished_collection = self.initialize_unpublished_collection()
+            init_dataset = unpublished_collection.datasets[0]
+            new_dataset = self.database_provider.replace_dataset_in_collection_version(
+                unpublished_collection.version_id, init_dataset.version_id
+            )
+            self.business_logic.restore_previous_dataset_version(
+                unpublished_collection.version_id, new_dataset.dataset_id
+            )
+            dataset_version = self.business_logic.get_dataset_version_from_canonical(init_dataset.dataset_id)
+            self.assertEqual(dataset_version.version_id, init_dataset.version_id)
 
     def test_get_prior_published_versions_for_dataset(self):
         """


### PR DESCRIPTION
Change relevant db provider methods to strictly rely on datasets associated with latest CollectionVersion as the 'active' DatasetVersion for a given DatasetId. This fixes a bug introduced by #5355 which allows rollback to previous DatasetVersions without deleting the most-recently-created DatasetVersion row.

## Reason for Change

- #4811 

## Changes

- replace usage of `get_all_versions_for_dataset` to find latest (active) DatasetVersion with a new db provider method `get_most_recent_active_dataset_version`.

## Testing steps

- unit tested

## Notes for Reviewer
