### PR TITLE
feat: add Serializable isolation for select db operations

### DIFF
--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -5,13 +5,13 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime
 from typing import Any, Iterable, List, Optional, Tuple
-from tenacity import retry
-from tenacity.stop import stop_after_attempt
-from tenacity.wait import wait_fixed
 
 from sqlalchemy import create_engine
 from sqlalchemy.exc import ProgrammingError, SQLAlchemyError
 from sqlalchemy.orm import sessionmaker
+from tenacity import retry
+from tenacity.stop import stop_after_attempt
+from tenacity.wait import wait_fixed
 
 from backend.common.corpora_config import CorporaDbConfig
 from backend.layers.business.exceptions import CollectionIsPublishedException

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1787,11 +1787,13 @@ class TestSetPreviousDatasetVersion(BaseBusinessLogicTestCase):
         assert new_dataset_version_id not in datasets
         assert previous_dataset.version_id in datasets
 
+
 class TestConcurrentUpdates(BaseBusinessLogicTestCase):
     """
     Test that concurrent updates to a "shared" field in DatasetVersion are supported properly.
     This is simulated by calling a method that updates such field concurrently, using a thread pool.
     """
+
     def test_concurrency(self):
         collection = self.initialize_published_collection(num_datasets=1)
         dataset = collection.datasets[0]
@@ -1802,6 +1804,7 @@ class TestConcurrentUpdates(BaseBusinessLogicTestCase):
         self.assertEqual(len(dataset.artifacts), 3)
 
         from concurrent.futures import ThreadPoolExecutor
+
         with ThreadPoolExecutor(max_workers=4) as e:
             for _ in range(10):
                 e.submit(add_artifact)

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1790,8 +1790,11 @@ class TestSetPreviousDatasetVersion(BaseBusinessLogicTestCase):
 
 class TestConcurrentUpdates(BaseBusinessLogicTestCase):
     """
-    Test that concurrent updates to a "shared" field in DatasetVersion are supported properly.
+    Test that concurrent updates to a "shared" field in DatasetVersion are properly supported.
     This is simulated by calling a method that updates such field concurrently, using a thread pool.
+    Note: this test should always pass, but we can't guarantee that it actually prevents a race condition.
+    Different hosts might have different behaviors and might not yield a race condition in the first place
+    (for instance, if the runtime can only give 1 worker to ThreadPoolExecutor).
     """
 
     def test_concurrency(self):


### PR DESCRIPTION
## Reason for Change

Fixes #5424 

## Changes

- Enforces a stricter transaction isolation level for some database operations. This should hopefully mitigate a race condition where the two pipelines (RDS and CXG) can update the same database record concurrently if they complete at the same time.
- TODO: this will only cause one of the transactions to fail. This will at least mark the dataset as failed, and not yield a silent failure like today. A better alternative is to add retries [as recommended by the PostgreSQL docs](https://www.postgresql.org/docs/current/transaction-iso.html). This can be done as part of this PR or as a follow up.

## Testing steps

- Added a unit test that simulates the concurrency via threading. I tried the unit test it main and it doesn't pass (as it should)
- For what it's worth, I tested this in rdev to make sure that the change doesn't affect the happy path.