### PR TITLE
fix: CellGuide header to h1

### DIFF
--- a/frontend/src/views/CellGuide/components/CellGuideCard/style.ts
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/style.ts
@@ -63,9 +63,10 @@ export const CellGuideCardHeader = styled.div`
   justify-content: space-between;
 `;
 
-export const CellGuideCardName = styled.div`
+export const CellGuideCardName = styled.h1`
   ${fontHeaderXxl}
   font-weight: 700;
+  margin-bottom: 0;
 `;
 
 export const StyledTag = styled(Tag)`


### PR DESCRIPTION
## Reason for Change

- per SEO Jackie, we need to use h1! [Slack](https://czi-sci.slack.com/archives/C04CP2N7XC5/p1691605196636249)

## Changes

1. Change header from `div` to `h1`

## Testing steps

Like this:
<img width="557" alt="Screenshot 2023-08-10 at 10 39 07 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/5858b7b9-34e9-4174-9110-b931c4d21052">

## Notes for Reviewer
