### PR TITLE
feat(cellguide): remove nodes from tissue ontology view that are not found in the tissue

### DIFF
--- a/frontend/src/pages/cellguide/tissues/[tissueId].tsx
+++ b/frontend/src/pages/cellguide/tissues/[tissueId].tsx
@@ -15,7 +15,7 @@ const Page = ({
   description,
   name,
 }: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element => (
-  <TissueCard name={name} description={description} />
+  <TissueCard key={name} name={name} description={description} />
 );
 
 export const getServerSideProps: GetServerSideProps<{

--- a/frontend/src/views/CellGuide/components/CellGuideCard/index.tsx
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/index.tsx
@@ -165,7 +165,11 @@ export default function CellGuideCard({
           {/* Cell Ontology section */}
           <div ref={sectionRef1} id="section-1" data-testid="section-1" />
           <FullScreenProvider>
-            <OntologyDagView cellTypeId={cellTypeId} skinnyMode={skinnyMode} />
+            <OntologyDagView
+              key={cellTypeId}
+              cellTypeId={cellTypeId}
+              skinnyMode={skinnyMode}
+            />
           </FullScreenProvider>
 
           {/* Marker Genes section */}

--- a/frontend/src/views/CellGuide/components/TissueCard/index.tsx
+++ b/frontend/src/views/CellGuide/components/TissueCard/index.tsx
@@ -118,6 +118,7 @@ export default function TissueCard({ description, name }: Props): JSX.Element {
         </DescriptionWrapper>
         <FullScreenProvider>
           <OntologyDagView
+            key={tissueId}
             tissueId={tissueId}
             tissueName={tissueName}
             skinnyMode={false}

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -197,6 +197,7 @@ export default function OntologyDagView({
       const tissueCounts = initialTreeState?.tissueCounts ?? {};
       if (Object.keys(tissueCounts).length > 0) {
         setCellCountsInRawTree(newTree, tissueCounts);
+        deleteNodesWithNoDescendants(newTree);
       }
     }
     return newTree;
@@ -229,9 +230,9 @@ export default function OntologyDagView({
           }
         }
 
-        if (appendDummy && !d.showAllChildren) {
-          const numHiddenChildren =
-            (d.children?.length ?? 0) - newChildren.length;
+        const numHiddenChildren =
+          (d.children?.length ?? 0) - newChildren.length;
+        if (appendDummy && !d.showAllChildren && numHiddenChildren > 0) {
           newChildren.push({
             id: `dummy-child-${d.id}`,
             name: `${numHiddenChildren} cell types`,
@@ -485,5 +486,14 @@ function setCellCountsInRawTree(
     for (const child of graph.children) {
       setCellCountsInRawTree(child, tissueCounts);
     }
+  }
+}
+
+function deleteNodesWithNoDescendants(graph: TreeNodeWithState): void {
+  if (graph.children) {
+    graph.children = graph.children.filter((child) => {
+      deleteNodesWithNoDescendants(child);
+      return child.n_cells_rollup !== 0;
+    });
   }
 }

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -258,31 +258,29 @@ export default function OntologyDagView({
   const data = useMemo(() => {
     if (!treeData) return null;
     return hierarchy(treeData, (d) => {
-      if (d.isExpanded && d.children) {
+      if (d.isExpanded && d.children && initialTreeState) {
         const newChildren: TreeNodeWithState[] = [];
         const notShownWhenExpandedNodes =
-          initialTreeState?.notShownWhenExpandedNodes ?? {};
-        // If this node is a key in `notShownWhenExpandedNodes`, then it is a parent to nodes
-        // that should be collapsed. Therefore, set `appendDummy` to `true`.
-        // The term "dummy" here is used to describe the collapsed node containing hidden terms.
-        // The text label of a "dummy" is the number of hidden terms, e.g. 52 cell types.
-        const appendDummy = d.id in notShownWhenExpandedNodes;
+          initialTreeState.notShownWhenExpandedNodes;
+        /**
+         * If a node is a key in `notShownWhenExpandedNodes`, then it is a parent to nodes
+         * that should be collapsed. The text label of this "dummy" node is the number of hidden terms,
+         * e.g. 52 cell types.
+         * `showAllChildren` is a flag that is set to `true` when the user clicks on a collapsed node.
+         * It indicates that all of the children of the node should be shown.
+         */
 
-        // `showAllChildren` is a flag that is set to `true` when the user clicks on a collapsed node.
-        // It indicates that all of the children of the node should be shown.
         for (const child of d.children) {
           if (
             d.showAllChildren ||
-            !appendDummy ||
-            // This is a child that should be shown because it is in a path to the target node.
-            (appendDummy && !notShownWhenExpandedNodes[d.id].includes(child.id))
+            !notShownWhenExpandedNodes[d.id]?.includes(child.id)
           ) {
             newChildren.push(child);
           }
         }
 
         const numHiddenChildren = d.children.length - newChildren.length;
-        if (appendDummy && numHiddenChildren > 0) {
+        if (numHiddenChildren > 0) {
           newChildren.push({
             id: `dummy-child-${d.id}`,
             name: `${numHiddenChildren} cell types`,

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -102,12 +102,7 @@ export default function OntologyDagView({
   initialHeight,
   initialWidth,
 }: TreeProps) {
-  // isTissue = not cellTypeId and tissueId
-  const isTissue = (!cellTypeId && !!tissueId) || (!!cellTypeId && !!tissueId);
-  const isCellType =
-    (!!cellTypeId && !tissueId) || (!!cellTypeId && !!tissueId);
-
-  skinnyMode = isCellType ? skinnyMode : true;
+  skinnyMode = cellTypeId ? skinnyMode : true;
   const defaultHeight = initialHeight ?? DEFAULT_ONTOLOGY_HEIGHT;
   const defaultWidth = initialWidth ?? DEFAULT_ONTOLOGY_WIDTH;
 
@@ -263,8 +258,8 @@ export default function OntologyDagView({
   const data = useMemo(() => {
     if (!treeData) return null;
     return hierarchy(treeData, (d) => {
-      const newChildren: TreeNodeWithState[] = [];
-      if (d.isExpanded) {
+      if (d.isExpanded && d.children) {
+        const newChildren: TreeNodeWithState[] = [];
         const notShownWhenExpandedNodes =
           initialTreeState?.notShownWhenExpandedNodes ?? {};
         // If this node is a key in `notShownWhenExpandedNodes`, then it is a parent to nodes
@@ -275,7 +270,7 @@ export default function OntologyDagView({
 
         // `showAllChildren` is a flag that is set to `true` when the user clicks on a collapsed node.
         // It indicates that all of the children of the node should be shown.
-        for (const child of d?.children ?? []) {
+        for (const child of d.children) {
           if (
             d.showAllChildren ||
             !appendDummy ||
@@ -286,9 +281,8 @@ export default function OntologyDagView({
           }
         }
 
-        const numHiddenChildren =
-          (d.children?.length ?? 0) - newChildren.length;
-        if (appendDummy && !d.showAllChildren && numHiddenChildren > 0) {
+        const numHiddenChildren = d.children.length - newChildren.length;
+        if (appendDummy && numHiddenChildren > 0) {
           newChildren.push({
             id: `dummy-child-${d.id}`,
             name: `${numHiddenChildren} cell types`,
@@ -297,8 +291,8 @@ export default function OntologyDagView({
             isExpanded: false,
           });
         }
+        return newChildren;
       }
-      return newChildren.length ? newChildren : null;
     });
   }, [treeData, triggerRender, initialTreeState]);
 

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -95,7 +95,6 @@ export default function OntologyDagView({
   initialWidth,
 }: TreeProps) {
   skinnyMode = cellTypeId ? skinnyMode : true;
-
   const defaultHeight = initialHeight ?? DEFAULT_ONTOLOGY_HEIGHT;
   const defaultWidth = initialWidth ?? DEFAULT_ONTOLOGY_WIDTH;
 
@@ -172,7 +171,6 @@ export default function OntologyDagView({
   const toggleTriggerRender = () => {
     setTriggerRender(!triggerRender);
   };
-
   // Animation duration - initially zero so the animation doesn't play on load
   const [duration, setDuration] = useState(0);
 
@@ -180,7 +178,6 @@ export default function OntologyDagView({
   // the "isExpanded" property that is used to track the expanded state of each node, along with
   // other properties like the positions of the nodes.
   const { data: rawTree } = useCellOntologyTree();
-
   const entityId = cellTypeId ?? tissueId ?? "";
   const useTreeState = cellTypeId
     ? useCellOntologyTreeState
@@ -481,9 +478,8 @@ function setCellCountsInRawTree(
 ) {
   const cellTypeId = graph.id.split("__").at(0) ?? graph.id;
 
-  graph.n_cells = tissueCounts[cellTypeId]?.n_cells ?? graph.n_cells;
-  graph.n_cells_rollup =
-    tissueCounts[cellTypeId]?.n_cells_rollup ?? graph.n_cells_rollup;
+  graph.n_cells = tissueCounts[cellTypeId]?.n_cells ?? 0;
+  graph.n_cells_rollup = tissueCounts[cellTypeId]?.n_cells_rollup ?? 0;
 
   if (graph.children) {
     for (const child of graph.children) {

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -345,11 +345,6 @@ export default function OntologyDagView({
     }
   }, [data, cellTypeId, width, height]);
 
-  // Trigger re-render when full screen mode is toggled
-  useEffect(() => {
-    toggleTriggerRender();
-  }, [isFullScreen]);
-
   // Hover over node tooltip
   const {
     tooltipData,


### PR DESCRIPTION
## Reason for Change

- #5037  

## Changes

- The goal is to remove branches with 0 cells in the tissue.
- A secondary goal of this PR is to prep the `OntologyDagView` component for the situation where a tissue AND a cell type is specified. This will be used in the case where users can set a global tissue filter on each CellGuideCard (see #5368 for details). In this case, the expanded nodes will be the intersection of the expanded nodes in the specified tissue and the specified cell type. The "hidden" nodes when a parent is expanded will be the _union_ of those in the specified tissue and the specified cell type.

## Testing steps

- No functional behavior changes expected in this PR except for the content that is displayed in tissue ontology views. Therefore, no tests added. When the global tissue filter is added, then E2E tests will be added to test that the ontology dag view is indeed changing in response to the tissue filter.
- E2E tests pass.
