### PR TITLE
feat: script to annotate offending lines with type ignore

### DIFF
--- a/backend/api_server/app.py
+++ b/backend/api_server/app.py
@@ -102,7 +102,7 @@ def configure_flask_app(flask_app):
     return flask_app
 
 
-api_base_paths = []
+api_base_paths = []  # type: ignore
 
 app = configure_flask_app(create_flask_app())
 

--- a/backend/common/auth0_manager.py
+++ b/backend/common/auth0_manager.py
@@ -1,8 +1,8 @@
 import logging
 
-import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util import Retry
+import requests  # type: ignore
+from requests.adapters import HTTPAdapter  # type: ignore
+from requests.packages.urllib3.util import Retry  # type: ignore
 
 from backend.common.corpora_config import CorporaAuthConfig
 
@@ -84,7 +84,7 @@ class Auth0ManagementSession:
             if i["connection"] == self.config.api_key_connection_name:
                 identity = i
                 break
-        return identity
+        return identity  # type: ignore
 
     def delete_api_key(self, primary_id: str, identity: dict) -> None:
         user_id, provider = identity["user_id"], identity["provider"]

--- a/backend/common/authorizer.py
+++ b/backend/common/authorizer.py
@@ -1,8 +1,8 @@
 import os
 from functools import lru_cache
 
-import requests
-from requests.adapters import HTTPAdapter
+import requests  # type: ignore
+from requests.adapters import HTTPAdapter  # type: ignore
 from urllib3 import Retry
 
 from backend.common.corpora_config import CorporaAuthConfig
@@ -21,7 +21,7 @@ def get_auth0_session_with_retry():
     return _auth0_session_with_retry
 
 
-def assert_authorized_token(token: str, audience: str = None) -> dict:
+def assert_authorized_token(token: str, audience: str = None) -> dict:  # type: ignore
     """
     Determines if the Access Token is valid and return the decoded token. Userinfo is added to the token if it exists.
     :param token: The token

--- a/backend/common/providers/crossref_provider.py
+++ b/backend/common/providers/crossref_provider.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from urllib.parse import urlparse
 
-import requests
+import requests  # type: ignore
 
 from backend.common.corpora_config import CorporaConfig
 
@@ -77,7 +77,7 @@ class CrossrefProvider:
 
         res = self._fetch_crossref_payload(doi)
         if not res:
-            return
+            return  # type: ignore
 
         try:
             message = res.json()["message"]

--- a/backend/common/utils/db_session.py
+++ b/backend/common/utils/db_session.py
@@ -17,7 +17,7 @@ class DBSessionMaker:
     _session_maker = None
     engine = None
 
-    def __init__(self, database_uri: str = None):
+    def __init__(self, database_uri: str = None):  # type: ignore
         if not self.engine:
             self.database_uri = database_uri if database_uri else CorporaDbConfig().database_uri
             self.engine = create_engine(self.database_uri, connect_args={"connect_timeout": 5})

--- a/backend/common/utils/dl_sources/url.py
+++ b/backend/common/utils/dl_sources/url.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from urllib.parse import ParseResult, urlparse
 
 import boto3
-import requests
+import requests  # type: ignore
 
 
 class MissingHeaderException(Exception):
@@ -166,7 +166,7 @@ class S3URI(URL):
 class RegisteredSources:
     """Manages all of the download sources."""
 
-    _registered = set()
+    _registered = set()  # type: ignore
 
     @classmethod
     def add(cls, parser: typing.Type[URL]):
@@ -184,7 +184,7 @@ class RegisteredSources:
         return cls._registered
 
 
-def from_url(url: str) -> URL:
+def from_url(url: str) -> URL:  # type: ignore
     """Given a URL return a object that can be used by the processing container to download data."""
     for source in RegisteredSources.get():
         url_obj = source.validate(url)

--- a/backend/common/utils/http_exceptions.py
+++ b/backend/common/utils/http_exceptions.py
@@ -1,4 +1,4 @@
-import requests
+import requests  # type: ignore
 from connexion.exceptions import ProblemException
 
 
@@ -40,7 +40,7 @@ class TooLargeHTTPException(ProblemException):
 class InvalidParametersHTTPException(ProblemException):
     _default_detail = "One or more parameters is invalid."
 
-    def __init__(self, detail: str = None, *args, **kwargs) -> None:
+    def __init__(self, detail: str = None, *args, **kwargs) -> None:  # type: ignore
         detail = detail if detail else self._default_detail
         super().__init__(*args, **kwargs, status=400, title="Bad Request", detail=detail)
 

--- a/backend/common/utils/result_notification.py
+++ b/backend/common/utils/result_notification.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 
-import requests
+import requests  # type: ignore
 
 from backend.common.corpora_config import CorporaConfig
 

--- a/backend/common/utils/type_conversion_utils.py
+++ b/backend/common/utils/type_conversion_utils.py
@@ -82,17 +82,17 @@ def _get_type_info_from_dtype(dtype) -> Optional[Tuple[np.dtype, dict]]:
     are available for typing.
     """
     if dtype.kind == "b":
-        return (np.uint8, {"type": "boolean"})
+        return (np.uint8, {"type": "boolean"})  # type: ignore
 
     if dtype.kind == "U":
         return (np.dtype(str), {"type": "string"})
 
     if dtype.kind in ["i", "u"] and np.can_cast(dtype, np.int32):
-        return (np.int32, {"type": "int32"})
+        return (np.int32, {"type": "int32"})  # type: ignore
 
     if dtype.kind == "f":
         _float64_warning(dtype)
-        return (np.float32, {"type": "float32"})
+        return (np.float32, {"type": "float32"})  # type: ignore
 
     if dtype.kind == "O" and dtype.name != "category":
         return (np.dtype(str), {"type": "string"})
@@ -128,7 +128,7 @@ def _get_type_info(array: Union[np.ndarray, pd.Series, pd.Index]) -> Tuple[np.dt
             # NA/NaN (missing or undefined) categories.
             if dtype.categories.dtype.kind in ["f", "i", "u"]:
                 return (
-                    _get_type_info(array.to_numpy())[0],
+                    _get_type_info(array.to_numpy())[0],  # type: ignore
                     {"type": "categorical"},
                 )
             else:
@@ -138,11 +138,11 @@ def _get_type_info(array: Union[np.ndarray, pd.Series, pd.Index]) -> Tuple[np.dt
         return (np.dtype(str), {"type": "string"})
 
     if dtype.kind in ["i", "u"] and _can_cast_array_values_to_int32(array):
-        return (np.int32, {"type": "int32"})
+        return (np.int32, {"type": "int32"})  # type: ignore
 
     if dtype.kind == "f":
         _float64_warning(array.dtype)
-        return (np.float32, {"type": "float32"})
+        return (np.float32, {"type": "float32"})  # type: ignore
 
     raise TypeError(f"Annotations of type {dtype} are unsupported.")
 

--- a/backend/curation/api/v1/curation/collections/actions.py
+++ b/backend/curation/api/v1/curation/collections/actions.py
@@ -10,7 +10,7 @@ from backend.layers.common.entities import CollectionLinkType, CollectionMetadat
 from backend.portal.api.providers import get_business_logic
 
 
-def get(visibility: str, token_info: dict, curator: str = None):
+def get(visibility: str, token_info: dict, curator: str = None):  # type: ignore
     """
     Collections index endpoint for Curation API. Only return Collection data for which the curator is authorized.
     :param visibility: the CollectionVisibility in string form
@@ -35,12 +35,12 @@ def get(visibility: str, token_info: dict, curator: str = None):
         if not user_info.is_super_curator():
             raise ForbiddenHTTPException(detail="Not authorized to use the curator query parameter.")
         else:
-            filters["curator_name"] = curator
+            filters["curator_name"] = curator  # type: ignore
 
     print(filters)
 
     resp_collections = []
-    for collection_version in get_business_logic().get_collections(CollectionQueryFilter(**filters)):
+    for collection_version in get_business_logic().get_collections(CollectionQueryFilter(**filters)):  # type: ignore
         resp_collection = reshape_for_curation_api(collection_version, user_info, preview=True)
         resp_collections.append(resp_collection)
     return jsonify(resp_collections)
@@ -48,7 +48,7 @@ def get(visibility: str, token_info: dict, curator: str = None):
 
 def post(body: dict, token_info: dict):
     # Extract DOI into link
-    errors = []
+    errors = []  # type: ignore
     if (doi_url := body.get("doi")) and (doi_url := doi.curation_get_normalized_doi_url(doi_url, errors)):
         links = body.get("links", [])
         links.append({"link_type": CollectionLinkType.DOI.name, "link_url": doi_url})
@@ -68,9 +68,9 @@ def post(body: dict, token_info: dict):
     try:
         version = get_business_logic().create_collection(token_info["sub"], token_info["curator_name"], metadata)
     except InvalidMetadataException as ex:
-        errors.extend(ex.errors)
+        errors.extend(ex.errors)  # type: ignore
     except CollectionCreationException as ex:
-        errors.extend(ex.errors)
+        errors.extend(ex.errors)  # type: ignore
     if errors:
         raise InvalidParametersHTTPException(ext=dict(invalid_parameters=errors))
     return make_response(jsonify({"collection_id": version.collection_id.id}), 201)

--- a/backend/curation/api/v1/curation/collections/collection_id/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/actions.py
@@ -51,7 +51,7 @@ def patch(collection_id: str, body: dict, token_info: dict) -> Response:
             detail="Directly editing a public Collection is not allowed; you must create a revision."
         )
 
-    errors = []
+    errors = []  # type: ignore
     # Verify DOI
     if (doi_url := body.pop("doi", None)) and (doi_url := doi.curation_get_normalized_doi_url(doi_url, errors)):
         links = body.get("links", [])
@@ -89,7 +89,7 @@ def patch(collection_id: str, body: dict, token_info: dict) -> Response:
     except InvalidMetadataException as ex:
         raise InvalidParametersHTTPException(ext=dict(invalid_parameters=ex.errors)) from None
     except CollectionUpdateException as ex:
-        errors.extend(ex.errors)
+        errors.extend(ex.errors)  # type: ignore
     if errors:
         raise InvalidParametersHTTPException(ext=dict(invalid_parameters=errors))
     # Make Response

--- a/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
@@ -34,7 +34,7 @@ from backend.layers.common.entities import (
 from backend.portal.api.providers import get_business_logic
 
 
-def get(collection_id: str, dataset_id: str = None):
+def get(collection_id: str, dataset_id: str = None):  # type: ignore
     collection_version, dataset_version = _get_collection_and_dataset(collection_id, dataset_id)
 
     # A canonical url should be only used in two cases:

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -79,7 +79,7 @@ def extract_doi_from_links(links: List[Link]) -> Tuple[Optional[str], List[dict]
 
 def reshape_for_curation_api(
     collection_version: Union[CollectionVersion, CollectionVersionWithDatasets, CollectionVersionWithPublishedDatasets],
-    user_info: UserInfo = None,
+    user_info: UserInfo = None,  # type: ignore
     reshape_for_version_endpoint: bool = False,
     preview: bool = False,
 ) -> dict:
@@ -138,7 +138,7 @@ def reshape_for_curation_api(
     # get collection dataset attributes
     response_datasets = sorted(
         reshape_datasets_for_curation_api(
-            collection_version.datasets,
+            collection_version.datasets,  # type: ignore
             use_canonical_url,
             preview,
             as_version=reshape_for_version_endpoint,
@@ -165,7 +165,7 @@ def reshape_for_curation_api(
         name=collection_version.metadata.name,
         published_at=published_at,
         publisher_metadata=collection_version.publisher_metadata,
-        visibility=get_visibility(collection_version),
+        visibility=get_visibility(collection_version),  # type: ignore
     )
     if reshape_for_version_endpoint:
         response["dataset_versions"] = response_datasets
@@ -177,7 +177,7 @@ def reshape_for_curation_api(
             revision_of=revision_of,
         )
     if not is_published:
-        response.update(processing_status=get_collection_level_processing_status(collection_version.datasets))
+        response.update(processing_status=get_collection_level_processing_status(collection_version.datasets))  # type: ignore
     return response
 
 
@@ -332,7 +332,7 @@ def validate_uuid_else_forbidden(_id: str):
 
 def get_collection_level_processing_status(datasets: List[DatasetVersion]) -> str:
     if not datasets:  # Return None if no datasets.
-        return None
+        return None  # type: ignore
 
     return_status = DatasetProcessingStatus.SUCCESS
     for dv in datasets:
@@ -343,7 +343,7 @@ def get_collection_level_processing_status(datasets: List[DatasetVersion]) -> st
                 return_status = DatasetProcessingStatus.PENDING
             elif status == DatasetProcessingStatus.FAILURE:
                 return_status = status
-    return return_status
+    return return_status  # type: ignore
 
 
 def get_inferred_collection_version(_id: str) -> CollectionVersionWithDatasets:

--- a/backend/curation/api/v1/curation/datasets/actions.py
+++ b/backend/curation/api/v1/curation/datasets/actions.py
@@ -5,7 +5,7 @@ from backend.curation.api.v1.curation.collections.common import extract_doi_from
 from backend.portal.api.providers import get_business_logic
 
 
-def get(schema_version: str = None):
+def get(schema_version: str = None):  # type: ignore
     """
     Datasets index endpoint to retrieve full metadata for all public Datasets.
     """

--- a/backend/database/env.py
+++ b/backend/database/env.py
@@ -12,7 +12,7 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+fileConfig(config.config_file_name)  # type: ignore
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/backend/gene_info/api/ensembl_ids.py
+++ b/backend/gene_info/api/ensembl_ids.py
@@ -19,7 +19,7 @@ class GeneChecker:
         SupportedOrganisms.SARS_COV_2: base_prefix + "genes_sars_cov_2.csv.gz",
         SupportedOrganisms.ERCC: base_prefix + "genes_ercc.csv.gz",
     }
-    gene_dict = {}
+    gene_dict = {}  # type: ignore
 
     def __init__(self):
         if not GeneChecker.gene_dict:

--- a/backend/gene_info/api/ncbi_provider.py
+++ b/backend/gene_info/api/ncbi_provider.py
@@ -30,7 +30,7 @@ class NCBIProvider:
             self.api_key = f"&api_key={gene_info_config.ncbi_api_key}"
         except RuntimeError:
             logging.error("Could not find NCBI API key")
-            self.api_key = None
+            self.api_key = None  # type: ignore
 
     def fetch_gene_info_tree(self, uid):
         """

--- a/backend/gene_info/api/v1.py
+++ b/backend/gene_info/api/v1.py
@@ -7,7 +7,7 @@ from backend.gene_info.api.ensembl_ids import GeneChecker
 from backend.gene_info.api.ncbi_provider import NCBIAPIException, NCBIProvider, NCBIUnexpectedResultException
 
 
-def gene_info(gene: string = None, geneID: string = None):
+def gene_info(gene: string = None, geneID: string = None):  # type: ignore
     provider = NCBIProvider()
 
     # given just a gene name (finds corresponding gene ID)

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -97,7 +97,7 @@ class BusinessLogic(BusinessLogicInterface):
         self.uri_provider = uri_provider
         super().__init__()
 
-    def _get_publisher_metadata(self, doi: str, errors: list) -> Optional[dict]:
+    def _get_publisher_metadata(self, doi: str, errors: list) -> Optional[dict]:  # type: ignore
         """
         Retrieves publisher metadata from Crossref.
         """
@@ -120,7 +120,7 @@ class BusinessLogic(BusinessLogicInterface):
         sanitize(collection_metadata)
 
         # Check metadata is valid
-        errors = []
+        errors = []  # type: ignore
         validation.verify_collection_metadata(collection_metadata, errors)
 
         # TODO: Maybe switch link.type to be an enum
@@ -167,7 +167,7 @@ class BusinessLogic(BusinessLogicInterface):
             if canonical_collection_id not in collections:
                 collections[canonical_collection_id] = collection_version
             else:
-                if collection_version.published_at > collections[canonical_collection_id].published_at:
+                if collection_version.published_at > collections[canonical_collection_id].published_at:  # type: ignore
                     collections[canonical_collection_id] = collection_version
 
         # for each mapped collection version, populate its dataset versions' details
@@ -177,7 +177,7 @@ class BusinessLogic(BusinessLogicInterface):
             for collection in latest_collection_versions
             for dataset_version_id in collection.datasets
         ]
-        dataset_versions = self.database_provider.get_dataset_versions_by_id(dataset_version_ids)
+        dataset_versions = self.database_provider.get_dataset_versions_by_id(dataset_version_ids)  # type: ignore
         return self._map_collection_version_to_published_dataset_versions(latest_collection_versions, dataset_versions)
 
     def get_unpublished_collection_version_from_canonical(
@@ -202,7 +202,7 @@ class BusinessLogic(BusinessLogicInterface):
         """
         return self.database_provider.get_collection_version_with_datasets(version_id, get_tombstoned=get_tombstoned)
 
-    def get_collection_versions_from_canonical(
+    def get_collection_versions_from_canonical(  # type: ignore
         self, collection_id: CollectionId
     ) -> Iterable[CollectionVersionWithDatasets]:
         """
@@ -245,7 +245,7 @@ class BusinessLogic(BusinessLogicInterface):
         if filter.is_published is True:
             iterable = self.database_provider.get_all_mapped_collection_versions()
         else:
-            iterable = self.database_provider.get_all_collections_versions()
+            iterable = self.database_provider.get_all_collections_versions()  # type: ignore
 
         def predicate(version: CollectionVersion):
             # Combines all the filters into a single predicate, so that filtering can happen in a single iteration
@@ -275,7 +275,7 @@ class BusinessLogic(BusinessLogicInterface):
         # TODO: CollectionMetadataUpdate should probably be used for collection creation as well
         # TODO: link.type should DEFINITELY move to an enum. pylance will help with the refactor
         sanitize(body)
-        errors = []
+        errors = []  # type: ignore
 
         # Check metadata
         validation.verify_collection_metadata_update(body, errors)
@@ -331,7 +331,7 @@ class BusinessLogic(BusinessLogicInterface):
         This method should be called every time an update to a collection version is requested,
         since published collection versions are not allowed any changes.
         """
-        collection_version = self.database_provider.get_collection_version_with_datasets(collection_version_id)
+        collection_version = self.database_provider.get_collection_version_with_datasets(collection_version_id)  # type: ignore
         if collection_version is None:
             raise CollectionNotFoundException([f"Collection version {collection_version_id.id} does not exist"])
         if collection_version.published_at is not None:
@@ -404,7 +404,7 @@ class BusinessLogic(BusinessLogicInterface):
                     f"Dataset {existing_dataset_version_id.id} does not belong to the desired collection"
                 )
 
-            dataset_version = self.database_provider.get_dataset_version(existing_dataset_version_id)
+            dataset_version = self.database_provider.get_dataset_version(existing_dataset_version_id)  # type: ignore
             if dataset_version is None:
                 raise DatasetNotFoundException(
                     f"Trying to replace non existent dataset {existing_dataset_version_id.id}"
@@ -416,7 +416,7 @@ class BusinessLogic(BusinessLogicInterface):
                 DatasetProcessingStatus.INITIALIZED,
             ]:
                 raise DatasetInWrongStatusException(
-                    f"Unable to reprocess dataset {existing_dataset_version_id.id}: processing status is "
+                    f"Unable to reprocess dataset {existing_dataset_version_id.id}: processing status is "  # type: ignore
                     f"{dataset_version.status.processing_status.name}"
                 )
 
@@ -462,7 +462,7 @@ class BusinessLogic(BusinessLogicInterface):
         """
         self._assert_collection_version_unpublished(collection_version_id)
         if not delete_published:
-            dv = self.database_provider.get_dataset_version(dataset_version_id)
+            dv = self.database_provider.get_dataset_version(dataset_version_id)  # type: ignore
             if dv.canonical_dataset.published_at:
                 raise CollectionUpdateException from None
         self.database_provider.delete_dataset_from_collection_version(collection_version_id, dataset_version_id)
@@ -485,7 +485,7 @@ class BusinessLogic(BusinessLogicInterface):
         for collection in collections:
             datasest_ids = [d.id for d in collection.datasets]
             collection_datasets: List[DatasetVersion] = [
-                self.database_provider.get_dataset_version(DatasetVersionId(id)) for id in datasest_ids
+                self.database_provider.get_dataset_version(DatasetVersionId(id)) for id in datasest_ids  # type: ignore
             ]
             datasets.extend(collection_datasets)
         return datasets
@@ -506,7 +506,7 @@ class BusinessLogic(BusinessLogicInterface):
         """
         Returns all the artifacts for a dataset
         """
-        dataset = self.database_provider.get_dataset_version(dataset_version_id)
+        dataset = self.database_provider.get_dataset_version(dataset_version_id)  # type: ignore
         return dataset.artifacts
 
     def get_dataset_artifact_download_data(
@@ -591,9 +591,9 @@ class BusinessLogic(BusinessLogicInterface):
         """
         Updates uri for an existing artifact_id
         """
-        self.database_provider.update_dataset_artifact(artifact_id, artifact_uri)
+        self.database_provider.update_dataset_artifact(artifact_id, artifact_uri)  # type: ignore
 
-    def create_collection_version(self, collection_id: CollectionId) -> CollectionVersionWithDatasets:
+    def create_collection_version(self, collection_id: CollectionId) -> CollectionVersionWithDatasets:  # type: ignore
         """
         Creates a collection version for an existing canonical collection.
         Also ensures that the collection does not have any active, unpublished version
@@ -647,14 +647,14 @@ class BusinessLogic(BusinessLogicInterface):
         """
         Tombstones a canonical collection
         """
-        self.delete_all_dataset_versions_from_bucket_for_collection(collection_id, os.getenv("DATASETS_BUCKET"))
+        self.delete_all_dataset_versions_from_bucket_for_collection(collection_id, os.getenv("DATASETS_BUCKET"))  # type: ignore
         self.database_provider.delete_canonical_collection(collection_id)
 
     def publish_collection_version(self, version_id: CollectionVersionId) -> None:
         """
         Publishes a collection version.
         """
-        version = self.database_provider.get_collection_version_with_datasets(version_id)
+        version = self.database_provider.get_collection_version_with_datasets(version_id)  # type: ignore
 
         if version.published_at is not None:
             raise CollectionPublishException("Cannot publish an already published collection")
@@ -662,7 +662,7 @@ class BusinessLogic(BusinessLogicInterface):
         if len(version.datasets) == 0:
             raise CollectionPublishException("Cannot publish a collection with no datasets")
 
-        schema_versions = {dataset.metadata.schema_version for dataset in version.datasets}
+        schema_versions = {dataset.metadata.schema_version for dataset in version.datasets}  # type: ignore
         if len(schema_versions) != 1:
             raise CollectionPublishException("Cannot publish a collection with datasets of different schema versions")
         schema_version = next(iter(schema_versions))
@@ -678,18 +678,18 @@ class BusinessLogic(BusinessLogicInterface):
                 has_dataset_revisions = True
 
         dataset_version_ids_to_delete_from_s3 = self.database_provider.finalize_collection_version(
-            version.collection_id, version_id, schema_version, update_revised_at=has_dataset_revisions
+            version.collection_id, version_id, schema_version, update_revised_at=has_dataset_revisions  # type: ignore
         )
 
-        self.delete_dataset_versions_from_bucket(dataset_version_ids_to_delete_from_s3, os.getenv("DATASETS_BUCKET"))
+        self.delete_dataset_versions_from_bucket(dataset_version_ids_to_delete_from_s3, os.getenv("DATASETS_BUCKET"))  # type: ignore
 
-    def get_dataset_version(self, dataset_version_id: DatasetVersionId) -> Optional[DatasetVersion]:
+    def get_dataset_version(self, dataset_version_id: DatasetVersionId) -> Optional[DatasetVersion]:  # type: ignore
         """
         Returns a dataset version by id
         """
-        return self.database_provider.get_dataset_version(dataset_version_id)
+        return self.database_provider.get_dataset_version(dataset_version_id)  # type: ignore
 
-    def get_dataset_version_from_canonical(
+    def get_dataset_version_from_canonical(  # type: ignore
         self, dataset_id: DatasetId, get_tombstoned: bool = False
     ) -> Optional[DatasetVersion]:
         """
@@ -747,7 +747,7 @@ class BusinessLogic(BusinessLogicInterface):
         """
         dataset_version = self.database_provider.get_dataset_version(dataset_version_id, get_tombstoned=True)
         if not dataset_version:
-            return None
+            return None  # type: ignore
         if dataset_version.canonical_dataset.tombstoned:
             raise DatasetIsTombstonedException()
         collection_versions = self.database_provider.get_all_versions_for_collection(dataset_version.collection_id)
@@ -757,11 +757,11 @@ class BusinessLogic(BusinessLogicInterface):
             )
             return PublishedDatasetVersion(
                 collection_version_id=collection_version_id,
-                published_at=published_at,
+                published_at=published_at,  # type: ignore
                 **vars(dataset_version),
             )
         except DatasetVersionNotFoundException:
-            return None
+            return None  # type: ignore
 
     def _get_collection_and_dataset(
         self, collection_id: str, dataset_id: str
@@ -795,12 +795,12 @@ class BusinessLogic(BusinessLogicInterface):
         """
         # Construct dict of collection_id: [Datasets]
         datasets_by_collection_id = defaultdict(list)
-        [datasets_by_collection_id[d.collection_id.id].append(d) for d in mapped_dataset_versions]
+        [datasets_by_collection_id[d.collection_id.id].append(d) for d in mapped_dataset_versions]  # type: ignore
 
         # Construct dict of collection_id: [all published Collection versions]
-        all_collections_versions = self.database_provider.get_all_collections_versions()
+        all_collections_versions = self.database_provider.get_all_collections_versions()  # type: ignore
         collection_versions_by_collection_id = defaultdict(list)
-        [collection_versions_by_collection_id[c.collection_id.id].append(c) for c in all_collections_versions]
+        [collection_versions_by_collection_id[c.collection_id.id].append(c) for c in all_collections_versions]  # type: ignore
 
         # Determine published_at and collection_version_id for all mapped Dataset versions. Both values come from the
         # Collection version with which the Dataset version was first published.
@@ -820,12 +820,12 @@ class BusinessLogic(BusinessLogicInterface):
                 published_datasets_for_collection.append(
                     PublishedDatasetVersion(
                         collection_version_id=collection_version_id,
-                        revised_at=revised_at,  # Duped logic to avoid pitfall; no effect in present implementation
-                        published_at=mapped_dataset_version.canonical_dataset.published_at,
+                        revised_at=revised_at,  # type: ignore# Duped logic to avoid pitfall; no effect in present implementation
+                        published_at=mapped_dataset_version.canonical_dataset.published_at,  # type: ignore
                         **vars(mapped_dataset_version),
                     )
                 )
-            collection.datasets = published_datasets_for_collection  # hack to allow unpacking via **vars() below
+            collection.datasets = published_datasets_for_collection  # type: ignore# hack to allow unpacking via **vars() below
             collections_with_published_datasets.append(CollectionVersionWithPublishedDatasets(**vars(collection)))
 
         return collections_with_published_datasets
@@ -840,13 +840,13 @@ class BusinessLogic(BusinessLogicInterface):
         :param dataset_id: The dataset id to restore the previous version of.
         """
 
-        collection = self.database_provider.get_collection_version_with_datasets(collection_version_id)
+        collection = self.database_provider.get_collection_version_with_datasets(collection_version_id)  # type: ignore
         if collection.is_published():
             raise CollectionIsPublishedException(
-                f"Collection {collection_version_id} is published, unable to restore previous dataset version"
+                f"Collection {collection_version_id} is published, unable to restore previous dataset version"  # type: ignore
             )
         current_version: DatasetVersion = [dv for dv in collection.datasets if dv.dataset_id == dataset_id][0]
-        previous_version_id: DatasetVersionId = self.database_provider.get_previous_dataset_version_id(dataset_id)
+        previous_version_id: DatasetVersionId = self.database_provider.get_previous_dataset_version_id(dataset_id)  # type: ignore
         if previous_version_id is None:
             raise NoPreviousDatasetVersionException(f"No previous dataset version for dataset {dataset_id.id}")
         logger.info(

--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -26,7 +26,7 @@ from backend.layers.common.entities import (
 
 
 class BusinessLogicInterface:
-    def get_collections(self, filter: CollectionQueryFilter) -> Iterable[CollectionVersion]:
+    def get_collections(self, filter: CollectionQueryFilter) -> Iterable[CollectionVersion]:  # type: ignore
         pass
 
     def get_published_collection_version(self, collection_id: CollectionId) -> Optional[CollectionVersionWithDatasets]:
@@ -37,12 +37,12 @@ class BusinessLogicInterface:
     ) -> Optional[CollectionVersionWithDatasets]:
         pass
 
-    def get_collection_version(
+    def get_collection_version(  # type: ignore
         self, version_id: CollectionVersionId, get_tombstoned: bool
     ) -> CollectionVersionWithDatasets:
         pass
 
-    def get_collection_versions_from_canonical(self, collection_id: CollectionId) -> Iterable[CollectionVersion]:
+    def get_collection_versions_from_canonical(self, collection_id: CollectionId) -> Iterable[CollectionVersion]:  # type: ignore
         pass
 
     def get_collection_version_from_canonical(
@@ -50,15 +50,15 @@ class BusinessLogicInterface:
     ) -> Optional[CollectionVersionWithDatasets]:
         pass
 
-    def create_collection(
+    def create_collection(  # type: ignore
         self, owner: str, curator_name: str, collection_metadata: CollectionMetadata
     ) -> CollectionVersion:
         pass
 
-    def delete_dataset_versions_from_bucket(self, dataset_version_ids: List[str], bucket: str) -> List[str]:
+    def delete_dataset_versions_from_bucket(self, dataset_version_ids: List[str], bucket: str) -> List[str]:  # type: ignore
         pass
 
-    def delete_all_dataset_versions_from_bucket_for_collection(
+    def delete_all_dataset_versions_from_bucket_for_collection(  # type: ignore
         self, collection_id: CollectionId, bucket: str
     ) -> List[str]:
         pass
@@ -69,7 +69,7 @@ class BusinessLogicInterface:
     def update_collection_version(self, version_id: CollectionVersionId, body: CollectionMetadataUpdate) -> None:
         pass
 
-    def create_collection_version(self, collection_id: CollectionId) -> CollectionVersion:
+    def create_collection_version(self, collection_id: CollectionId) -> CollectionVersion:  # type: ignore
         pass
 
     def delete_collection_version(self, version_id: CollectionVersionId) -> None:
@@ -78,7 +78,7 @@ class BusinessLogicInterface:
     def publish_collection_version(self, version_id: CollectionVersionId) -> None:
         pass
 
-    def ingest_dataset(
+    def ingest_dataset(  # type: ignore
         self,
         collection_version_id: CollectionVersionId,
         url: str,
@@ -87,10 +87,10 @@ class BusinessLogicInterface:
     ) -> Tuple[DatasetVersionId, DatasetId]:
         pass
 
-    def get_all_mapped_datasets(self) -> List[DatasetVersion]:
+    def get_all_mapped_datasets(self) -> List[DatasetVersion]:  # type: ignore
         pass
 
-    def get_all_mapped_collection_versions_with_datasets(self) -> List[CollectionVersionWithPublishedDatasets]:
+    def get_all_mapped_collection_versions_with_datasets(self) -> List[CollectionVersionWithPublishedDatasets]:  # type: ignore
         pass
 
     def remove_dataset_version(
@@ -101,10 +101,10 @@ class BusinessLogicInterface:
     def set_dataset_metadata(self, dataset_version_id: DatasetVersionId, metadata: DatasetMetadata) -> None:
         pass
 
-    def get_dataset_artifacts(self, dataset_version_id: DatasetVersionId) -> Iterable[DatasetArtifact]:
+    def get_dataset_artifacts(self, dataset_version_id: DatasetVersionId) -> Iterable[DatasetArtifact]:  # type: ignore
         pass
 
-    def get_dataset_artifact_download_data(
+    def get_dataset_artifact_download_data(  # type: ignore
         self, dataset_version_id: DatasetVersionId, artifact_id: DatasetArtifactId
     ) -> DatasetArtifactDownloadData:
         pass
@@ -118,27 +118,27 @@ class BusinessLogicInterface:
     ) -> None:
         pass
 
-    def add_dataset_artifact(
+    def add_dataset_artifact(  # type: ignore
         self, dataset_version_id: DatasetVersionId, artifact_type: str, artifact_uri: str
     ) -> DatasetArtifactId:
         pass
 
-    def get_dataset_status(self, dataset_version_id: DatasetVersionId) -> DatasetStatus:
+    def get_dataset_status(self, dataset_version_id: DatasetVersionId) -> DatasetStatus:  # type: ignore
         pass
 
-    def get_dataset_version(self, dataset_version_id: DatasetVersionId) -> DatasetVersion:
+    def get_dataset_version(self, dataset_version_id: DatasetVersionId) -> DatasetVersion:  # type: ignore
         pass
 
-    def get_prior_published_versions_for_dataset(self, dataset_id: DatasetId) -> List[PublishedDatasetVersion]:
+    def get_prior_published_versions_for_dataset(self, dataset_id: DatasetId) -> List[PublishedDatasetVersion]:  # type: ignore
         pass
 
-    def get_prior_published_dataset_version(self, dataset_version_id: DatasetVersionId) -> PublishedDatasetVersion:
+    def get_prior_published_dataset_version(self, dataset_version_id: DatasetVersionId) -> PublishedDatasetVersion:  # type: ignore
         pass
 
-    def get_dataset_version_from_canonical(self, dataset_id: DatasetId, get_tombstoned: bool) -> DatasetVersion:
+    def get_dataset_version_from_canonical(self, dataset_id: DatasetId, get_tombstoned: bool) -> DatasetVersion:  # type: ignore
         pass
 
-    def get_latest_published_collection_versions_by_schema(
+    def get_latest_published_collection_versions_by_schema(  # type: ignore
         self, schema_version: str
     ) -> List[CollectionVersionWithPublishedDatasets]:
         pass

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -115,7 +115,7 @@ class DatasetStatus:
 class EntityId:
     id: str
 
-    def __init__(self, entity_id: str = None):
+    def __init__(self, entity_id: str = None):  # type: ignore
         self.id = str(entity_id) if entity_id is not None else str(uuid.uuid4())
 
     def __repr__(self) -> str:
@@ -205,7 +205,7 @@ class DatasetVersion:
 class PublishedDatasetVersion(DatasetVersion):
     collection_version_id: CollectionVersionId  # Pointer to collection version it was originally published under
     published_at: datetime
-    revised_at: datetime = None
+    revised_at: datetime = None  # type: ignore
 
 
 @dataclass

--- a/backend/layers/common/helpers.py
+++ b/backend/layers/common/helpers.py
@@ -46,7 +46,7 @@ def set_revised_at_field(dataset_versions: List[DatasetVersion], collection_vers
             version_published_at, collection_version_id = get_published_at_and_collection_version_id_else_not_found(
                 dataset_version, collection_versions
             )
-            if version_published_at > dataset_version.canonical_dataset.published_at:
+            if version_published_at > dataset_version.canonical_dataset.published_at:  # type: ignore
                 # Dataset has been revised
                 dataset_version.canonical_dataset.revised_at = version_published_at
         except DatasetVersionNotFoundException:
@@ -71,7 +71,7 @@ def get_dataset_versions_with_published_at_and_collection_version_id(
         published_datasets_for_collection.append(
             PublishedDatasetVersion(
                 collection_version_id=collection_version_id,
-                published_at=published_at,
+                published_at=published_at,  # type: ignore
                 **vars(dataset_version),
             )
         )

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -28,7 +28,7 @@ class PersistenceException(Exception):
 
 
 class DatabaseProviderInterface:
-    def create_canonical_collection(
+    def create_canonical_collection(  # type: ignore
         self, owner: str, curator_name: str, collection_metadata: CollectionMetadata
     ) -> CollectionVersion:
         """
@@ -36,22 +36,22 @@ class DatabaseProviderInterface:
         Returns the newly created CollectionVersion
         """
 
-    def get_canonical_collection(self, collection_id: CollectionId) -> CanonicalCollection:
+    def get_canonical_collection(self, collection_id: CollectionId) -> CanonicalCollection:  # type: ignore
         """
         Return the canonical collection with id `collection_id`
         """
 
-    def get_canonical_dataset(self, dataset_id: DatasetId) -> CanonicalDataset:
+    def get_canonical_dataset(self, dataset_id: DatasetId) -> CanonicalDataset:  # type: ignore
         """
         Return the canonical Dataset with id `dataset_id`
         """
 
-    def get_collection_version(self, version_id: CollectionVersionId) -> CollectionVersion:
+    def get_collection_version(self, version_id: CollectionVersionId) -> CollectionVersion:  # type: ignore
         """
         Retrieves a specific collection version by id
         """
 
-    def get_collection_version_with_datasets(
+    def get_collection_version_with_datasets(  # type: ignore
         self, version_id: CollectionVersionId, get_tombstoned: bool
     ) -> CollectionVersionWithDatasets:
         """
@@ -63,18 +63,18 @@ class DatabaseProviderInterface:
         Retrieves the latest mapped version for a collection
         """
 
-    def get_all_versions_for_collection(self, collection_id: CollectionId) -> List[CollectionVersionWithDatasets]:
+    def get_all_versions_for_collection(self, collection_id: CollectionId) -> List[CollectionVersionWithDatasets]:  # type: ignore
         """
         Retrieves all versions for a specific collections, without filtering
         """
 
-    def get_all_collections_versions(self, get_tombstoned: bool) -> Iterable[CollectionVersion]:
+    def get_all_collections_versions(self, get_tombstoned: bool) -> Iterable[CollectionVersion]:  # type: ignore
         """
         Retrieves all versions of all collections.
         TODO: for performance reasons, it might be necessary to add a filtering parameter here.
         """
 
-    def get_all_mapped_collection_versions(self) -> Iterable[CollectionVersion]:
+    def get_all_mapped_collection_versions(self) -> Iterable[CollectionVersion]:  # type: ignore
         """
         Retrieves all the collection versions that are mapped to a canonical collection.
         """
@@ -98,7 +98,7 @@ class DatabaseProviderInterface:
         Saves publisher metadata for a collection version. Specify None to remove it
         """
 
-    def add_collection_version(self, collection_id: CollectionId) -> CollectionVersionId:
+    def add_collection_version(self, collection_id: CollectionId) -> CollectionVersionId:  # type: ignore
         """
         Adds a collection version to an existing canonical collection. The new version copies the following data from
          the previous version: owner, metadata, publisher_metadata, datasets (IDs).
@@ -110,7 +110,7 @@ class DatabaseProviderInterface:
         Deletes a collection version.
         """
 
-    def finalize_collection_version(
+    def finalize_collection_version(  # type: ignore
         self,
         collection_id: CollectionId,
         version_id: CollectionVersionId,
@@ -133,7 +133,7 @@ class DatabaseProviderInterface:
         Sets the `published_at` datetime for a collection version and its datasets
         """
 
-    def get_dataset_version(self, dataset_version_id: DatasetVersionId, get_tombstoned: bool) -> DatasetVersion:
+    def get_dataset_version(self, dataset_version_id: DatasetVersionId, get_tombstoned: bool) -> DatasetVersion:  # type: ignore
         """
         Returns a dataset version by id.
         """
@@ -143,12 +143,12 @@ class DatabaseProviderInterface:
         Returns the most recent, active Dataset version for a canonical dataset_id
         """
 
-    def get_all_versions_for_dataset(self, dataset_id: DatasetId) -> List[DatasetVersion]:
+    def get_all_versions_for_dataset(self, dataset_id: DatasetId) -> List[DatasetVersion]:  # type: ignore
         """
         Returns all dataset versions for a canonical dataset_id
         """
 
-    def get_all_mapped_datasets_and_collections(
+    def get_all_mapped_datasets_and_collections(  # type: ignore
         self,
     ) -> Tuple[List[DatasetVersion], List[CollectionVersion]]:  # TODO: add filters if needed
         """
@@ -156,18 +156,18 @@ class DatabaseProviderInterface:
         # TODO: Add filtering
         """
 
-    def get_dataset_artifacts_by_version_id(self, dataset_version_id: DatasetVersionId) -> List[DatasetArtifact]:
+    def get_dataset_artifacts_by_version_id(self, dataset_version_id: DatasetVersionId) -> List[DatasetArtifact]:  # type: ignore
         """
         Returns all the artifacts for a specific dataset version
         """
 
-    def create_canonical_dataset(self, collection_version_id: CollectionVersionId) -> DatasetVersion:
+    def create_canonical_dataset(self, collection_version_id: CollectionVersionId) -> DatasetVersion:  # type: ignore
         """
         Initializes a canonical dataset, generating a dataset_id and a dataset_version_id.
         Returns the newly created DatasetVersion.
         """
 
-    def add_dataset_artifact(
+    def add_dataset_artifact(  # type: ignore
         self, version_id: DatasetVersionId, artifact_type: str, artifact_uri: str
     ) -> DatasetArtifactId:
         """
@@ -201,7 +201,7 @@ class DatabaseProviderInterface:
         Updates the validation message for a dataset version
         """
 
-    def get_dataset_version_status(self, version_id: DatasetVersionId) -> DatasetStatus:
+    def get_dataset_version_status(self, version_id: DatasetVersionId) -> DatasetStatus:  # type: ignore
         """
         Returns the status for a dataset version
         """
@@ -225,11 +225,11 @@ class DatabaseProviderInterface:
         Removes a mapping between a collection version and a dataset version
         """
 
-    def replace_dataset_in_collection_version(
+    def replace_dataset_in_collection_version(  # type: ignore
         self,
         collection_version_id: CollectionVersionId,
         old_dataset_version_id: DatasetVersionId,
-        new_dataset_version_id: DatasetVersionId = None,
+        new_dataset_version_id: DatasetVersionId = None,  # type: ignore
     ) -> DatasetVersion:
         """
         Replaces an existing mapping between a collection version and a dataset version
@@ -240,7 +240,7 @@ class DatabaseProviderInterface:
         Returns the dataset version mapped to a canonical dataset_id, or None if not existing
         """
 
-    def get_collection_versions_by_schema(self, schema_version: str, has_wildcards: bool) -> List[CollectionVersion]:
+    def get_collection_versions_by_schema(self, schema_version: str, has_wildcards: bool) -> List[CollectionVersion]:  # type: ignore
         """
         Returns a list with all collection versions that match the given schema_version. schema_version may contain
          wildcards.

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -74,7 +74,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             publisher_metadata=None,
             published_at=None,
             created_at=datetime.utcnow(),
-            schema_version=None,
+            schema_version=None,  # type: ignore
             canonical_collection=canonical,
             datasets=[],
         )
@@ -95,7 +95,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
         if update_datasets:
             datasets_to_include = []
             for dataset_id in copied_version.datasets:
-                if dataset_version := self.get_dataset_version(dataset_id):
+                if dataset_version := self.get_dataset_version(dataset_id):  # type: ignore
                     datasets_to_include.append(dataset_version)
             copied_version.datasets = datasets_to_include
             # Hack for business logic that uses isinstance
@@ -114,10 +114,10 @@ class DatabaseProviderMock(DatabaseProviderInterface):
         copied_version.canonical_dataset = cd
         return copied_version
 
-    def get_collection_mapped_version(self, collection_id: CollectionId) -> Optional[CollectionVersionWithDatasets]:
+    def get_collection_mapped_version(self, collection_id: CollectionId) -> Optional[CollectionVersionWithDatasets]:  # type: ignore
         cc = self.collections.get(collection_id.id)
         if cc is not None:
-            return self.get_collection_version_with_datasets(cc.version_id, get_tombstoned=True)
+            return self.get_collection_version_with_datasets(cc.version_id, get_tombstoned=True)  # type: ignore
 
     def get_all_collections_versions(
         self, get_tombstoned: bool = False
@@ -133,14 +133,14 @@ class DatabaseProviderMock(DatabaseProviderInterface):
                 included_dataset_version_ids.append(d_v_id)
             yield updated_version
 
-    def get_canonical_collection(self, collection_id: CollectionId) -> Optional[CanonicalCollection]:
+    def get_canonical_collection(self, collection_id: CollectionId) -> Optional[CanonicalCollection]:  # type: ignore
         return self.collections.get(collection_id.id, None)
 
     def get_all_mapped_collection_versions(
         self, get_tombstoned: bool = False
     ) -> Iterable[CollectionVersion]:  # TODO: add filters if needed
         for version_id, collection_version in self.collections_versions.items():
-            if version_id in [c.version_id.id for c in self.collections.values()]:
+            if version_id in [c.version_id.id for c in self.collections.values()]:  # type: ignore
                 collection_id = collection_version.collection_id.id
                 if not get_tombstoned and self.collections[collection_id].tombstoned:
                     continue
@@ -168,7 +168,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
     def add_collection_version(self, collection_id: CollectionId) -> CollectionVersionId:
         cc = self.collections[collection_id.id]
         current_version_id = cc.version_id
-        current_version = self.collections_versions[current_version_id.id]
+        current_version = self.collections_versions[current_version_id.id]  # type: ignore
         new_version_id = CollectionVersionId()
         # Note: since datasets are immutable, there is no need to clone datasets here,
         # but the list that contains datasets needs to be copied, since it's a pointer.
@@ -184,7 +184,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             datasets=new_dataset_list,
             published_at=None,
             created_at=datetime.utcnow(),
-            schema_version=None,
+            schema_version=None,  # type: ignore
             canonical_collection=cc,
         )
         self.collections_versions[new_version_id.id] = collection_version
@@ -193,15 +193,15 @@ class DatabaseProviderMock(DatabaseProviderInterface):
     def delete_collection_version(self, version_id: CollectionVersionId) -> None:
         collection_version = self.collections_versions.get(version_id.id)
         if collection_version and collection_version.published_at is not None:
-            raise CollectionIsPublishedException("Can only delete unpublished collections")
+            raise CollectionIsPublishedException("Can only delete unpublished collections")  # type: ignore
         del self.collections_versions[version_id.id]
 
-    def get_collection_version(self, version_id: CollectionVersionId) -> CollectionVersion:
+    def get_collection_version(self, version_id: CollectionVersionId) -> CollectionVersion:  # type: ignore
         version = self.collections_versions.get(version_id.id)
         if version is not None:
             return self._update_version_with_canonical(version)
 
-    def get_all_versions_for_collection(self, collection_id: CollectionId) -> Iterable[CollectionVersionWithDatasets]:
+    def get_all_versions_for_collection(self, collection_id: CollectionId) -> Iterable[CollectionVersionWithDatasets]:  # type: ignore
         # On a database, will require a secondary index on `collection_id` for an optimized lookup
         versions = []
         for collection_version in self.collections_versions.values():
@@ -214,14 +214,14 @@ class DatabaseProviderMock(DatabaseProviderInterface):
     ) -> CollectionVersionWithDatasets:
         version = self.collections_versions.get(version_id.id)
         if not version:
-            return None
+            return None  # type: ignore
         version = self._update_version_with_canonical(version, update_datasets=True)
-        if not get_tombstoned and version.canonical_collection.tombstoned:
-            return None
-        return version
+        if not get_tombstoned and version.canonical_collection.tombstoned:  # type: ignore
+            return None  # type: ignore
+        return version  # type: ignore
 
     # MAYBE
-    def finalize_collection_version(
+    def finalize_collection_version(  # type: ignore
         self,
         collection_id: CollectionId,
         version_id: CollectionVersionId,
@@ -256,7 +256,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
 
         else:
             # Check to see if any Datasets are missing from new version, tombstone if so
-            current_dataset_version_ids = self.collections_versions[cc.version_id.id].datasets
+            current_dataset_version_ids = self.collections_versions[cc.version_id.id].datasets  # type: ignore
             current_dataset_ids = [
                 self.datasets_versions[d_v_id.id].dataset_id.id for d_v_id in current_dataset_version_ids
             ]
@@ -289,14 +289,14 @@ class DatabaseProviderMock(DatabaseProviderInterface):
 
     def get_canonical_dataset(self, dataset_id: DatasetId) -> CanonicalDataset:
         if dataset_id.id is None or dataset_id.id not in self.datasets:
-            return None
+            return None  # type: ignore
         return self.datasets[dataset_id.id]
 
-    def get_dataset_version(self, version_id: DatasetVersionId, get_tombstoned: bool = False) -> DatasetVersion:
+    def get_dataset_version(self, version_id: DatasetVersionId, get_tombstoned: bool = False) -> DatasetVersion:  # type: ignore
         dataset_version = self.datasets_versions.get(version_id.id)
         if dataset_version:
             if not get_tombstoned and dataset_version.canonical_dataset.tombstoned:
-                return None
+                return None  # type: ignore
             return self._update_dataset_version_with_canonical(dataset_version)
 
     def get_all_mapped_datasets_and_collections(self) -> Tuple[List[DatasetVersion], List[CollectionVersion]]:
@@ -322,7 +322,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             dataset_versions.append(dataset_version)
         return dataset_versions
 
-    def get_most_recent_active_dataset_version(self, dataset_id: DatasetId) -> Optional[DatasetVersion]:
+    def get_most_recent_active_dataset_version(self, dataset_id: DatasetId) -> Optional[DatasetVersion]:  # type: ignore
         """
         Returns the most recent, active Dataset version for a canonical dataset_id
         """
@@ -342,7 +342,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
         for cv_dataset_versions in cv_dataset_versions_ids:
             for dv_id in dataset_versions_map:
                 if DatasetVersionId(dv_id) in cv_dataset_versions:
-                    return self._update_dataset_version_with_canonical(dataset_versions_map.get(dv_id))
+                    return self._update_dataset_version_with_canonical(dataset_versions_map.get(dv_id))  # type: ignore
 
     def get_all_versions_for_dataset(self, dataset_id: DatasetId) -> List[DatasetVersion]:
         """
@@ -362,7 +362,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             if version_id in self.datasets.values():
                 yield self._update_dataset_version_with_canonical(dataset_version)
 
-    def get_dataset_artifacts_by_version_id(self, dataset_version_id: DatasetId) -> List[DatasetArtifact]:
+    def get_dataset_artifacts_by_version_id(self, dataset_version_id: DatasetId) -> List[DatasetArtifact]:  # type: ignore
         dataset = self.datasets_versions[dataset_version_id.id]
         return copy.deepcopy(dataset.artifacts)
 
@@ -397,7 +397,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
     ) -> DatasetArtifactId:
         version = self.datasets_versions[version_id.id]
         artifact_id = DatasetArtifactId()
-        version.artifacts.append(DatasetArtifact(artifact_id, artifact_type, artifact_uri))
+        version.artifacts.append(DatasetArtifact(artifact_id, artifact_type, artifact_uri))  # type: ignore
         return artifact_id
 
     def update_dataset_artifact(self, artifact_id: DatasetArtifactId, artifact_uri: str) -> None:
@@ -453,7 +453,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
         self,
         collection_version_id: CollectionVersionId,
         old_dataset_version_id: DatasetVersionId,
-        new_dataset_version_id: DatasetVersionId = None,
+        new_dataset_version_id: DatasetVersionId = None,  # type: ignore
     ) -> DatasetVersion:
         old_version = self.get_dataset_version(old_dataset_version_id)
         collection_version = self.collections_versions[collection_version_id.id]
@@ -484,7 +484,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
     def get_dataset_version_status(self, version_id: DatasetVersionId) -> DatasetStatus:
         return copy.deepcopy(self.datasets_versions[version_id.id].status)
 
-    def get_dataset_mapped_version(
+    def get_dataset_mapped_version(  # type: ignore
         self, dataset_id: DatasetId, get_tombstoned: bool = False
     ) -> Optional[DatasetVersion]:
         cd = self.datasets.get(dataset_id.id)

--- a/backend/layers/processing/downloader.py
+++ b/backend/layers/processing/downloader.py
@@ -3,7 +3,7 @@ import logging
 import shutil
 import threading
 
-import requests
+import requests  # type: ignore
 
 from backend.layers.business.business_interface import BusinessLogicInterface
 from backend.layers.common.entities import DatasetStatusKey, DatasetUploadStatus, DatasetVersionId
@@ -19,7 +19,7 @@ class ProgressTracker:
         self.progress_lock: threading.Lock = threading.Lock()  # prevent concurrent access of ProgressTracker._progress
         self.stop_updater: threading.Event = threading.Event()  # Stops the update_progress thread
         self.stop_downloader: threading.Event = threading.Event()  # Stops the downloader threads
-        self.error: Exception = None  # Track errors
+        self.error: Exception = None  # type: ignore# Track errors
         self.tombstoned: bool = False  # Track if dataset tombstoned
 
     def progress(self):
@@ -47,7 +47,7 @@ class NoOpProgressTracker:
         self.progress_lock: threading.Lock = threading.Lock()  # prevent concurrent access of ProgressTracker._progress
         self.stop_updater: threading.Event = threading.Event()  # Stops the update_progress thread
         self.stop_downloader: threading.Event = threading.Event()  # Stops the downloader threads
-        self.error: Exception = None  # Track errors
+        self.error: Exception = None  # type: ignore# Track errors
         self.tombstoned: bool = False  # Track if dataset tombstoned
 
     def progress(self):

--- a/backend/layers/processing/process.py
+++ b/backend/layers/processing/process.py
@@ -65,7 +65,7 @@ class ProcessMain(ProcessingLogic):
         )
         self.process_seurat = ProcessSeurat(self.business_logic, self.uri_provider, self.s3_provider)
         self.process_cxg = ProcessCxg(self.business_logic, self.uri_provider, self.s3_provider)
-        self.schema_migrate = SchemaMigrate(business_logic)
+        self.schema_migrate = SchemaMigrate(business_logic)  # type: ignore
 
     def log_batch_environment(self):
         batch_environment_variables = [
@@ -99,18 +99,18 @@ class ProcessMain(ProcessingLogic):
         """
         Gets called by the step function at every different step, as defined by `step_name`
         """
-        self.logger.info(f"Processing dataset {dataset_id}")
+        self.logger.info(f"Processing dataset {dataset_id}")  # type: ignore
         try:
             if step_name == "download-validate":
-                self.process_download_validate.process(dataset_id, dropbox_uri, artifact_bucket, datasets_bucket)
+                self.process_download_validate.process(dataset_id, dropbox_uri, artifact_bucket, datasets_bucket)  # type: ignore
             elif step_name == "cxg":
-                self.process_cxg.process(dataset_id, artifact_bucket, cxg_bucket)
+                self.process_cxg.process(dataset_id, artifact_bucket, cxg_bucket)  # type: ignore
             elif step_name == "cxg_remaster":
-                self.process_cxg.process(dataset_id, artifact_bucket, cxg_bucket, is_reprocess=True)
+                self.process_cxg.process(dataset_id, artifact_bucket, cxg_bucket, is_reprocess=True)  # type: ignore
             elif step_name == "seurat":
-                self.process_seurat.process(dataset_id, artifact_bucket, datasets_bucket)
+                self.process_seurat.process(dataset_id, artifact_bucket, datasets_bucket)  # type: ignore
             else:
-                self.logger.error(f"Step function configuration error: Unexpected STEP_NAME '{step_name}'")
+                self.logger.error(f"Step function configuration error: Unexpected STEP_NAME '{step_name}'")  # type: ignore
 
         # TODO: this could be better - maybe collapse all these exceptions and pass in the status key and value
         except ProcessingCanceled:
@@ -130,7 +130,7 @@ class ProcessMain(ProcessingLogic):
             self.update_processing_status(dataset_id, e.failed_status, DatasetConversionStatus.FAILED)
             return False
         except Exception as e:
-            self.logger.exception(f"An unexpected error occurred while processing the data set: {e}")
+            self.logger.exception(f"An unexpected error occurred while processing the data set: {e}")  # type: ignore
             if step_name == "download-validate":
                 self.update_processing_status(dataset_id, DatasetStatusKey.UPLOAD, DatasetUploadStatus.FAILED)
             elif step_name == "seurat":
@@ -172,8 +172,8 @@ if __name__ == "__main__":
 
     business_logic = BusinessLogic(
         database_provider,
-        None,  # Not required - decide if we should pass for safety
-        None,  # Not required - decide if we should pass for safety
+        None,  # type: ignore# Not required - decide if we should pass for safety
+        None,  # type: ignore# Not required - decide if we should pass for safety
         s3_provider,
         uri_provider,
     )

--- a/backend/layers/processing/process_cxg.py
+++ b/backend/layers/processing/process_cxg.py
@@ -55,7 +55,7 @@ class ProcessCxg(ProcessingLogic):
             current_artifacts = self.business_logic.get_dataset_artifacts(dataset_id)
             existing_h5ad = [artifact for artifact in current_artifacts if artifact.type == DatasetArtifactType.H5AD][0]
             if existing_h5ad:
-                _, object_key = self.s3_provider.parse_s3_uri(existing_h5ad.uri)
+                _, object_key = self.s3_provider.parse_s3_uri(existing_h5ad.uri)  # type: ignore
         if object_key is None:
             key_prefix = self.get_key_prefix(dataset_id.id)
             object_key = f"{key_prefix}/{labeled_h5ad_filename}"

--- a/backend/layers/processing/process_download_validate.py
+++ b/backend/layers/processing/process_download_validate.py
@@ -75,7 +75,7 @@ class ProcessDownloadValidate(ProcessingLogic):
                 local_filename, output_filename
             )
         except Exception as e:
-            self.logger.exception("validation failed")
+            self.logger.exception("validation failed")  # type: ignore
             raise ValidationFailed([str(e)]) from None
 
         if not is_valid:
@@ -155,7 +155,7 @@ class ProcessDownloadValidate(ProcessingLogic):
             cell_type=_get_term_pairs("cell_type"),
             x_approximate_distribution=_get_x_approximate_distribution(),  # TODO: pay attention
             schema_version=adata.uns["schema_version"],
-            batch_condition=_get_batch_condition(),  # TODO: pay attention
+            batch_condition=_get_batch_condition(),  # type: ignore# TODO: pay attention
             donor_id=adata.obs["donor_id"].unique(),
             suspension_type=adata.obs["suspension_type"].unique(),
         )
@@ -184,7 +184,7 @@ class ProcessDownloadValidate(ProcessingLogic):
         """Given a source URI, download it to local_path.
         Handles fixing the url so it downloads directly.
         """
-        self.logger.info("Start download")
+        self.logger.info("Start download")  # type: ignore
         file_url = self.uri_provider.parse(source_uri)
         if not file_url:
             raise ValueError(f"Malformed source URI: {source_uri}")
@@ -192,8 +192,8 @@ class ProcessDownloadValidate(ProcessingLogic):
         # This is a bit ugly and should be done polymorphically instead, but Dropbox support will be dropped soon
         if file_url.scheme == "https":
             file_info = self.uri_provider.get_file_info(source_uri)
-            status = self.downloader.download(dataset_id, file_url.url, local_path, file_info.size)
-            self.logger.info(status)  # TODO: this log is awful
+            status = self.downloader.download(dataset_id, file_url.url, local_path, file_info.size)  # type: ignore
+            self.logger.info(status)  # type: ignore# TODO: this log is awful
         elif file_url.scheme == "s3":
             bucket_name = file_url.netloc
             key = self.remove_prefix(file_url.path, "/")
@@ -206,7 +206,7 @@ class ProcessDownloadValidate(ProcessingLogic):
         else:
             raise ValueError(f"Download for URI scheme '{file_url.scheme}' not implemented")
 
-        self.logger.info("Download complete")  # TODO: remove
+        self.logger.info("Download complete")  # type: ignore# TODO: remove
         return local_path
 
     # TODO: after upgrading to Python 3.9, replace this with removeprefix()
@@ -246,7 +246,7 @@ class ProcessDownloadValidate(ProcessingLogic):
 
         if not can_convert_to_seurat:
             self.update_processing_status(dataset_id, DatasetStatusKey.RDS, DatasetConversionStatus.SKIPPED)
-            self.logger.info(f"Skipping Seurat conversion for dataset {dataset_id}")
+            self.logger.info(f"Skipping Seurat conversion for dataset {dataset_id}")  # type: ignore
 
         key_prefix = self.get_key_prefix(dataset_id.id)
         # Upload the original dataset to the artifact bucket

--- a/backend/layers/processing/process_logic.py
+++ b/backend/layers/processing/process_logic.py
@@ -26,7 +26,7 @@ class ProcessingLogic:  # TODO: ProcessingLogicBase
     uri_provider: UriProviderInterface
     s3_provider: S3ProviderInterface
     downloader: Downloader
-    logger: logging
+    logger: logging  # type: ignore
 
     def __init__(self) -> None:
         self.logger = logging.getLogger("processing")
@@ -40,7 +40,7 @@ class ProcessingLogic:  # TODO: ProcessingLogicBase
     ):
         validation_message = "\n".join(validation_errors) if validation_errors is not None else None
         self.business_logic.update_dataset_version_status(dataset_id, status_key, status_value, validation_message)
-        self.logger.info(
+        self.logger.info(  # type: ignore
             "Updating processing status",
             extra=dict(validation_message=validation_message, status_key=status_key, status_value=status_value),
         )
@@ -81,16 +81,16 @@ class ProcessingLogic:  # TODO: ProcessingLogicBase
         self.update_processing_status(dataset_id, processing_status_key, DatasetConversionStatus.UPLOADING)
         try:
             s3_uri = self.upload_artifact(file_name, key_prefix, artifact_bucket)
-            self.logger.info(f"Uploaded [{dataset_id}/{file_name}] to {s3_uri}")
+            self.logger.info(f"Uploaded [{dataset_id}/{file_name}] to {s3_uri}")  # type: ignore
             self.business_logic.add_dataset_artifact(dataset_id, artifact_type, s3_uri)
-            self.logger.info(f"Updated database with {artifact_type}.")
+            self.logger.info(f"Updated database with {artifact_type}.")  # type: ignore
             if datasets_bucket:
                 key = ".".join((key_prefix, artifact_type))
                 self.s3_provider.upload_file(
                     file_name, datasets_bucket, key, extra_args={"ACL": "bucket-owner-full-control"}
                 )
                 datasets_s3_uri = self.make_s3_uri(datasets_bucket, key_prefix, key)
-                self.logger.info(f"Uploaded {dataset_id}.{artifact_type} to {datasets_s3_uri}")
+                self.logger.info(f"Uploaded {dataset_id}.{artifact_type} to {datasets_s3_uri}")  # type: ignore
             self.update_processing_status(dataset_id, processing_status_key, DatasetConversionStatus.UPLOADED)
         except Exception:
             raise ConversionFailed(processing_status_key) from None
@@ -103,13 +103,13 @@ class ProcessingLogic:  # TODO: ProcessingLogicBase
         dataset_id: DatasetVersionId,
         processing_status_key: DatasetStatusKey,
     ) -> str:
-        self.logger.info(f"Converting {local_filename}")
+        self.logger.info(f"Converting {local_filename}")  # type: ignore
         start = datetime.now()
         try:
             self.update_processing_status(dataset_id, processing_status_key, DatasetConversionStatus.CONVERTING)
             file_dir = converter(local_filename)
             self.update_processing_status(dataset_id, processing_status_key, DatasetConversionStatus.CONVERTED)
-            self.logger.info(f"Finished converting {converter} in {datetime.now()- start}")
+            self.logger.info(f"Finished converting {converter} in {datetime.now()- start}")  # type: ignore
         except Exception:
             raise ConversionFailed(processing_status_key) from None
         return file_dir

--- a/backend/layers/processing/process_seurat.py
+++ b/backend/layers/processing/process_seurat.py
@@ -55,7 +55,7 @@ class ProcessSeurat(ProcessingLogic):
             raise Exception("Dataset not found")  # TODO: maybe improve
 
         if dataset.status.rds_status == DatasetConversionStatus.SKIPPED:
-            self.logger.info("Skipping Seurat conversion")
+            self.logger.info("Skipping Seurat conversion")  # type: ignore
             return
 
         labeled_h5ad_filename = "local.h5ad"

--- a/backend/layers/processing/submissions/app.py
+++ b/backend/layers/processing/submissions/app.py
@@ -111,7 +111,7 @@ def parse_s3_event_record(s3_event_record: dict) -> Tuple[str, str, int]:
     return bucket, key, size
 
 
-def parse_key(key: str) -> Optional[dict]:
+def parse_key(key: str) -> Optional[dict]:  # type: ignore
     """
     Parses the S3 object key to extract the Collection ID and Dataset ID, ignoring the REMOTE_DEV_PREFIX
 

--- a/backend/layers/processing/upload_failures/app.py
+++ b/backend/layers/processing/upload_failures/app.py
@@ -84,20 +84,20 @@ def get_failure_slack_notification_message(
     execution_arn: str,
 ) -> dict:
     if dataset_id is None:
-        logger.error("Dataset ID not found")
+        logger.error("Dataset ID not found")  # type: ignore
         dataset_id = "None"
         dataset = None
     else:
         dataset = get_business_logic().get_dataset_version(DatasetVersionId(dataset_id))
     if dataset is None:
-        logger.error(f"Dataset {dataset_id} not found")
+        logger.error(f"Dataset {dataset_id} not found")  # type: ignore
         dataset_id = dataset_id + "(not found)"
         collection_owner, processing_status = "", ""
     else:
         collection_id = dataset.collection_id
         collection = get_business_logic().get_unpublished_collection_version_from_canonical(collection_id)
         if collection is None:
-            logger.error(f"Collection {collection_id} not found")
+            logger.error(f"Collection {collection_id} not found")  # type: ignore
             collection_owner = ""
         else:
             collection_owner = collection.owner
@@ -151,7 +151,7 @@ def trigger_slack_notification(
 ) -> None:
     with logger.LogSuppressed(Exception, message="Failed to send slack notification"):
         data = get_failure_slack_notification_message(
-            dataset_id, collection_version_id, step_name, job_id, aws_region, execution_arn
+            dataset_id, collection_version_id, step_name, job_id, aws_region, execution_arn  # type: ignore
         )
         notify_slack(data)
 

--- a/backend/layers/processing/upload_success/app.py
+++ b/backend/layers/processing/upload_success/app.py
@@ -5,7 +5,7 @@ from backend.layers.common.entities import DatasetProcessingStatus, DatasetStatu
 from backend.layers.persistence.persistence import DatabaseProvider
 
 database_provider = DatabaseProvider()
-business_logic = BusinessLogic(database_provider, None, None, None, None)
+business_logic = BusinessLogic(database_provider, None, None, None, None)  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/backend/layers/thirdparty/crossref_provider.py
+++ b/backend/layers/thirdparty/crossref_provider.py
@@ -2,13 +2,13 @@ import logging
 from datetime import datetime
 from urllib.parse import urlparse
 
-import requests
+import requests  # type: ignore
 
 from backend.common.corpora_config import CorporaConfig
 
 
 class CrossrefProviderInterface:
-    def fetch_metadata(self, doi: str) -> dict:
+    def fetch_metadata(self, doi: str) -> dict:  # type: ignore
         pass
 
     def fetch_preprint_published_doi(self, doi):

--- a/backend/layers/thirdparty/s3_provider.py
+++ b/backend/layers/thirdparty/s3_provider.py
@@ -31,7 +31,7 @@ class S3Provider(S3ProviderInterface):
         try:
             response = self.client.head_object(Bucket=bucket, Key=key)
         except Exception:
-            return None
+            return None  # type: ignore
         return response["ContentLength"]
 
     def generate_presigned_url(self, path: str, expiration: int = 604800) -> str:

--- a/backend/layers/thirdparty/s3_provider_interface.py
+++ b/backend/layers/thirdparty/s3_provider_interface.py
@@ -2,10 +2,10 @@ from typing import Iterable, List
 
 
 class S3ProviderInterface:
-    def get_file_size(self, path: str) -> int:
+    def get_file_size(self, path: str) -> int:  # type: ignore
         pass
 
-    def generate_presigned_url(self, path: str) -> str:
+    def generate_presigned_url(self, path: str) -> str:  # type: ignore
         pass
 
     def upload_file(self, src_file: str, bucket_name: str, dst_file: str, extra_args: dict):
@@ -20,5 +20,5 @@ class S3ProviderInterface:
     def upload_directory(self, src_dir: str, s3_uri: str):
         pass
 
-    def list_directory(self, bucket_name: str, src_dir: str) -> Iterable[str]:
+    def list_directory(self, bucket_name: str, src_dir: str) -> Iterable[str]:  # type: ignore
         pass

--- a/backend/layers/thirdparty/s3_provider_mock.py
+++ b/backend/layers/thirdparty/s3_provider_mock.py
@@ -11,7 +11,7 @@ class MockS3Provider(S3ProviderInterface):
     """
 
     def __init__(self) -> None:
-        self.mock_s3_fs = []
+        self.mock_s3_fs = []  # type: ignore
 
     def parse_s3_uri(self, s3_uri: str):
         parsed_url = urlparse(s3_uri)

--- a/backend/layers/thirdparty/schema_validator_provider.py
+++ b/backend/layers/thirdparty/schema_validator_provider.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 
 class SchemaValidatorProviderInterface:
-    def validate_and_save_labels(self, input_file: str, output_file: str) -> Tuple[bool, list, bool]:
+    def validate_and_save_labels(self, input_file: str, output_file: str) -> Tuple[bool, list, bool]:  # type: ignore
         pass
 
 

--- a/backend/layers/thirdparty/uri_provider.py
+++ b/backend/layers/thirdparty/uri_provider.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-import requests
+import requests  # type: ignore
 
 from backend.common.utils.dl_sources.url import URL, MissingHeaderException, from_url
 
@@ -16,13 +16,13 @@ class FileInfoException(Exception):
 
 
 class UriProviderInterface:
-    def validate(self, uri: str) -> bool:
+    def validate(self, uri: str) -> bool:  # type: ignore
         pass
 
-    def parse(self, uri: str) -> URL:
+    def parse(self, uri: str) -> URL:  # type: ignore
         pass
 
-    def get_file_info(self, uri: str) -> FileInfo:
+    def get_file_info(self, uri: str) -> FileInfo:  # type: ignore
         pass
 
 

--- a/backend/portal/api/app/v1/authentication.py
+++ b/backend/portal/api/app/v1/authentication.py
@@ -6,7 +6,7 @@ import os
 from typing import Optional
 from urllib.parse import urlencode
 
-import requests
+import requests  # type: ignore
 from authlib.integrations.flask_client import OAuth
 from authlib.integrations.flask_client.remote_app import FlaskRemoteApp
 from flask import Response, after_this_request, current_app, g, jsonify, make_response, redirect, request, session
@@ -82,7 +82,7 @@ def logout() -> Response:
     response = redirect(client.api_base_url + "/v2/logout?" + urlencode(params))
     # remove the cookie
     remove_token(config.cookie_name)
-    return response
+    return response  # type: ignore
 
 
 def oauth2_callback() -> Response:
@@ -100,7 +100,7 @@ def oauth2_callback() -> Response:
         raise UnauthorizedError(detail=f"Response from oauth server not valid. {e}") from None
 
     return_to = session.pop("oauth_corpora_callback_redirect", "/")
-    return redirect(return_to)
+    return redirect(return_to)  # type: ignore
 
 
 def save_token(cookie_name: str, token: dict) -> None:
@@ -166,7 +166,7 @@ def get_token(cookie_name: str) -> dict:
         return g.token
 
     tokenstr = request.cookies.get(cookie_name)
-    g.token = decode_token(tokenstr)
+    g.token = decode_token(tokenstr)  # type: ignore
     return g.token
 
 
@@ -179,15 +179,15 @@ def check_token(token: dict) -> dict:
     :param token: a dictionary that contains the token information.
     """
     try:
-        payload = assert_authorized_token(token.get("access_token"))
+        payload = assert_authorized_token(token.get("access_token"))  # type: ignore
     except ExpiredCredentialsError:
         # attempt to refresh the token
         auth_config = CorporaAuthConfig()
         try:
-            token = refresh_expired_token(token)
+            token = refresh_expired_token(token)  # type: ignore
             if token is None:
                 raise
-            payload = assert_authorized_token(token.get("access_token"))
+            payload = assert_authorized_token(token.get("access_token"))  # type: ignore
             # update the cookie with then refreshed token
             save_token(auth_config.cookie_name, token)
         except ExpiredCredentialsError:

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -57,7 +57,7 @@ from backend.portal.api.enrichment import enrich_dataset_with_ancestors
 from backend.portal.api.providers import get_business_logic, get_cloudfront_provider
 
 
-def get_collections_list(from_date: int = None, to_date: int = None, token_info: Optional[dict] = None):
+def get_collections_list(from_date: int = None, to_date: int = None, token_info: Optional[dict] = None):  # type: ignore
     """
     Returns all collections that are either published or belong to the user.
     `from_date` and `to_date` are deprecated parameters and should not be used.
@@ -163,7 +163,7 @@ def remove_none(body: dict):
 
 # Note: `metadata` can be none while the dataset is uploading
 def _dataset_to_response(
-    dataset: DatasetVersion, is_tombstoned: bool, is_in_revision: bool = False, revision_created_at: datetime = None
+    dataset: DatasetVersion, is_tombstoned: bool, is_in_revision: bool = False, revision_created_at: datetime = None  # type: ignore
 ):
     """
     Converts a DatasetVersion object to an object compliant to the API specifications
@@ -375,7 +375,7 @@ def create_collection(body: dict, user: str):
     All exceptions are caught and raised as an InvalidParametersHTTPException.
     """
 
-    errors = []
+    errors = []  # type: ignore
     doi_url = None
     if (doi_node := doi.get_doi_link_node(body, errors)) and (
         doi_url := doi.portal_get_normalized_doi_url(doi_node, errors)
@@ -385,7 +385,7 @@ def create_collection(body: dict, user: str):
     if curator_name is None:
         errors.append("Create Collection body is missing field 'curator_name'")
     if errors:
-        raise InvalidParametersHTTPException(detail=errors)  # TODO: rewrite this exception?
+        raise InvalidParametersHTTPException(detail=errors)  # type: ignore# TODO: rewrite this exception?
 
     metadata = CollectionMetadata(
         body["name"],
@@ -399,7 +399,7 @@ def create_collection(body: dict, user: str):
     try:
         version = get_business_logic().create_collection(user, curator_name, metadata)
     except (InvalidMetadataException, CollectionCreationException) as ex:
-        raise InvalidParametersHTTPException(detail=ex.errors) from None
+        raise InvalidParametersHTTPException(detail=ex.errors) from None  # type: ignore
 
     return make_response(jsonify({"collection_id": version.collection_id.id}), 201)
 
@@ -509,7 +509,7 @@ def delete_collection(collection_id: str, token_info: dict):
     resource_id = CollectionVersionId(collection_id)
     version = get_business_logic().get_collection_version(resource_id)
     if version is None:
-        resource_id = CollectionId(collection_id)
+        resource_id = CollectionId(collection_id)  # type: ignore
         version = get_business_logic().get_collection_version_from_canonical(resource_id)
         if version is None:
             raise ForbiddenHTTPException()
@@ -537,14 +537,14 @@ def update_collection(collection_id: str, body: dict, token_info: dict):
     Updates a collection using the fields specified in `body`
     """
 
-    errors = []
+    errors = []  # type: ignore
     doi_url = None
     if (doi_node := doi.get_doi_link_node(body, errors)) and (
         doi_url := doi.portal_get_normalized_doi_url(doi_node, errors)
     ):
         doi_node["link_url"] = doi_url
     if errors:
-        raise InvalidParametersHTTPException(detail=errors)  # TODO: rewrite this exception?
+        raise InvalidParametersHTTPException(detail=errors)  # type: ignore# TODO: rewrite this exception?
 
     # Ensure that the version exists and the user is authorized to update it
     version = lookup_collection(collection_id)
@@ -565,9 +565,9 @@ def update_collection(collection_id: str, body: dict, token_info: dict):
     try:
         get_business_logic().update_collection_version(version.version_id, payload)
     except InvalidMetadataException as ex:
-        raise InvalidParametersHTTPException(detail=ex.errors) from None
+        raise InvalidParametersHTTPException(detail=ex.errors) from None  # type: ignore
     except CollectionUpdateException as ex:
-        raise InvalidParametersHTTPException(detail=ex.errors) from None
+        raise InvalidParametersHTTPException(detail=ex.errors) from None  # type: ignore
 
     # Requires strong consistency w.r.t. the operation above - if not available, the update needs
     # to be done in memory
@@ -595,7 +595,7 @@ def publish_post(collection_id: str, body: object, token_info: dict):
     return make_response({"collection_id": version.collection_id.id, "visibility": "PUBLIC"}, 202)
 
 
-def upload_from_link(collection_id: str, token_info: dict, url: str, dataset_id: str = None):
+def upload_from_link(collection_id: str, token_info: dict, url: str, dataset_id: str = None):  # type: ignore
     version = lookup_collection(collection_id)
     if version is None or not UserInfo(token_info).is_user_owner_or_allowed(version.owner):
         raise ForbiddenHTTPException()
@@ -648,7 +648,7 @@ def upload_relink(collection_id: str, body: dict, token_info: dict):
         collection_id,
         token_info,
         body.get("url", body.get("link")),
-        body.get("id"),
+        body.get("id"),  # type: ignore
     )
     return make_response({"dataset_id": dataset_id.id}, 202)
 

--- a/backend/scripts/wmg_query_examples.py
+++ b/backend/scripts/wmg_query_examples.py
@@ -30,7 +30,7 @@ def load_snapshot(snapshot_id) -> WmgSnapshot:
     cube_fmg = _open_cube(
         f's3://cellxgene-wmg-{os.environ["DEPLOYMENT_STAGE"]}/{snapshot_id}/{EXPRESSION_SUMMARY_FMG_CUBE_NAME}/'
     )
-    return WmgSnapshot(
+    return WmgSnapshot(  # type: ignore
         snapshot_identifier=snapshot_id,
         expression_summary_cube=cube,
         cell_counts_cube=None,
@@ -39,7 +39,7 @@ def load_snapshot(snapshot_id) -> WmgSnapshot:
         expression_summary_fmg_cube=cube_fmg,
         dataset_to_gene_ids={},
         marker_genes_cube=None,
-        filter_relationships=None,
+        filter_relationships=None,  # type: ignore
     )
 
 

--- a/backend/wmg/api/common/expression_dotplot.py
+++ b/backend/wmg/api/common/expression_dotplot.py
@@ -13,7 +13,7 @@ DEFAULT_GROUP_BY_TERMS = ["tissue_ontology_term_id", "cell_type_ontology_term_id
 ######################### PUBLIC FUNCTIONS IN ALPHABETICAL ORDER ##################################
 
 
-def agg_cell_type_counts(cell_counts: DataFrame, group_by_terms: List[str] = None) -> DataFrame:
+def agg_cell_type_counts(cell_counts: DataFrame, group_by_terms: List[str] = None) -> DataFrame:  # type: ignore
     # Aggregate cube data by tissue, cell type
     if group_by_terms is None:
         group_by_terms = DEFAULT_GROUP_BY_TERMS
@@ -33,7 +33,7 @@ def build_dot_plot_matrix(
     raw_gene_expression: DataFrame,
     cell_counts_cell_type_agg: DataFrame,
     cell_counts_tissue_agg: DataFrame,
-    group_by_terms: List[str] = None,
+    group_by_terms: List[str] = None,  # type: ignore
 ) -> DataFrame:
     if group_by_terms is None:
         group_by_terms = DEFAULT_GROUP_BY_TERMS
@@ -50,7 +50,7 @@ def build_dot_plot_matrix(
 def get_dot_plot_data(
     raw_gene_expression: DataFrame,
     cell_counts: DataFrame,
-    group_by_terms: List[str] = None,
+    group_by_terms: List[str] = None,  # type: ignore
 ) -> Tuple[DataFrame, DataFrame]:
     if group_by_terms is None:
         group_by_terms = DEFAULT_GROUP_BY_TERMS

--- a/backend/wmg/api/v1.py
+++ b/backend/wmg/api/v1.py
@@ -138,18 +138,18 @@ def find_dimension_id_from_compare(compare: str) -> str:
     elif compare == "disease":
         return "disease_ontology_term_id"
     else:
-        return None
+        return None  # type: ignore
 
 
 def is_criteria_empty(criteria: WmgFiltersQueryCriteria) -> bool:
-    criteria = criteria.dict()
+    criteria = criteria.dict()  # type: ignore
     for key in criteria:
         if key != "organism_ontology_term_id":
-            if isinstance(criteria[key], list):
-                if len(criteria[key]) > 0:
+            if isinstance(criteria[key], list):  # type: ignore
+                if len(criteria[key]) > 0:  # type: ignore
                     return False
             else:
-                if criteria[key] != "":
+                if criteria[key] != "":  # type: ignore
                     return False
     return True
 
@@ -204,9 +204,9 @@ def build_filter_dims_values(criteria: WmgFiltersQueryCriteria, snapshot: WmgSna
     }
     for dim in dims:
         dims[dim] = (
-            find_all_dim_option_values(snapshot, criteria.organism_ontology_term_id, dim)
+            find_all_dim_option_values(snapshot, criteria.organism_ontology_term_id, dim)  # type: ignore
             if is_criteria_empty(criteria)
-            else find_dim_option_values(criteria, snapshot, dim)
+            else find_dim_option_values(criteria, snapshot, dim)  # type: ignore
         )
 
     response_filter_dims_values = dict(

--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -175,18 +175,18 @@ def find_dimension_id_from_compare(compare: str) -> str:
     elif compare == "publication":
         return "publication_citation"
     else:
-        return None
+        return None  # type: ignore
 
 
 def is_criteria_empty(criteria: WmgFiltersQueryCriteria) -> bool:
-    criteria = criteria.dict()
+    criteria = criteria.dict()  # type: ignore
     for key in criteria:
         if key != "organism_ontology_term_id":
-            if isinstance(criteria[key], list):
-                if len(criteria[key]) > 0:
+            if isinstance(criteria[key], list):  # type: ignore
+                if len(criteria[key]) > 0:  # type: ignore
                     return False
             else:
-                if criteria[key] != "":
+                if criteria[key] != "":  # type: ignore
                     return False
     return True
 
@@ -204,9 +204,9 @@ def build_filter_dims_values(criteria: WmgFiltersQueryCriteria, snapshot: WmgSna
     }
     for dim in dims:
         dims[dim] = (
-            find_all_dim_option_values(snapshot, criteria.organism_ontology_term_id, dim)
+            find_all_dim_option_values(snapshot, criteria.organism_ontology_term_id, dim)  # type: ignore
             if is_criteria_empty(criteria)
-            else find_dim_option_values(criteria, snapshot, dim)
+            else find_dim_option_values(criteria, snapshot, dim)  # type: ignore
         )
 
     response_filter_dims_values = dict(

--- a/backend/wmg/data/load_cube.py
+++ b/backend/wmg/data/load_cube.py
@@ -70,7 +70,7 @@ def upload_artifacts_to_s3(
     -------
     snapshot_s3_dest_path: A string that contains the location of the uploaded data
     """
-    snapshot_id = str(snapshot_id)
+    snapshot_id = str(snapshot_id)  # type: ignore
 
     # cleanup files we do not wish to upload
     shutil.rmtree(f"{snapshot_source_path}/{INTEGRATED_ARRAY_NAME}")
@@ -78,14 +78,14 @@ def upload_artifacts_to_s3(
     shutil.rmtree(f"{snapshot_source_path}/{VAR_ARRAY_NAME}")
 
     snapshot_s3_dest_path = _get_wmg_snapshot_s3_fullpath(
-        snapshot_schema_version, snapshot_id, is_snapshot_validation_successful
+        snapshot_schema_version, snapshot_id, is_snapshot_validation_successful  # type: ignore
     )
 
     logger.info(f"Writing snapshot data to {snapshot_s3_dest_path}")
     sync_command = ["aws", "s3", "sync", snapshot_source_path, snapshot_s3_dest_path]
     subprocess.run(sync_command)
 
-    _write_snapshot_metadata(snapshot_schema_version, snapshot_id, is_snapshot_validation_successful)
+    _write_snapshot_metadata(snapshot_schema_version, snapshot_id, is_snapshot_validation_successful)  # type: ignore
 
     return snapshot_s3_dest_path
 
@@ -207,7 +207,7 @@ def _write_latest_snapshot_run_file(
     file_name = "latest_snapshot_run"
 
     key_path = f"{wmg_s3_root_dir_path}/{file_name}" if wmg_s3_root_dir_path else file_name
-    snapshot_path = _get_wmg_snapshot_s3_path(snapshot_schema_version, snapshot_id, is_snapshot_validation_successful)
+    snapshot_path = _get_wmg_snapshot_s3_path(snapshot_schema_version, snapshot_id, is_snapshot_validation_successful)  # type: ignore
 
     logger.info(f"Writing latest snapshot run file to {key_path} with value {snapshot_path}")
     _write_value_to_s3_key(key_path=key_path, value=snapshot_path)

--- a/backend/wmg/data/ontology_labels.py
+++ b/backend/wmg/data/ontology_labels.py
@@ -37,7 +37,7 @@ def ontology_term_label(ontology_term_id: str) -> Optional[str]:
 
     if suffix_to_strip:
         ontology_term_id = ontology_term_id.split(f"({suffix_to_strip})")[0].strip()
-    ontology_term_id_label = ontology_term_id_labels.get(ontology_term_id)
+    ontology_term_id_label = ontology_term_id_labels.get(ontology_term_id)  # type: ignore
     if suffix_to_strip:
         ontology_term_id_label = ontology_term_id_label + f" ({suffix_to_strip})"
 
@@ -49,36 +49,36 @@ def gene_term_label(gene_ontology_term_id: str) -> Optional[str]:
     Returns the label for a gene ontology term, given its id. Return None if ontology term id is invalid.
     """
     global gene_term_id_labels
-    return gene_term_id_labels.get(gene_ontology_term_id)
+    return gene_term_id_labels.get(gene_ontology_term_id)  # type: ignore
 
 
 def __load_ontologies() -> None:
     global ontology_term_id_labels
 
-    ontology_term_id_labels = {}
+    ontology_term_id_labels = {}  # type: ignore
     all_ontologies = json.loads(__open_ontology_resource(all_ontologies_json_file).read().decode("utf-8"))
     for _, ontology_dict in all_ontologies.items():
         for term_id, term in ontology_dict.items():
-            ontology_term_id_labels[term_id] = term["label"]
+            ontology_term_id_labels[term_id] = term["label"]  # type: ignore
 
 
 def __load_genes() -> None:
     global gene_term_id_labels
 
-    gene_term_id_labels = {}
+    gene_term_id_labels = {}  # type: ignore
     for genes_file in genes_files:
         for row in csv.DictReader(
             __open_ontology_resource(genes_file).read().decode("utf-8").split("\n"),
             fieldnames=["term_id", "label", "version"],
         ):
-            gene_term_id_labels[row["term_id"]] = row["label"]
+            gene_term_id_labels[row["term_id"]] = row["label"]  # type: ignore
 
 
 def __open_ontology_resource(file) -> IO:
     curr_path = pathlib.Path(__file__).parent.absolute()
     root_path = curr_path.parent.parent
     file_path = root_path.joinpath("common", "ontology_files", file)
-    return gzip.open(file_path)
+    return gzip.open(file_path)  # type: ignore
 
 
 __load_ontologies()

--- a/backend/wmg/data/query.py
+++ b/backend/wmg/data/query.py
@@ -168,18 +168,18 @@ class WmgQuery:
             else:
                 tiledb_dims_query.append([])
 
-        tiledb_dims_query = tuple(tiledb_dims_query)
+        tiledb_dims_query = tuple(tiledb_dims_query)  # type: ignore
         numeric_attrs = [attr.name for attr in cube.schema if np.issubdtype(attr.dtype, np.number)]
 
         # get valid attributes from schema
         # valid means it is a required column for downstream processing
-        attrs = self._cube_query_params.get_attrs_for_cube_query(cube)
+        attrs = self._cube_query_params.get_attrs_for_cube_query(cube)  # type: ignore
         if compare_dimension is not None:
-            attrs.append(compare_dimension)
+            attrs.append(compare_dimension)  # type: ignore
         if isinstance(criteria, FmgQueryCriteria) and compare_dimension != "dataset_id":
-            attrs.append("dataset_id")
+            attrs.append("dataset_id")  # type: ignore
 
-        attrs += numeric_attrs
+        attrs += numeric_attrs  # type: ignore
 
         # get valid dimensions from schema
         dims = self._cube_query_params.get_dims_for_cube_query(cube)

--- a/backend/wmg/data/rollup.py
+++ b/backend/wmg/data/rollup.py
@@ -136,7 +136,7 @@ def rollup_across_cell_type_descendants(
         dim_indices.append(indices)
     # the last dimension corresponds to the numeric columns
     dim_shapes.append(numeric_df.shape[1])
-    dim_shapes = tuple(dim_shapes)
+    dim_shapes = tuple(dim_shapes)  # type: ignore
     array_to_sum = np.zeros(dim_shapes)
     # slot the numeric data into the multi-dimensional numpy array
 
@@ -185,7 +185,7 @@ def rollup_across_cell_type_descendants_array(array_to_sum, cell_types) -> np.nd
     for ix in descendants_indexes:
         z += len(ix)
         linear_indices.append(z)
-    linear_indices = np.array(linear_indices)
+    linear_indices = np.array(linear_indices)  # type: ignore
     descendants_indexes = np.concatenate(descendants_indexes)
 
     # roll up the multi-dimensional array across cell types (first axis)

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -137,7 +137,7 @@ def load_snapshot(
         )
         cached_snapshot.build_dataset_metadata_dict()
 
-    return cached_snapshot
+    return cached_snapshot  # type: ignore
 
 
 ###################################### PRIVATE INTERFACE #################################
@@ -221,7 +221,7 @@ def _load_snapshot(*, snapshot_schema_version: str, snapshot_id: str, read_versi
         cell_type_orderings=cell_type_orderings,
         primary_filter_dimensions=primary_filter_dimensions,
         dataset_to_gene_ids=dataset_to_gene_ids,
-        filter_relationships=filter_relationships,
+        filter_relationships=filter_relationships,  # type: ignore
     )
 
 
@@ -252,7 +252,7 @@ def _load_filter_graph_data(snapshot_dir_path: str) -> str:
         logger.warning(
             f"{_get_wmg_snapshot_dir_s3_uri(snapshot_dir_path)}/{FILTER_RELATIONSHIPS_FILENAME} could not be loaded"
         )
-        return None
+        return None  # type: ignore
 
 
 def _read_value_at_s3_key(key_path: str):

--- a/backend/wmg/data/tissue_mapper.py
+++ b/backend/wmg/data/tissue_mapper.py
@@ -197,7 +197,7 @@ class TissueMapper:
                 raise ValueError(f"{ontology_term_id} is an invalid ontology term id, it must contain exactly one ':'")
             return ontology_term_id.replace(":", "_")
 
-    def _list_ancestors(self, entity: owlready2.entity.ThingClass, ancestors: Optional[List[str]] = None) -> List[str]:
+    def _list_ancestors(self, entity: owlready2.entity.ThingClass, ancestors: Optional[List[str]] = None) -> List[str]:  # type: ignore
         """
         Recursive function that given an entity of an ontology, it traverses the ontology and returns
         a list of all ancestors associated with the entity.

--- a/backend/wmg/data/transform.py
+++ b/backend/wmg/data/transform.py
@@ -96,15 +96,15 @@ def _cell_type_ordering_compute(cells: Set[str], root: str) -> pd.DataFrame:
     from pronto import Ontology
 
     onto = Ontology(CL_BASIC_PERMANENT_URL_PRONTO)
-    ancestors = [list(onto[t].superclasses()) for t in cells if t in onto]
+    ancestors = [list(onto[t].superclasses()) for t in cells if t in onto]  # type: ignore
     ancestors = [i for s in ancestors for i in s]
-    ancestors = set(ancestors)
+    ancestors = set(ancestors)  # type: ignore
 
     G = pgv.AGraph()
     for a in ancestors:
-        for s in a.subclasses(with_self=False, distance=1):
+        for s in a.subclasses(with_self=False, distance=1):  # type: ignore
             if s in ancestors:
-                G.add_edge(a.id, s.id)
+                G.add_edge(a.id, s.id)  # type: ignore
 
     G.layout(prog="dot")
 
@@ -113,7 +113,7 @@ def _cell_type_ordering_compute(cells: Set[str], root: str) -> pd.DataFrame:
         pos = n.attr["pos"].split(",")
         positions[n] = (float(pos[0]), float(pos[1]))
 
-    ancestor_ids = [a.id for a in ancestors]
+    ancestor_ids = [a.id for a in ancestors]  # type: ignore
 
     def cell_entity(node, depth):
         return {"id": node, "depth": depth}
@@ -131,7 +131,7 @@ def _cell_type_ordering_compute(cells: Set[str], root: str) -> pd.DataFrame:
                 depth += 1
 
         children = [
-            (c, positions[c.id]) for c in onto[node].subclasses(with_self=False, distance=1) if c.id in ancestor_ids
+            (c, positions[c.id]) for c in onto[node].subclasses(with_self=False, distance=1) if c.id in ancestor_ids  # type: ignore
         ]
         sorted_children = sorted(children, key=lambda x: x[1][0])
         for child in sorted_children:

--- a/backend/wmg/data/utils.py
+++ b/backend/wmg/data/utils.py
@@ -3,9 +3,9 @@ import os
 import time
 from typing import Dict, List
 
-import requests
+import requests  # type: ignore
 import tiledb
-from requests.adapters import HTTPAdapter
+from requests.adapters import HTTPAdapter  # type: ignore
 from urllib3.util import Retry
 
 from backend.wmg.data.schemas.corpus_schema import OBS_ARRAY_NAME
@@ -74,7 +74,7 @@ def find_dim_option_values(criteria: Dict, snapshot, dimension: str) -> list:
     linked_filter_sets = []
 
     # `all_criteria_attributes` is the set of all attributes specified across all criteria
-    all_criteria_attributes = set()
+    all_criteria_attributes = set()  # type: ignore
 
     for key in filter_options_criteria:
         attrs = filter_options_criteria[key]
@@ -92,7 +92,7 @@ def find_dim_option_values(criteria: Dict, snapshot, dimension: str) -> list:
 
                     # for each attribute (attr) in `prefixed_attributes`,
                     # get the set of filters for the specified dimension that are linked to `attr`
-                    linked_filter_set = set()
+                    linked_filter_set = set()  # type: ignore
                     for attr in prefixed_attributes:
                         if dimension in snapshot.filter_relationships.get(attr, {}):
                             linked_filter_set = linked_filter_set.union(

--- a/backend/wmg/pipeline/cube_pipeline.py
+++ b/backend/wmg/pipeline/cube_pipeline.py
@@ -48,7 +48,7 @@ def load_data_and_create_cube(
     snapshot_path = path if path else pathlib.Path().resolve()
     corpus_path = f"{snapshot_path}/{snapshot_id}"
 
-    integrated_corpus.run(path_to_h5ad_datasets, corpus_path, extract_data)
+    integrated_corpus.run(path_to_h5ad_datasets, corpus_path, extract_data)  # type: ignore
     try:
         summary_cubes.run(corpus_path, validate_cube)
     except CubeValidationException as e:

--- a/backend/wmg/pipeline/integrated_corpus/job.py
+++ b/backend/wmg/pipeline/integrated_corpus/job.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 @log_func_runtime
 def extract_datasets(dataset_directory: List):
     asset_urls = extract.get_dataset_asset_urls()
-    extract.copy_datasets_to_instance(asset_urls, dataset_directory)
+    extract.copy_datasets_to_instance(asset_urls, dataset_directory)  # type: ignore
     logger.info("Copied datasets to instance")
 
 
@@ -42,14 +42,14 @@ def build_integrated_corpus(dataset_directory: List, corpus_path: str):
                     in the integrated corpus
     """
     with tiledb.scope_ctx(create_ctx()):
-        dataset_count = len(os.listdir(dataset_directory))
+        dataset_count = len(os.listdir(dataset_directory))  # type: ignore
         if os.path.exists(f"{corpus_path}/{DATASET_TO_GENE_IDS_NAME}.json"):
             with open(f"{corpus_path}/{DATASET_TO_GENE_IDS_NAME}.json", "r") as fp:
                 dataset_gene_mapping = json.load(fp)
         else:
             dataset_gene_mapping = {}
 
-        for index, dataset in enumerate(os.listdir(dataset_directory)):
+        for index, dataset in enumerate(os.listdir(dataset_directory)):  # type: ignore
             logger.info(f"Processing dataset {index + 1} of {dataset_count}")
             h5ad_file_path = f"{dataset_directory}/{dataset}/local.h5ad"
             logger.info(f"{h5ad_file_path=}")
@@ -113,4 +113,4 @@ def process_h5ad_for_corpus(h5ad_path: str, corpus_path: str) -> Union[Tuple[str
 
     # load
     load.load_dataset(corpus_path, anndata_object, dataset_id)
-    return dataset_id, list(anndata_object.var_names)
+    return dataset_id, list(anndata_object.var_names)  # type: ignore

--- a/backend/wmg/pipeline/integrated_corpus/transform.py
+++ b/backend/wmg/pipeline/integrated_corpus/transform.py
@@ -27,7 +27,7 @@ from backend.wmg.pipeline.utils import (
 logger = logging.getLogger(__name__)
 
 
-def apply_pre_concatenation_filters(anndata_object: anndata.AnnData, min_genes: int = None) -> anndata.AnnData:
+def apply_pre_concatenation_filters(anndata_object: anndata.AnnData, min_genes: int = None) -> anndata.AnnData:  # type: ignore
     min_genes = min_genes if min_genes is not None else GENE_EXPRESSION_COUNT_MIN_THRESHOLD
 
     logger.info("Capturing cells to filter out: assays without gene length normalization, and lowly-covered cells")

--- a/backend/wmg/pipeline/integrated_corpus/validate.py
+++ b/backend/wmg/pipeline/integrated_corpus/validate.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def should_load_dataset(h5ad_path: str, corpus_path: str) -> str:
     dataset_id = get_dataset_id(h5ad_path)
     if is_dataset_already_loaded(corpus_path, dataset_id):
-        return None
+        return None  # type: ignore
     return dataset_id
 
 

--- a/backend/wmg/pipeline/summary_cubes/__init__.py
+++ b/backend/wmg/pipeline/summary_cubes/__init__.py
@@ -11,7 +11,7 @@ from backend.wmg.pipeline.summary_cubes.expression_summary_fmg.job import create
 from backend.wmg.pipeline.summary_cubes.marker_genes import create_marker_genes_cube
 
 
-def run(corpus_path: str, validate_cube: bool) -> dict:
+def run(corpus_path: str, validate_cube: bool) -> dict:  # type: ignore
     """
     Build expression summary cube and cell count cube based
     on cell data stored in integrated corpus

--- a/backend/wmg/pipeline/summary_cubes/calculate_markers.py
+++ b/backend/wmg/pipeline/summary_cubes/calculate_markers.py
@@ -109,8 +109,8 @@ def _query_tiledb_context_memoized(
         expression_summary_cube=None,
         expression_summary_default_cube=None,
         cell_type_orderings=None,
-        primary_filter_dimensions=None,
-        filter_relationships=None,
+        primary_filter_dimensions=None,  # type: ignore
+        filter_relationships=None,  # type: ignore
     )
     cube_query_params = WmgCubeQueryParams(
         cube_query_valid_attrs=WRITER_WMG_CUBE_QUERY_VALID_ATTRIBUTES,
@@ -207,7 +207,7 @@ def _query_target(
     target_filters: dict,
     context_filters: dict,
     context_agg: pd.DataFrame,
-    n_cells_per_gene_context: np.array,
+    n_cells_per_gene_context: np.array,  # type: ignore
     n_cells_index_context: pd.MultiIndex,
 ):
     """
@@ -257,7 +257,7 @@ def _query_target(
         raise MarkerGeneCalculationException("No cells found for target population.")
 
     target_agg = context_agg[filt]
-    n_cells_per_gene_target = n_cells_per_gene_context[filt_ncells].sum(axis=0, keepdims=True)
+    n_cells_per_gene_target = n_cells_per_gene_context[filt_ncells].sum(axis=0, keepdims=True)  # type: ignore
     return target_agg, n_cells_per_gene_target
 
 

--- a/backend/wmg/pipeline/summary_cubes/cell_count.py
+++ b/backend/wmg/pipeline/summary_cubes/cell_count.py
@@ -155,8 +155,8 @@ def create_filter_relationships_graph(df: pd.DataFrame) -> dict:
 
     # for each cell, get all pairwise combinations of filters compresent in that cell
     # these are the edges of the filter relationships graph
-    Xs = []
-    Ys = []
+    Xs = []  # type: ignore
+    Ys = []  # type: ignore
     for i in range(mat.shape[0]):
         Xs.extend(np.repeat(mat[i], mat[i].size))
         Ys.extend(np.tile(mat[i], mat[i].size))

--- a/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/transform.py
+++ b/backend/wmg/pipeline/summary_cubes/expression_summary_fmg/transform.py
@@ -18,7 +18,7 @@ BINOMIAL_NNZ_RANKIT_THR = 1
 
 def transform(
     corpus_path: str, gene_ontology_term_ids: list, cube_dims: list
-) -> (pd.DataFrame, np.ndarray, np.ndarray):
+) -> (pd.DataFrame, np.ndarray, np.ndarray):  # type: ignore
     """
     Build the summary cube with rankit expression sum & sum of squares, nnz
     (num cells with non zero expression) values for each gene for each possible
@@ -99,7 +99,7 @@ def gene_expression_sum_x_cube_dimension(
             nnz_thr_into[grp_idx, cidx] += val >= BINOMIAL_NNZ_RANKIT_THR
 
 
-def make_cube_index(tdb_group: str, cube_dims: list) -> (pd.DataFrame, pd.DataFrame):
+def make_cube_index(tdb_group: str, cube_dims: list) -> (pd.DataFrame, pd.DataFrame):  # type: ignore
     """
     Create index for queryable dimensions
     """

--- a/scripts/collection_copy.py
+++ b/scripts/collection_copy.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 import click
-import requests
+import requests  # type: ignore
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
 sys.path.insert(0, pkg_root)  # noqa

--- a/scripts/cxg_admin.py
+++ b/scripts/cxg_admin.py
@@ -370,7 +370,7 @@ def rollback_datasets(ctx, report_path: str):
 
     ./scripts/cxg_admin.py --deployment dev rollback-dataset report.json
     """
-    schema_migration.rollback_dataset(ctx, report_path)
+    schema_migration.rollback_dataset(ctx, report_path)  # type: ignore
 
 
 if __name__ == "__main__":

--- a/scripts/cxg_admin_scripts/updates.py
+++ b/scripts/cxg_admin_scripts/updates.py
@@ -3,7 +3,7 @@ import os
 import sys
 import time
 
-import requests
+import requests  # type: ignore
 from furl import furl
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..."))  # noqa

--- a/scripts/login.py
+++ b/scripts/login.py
@@ -2,7 +2,7 @@ import json
 import re
 from urllib import parse
 
-import requests
+import requests  # type: ignore
 
 
 def get_cxguser_cookie():

--- a/scripts/populate_db.py
+++ b/scripts/populate_db.py
@@ -11,7 +11,7 @@ from backend.common.corpora_config import CorporaDbConfig
 
 # Importing tests.unit overwrites our deployment stage env var.
 # So we're putting it back here.
-os.environ["DEPLOYMENT_STAGE"] = env
+os.environ["DEPLOYMENT_STAGE"] = env  # type: ignore
 
 
 @click.command()

--- a/scripts/run_mypy_and_annotate.py
+++ b/scripts/run_mypy_and_annotate.py
@@ -1,0 +1,37 @@
+import re
+import subprocess
+
+
+def run_mypy():
+    result = subprocess.run(["mypy", "--ignore-missing-imports", "."], capture_output=True, text=True)
+    return result.stdout
+
+
+def annotate_errors(output):
+    error_pattern = re.compile(r"([^:]+:\d+): error:.*$")
+    for line in output.splitlines():
+        match = error_pattern.match(line)
+        if match:
+            file_and_line = match.group(1)
+            file_path, line_number = file_and_line.split(":")
+            if file_path.endswith(".py"):
+                with open(file_path, "r+") as file:
+                    lines = file.readlines()
+                    line_number = int(line_number)
+                    if line_number <= len(lines):
+                        line = lines[line_number - 1].rstrip()  # Remove trailing newline
+                        if "# type: ignore" not in line:
+                            comment_index = line.find("#")
+                            if comment_index >= 0:
+                                line_parts = [line[:comment_index], line[comment_index:]]
+                            else:
+                                line_parts = [line, ""]
+                            updated_line = f"{line_parts[0]}  # type: ignore{line_parts[1]}\n"
+                            lines[line_number - 1] = updated_line
+                            file.seek(0)
+                            file.writelines(lines)
+
+
+if __name__ == "__main__":
+    mypy_output = run_mypy()
+    annotate_errors(mypy_output)

--- a/scripts/thrash_api.py
+++ b/scripts/thrash_api.py
@@ -11,7 +11,7 @@ import multiprocessing
 import sys
 import urllib.parse
 
-import requests
+import requests  # type: ignore
 
 CXG_BASE_URI = "https://api.cellxgene.cziscience.com/"  # default - can override on the CLI
 

--- a/tests/functional/backend/common.py
+++ b/tests/functional/backend/common.py
@@ -4,9 +4,9 @@ import os
 import time
 import unittest
 
-import requests
-from requests.adapters import HTTPAdapter, Response
-from requests.packages.urllib3.util import Retry
+import requests  # type: ignore
+from requests.adapters import HTTPAdapter, Response  # type: ignore
+from requests.packages.urllib3.util import Retry  # type: ignore
 
 from backend.common.corpora_config import CorporaAuthConfig
 
@@ -59,24 +59,24 @@ class BaseFunctionalTestCase(unittest.TestCase):
         return response.json()["access_token"]
 
     @classmethod
-    def get_auth_token(cls, username: str, password: str, additional_claims: list = None):
+    def get_auth_token(cls, username: str, password: str, additional_claims: list = None):  # type: ignore
         standard_claims = "openid profile email offline"
         if additional_claims:
             additional_claims.append(standard_claims)
             claims = " ".join(additional_claims)
         else:
             claims = standard_claims
-        response = cls.session.post(
+        response = cls.session.post(  # type: ignore
             "https://czi-cellxgene-dev.us.auth0.com/oauth/token",
             headers={"content-type": "application/x-www-form-urlencoded"},
             data=dict(
                 grant_type="password",
                 username=username,
                 password=password,
-                audience=AUDIENCE.get(cls.deployment_stage),
+                audience=AUDIENCE.get(cls.deployment_stage),  # type: ignore
                 scope=claims,
-                client_id=cls.config.client_id,
-                client_secret=cls.config.client_secret,
+                client_id=cls.config.client_id,  # type: ignore
+                client_secret=cls.config.client_secret,  # type: ignore
             ),
         )
         access_token = response.json()["access_token"]

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -3,7 +3,7 @@ import os
 import time
 import unittest
 
-import requests
+import requests  # type: ignore
 from requests import HTTPError
 
 from tests.functional.backend.common import BaseFunctionalTestCase

--- a/tests/functional/backend/corpora/test_collection_access.py
+++ b/tests/functional/backend/corpora/test_collection_access.py
@@ -1,6 +1,6 @@
 import unittest
 
-import requests
+import requests  # type: ignore
 from jose import jwt
 
 from tests.functional.backend.common import BaseFunctionalTestCase

--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from urllib.parse import quote
 
-import requests
+import requests  # type: ignore
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from tests.functional.backend.common import BaseFunctionalTestCase

--- a/tests/functional/backend/wmg/test_wmg_api.py
+++ b/tests/functional/backend/wmg/test_wmg_api.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-import requests
+import requests  # type: ignore
 
 from tests.functional.backend.common import BaseFunctionalTestCase
 from tests.functional.backend.wmg.fixtures import (

--- a/tests/performance/test_wmg_apis.py
+++ b/tests/performance/test_wmg_apis.py
@@ -4,7 +4,7 @@ import os
 import timeit
 import unittest
 
-import requests
+import requests  # type: ignore
 
 from tests.functional.backend.wmg.fixtures import (
     secondary_filter_common_case_request_data,

--- a/tests/unit/backend/fixtures/data_portal_test_case.py
+++ b/tests/unit/backend/fixtures/data_portal_test_case.py
@@ -3,9 +3,9 @@ from tests.unit.backend.layers.common.base_test import BaseTest
 
 
 class DataPortalTestCase(BaseTest):
-    def generate_collection(self, **params) -> CollectionVersion:
+    def generate_collection(self, **params) -> CollectionVersion:  # type: ignore
         visibility = params.pop("visibility", "PUBLIC")
         if visibility == "PUBLIC":
-            return self.generate_published_collection(**params)
+            return self.generate_published_collection(**params)  # type: ignore
         else:
             return self.generate_unpublished_collection(**params)

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -144,7 +144,7 @@ class TestS3Credentials(BaseAPIPortalTest):
 
             with self.subTest(f"{token}, unpublished revision"):
                 collection_id = self.generate_published_collection().collection_id
-                _id = self.generate_revision(collection_id).version_id
+                _id = self.generate_revision(collection_id).version_id  # type: ignore
                 response = self.app.get(f"/curation/v1/collections/{_id}/s3-upload-credentials", headers=headers)
                 self.assertEqual(200, response.status_code)
                 token_sub = self._mock_assert_authorized_token(token)["sub"]
@@ -560,7 +560,7 @@ class TestGetCollectionVersions(BaseAPIPortalTest):
         # Confirm fields are present on Collection version body but ignore equality comparison for timestamps
         self.assertIn("created_at", received_body)
         self.assertIn("published_at", received_body)
-        [self.assertIn("published_at", d) for d in received_body["dataset_versions"]]
+        [self.assertIn("published_at", d) for d in received_body["dataset_versions"]]  # type: ignore
         received_body.pop("created_at")
         received_body.pop("published_at")
         [d.pop("published_at") for d in received_body["dataset_versions"]]
@@ -669,9 +669,9 @@ class TestGetCollectionID(BaseAPIPortalTest):
                 "link_url": "http://test_no_link_name_data_source_url.place",
             },
         ]
-        collection_version = self.generate_collection(links=links, visibility="PRIVATE")
+        collection_version = self.generate_collection(links=links, visibility="PRIVATE")  # type: ignore
         self.generate_dataset(
-            collection_version=collection_version,
+            collection_version=collection_version,  # type: ignore
             metadata=dataset_metadata,
             artifacts=[
                 DatasetArtifactUpdate(type="h5ad", uri="http://test_filename/1234-5678-9/local.h5ad"),
@@ -684,7 +684,7 @@ class TestGetCollectionID(BaseAPIPortalTest):
         collection_version = self.business_logic.get_collection_version(collection_version.version_id)
         dataset = collection_version.datasets[0]
         # expected results
-        expect_dataset = asdict(collection_version.datasets[0].metadata)
+        expect_dataset = asdict(collection_version.datasets[0].metadata)  # type: ignore
         expect_dataset["title"] = expect_dataset.pop("name")
         expect_dataset.update(
             **{
@@ -734,8 +734,8 @@ class TestGetCollectionID(BaseAPIPortalTest):
         del res_body["revised_at"]  # too finicky; ignore
         del res_body["published_at"]  # too finicky; ignore
         for dataset in res_body["datasets"]:
-            del dataset["revised_at"]  # too finicky; ignore
-            del dataset["published_at"]  # too finicky; ignore
+            del dataset["revised_at"]  # type: ignore# too finicky; ignore
+            del dataset["published_at"]  # type: ignore# too finicky; ignore
         self.maxDiff = None
         self.assertDictEqual(expected_body, res_body)  # Confirm dict has been packaged in list
         self.assertEqual(json.dumps(expected_body, sort_keys=True), json.dumps(res_body))
@@ -777,7 +777,7 @@ class TestGetCollectionID(BaseAPIPortalTest):
                 self.assertTrue(resp.json["collection_url"].endswith(expected_id.id))
                 if not response:
                     response = resp
-            return response.json
+            return response.json  # type: ignore
 
         privileged_access_headers = [self.make_owner_header(), self.make_super_curator_header()]
         restricted_access_headers = [self.make_not_owner_header(), self.make_not_auth_header()]
@@ -1663,7 +1663,7 @@ class TestGetDatasets(BaseAPIPortalTest):
         collection_id = self.generate_published_collection(add_datasets=2).canonical_collection.id
         version = self.generate_revision(collection_id)
         dataset_version = self.generate_dataset(
-            collection_version=version, replace_dataset_version_id=version.datasets[0].version_id
+            collection_version=version, replace_dataset_version_id=version.datasets[0].version_id  # type: ignore
         )
         test_url = f"/curation/v1/collections/{version.version_id}/datasets/{dataset_version.dataset_id}"
         response = self.app.get(test_url)
@@ -1704,7 +1704,7 @@ class TestGetDatasets(BaseAPIPortalTest):
         self.assertEqual(expected_assets, body["assets"])
 
         # retrieve a newly added dataset in a revision Collection
-        new_dataset = self.generate_dataset(collection_version=version)
+        new_dataset = self.generate_dataset(collection_version=version)  # type: ignore
         test_url = f"/curation/v1/collections/{version.version_id}/datasets/{new_dataset.dataset_id}"
         response = self.app.get(test_url)
         body = response.json
@@ -1831,7 +1831,7 @@ class TestGetDatasets(BaseAPIPortalTest):
             self.assertEqual(expected_collection_dois, received_collection_dois)
 
         self.generate_dataset(
-            collection_version=revision,
+            collection_version=revision,  # type: ignore
             replace_dataset_version_id=revision.datasets[0].version_id,
             publish=True,
         )
@@ -1998,7 +1998,7 @@ class TestGetDatasetVersion(BaseAPIPortalTest):
         initial_published_dataset_version_id = collection.datasets[0].version_id
         published_revision = self.generate_revision(collection_id)
         published_dataset_revision = self.generate_dataset(
-            collection_version=published_revision,
+            collection_version=published_revision,  # type: ignore
             replace_dataset_version_id=initial_published_dataset_version_id,
             publish=True,
         )

--- a/tests/unit/backend/layers/api/test_gene_info.py
+++ b/tests/unit/backend/layers/api/test_gene_info.py
@@ -3,7 +3,7 @@ import unittest
 import xml.etree.ElementTree as ET
 from unittest.mock import call, patch
 
-import requests
+import requests  # type: ignore
 
 from backend.api_server.app import app
 from backend.common.utils.http_exceptions import NotFoundHTTPException

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -63,15 +63,15 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.run_as_integration = os.environ.get("INTEGRATION_TEST", "false").lower() == "true"
-        if cls.run_as_integration:
+        cls.run_as_integration = os.environ.get("INTEGRATION_TEST", "false").lower() == "true"  # type: ignore
+        if cls.run_as_integration:  # type: ignore
             database_uri = os.environ.get("DB_URI", "postgresql://postgres:secret@localhost")
-            cls.database_provider = DatabaseProvider(database_uri=database_uri)
-            cls.database_provider._drop_schema()
+            cls.database_provider = DatabaseProvider(database_uri=database_uri)  # type: ignore
+            cls.database_provider._drop_schema()  # type: ignore
 
     def setUp(self) -> None:
-        if self.run_as_integration:
-            self.database_provider._create_schema()
+        if self.run_as_integration:  # type: ignore
+            self.database_provider._create_schema()  # type: ignore
         else:
             self.database_provider = DatabaseProviderMock()
 
@@ -97,11 +97,11 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
         # By default these do nothing. They can be mocked by single test cases.
         self.crossref_provider = CrossrefProviderInterface()
         self.step_function_provider = StepFunctionProviderInterface()
-        self.step_function_provider.start_step_function = Mock()
+        self.step_function_provider.start_step_function = Mock()  # type: ignore
         self.s3_provider = MockS3Provider()
         self.uri_provider = UriProviderInterface()
-        self.uri_provider.validate = Mock(return_value=True)  # By default, every link should be valid
-        self.uri_provider.get_file_info = Mock(return_value=FileInfo(1, "file.h5ad"))
+        self.uri_provider.validate = Mock(return_value=True)  # type: ignore# By default, every link should be valid
+        self.uri_provider.get_file_info = Mock(return_value=FileInfo(1, "file.h5ad"))  # type: ignore
 
         self.business_logic = BusinessLogic(
             database_provider=self.database_provider,
@@ -152,8 +152,8 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        if cls.run_as_integration:
-            cls.database_provider._engine.dispose()
+        if cls.run_as_integration:  # type: ignore
+            cls.database_provider._engine.dispose()  # type: ignore
 
     def initialize_empty_unpublished_collection(
         self, owner: str = test_user_name, curator_name: str = test_curator_name
@@ -197,7 +197,7 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
         self,
         owner: str = test_user_name,
         curator_name: str = test_curator_name,
-        published_at: datetime = None,
+        published_at: datetime = None,  # type: ignore
         num_datasets: int = 2,
     ) -> CollectionVersionWithDatasets:
         """
@@ -214,7 +214,7 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
         self,
         owner: str = test_user_name,
         curator_name: str = test_curator_name,
-        published_at: datetime = None,
+        published_at: datetime = None,  # type: ignore
         num_datasets: int = 2,
     ) -> Tuple[CollectionVersionWithDatasets, CollectionVersionWithDatasets]:
 
@@ -231,7 +231,7 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
         self,
         owner: str = test_user_name,
         curator_name: str = test_curator_name,
-        published_at: datetime = None,
+        published_at: datetime = None,  # type: ignore
         num_datasets: int = 2,
     ) -> Tuple[CollectionVersionWithDatasets, CollectionVersionWithDatasets]:
 

--- a/tests/unit/backend/layers/common/base_api_test.py
+++ b/tests/unit/backend/layers/common/base_api_test.py
@@ -43,7 +43,7 @@ class BaseAuthAPITest(unittest.TestCase):
     def make_not_auth_header(self):
         return {"Content-Type": "application/json"}
 
-    def _mock_assert_authorized_token(self, token: str, audience: str = None):
+    def _mock_assert_authorized_token(self, token: str, audience: str = None):  # type: ignore
         if token == "owner":
             return {"sub": "test_user_id", "email": "fake_user@email.com", "scope": [], "curator_name": "First Last"}
         elif token == "not_owner":

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -68,8 +68,8 @@ class BaseTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.run_as_integration = os.environ.get("INTEGRATION_TEST", "false").lower() == "true"
-        if cls.run_as_integration:
+        cls.run_as_integration = os.environ.get("INTEGRATION_TEST", "false").lower() == "true"  # type: ignore
+        if cls.run_as_integration:  # type: ignore
             database_uri = os.environ.get("DB_URI", "postgresql://postgres:secret@localhost")
             cls.database_provider = DatabaseProvider(database_uri=database_uri)
             cls.database_provider._drop_schema()
@@ -154,7 +154,7 @@ class BaseTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        if cls.run_as_integration:
+        if cls.run_as_integration:  # type: ignore
             cls.database_provider._engine.dispose()
 
     def get_sample_dataset_metadata(self):
@@ -168,7 +168,7 @@ class BaseTest(unittest.TestCase):
         self,
         owner="test_user_id",
         curator_name="Test User",
-        links: List[Link] = None,
+        links: List[Link] = None,  # type: ignore
         add_datasets: int = 0,
         metadata=None,
         dataset_schema_version="3.0.0",
@@ -199,13 +199,13 @@ class BaseTest(unittest.TestCase):
             )
             # TODO: set a proper dataset status
 
-        return self.business_logic.get_collection_version(collection.version_id)
+        return self.business_logic.get_collection_version(collection.version_id)  # type: ignore
 
     # Public collections need to have at least one dataset!
     def generate_published_collection(
         self,
         owner="test_user_id",
-        links: List[Link] = None,
+        links: List[Link] = None,  # type: ignore
         add_datasets: int = 1,
         curator_name: str = "Jane Smith",
         metadata=None,
@@ -233,9 +233,9 @@ class BaseTest(unittest.TestCase):
         collection_version: Optional[CollectionVersion] = None,
         metadata: Optional[DatasetMetadata] = None,
         name: Optional[str] = None,
-        statuses: List[DatasetStatusUpdate] = None,
-        validation_message: str = None,
-        artifacts: List[DatasetArtifactUpdate] = None,
+        statuses: List[DatasetStatusUpdate] = None,  # type: ignore
+        validation_message: str = None,  # type: ignore
+        artifacts: List[DatasetArtifactUpdate] = None,  # type: ignore
         publish: bool = False,
         replace_dataset_version_id: Optional[DatasetVersionId] = None,
     ) -> DatasetData:
@@ -286,21 +286,21 @@ class BaseTest(unittest.TestCase):
             [a.id for a in artifact_ids],
         )
 
-    def remove_timestamps(self, body: dict, remove: typing.List[str] = None) -> dict:
+    def remove_timestamps(self, body: dict, remove: typing.List[str] = None) -> dict:  # type: ignore
         # TODO: implement as needed
         return body
 
-    def generate_collection(self, links: List[dict] = None, **kwargs) -> CollectionVersionWithDatasets:
+    def generate_collection(self, links: List[dict] = None, **kwargs) -> CollectionVersionWithDatasets:  # type: ignore
         """Generated a collection
         Adding to for compatibility with old tests
         """
         links = links if links else []
-        links = [api_link_dict_to_link_class(lk) for lk in links]
+        links = [api_link_dict_to_link_class(lk) for lk in links]  # type: ignore
         visibility = kwargs.pop("visibility", "PUBLIC")
         if visibility == "PUBLIC":
-            return self.generate_published_collection(links=links, **kwargs)
+            return self.generate_published_collection(links=links, **kwargs)  # type: ignore
         else:
-            return self.generate_unpublished_collection(links=links, **kwargs)
+            return self.generate_unpublished_collection(links=links, **kwargs)  # type: ignore
 
     def generate_collection_revision(self, owner="test_user_id") -> CollectionVersionWithDatasets:
         published_collection = self.generate_published_collection(owner)

--- a/tests/unit/backend/layers/common/test_auth0_manager.py
+++ b/tests/unit/backend/layers/common/test_auth0_manager.py
@@ -4,7 +4,7 @@ from multiprocessing import Process
 from random import randint
 from unittest.mock import MagicMock
 
-import requests
+import requests  # type: ignore
 from flask import Flask, make_response, request
 
 from backend.common.auth0_manager import auth0_management_session

--- a/tests/unit/backend/layers/thirdparty/test_crossref_provider.py
+++ b/tests/unit/backend/layers/thirdparty/test_crossref_provider.py
@@ -2,8 +2,8 @@ import json
 import unittest
 from unittest.mock import patch
 
-from requests import RequestException
-from requests.models import HTTPError, Response
+from requests import RequestException  # type: ignore
+from requests.models import HTTPError, Response  # type: ignore
 
 from backend.common.providers.crossref_provider import (
     CrossrefDOINotFoundException,

--- a/tests/unit/backend/layers/utils/test_type_conversion_utils.py
+++ b/tests/unit/backend/layers/utils/test_type_conversion_utils.py
@@ -134,7 +134,7 @@ float_OK_cases = [
         pd.Series(np.arange(-128, 1000, dtype=dtype)),
         pd.Index(np.arange(-129, 1000, dtype=dtype)),
         np.array([-np.nan, np.NINF, -1, np.NZERO, 0, np.PZERO, 1, np.PINF, np.nan], dtype=dtype),
-        np.array([np.finfo(dtype).min, 0, np.finfo(dtype).max], dtype=dtype),
+        np.array([np.finfo(dtype).min, 0, np.finfo(dtype).max], dtype=dtype),  # type: ignore
         sparse.csr_matrix((10, 100), dtype=dtype),
     ]
 ]

--- a/tests/unit/backend/wmg/api/test_v2.py
+++ b/tests/unit/backend/wmg/api/test_v2.py
@@ -64,7 +64,7 @@ def generate_expected_term_id_labels_dictionary(
             ["cell_types"][<tissue_ontology_term_id>][<cell_type_ontology_term_id>][<compare_dimension>]
     """
 
-    result = {}
+    result = {}  # type: ignore
     result["cell_types"] = {}
     # assume tissues are sorted, and cell types are sorted within each tissue
     # assume the length of cell types is the dimensionality of each column in the
@@ -155,7 +155,7 @@ def generate_expected_expression_summary_dictionary(
     result: A dictionary containing gene expression stats that is indexable by
             [<gene_ontology_term_id>][<tissue_ontology_term_id>][<cell_type_ontology_term_id>][<compare_dimension>]
     """
-    result = {}
+    result = {}  # type: ignore
     for gene in genes:
         if gene != ".":
             result[gene] = {}

--- a/tests/unit/backend/wmg/fixtures/test_snapshot.py
+++ b/tests/unit/backend/wmg/fixtures/test_snapshot.py
@@ -59,15 +59,15 @@ def semi_real_dimension_values_generator(dimension_name: str, dim_size: int) -> 
     # must import lazily
     import backend.wmg.data.ontology_labels as ontology_labels
 
-    if ontology_labels.ontology_term_id_labels is None:
+    if ontology_labels.ontology_term_id_labels is None:  # type: ignore
         ontology_labels.__load_ontologies()
-    if ontology_labels.gene_term_id_labels is None:
+    if ontology_labels.gene_term_id_labels is None:  # type: ignore
         ontology_labels.__load_genes()
 
-    deterministic_term_ids = sorted(ontology_labels.ontology_term_id_labels.keys())
+    deterministic_term_ids = sorted(ontology_labels.ontology_term_id_labels.keys())  # type: ignore
 
     if dimension_name == "gene_ontology_term_id":
-        return sorted(ontology_labels.gene_term_id_labels.keys())[:dim_size]
+        return sorted(ontology_labels.gene_term_id_labels.keys())[:dim_size]  # type: ignore
     if dimension_name == "tissue_ontology_term_id":
         return [term_id for term_id in deterministic_term_ids if term_id.startswith("UBERON")][:dim_size]
     if dimension_name == "tissue_original_ontology_term_id":
@@ -147,7 +147,7 @@ def exclude_all_but_one_gene_per_organism(logical_coord: NamedTuple) -> bool:
     # include gene_ontology_term_id
     if "gene_ontology_term_id" not in logical_coord._fields:
         return False
-    return logical_coord.gene_ontology_term_id != logical_coord.organism_ontology_term_id.replace("organism", "gene")
+    return logical_coord.gene_ontology_term_id != logical_coord.organism_ontology_term_id.replace("organism", "gene")  # type: ignore
 
 
 def forward_cell_type_ordering(cell_type_ontology_ids: List[str]) -> List[int]:
@@ -158,8 +158,8 @@ def reverse_cell_type_ordering(cell_type_ontology_ids: List[str]) -> List[int]:
     return list(range(len(cell_type_ontology_ids), 0, -1))
 
 
-@contextlib.contextmanager
-def load_realistic_test_snapshot(snapshot_name: str) -> WmgSnapshot:
+@contextlib.contextmanager  # type: ignore
+def load_realistic_test_snapshot(snapshot_name: str) -> WmgSnapshot:  # type: ignore
     with tempfile.TemporaryDirectory() as cube_dir:
         cell_counts = pd.read_csv(f"{FIXTURES_ROOT}/{snapshot_name}/cell_counts.csv.gz", index_col=0)
         expression_summary = pd.read_csv(f"{FIXTURES_ROOT}/{snapshot_name}/expression_summary.csv.gz", index_col=0)
@@ -208,18 +208,18 @@ def load_realistic_test_snapshot(snapshot_name: str) -> WmgSnapshot:
                 marker_genes_cube=marker_genes_cube,
                 cell_counts_cube=cell_counts_cube,
                 cell_type_orderings=None,
-                primary_filter_dimensions=None,
+                primary_filter_dimensions=None,  # type: ignore
                 dataset_to_gene_ids=dataset_to_gene_ids,
                 filter_relationships=filter_relationships,
             )
 
 
-@contextlib.contextmanager
-def create_temp_wmg_snapshot(
+@contextlib.contextmanager  # type: ignore
+def create_temp_wmg_snapshot(  # type: ignore
     dim_size=3,
     snapshot_name="dummy-snapshot",
     expression_summary_vals_fn: Callable[[List[Tuple]], Dict[str, List]] = random_expression_summary_values,
-    exclude_logical_coord_fn: Callable[[NamedTuple], bool] = None,
+    exclude_logical_coord_fn: Callable[[NamedTuple], bool] = None,  # type: ignore
     cell_counts_generator_fn: Callable[[List[Tuple]], List] = random_cell_counts_values,
     cell_ordering_generator_fn: Callable[[List[str]], List[int]] = forward_cell_type_ordering,
 ) -> WmgSnapshot:
@@ -227,7 +227,7 @@ def create_temp_wmg_snapshot(
         expression_summary_cube_dir, cell_counts_cube_dir = create_cubes(
             cube_dir,
             dim_size,
-            exclude_logical_coord_fn=exclude_logical_coord_fn,
+            exclude_logical_coord_fn=exclude_logical_coord_fn,  # type: ignore
             expression_summary_vals_fn=expression_summary_vals_fn,
             cell_counts_fn=cell_counts_generator_fn,
         )
@@ -249,7 +249,7 @@ def create_temp_wmg_snapshot(
                 cell_counts_cube=cell_counts_cube,
                 cell_type_orderings=cell_type_orderings,
                 primary_filter_dimensions=primary_filter_dimensions,
-                dataset_to_gene_ids=None,
+                dataset_to_gene_ids=None,  # type: ignore
                 filter_relationships=filter_relationships,
             )
 
@@ -280,19 +280,19 @@ def create_cubes(
     data_dir,
     dim_size: int = 3,
     dim_ontology_term_ids_generator_fn: Callable[[str, int], List[str]] = simple_ontology_terms_generator,
-    exclude_logical_coord_fn: Callable[[List[str], Tuple], bool] = None,
+    exclude_logical_coord_fn: Callable[[List[str], Tuple], bool] = None,  # type: ignore
     expression_summary_vals_fn: Callable[[List[Tuple]], Dict[str, List]] = random_expression_summary_values,
     cell_counts_fn: Callable[[List[Tuple]], List[int]] = random_cell_counts_values,
 ) -> Tuple[str, str]:
     coords, dim_values = build_coords(
-        expression_summary_logical_dims, dim_size, dim_ontology_term_ids_generator_fn, exclude_logical_coord_fn
+        expression_summary_logical_dims, dim_size, dim_ontology_term_ids_generator_fn, exclude_logical_coord_fn  # type: ignore
     )
     expression_summary_cube_dir = create_expression_summary_cube(
         data_dir, coords, dim_values, expression_summary_vals_fn=expression_summary_vals_fn
     )
 
     coords, dim_values = build_coords(
-        cell_counts_logical_dims, dim_size, dim_ontology_term_ids_generator_fn, exclude_logical_coord_fn
+        cell_counts_logical_dims, dim_size, dim_ontology_term_ids_generator_fn, exclude_logical_coord_fn  # type: ignore
     )
     cell_counts_cube_dir = create_cell_counts_cube(data_dir, coords, dim_values, cell_counts_fn=cell_counts_fn)
 
@@ -349,7 +349,7 @@ def build_coords(
     logical_dims,
     dim_size,
     dim_ontology_term_ids_generator_fn: Callable[[str, int], List[str]] = simple_ontology_terms_generator,
-    exclude_coord_fn: Callable[[Tuple], bool] = None,
+    exclude_coord_fn: Callable[[Tuple], bool] = None,  # type: ignore
 ) -> Tuple[List[Tuple], List[List]]:
     n_dims = len(logical_dims)
     n_coords = dim_size**n_dims
@@ -367,10 +367,10 @@ def build_coords(
         for i_dim in range(n_dims)
     ]
     coords = list(zip(*dim_values))
-    if exclude_coord_fn:
-        Coord = namedtuple("Coord", logical_dims)
-        coords: List[Tuple] = list(filterfalse(exclude_coord_fn, (Coord(*c) for c in coords)))
-        dim_values: List[List] = [[coord_tuple[i_dim] for coord_tuple in coords] for i_dim in range(n_dims)]
+    if exclude_coord_fn:  # type: ignore
+        Coord = namedtuple("Coord", logical_dims)  # type: ignore
+        coords: List[Tuple] = list(filterfalse(exclude_coord_fn, (Coord(*c) for c in coords)))  # type: ignore
+        dim_values: List[List] = [[coord_tuple[i_dim] for coord_tuple in coords] for i_dim in range(n_dims)]  # type: ignore
     assert all([len(dim_values[i_dim]) == len(coords) for i_dim in range(n_dims)])
     return coords, dim_values
 
@@ -384,7 +384,7 @@ if __name__ == "__main__":
         output_cube_dir,
         dim_size=4,
         dim_ontology_term_ids_generator_fn=semi_real_dimension_values_generator,
-        exclude_logical_coord_fn=exclude_random_coords_75pct,
+        exclude_logical_coord_fn=exclude_random_coords_75pct,  # type: ignore
         expression_summary_vals_fn=random_expression_summary_values,
         cell_counts_fn=random_cell_counts_values,
     )

--- a/tests/unit/backend/wmg/test_query.py
+++ b/tests/unit/backend/wmg/test_query.py
@@ -178,7 +178,7 @@ class QueryPrimaryFilterDimensionsTest(unittest.TestCase):
         dim_size = 3
 
         def exclude_one_tissue_per_organism(logical_coord: NamedTuple) -> bool:
-            return logical_coord.tissue_ontology_term_id == logical_coord.organism_ontology_term_id.replace(
+            return logical_coord.tissue_ontology_term_id == logical_coord.organism_ontology_term_id.replace(  # type: ignore
                 "organism", "tissue"
             )
 

--- a/tests/unit/processing/schema_migration/conftest.py
+++ b/tests/unit/processing/schema_migration/conftest.py
@@ -16,7 +16,7 @@ from backend.layers.processing.schema_migration import SchemaMigrate
 
 
 def make_mock_dataset_version(
-    dataset_id: str = None, version_id: str = None, status: dict = None, metadata: dict = None
+    dataset_id: str = None, version_id: str = None, status: dict = None, metadata: dict = None  # type: ignore
 ):
     dataset_version = mock.Mock()
     dataset_version.dataset_id = DatasetId(dataset_id)

--- a/tests/unit/wmg_processing/test_data_artifact_correctness.py
+++ b/tests/unit/wmg_processing/test_data_artifact_correctness.py
@@ -13,7 +13,7 @@ NORMAL_CELL_DISEASE_ONTOLOGY_TERM_ID = "PATO:0000461"
 def find_dim_option_values_pandas(criteria: Dict, snapshot: WmgSnapshot, dimension: str) -> set:
     """Find values for the specified dimension that satisfy the given filtering criteria,
     ignoring any criteria specified for the given dimension."""
-    filter_options_criteria = criteria.copy(update={dimension + "s": []}, deep=True)
+    filter_options_criteria = criteria.copy(update={dimension + "s": []}, deep=True)  # type: ignore
     cell_counts_df = snapshot.cell_counts_cube.df[:]
 
     for key, vals in filter_options_criteria:
@@ -23,7 +23,7 @@ def find_dim_option_values_pandas(criteria: Dict, snapshot: WmgSnapshot, dimensi
             cell_counts_df = cell_counts_df[cell_counts_df[key].isin(vals)]
 
     filter_dims = list(cell_counts_df.groupby(dimension).groups.keys())
-    return filter_dims
+    return filter_dims  # type: ignore
 
 
 class DataArtifactCorrectness(unittest.TestCase):

--- a/tests/unit/wmg_processing/test_load_corpus.py
+++ b/tests/unit/wmg_processing/test_load_corpus.py
@@ -35,22 +35,22 @@ class TestCorpusLoad(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        super().setUp(cls)
-        cls.tmp_dir = tempfile.mkdtemp()
-        cls.path_to_datasets = pathlib.Path(cls.tmp_dir, "datasets")
+        super().setUp(cls)  # type: ignore
+        cls.tmp_dir = tempfile.mkdtemp()  # type: ignore
+        cls.path_to_datasets = pathlib.Path(cls.tmp_dir, "datasets")  # type: ignore
         os.mkdir(cls.path_to_datasets)
-        cls.small_anndata_filename = create_anndata_test_fixture(cls.path_to_datasets, "basic_test_dataset", 3, 5)
-        cls.large_anndata_filename = create_anndata_test_fixture(cls.path_to_datasets, "large_test_dataset", 1000, 5000)
+        cls.small_anndata_filename = create_anndata_test_fixture(cls.path_to_datasets, "basic_test_dataset", 3, 5)  # type: ignore
+        cls.large_anndata_filename = create_anndata_test_fixture(cls.path_to_datasets, "large_test_dataset", 1000, 5000)  # type: ignore
 
     @classmethod
     def tearDownClass(cls) -> None:
         super().tearDownClass()
-        shutil.rmtree(cls.tmp_dir)
+        shutil.rmtree(cls.tmp_dir)  # type: ignore
 
     def setUp(self) -> None:
         super().setUp()
-        self.path_to_datasets = pathlib.Path(self.tmp_dir, "datasets")
-        self.corpus_path = f"{self.tmp_dir}/test-corpus"
+        self.path_to_datasets = pathlib.Path(self.tmp_dir, "datasets")  # type: ignore
+        self.corpus_path = f"{self.tmp_dir}/test-corpus"  # type: ignore
         if not tiledb.VFS().is_dir(self.corpus_path):
             create_tdb_integrated_corpus(self.corpus_path)
             # self.pbmc3k_anndata_object = get_test_anndata_dataset()


### PR DESCRIPTION
## Reason for Change

part of: https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell/539

## Changes
- wrote a script, `run_mypy_and_annotate.py` that will:
  - run mypy and capture the output of it
  - using the output of that, appends each offending line with `type: ignore` in the codebase

this PR includes both the actual script as well as the changes the script generated. overall this took me about half

## Testing steps

- ran several iterations of the script until i verified that i could run the script and that running `mypy --ignore-missing-imports .` from the root directory of the project results in 0 errors
![image](https://github.com/chanzuckerberg/single-cell-data-portal/assets/5653616/7a2c1ecd-cbab-476b-b1e1-0ae252e3c597)


## Notes for Reviewer

stating the obvious here a bit, but this PR is going to cause a bunch of merge conflicts and i full expect to have to re-run the script :)