### PR TITLE
fix: add codecov reports on merges to main

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -22,6 +22,39 @@ permissions:
   deployments: write
 
 jobs:
+  submit-codecoverage:
+    runs-on: ubuntu-22.04
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Login to ECR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.ECR_REPO }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage
+          path: .
+      - name: coverage report
+        run: |
+          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          make coverage/report-xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          env_vars: OS,PYTHON
+          files: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
   build-frontend-backend-images:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -22,39 +22,6 @@ permissions:
   deployments: write
 
 jobs:
-  submit-codecoverage:
-    runs-on: ubuntu-22.04
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1800
-      - name: Login to ECR
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ secrets.ECR_REPO }}
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/download-artifact@v3
-        with:
-          name: coverage
-          path: .
-      - name: coverage report
-        run: |
-          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
-          make coverage/report-xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          env_vars: OS,PYTHON
-          files: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
   build-frontend-backend-images:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - "*"
-  merge:
+  push:
     branches:
       - "main"
 

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - "*"
-  merge_group:
+  merge:
     branches:
       - "main"
 


### PR DESCRIPTION
## Reason for Change

Submit `codecov` reports when merging a commit to main. We're currently submitting them on PRs (push-tests.yml), but since we do squash and merge, the commit that ends up in main will be different. This is causing codecov not to record all the commits.