### PR TITLE
fix: Staging hotfix 08/19/2023

### DIFF
--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -13,7 +13,7 @@ module stack {
   frontend_url                 = "https://cellxgene.cziscience.com"
   backend_url                  = "https://api.cellxgene.cziscience.com"
   stack_prefix                 = ""
-  batch_container_memory_limit = 300000
+  batch_container_memory_limit = 63500
   wmg_batch_container_memory_limit = 248000
   wmg_desired_vcpus                = 128
   backend_memory               = 30 * 1024

--- a/.happy/terraform/envs/stage/main.tf
+++ b/.happy/terraform/envs/stage/main.tf
@@ -13,7 +13,7 @@ module stack {
   frontend_url                 = "https://cellxgene.staging.single-cell.czi.technology"
   backend_url                  = "https://api.cellxgene.staging.single-cell.czi.technology"
   stack_prefix                 = ""
-  batch_container_memory_limit = 300000
+  batch_container_memory_limit = 635600
   wmg_batch_container_memory_limit = 248000
   wmg_desired_vcpus                = 128
   backend_memory               = 8192

--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -8,11 +8,10 @@ data aws_caller_identity current {}
 resource aws_batch_job_definition batch_job_def {
   type = "container"
   name = "dp-${var.deployment_stage}-${var.custom_stack_name}-upload"
-  container_properties = <<EOF
-{
+  container_properties = jsonencode({
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
-  "memory": ${var.batch_container_memory_limit},
+  "memory": var.batch_container_memory_limit,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",
@@ -55,8 +54,7 @@ resource aws_batch_job_definition batch_job_def {
       "awslogs-region": "${data.aws_region.current.name}"
     }
   }
-}
-EOF
+})
 }
 
 resource aws_cloudwatch_log_group cloud_watch_logs_group {

--- a/backend/layers/processing/schema_migration.py
+++ b/backend/layers/processing/schema_migration.py
@@ -224,7 +224,7 @@ class SchemaMigrate(ProcessingLogic):
         if errors:
             self._store_sfn_response("report", collection_version_id, errors)
         elif can_publish:
-            self.business_logic.publish_collection_version(collection_version_id)
+            self.business_logic.publish_collection_version(collection_version.version_id)
         self.logger.info(
             "Deleting files", extra={"artifact_bucket": self.artifact_bucket, "object_keys": object_keys_to_delete}
         )

--- a/tests/unit/processing/schema_migration/test_publish_and_cleanup.py
+++ b/tests/unit/processing/schema_migration/test_publish_and_cleanup.py
@@ -47,7 +47,9 @@ class TestPublishAndCleanup:
 
         errors = local_schema_migrate.publish_and_cleanup(collection_version.version_id.id, True)
         assert errors == []
-        local_schema_migrate.business_logic.publish_collection_version.assert_called_once()
+        local_schema_migrate.business_logic.publish_collection_version.assert_called_once_with(
+            collection_version.version_id
+        )
         local_schema_migrate.s3_provider.delete_files.assert_any_call(
             "artifact-bucket", ["schema_migration/test-execution-arn/publish_and_cleanup/collection_id.json"]
         )


### PR DESCRIPTION
## Reason for Change

- #5555 

## Changes
- Updating batch job memory limits for upload jobs
- Fixing input datatype error when passing into downstream publish function

## Testing steps
- Completed an end-to-end rdev migration with a subset of datasets
- After merging, I will test a partial migration in staging (i.e. will stop once I confirm publish step works for at least one collection)

## Notes for Reviewer
