### PR TITLE
fix(wmg): add correct tooltip cell type for tissue rows and add test coverage

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/Chart/index.tsx
@@ -306,9 +306,13 @@ export default memo(function Chart({
       ],
     };
 
+    const cellTypeName = cellType.cellTypeName.startsWith("UBERON")
+      ? cellType.name
+      : cellType.cellTypeName;
+
     const secondPanel = {
       dataRows: [
-        { label: "Cell Type", value: cellType.cellTypeName },
+        { label: "Cell Type", value: cellTypeName },
         {
           label: "Tissue Composition",
           value: tissuePercentage + "%" || "",

--- a/frontend/tests/features/wheresMyGene/cellTooltip.test.ts
+++ b/frontend/tests/features/wheresMyGene/cellTooltip.test.ts
@@ -60,6 +60,7 @@ describe("cell tooltip", () => {
 
           //expect the hover text to be displayed
           await expect(page.getByText(hoverText)).toBeVisible();
+          expect(hoverText).not.toContain("UBERON");
         },
         { page }
       );

--- a/frontend/tests/features/wheresMyGene/cellTooltip.test.ts
+++ b/frontend/tests/features/wheresMyGene/cellTooltip.test.ts
@@ -60,7 +60,6 @@ describe("cell tooltip", () => {
 
           //expect the hover text to be displayed
           await expect(page.getByText(hoverText)).toBeVisible();
-          expect(hoverText).not.toContain("UBERON");
         },
         { page }
       );


### PR DESCRIPTION
## Reason for Change

- #5559

## Changes

- add
  -  Adds logic fork for tissue tooltips, uses `celltype.name` instead of celltype.cellTypeName` if the `name` contains `"UBERON"`
  -  ~Adds test to ensure UBERON isn't present in the tooltip text~
