### PR TITLE
fix: redirect withdrawn collection to collections

### DIFF
--- a/frontend/src/components/Collections/common/utils.ts
+++ b/frontend/src/components/Collections/common/utils.ts
@@ -22,7 +22,7 @@ export function useExplainTombstoned(): void {
         icon: IconNames.ISSUE,
         intent: Intent.PRIMARY,
         message:
-          "This collection was withdrawn. You’ve been redirected to the cellxgene Data Portal homepage.",
+          "This collection was withdrawn. You’ve been redirected to Collections.",
       });
       removeParams("tombstoned_collection_id");
     }

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -70,7 +70,7 @@ const Collection: FC = () => {
 
   useEffect(() => {
     if (isTombstonedCollection(collection)) {
-      const redirectUrl = ROUTES.HOMEPAGE;
+      const redirectUrl = ROUTES.COLLECTIONS;
       router.push(redirectUrl + "?tombstoned_collection_id=" + id);
     }
   }, [collection, id, router]);


### PR DESCRIPTION
## Reason for Change
- #5004

## Changes

- Updated redirect on view of withdrawn collection to collections page (instead of home page).
- Updated toast text.

## Testing steps

1. Delete collection
1. View deleted collection
1. Confirm browser redirects to collections page and pops toast with updated text
