### PR TITLE
fix: override default so that issues are not marked as stale

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
+          days-before-issue-stale: -1 # Do not mark any issues as stale
           days-before-pr-stale: 14
           days-before-pr-close: 3
           stale-pr-message: "This PR has not seen any activity in the past 2 weeks; if nobody comments or reviews it in the next 3 days, this PR will be closed."


### PR DESCRIPTION
## Reason for Change

The default setting for the Github Action to automatically mark PRs as stale sets issues as `stale` after 60 days. This PR fixes that by overriding the default to -1 which ensures that issues are never marked as stale.

## Ticket Number
#560 

## Changes

### Additions

None.

### Deletions

None.

### Modifications

The `close-inactive-prs` Github Action has been modified to never set issues as stale.

## Testing steps

Not tested.

## Notes for Reviewer

None.
