### PR TITLE
fix(cellguide): add wmg api backend to cellguide image (DO NOT MERGE)

### DIFF
--- a/Dockerfile.cellguide_pipeline
+++ b/Dockerfile.cellguide_pipeline
@@ -16,6 +16,7 @@ RUN pip3 install -r requirements-cellguide-pipeline.txt
 ADD backend/__init__.py backend/__init__.py
 ADD backend/wmg/config.py backend/wmg/config.py
 ADD backend/wmg/data backend/wmg/data
+ADD backend/wmg/api backend/wmg/api
 ADD backend/cellguide/pipeline backend/cellguide/pipeline
 ADD backend/common backend/common
 


### PR DESCRIPTION
## Reason for Change

- Missing modules for the pipeline to run inside the CellGuide container

## Testing
 - RDEV pipeline running successfully (logs to be added)