### PR TITLE
chore(wmg): rebuild dataset dict if previous load_snapshot failed to do so

### DIFF
--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -135,6 +135,8 @@ def load_snapshot(
             snapshot_id=snapshot_id,
             read_versioned_snapshot=read_versioned_snapshot,
         )
+
+    if not hasattr(cached_snapshot, "dataset_dict"):
         cached_snapshot.build_dataset_metadata_dict()
 
     return cached_snapshot


### PR DESCRIPTION
## Reason for Change

- [Slack context](https://czi-sci.slack.com/archives/C023Q1APASK/p1693329070018309)

## Changes

- disentangle dataset_dict building from snapshot loading. Even if the snapshot exists, if dataset_dict does not exist as an attribute, it should be rebuilt.