### PR TITLE
chore(cellguide): handle s3 upload and file checking for rdevs

### DIFF
--- a/backend/cellguide/pipeline/__init__.py
+++ b/backend/cellguide/pipeline/__init__.py
@@ -102,7 +102,7 @@ def upload_gpt_descriptions_to_s3(*, gpt_output_directory: str, gpt_seo_output_d
         s3_provider.sync_directory(src_dir=src_directory, s3_uri=f"{bucket_path}{dst_directory}/")
 
         num_descriptions = len(glob(f"{src_directory}/*.json"))
-        logger.info(f"Uploaded {num_descriptions} GPT descriptions to s3://{bucket_path}{dst_directory}/")
+        logger.info(f"Uploaded {num_descriptions} GPT descriptions to {bucket_path}{dst_directory}/")
 
 
 def cleanup(*, output_directory: str):

--- a/backend/cellguide/pipeline/__init__.py
+++ b/backend/cellguide/pipeline/__init__.py
@@ -14,6 +14,7 @@ from backend.cellguide.pipeline.metadata import run as run_metadata_pipeline
 from backend.cellguide.pipeline.ontology_tree import run as run_ontology_tree_pipeline
 from backend.cellguide.pipeline.providers.s3_provider import S3Provider
 from backend.cellguide.pipeline.source_collections import run as run_source_collections_pipeline
+from backend.cellguide.pipeline.utils import get_bucket_path, get_object_key
 from backend.common.utils.cloudfront import create_invalidation_for_cellguide_data
 
 logger = logging.getLogger(__name__)
@@ -64,29 +65,12 @@ def upload_cellguide_pipeline_output_to_s3(*, output_directory: str):
     If the pipeline is running in a deployed environment, then this function uploads
     the CellGuide snapshot to the corresponding environment's CellGuide data bucket.
     """
-    deployment_stage = os.getenv("DEPLOYMENT_STAGE")
-    remote_dev_prefix = os.getenv("REMOTE_DEV_PREFIX")
+
     s3_provider = S3Provider()
+    bucket = CellGuideConfig().bucket
 
-    if not deployment_stage:
-        logger.warning(f"Not uploading the pipeline output at {output_directory} to S3 as DEPLOYMENT_STAGE is not set.")
-        return
-
-    if deployment_stage == "rdev" and remote_dev_prefix is None:
-        logger.warning(
-            f"Not uploading the pipeline output at {output_directory} to S3 as REMOTE_DEV_PREFIX is not set when DEPLOYMENT_STAGE is rdev."
-        )
-        return
-    elif deployment_stage == "rdev":
-        bucket = CellGuideConfig().bucket
-        bucket_path = f"s3://{bucket}/{remote_dev_prefix}/"
-    elif deployment_stage in ["dev", "staging", "prod"]:
-        bucket = CellGuideConfig().bucket
-        bucket_path = f"s3://{bucket}/"
-    else:
-        logger.warning(
-            f"Invalid DEPLOYMENT_STAGE value: {deployment_stage}. Please set DEPLOYMENT_STAGE to one of rdev, dev, staging, or prod"
-        )
+    bucket_path = get_bucket_path()
+    if bucket_path is None:
         return
 
     logger.info(f"Uploading the pipeline output at {output_directory} to {bucket_path}")
@@ -94,7 +78,9 @@ def upload_cellguide_pipeline_output_to_s3(*, output_directory: str):
 
     with open("latest_snapshot_identifier", "w") as file:
         file.write(output_directory)
-    s3_provider.upload_file("latest_snapshot_identifier", bucket, "latest_snapshot_identifier", {})
+
+    object_key = get_object_key(object="latest_snapshot_identifier")
+    s3_provider.upload_file("latest_snapshot_identifier", bucket, object_key, {})
 
     # Create an empty file named 404
     with open("404", "w") as file:
@@ -105,17 +91,18 @@ def upload_cellguide_pipeline_output_to_s3(*, output_directory: str):
 
 
 def upload_gpt_descriptions_to_s3(*, gpt_output_directory: str, gpt_seo_output_directory: str) -> None:
-    bucket_name = CellGuideConfig().bucket
+    bucket_path = get_bucket_path()
+
     s3_provider = S3Provider()
     for src_directory, dst_directory in zip(
         [gpt_output_directory, gpt_seo_output_directory],
         [GPT_OUTPUT_DIRECTORY_FOLDERNAME, GPT_SEO_OUTPUT_DIRECTORY_FOLDERNAME],
     ):
         # upload to s3
-        s3_provider.sync_directory(src_dir=src_directory, s3_uri=f"s3://{bucket_name}/{dst_directory}/")
+        s3_provider.sync_directory(src_dir=src_directory, s3_uri=f"{bucket_path}{dst_directory}/")
 
         num_descriptions = len(glob(f"{src_directory}/*.json"))
-        logger.info(f"Uploaded {num_descriptions} GPT descriptions to s3://{bucket_name}/{dst_directory}/")
+        logger.info(f"Uploaded {num_descriptions} GPT descriptions to s3://{bucket_path}{dst_directory}/")
 
 
 def cleanup(*, output_directory: str):

--- a/backend/cellguide/pipeline/gpt_descriptions/gpt_description_generator.py
+++ b/backend/cellguide/pipeline/gpt_descriptions/gpt_description_generator.py
@@ -10,6 +10,7 @@ from backend.cellguide.pipeline.gpt_descriptions.constants import (
 )
 from backend.cellguide.pipeline.providers.openai_provider import OpenAIProvider
 from backend.cellguide.pipeline.providers.s3_provider import S3Provider
+from backend.cellguide.pipeline.utils import get_object_key
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ def generate_new_gpt_descriptions(all_cell_type_ids_to_labels_in_corpus: dict[st
     new_gpt_descriptions: dict[str, str] = {}
     for cell_type_id in all_cell_type_ids_to_labels_in_corpus:
         cell_type_id_filename = cell_type_id.replace(":", "_")
-        object_key = f"{GPT_OUTPUT_DIRECTORY_FOLDERNAME}/{cell_type_id_filename}.json"
+        object_key = get_object_key(object=f"{GPT_OUTPUT_DIRECTORY_FOLDERNAME}/{cell_type_id_filename}.json")
         if not s3_provider.does_object_exist(bucket_name=bucket_name, object_key=object_key):
             cell_type_label = all_cell_type_ids_to_labels_in_corpus[cell_type_id]
             logger.info(f"GPT description does not exist yet for {cell_type_id} ({cell_type_label}), generating...")
@@ -69,7 +70,7 @@ def generate_new_seo_gpt_descriptions(new_gpt_descriptions: dict[str, str]) -> d
     new_gpt_seo_descriptions: dict[str, str] = {}
     for cell_type_id in new_gpt_descriptions:
         cell_type_id_filename = cell_type_id.replace(":", "_")
-        object_key = f"{GPT_SEO_OUTPUT_DIRECTORY_FOLDERNAME}/{cell_type_id_filename}.json"
+        object_key = get_object_key(object=f"{GPT_SEO_OUTPUT_DIRECTORY_FOLDERNAME}/{cell_type_id_filename}.json")
         if not s3_provider.does_object_exist(bucket_name=bucket_name, object_key=object_key):
             logger.info(f"GPT SEO description does not exist yet for {cell_type_id}, generating...")
             seo_description_str = openai_provider.generate_gpt_output(

--- a/backend/cellguide/pipeline/providers/s3_provider.py
+++ b/backend/cellguide/pipeline/providers/s3_provider.py
@@ -59,9 +59,17 @@ class S3Provider:
         """
         Returns True if the object exists in the bucket and is available to download
         """
-        if "/" in bucket_name:
+        deployment_stage = os.getenv("DEPLOYMENT_STAGE")
+        remote_dev_prefix = os.getenv("REMOTE_DEV_PREFIX")
+
+        if deployment_stage == "rdev" and remote_dev_prefix is not None:
+            # bucket_name is "cellguide-data-public-dev/env-rdev-cellguide"
+            # so subpath is "env-rdev-cellguide"
             bucket_name, subpath = bucket_name.split("/", 1)
-            object_key = f"{subpath}/{object_key}"
+            object_key = f"{subpath}{remote_dev_prefix}/{object_key}"
+        elif deployment_stage == "rdev":
+            raise ValueError("REMOTE_DEV_PREFIX must be set when DEPLOYMENT_STAGE is rdev")
+
         try:
             self.client.head_object(Bucket=bucket_name, Key=object_key)
             return True

--- a/backend/cellguide/pipeline/providers/s3_provider.py
+++ b/backend/cellguide/pipeline/providers/s3_provider.py
@@ -59,17 +59,6 @@ class S3Provider:
         """
         Returns True if the object exists in the bucket and is available to download
         """
-        deployment_stage = os.getenv("DEPLOYMENT_STAGE")
-        remote_dev_prefix = os.getenv("REMOTE_DEV_PREFIX")
-
-        if deployment_stage == "rdev" and remote_dev_prefix is not None:
-            # bucket_name is "cellguide-data-public-dev/env-rdev-cellguide"
-            # so subpath is "env-rdev-cellguide"
-            bucket_name, subpath = bucket_name.split("/", 1)
-            object_key = f"{subpath}{remote_dev_prefix}/{object_key}"
-        elif deployment_stage == "rdev":
-            raise ValueError("REMOTE_DEV_PREFIX must be set when DEPLOYMENT_STAGE is rdev")
-
         try:
             self.client.head_object(Bucket=bucket_name, Key=object_key)
             return True

--- a/backend/cellguide/pipeline/providers/s3_provider.py
+++ b/backend/cellguide/pipeline/providers/s3_provider.py
@@ -59,6 +59,9 @@ class S3Provider:
         """
         Returns True if the object exists in the bucket and is available to download
         """
+        if "/" in bucket_name:
+            bucket_name, subpath = bucket_name.split("/", 1)
+            object_key = f"{subpath}/{object_key}"
         try:
             self.client.head_object(Bucket=bucket_name, Key=object_key)
             return True

--- a/backend/cellguide/pipeline/utils.py
+++ b/backend/cellguide/pipeline/utils.py
@@ -1,12 +1,17 @@
 import json
+import logging
 import os
 import pathlib
 from dataclasses import dataclass
+from typing import Union
 
 import pandas as pd
 
+from backend.cellguide.pipeline.config import CellGuideConfig
 from backend.cellguide.pipeline.constants import ENSEMBL_GENE_ID_TO_DESCRIPTION_FILENAME
 from backend.common.utils.dataclass import convert_dataclass_to_dict
+
+logger = logging.getLogger(__name__)
 
 
 def output_json(data, path):
@@ -87,3 +92,72 @@ def get_gene_id_to_name_and_symbol() -> GeneMetadata:
     gene_id_to_name = gene_metadata.set_index("Ensembl GeneIDs")["Description"].to_dict()
     gene_id_to_symbol = gene_metadata.set_index("Ensembl GeneIDs")["Symbols"].to_dict()
     return GeneMetadata(gene_id_to_name=gene_id_to_name, gene_id_to_symbol=gene_id_to_symbol)
+
+
+def get_bucket_path() -> Union[str, None]:
+    """
+    This function generates a bucket path based on the deployment stage and remote development prefix.
+    If the deployment stage is 'rdev' and a remote development prefix is provided, the bucket path is prefixed
+    with 'env-rdev-cellguide' and the remote development prefix. Otherwise, the bucket path is the same as the
+    bucket name.
+
+    Returns
+    -------
+    str or None
+        The generated bucket path if the deployment stage is set and valid, None otherwise.
+    """
+
+    deployment_stage = os.getenv("DEPLOYMENT_STAGE")
+    remote_dev_prefix = os.getenv("REMOTE_DEV_PREFIX")
+
+    if not deployment_stage:
+        logger.warning("Not uploading the pipeline output to S3 as DEPLOYMENT_STAGE is not set.")
+        return
+
+    if deployment_stage == "rdev" and remote_dev_prefix is None:
+        logger.warning(
+            "Not uploading the pipeline output to S3 as REMOTE_DEV_PREFIX is not set when DEPLOYMENT_STAGE is rdev."
+        )
+        return
+    elif deployment_stage == "rdev":
+        bucket = CellGuideConfig().bucket
+        bucket_path = f"s3://{bucket}/env-rdev-cellguide{remote_dev_prefix}/"
+    elif deployment_stage in ["dev", "staging", "prod"]:
+        bucket = CellGuideConfig().bucket
+        bucket_path = f"s3://{bucket}/"
+    else:
+        logger.warning(
+            f"Invalid DEPLOYMENT_STAGE value: {deployment_stage}. Please set DEPLOYMENT_STAGE to one of rdev, dev, staging, or prod"
+        )
+        return
+
+    return bucket_path
+
+
+def get_object_key(*, object: str) -> str:
+    """
+    This function generates an object key for S3 based on the deployment stage and remote development prefix.
+    If the deployment stage is 'rdev' and a remote development prefix is provided, the object key is prefixed
+    with 'env-rdev-cellguide' and the remote development prefix. Otherwise, the object key is the same as the
+    input object.
+
+    Parameters
+    ----------
+    object : str
+        The input object for which the object key is to be generated.
+
+    Returns
+    -------
+    str
+        The generated object key.
+    """
+
+    deployment_stage = os.getenv("DEPLOYMENT_STAGE")
+    remote_dev_prefix = os.getenv("REMOTE_DEV_PREFIX")
+
+    object_key = object
+    if deployment_stage == "rdev" and remote_dev_prefix is not None:
+        CellGuideConfig().bucket
+        object_key = f"env-rdev-cellguide{remote_dev_prefix}/{object}"
+
+    return object_key

--- a/scripts/populate_rdev_with_cellguide_data.sh
+++ b/scripts/populate_rdev_with_cellguide_data.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 STACK_NAME=""
 SRC_DEPLOYMENT="staging"
+POPULATE_ONLY_GPT=false
 
 function usage {
-    echo "Usage: $0 [-s|--src_deployment <src_deployment>] <stack_name>"
+    echo "Usage: $0 [-s|--src_deployment <src_deployment>] [-g|--gpt_only] <stack_name>"
     echo "Make sure AWS_PROFILE is set to single-cell-dev prior to running this command."
     echo ""
     echo "Populates the specified rdev stack with data."
     echo ""
     echo "Options:"
     echo "  -s, --src_deployment    The source deployment to use. Can be either 'staging' or 'dev'. Default is 'staging'."
+    echo "  -g, --gpt_only          Only populate gpt_descriptions and gpt_seo_descriptions. Default is false."
     echo ""
     echo "Arguments:"
     echo "  stack_name              The name of the rdev stack to be populated."
@@ -28,6 +30,10 @@ while (( "$#" )); do
         exit 1
       fi
       shift 2
+      ;;
+    -g|--gpt_only)
+      POPULATE_ONLY_GPT=true
+      shift
       ;;
     --) # end argument parsing
       shift
@@ -55,8 +61,11 @@ if [ -n "$LATEST_SNAPSHOT_IDENTIFIER" ]
 then
   aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/gpt_seo_descriptions s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/gpt_seo_descriptions
   aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/gpt_descriptions s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/gpt_descriptions
-  aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/${LATEST_SNAPSHOT_IDENTIFIER} s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/${LATEST_SNAPSHOT_IDENTIFIER}
-  aws s3 cp s3://cellguide-data-public-${SRC_DEPLOYMENT}/latest_snapshot_identifier s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/latest_snapshot_identifier
+  if [ "$POPULATE_ONLY_GPT" = false ] ; then
+    aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/${LATEST_SNAPSHOT_IDENTIFIER} s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/${LATEST_SNAPSHOT_IDENTIFIER}
+    aws s3 cp s3://cellguide-data-public-${SRC_DEPLOYMENT}/latest_snapshot_identifier s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/latest_snapshot_identifier
+  fi
 else
   echo "Warning: LATEST_SNAPSHOT_IDENTIFIER is invalid"
 fi
+


### PR DESCRIPTION
## Changes

- added helper functions to get the bucket path and object keys for different deployments (namely rdev vs everything else)

## Testing steps

- Pipeline successfully completed, uploaded data to the right location, and created cloudfront invalidation
- Logs [here](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/%2Fdp%2Frdev%2Fcellguide-pipeline%2Fcg-pipeline/log-events/cg-rdev-cellguide-pipeline-cg-pipeline%2Fdefault%2F12d766f7563e4ca196167e39ed29379f)