### PR TITLE
feat(cellguide): improve DAG filtering by tissue

### DIFF
--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -198,9 +198,7 @@ export default function OntologyDagView({
         // When both cell and tissue tree states are available, inject the tissue tree counts
         // into the cell tree state.
         initialTreeState = {
-          isExpandedNodes: initialTreeStateCell.isExpandedNodes,
-          notShownWhenExpandedNodes:
-            initialTreeStateCell.notShownWhenExpandedNodes,
+          ...initialTreeStateCell.isExpandedNodes,
           tissueCounts: initialTreeStateTissue.tissueCounts,
         };
       } else if (initialTreeStateCell) {

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -198,7 +198,7 @@ export default function OntologyDagView({
         // When both cell and tissue tree states are available, inject the tissue tree counts
         // into the cell tree state.
         initialTreeState = {
-          ...initialTreeStateCell.isExpandedNodes,
+          ...initialTreeStateCell,
           tissueCounts: initialTreeStateTissue.tissueCounts,
         };
       } else if (initialTreeStateCell) {

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -190,44 +190,18 @@ export default function OntologyDagView({
   const { data: initialTreeStateTissue } = useCellOntologyTreeStateTissue(
     tissueId ?? ""
   );
-  // (alec) This now handles the case where the initial tree state for both cell type and tissue is defined. We take the intersection of isExpanded and union of notShownWhenExpanded.
+
   const initialTreeState: CellOntologyTreeStateResponse | undefined =
     useMemo(() => {
       let initialTreeState;
       if (initialTreeStateCell && initialTreeStateTissue) {
-        // Intersection of isExpandedNodes
-        const isExpandedIntersection =
-          initialTreeStateCell.isExpandedNodes.filter((node) =>
-            initialTreeStateTissue.isExpandedNodes.includes(node)
-          );
-
-        // Union of notShownWhenExpandedNodes
-        const notShownWhenExpandedUnion: {
-          [key: string]: string[];
-        } = { ...initialTreeStateCell.notShownWhenExpandedNodes };
-
-        for (const key of Object.keys(
-          initialTreeStateTissue.notShownWhenExpandedNodes
-        )) {
-          if (notShownWhenExpandedUnion[key]) {
-            // If the key exists in both, merge the arrays and de-duplicate
-            notShownWhenExpandedUnion[key] = Array.from(
-              new Set([
-                ...notShownWhenExpandedUnion[key],
-                ...initialTreeStateTissue.notShownWhenExpandedNodes[key],
-              ])
-            );
-          } else {
-            // If the key exists only in the tissue data, add it to the union
-            notShownWhenExpandedUnion[key] =
-              initialTreeStateTissue.notShownWhenExpandedNodes[key];
-          }
-        }
-
+        // When both cell and tissue tree states are available, inject the tissue tree counts
+        // into the cell tree state.
         initialTreeState = {
-          isExpandedNodes: isExpandedIntersection,
-          notShownWhenExpandedNodes: notShownWhenExpandedUnion,
-          tissueCounts: initialTreeStateTissue.tissueCounts, // Only specified for tissueId
+          isExpandedNodes: initialTreeStateCell.isExpandedNodes,
+          notShownWhenExpandedNodes:
+            initialTreeStateCell.notShownWhenExpandedNodes,
+          tissueCounts: initialTreeStateTissue.tissueCounts,
         };
       } else if (initialTreeStateCell) {
         initialTreeState = initialTreeStateCell;


### PR DESCRIPTION
## Reason for Change

- Previously, when selecting a tissue, we were filtering the DAG in a CellGuide Card by taking the intersection of the expanded nodes in the Tissue tree and the expanded nodes in the Cell tree. This led to invalid tree states with the target cell type being collapsed for certain tissues.
- In retrospect, there was no justification for choosing to intersect the expanded nodes in the tree DAG and the cell type DAG.
- The correct approach is to use the cell tree state but inject tissue counts into the tree state. This activates logic used for pruning subtrees that do not belong in the tissue (which was previously only being used in the tissue card DAGs).