### PR TITLE
chore: skip failing functional test

### DIFF
--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -14,6 +14,7 @@ class TestApi(BaseFunctionalTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
+    @unittest.skip("Skipping this test until the deployed_version feature is fixed")
     def test_version(self):
         res = self.session.get(f"{self.api}/dp/v1/deployed_version")
         res.raise_for_status()


### PR DESCRIPTION
## Reason for Change

- This test is failing as deployed_version is not working. Skipping it to unblock deployments. [It should be re-added once the feature is fixed](https://github.com/chanzuckerberg/single-cell-data-portal/issues/5664).
