### PR TITLE
feat: heatmap divider

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
@@ -67,10 +67,12 @@ export const StyledAutocomplete = styled(Autocomplete)`
 export const StyledTag = styled(Tag)`
   max-width: 258px;
 `;
+// copied to frontend/src/views/WheresMyGeneV2/components/HeatMap/style.ts
 interface TopLeftCornerMaskProps {
   height: number;
 }
 
+// copied to frontend/src/views/WheresMyGeneV2/components/HeatMap/style.ts
 export const TopLeftCornerMask = styled.div<TopLeftCornerMaskProps>`
   position: absolute;
   background-color: white;
@@ -129,6 +131,7 @@ export const XAxisMask = styled.div<XAxisMaskProps>`
   height: ${(props) => props.height}px;
 `;
 
+// copied to frontend/src/views/WheresMyGeneV2/components/HeatMap/style.ts
 export const XAxisWrapper = styled.div`
   display: flex;
   background-color: white;

--- a/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/utils.ts
@@ -12,7 +12,7 @@ import {
 } from "../../common/types";
 import { TISSUE_CELL_TYPE_DIVIDER } from "./hooks/useSortedGeneNames";
 
-export const Y_AXIS_CHART_WIDTH_PX = 400;
+export const Y_AXIS_CHART_WIDTH_PX = 352;
 
 /**
  * Used to calculate text pixel widths. Should be only created once.

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/index.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
+
 import {
   EMPTY_ARRAY,
   EMPTY_OBJECT,
@@ -52,9 +53,7 @@ import {
   Container,
   ContainerWrapper,
   StyledTag,
-  TopLeftCornerMask,
   XAxisMask,
-  XAxisWrapper,
   YAxisWrapper,
 } from "src/views/WheresMyGene/components/HeatMap/style";
 import { CellCountLabel } from "src/views/WheresMyGene/components/HeatMap/components/XAxisChart/style";
@@ -70,6 +69,7 @@ import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
 import { EXCLUDE_IN_SCREENSHOT_CLASS_NAME } from "../GeneSearchBar/components/SaveExport";
 import { Autocomplete, DefaultAutocompleteOption } from "@czi-sds/components";
+import { Divider, TopLeftCornerMask, XAxisWrapper } from "./style";
 
 interface Props {
   className?: string;
@@ -510,6 +510,7 @@ export default memo(function HeatMap({
             })}
           </ChartWrapper>
         </Container>
+        <Divider className={EXCLUDE_IN_SCREENSHOT_CLASS_NAME} />
       </ContainerWrapper>
     </>
   );

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/style.ts
@@ -1,0 +1,49 @@
+import styled from "@emotion/styled";
+import { gray300 } from "src/common/theme";
+import { X_AXIS_CHART_HEIGHT_PX } from "src/views/WheresMyGene/common/constants";
+import { Y_AXIS_CHART_WIDTH_PX } from "src/views/WheresMyGene/components/HeatMap/utils";
+
+enum ZIndex {
+  XAxisWrapper = 2,
+  TopLeftCornerMask = 3,
+  Divider = 4,
+}
+
+export const Divider = styled.div`
+  height: 100%;
+  position: absolute;
+  left: 24%;
+  width: 1px;
+  top: 0;
+  border-right: solid 0.5px ${gray300};
+  z-index: ${ZIndex.Divider};
+`;
+
+export const XAxisWrapper = styled.div`
+  display: flex;
+  background-color: white;
+  flex-direction: row;
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: ${ZIndex.XAxisWrapper};
+`;
+
+interface TopLeftCornerMaskProps {
+  height: number;
+}
+
+export const TopLeftCornerMask = styled.div<TopLeftCornerMaskProps>`
+  position: absolute;
+  background-color: white;
+  z-index: ${ZIndex.TopLeftCornerMask};
+  top: 0px;
+  left: 0px;
+  width: ${Y_AXIS_CHART_WIDTH_PX}px;
+  height: ${(props) => props.height || X_AXIS_CHART_HEIGHT_PX}px;
+  min-height: ${(props) => props.height}px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: end;
+`;


### PR DESCRIPTION
## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

1. Add divider

<img width="905" alt="Screenshot 2023-09-05 at 8 15 25 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/0d7c54cc-c0f2-4889-a7a8-3517952d6dba">

1. No divider in PNG/SVG

PNG:
<img width="831" alt="Screenshot 2023-09-05 at 8 21 22 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/51b5a330-5c44-49b3-be62-68f404228ef6">

SVG:
<img width="495" alt="Screenshot 2023-09-05 at 8 15 16 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/e17d29a3-7526-4132-8b59-29be0b634a4d">

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Notes for Reviewer
