### PR TITLE
feat: Update "download datasets" copy caption (#5586)

### DIFF
--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/CurlLink/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/CurlLink/index.tsx
@@ -1,6 +1,11 @@
+import { Link } from "@czi-sds/components";
 import copy from "clipboard-copy";
 import { FC, useState } from "react";
 import { Code, CodeMask, CodeWrapper, Tip } from "./style";
+
+const DISCOVER_API_URL = "https://api.cellxgene.cziscience.com/curation/ui/#/";
+const SCHEMA_URL =
+  "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.1.0/schema.md";
 
 interface Props {
   fileName: string;
@@ -29,9 +34,16 @@ const CurlLink: FC<Props> = ({ fileName, handleAnalytics, link }) => {
         </CodeMask>
       </CodeWrapper>
       <Tip>
-        If you prefer not to download this dataset directly in your browser, you
-        can optionally use the provided cURL link to download via the terminal.
-        The above link will be valid for 1 week.
+        This cURL command is valid forever. All datasets on CZ CELLxGENE
+        Discover adhere to its{" "}
+        <Link href={SCHEMA_URL} rel="noreferrer noopener" target="_blank">
+          schema
+        </Link>{" "}
+        and may be downloaded programmatically using the{" "}
+        <Link href={DISCOVER_API_URL} rel="noreferrer noopener" target="_blank">
+          Discover API
+        </Link>
+        .
       </Tip>
     </>
   );


### PR DESCRIPTION
## Reason for Change

- #5586

## Changes

- Modified download datasets copy caption text as per [mocks](https://www.figma.com/file/jEv0ZWQd0Q53aFl9nNRbBy/Portal?node-id=192%3A51303&mode=dev) to include a link to the schema and Discover API.
- Schema URL is updated to https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.1.0/schema.md as per [slack thread](https://clevercanary.slack.com/archives/C02CF7MQPGV/p1694028293166609?thread_ts=1694026581.496909&cid=C02CF7MQPGV).
