### PR TITLE
fix(e2e): add try-catch to ignore plausible errors in playwright tests

### DIFF
--- a/frontend/src/common/analytics/index.ts
+++ b/frontend/src/common/analytics/index.ts
@@ -20,8 +20,11 @@ const serializeProps = (
 
 export function track(event: EVENTS, props?: Record<string, unknown>): void {
   const options = serializeProps(props);
-  if (process.env.NODE_ENV !== "development") {
+  try {
     window.plausible(event, options);
+  } catch (e) {
+    // adding this to catch errors in tests
+    console.error(e);
   }
 
   if (API_URL !== "https://api.cellxgene.cziscience.com") {


### PR DESCRIPTION
## Reason for Change

- [Context](https://czi-sci.slack.com/archives/C0244PQK934/p1694004494357189?thread_ts=1693949072.510159&cid=C0244PQK934)

Not sure why window.plausible started erroring with the "not a function" TypeError during playwright tests..But this should fix it.
