### PR TITLE
fix(happy): prevent orphaned ECS tasks

### DIFF
--- a/.happy/config.json
+++ b/.happy/config.json
@@ -80,5 +80,8 @@
   "tasks": {
     "migrate": ["migrate_db_task_definition_arn"],
     "delete": ["delete_db_task_definition_arn"]
+  },
+  "features": {
+    "enable_dynamo_locking": true
   }
 }


### PR DESCRIPTION
## Reason for Change

When cleaning up an rdev environment sometime the ECS task would be left running. This will get expensive as we mmake more rdev environments.

This work is related to https://github.com/chanzuckerberg/single-cell-data-portal/issues/5439
## Changes

- add enable_dynamo_locking to prevent race conditions when cleaning up rdev environments

## Testing steps

- create an rdev and break it down.

## Notes for Reviewer
