### PR TITLE
feat(dp): add primary cell count to dataset metadata

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -977,6 +977,10 @@ components:
           description: The number of cells in the Dataset.
           nullable: true
           type: integer
+        primary_cell_count:
+          description: The number of primary cells in the Dataset.
+          nullable: true
+          type: integer
         cell_type:
           description: |
             [cell type label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.1.0/schema.md#cell_type)
@@ -1063,6 +1067,10 @@ components:
           $ref: "#/components/schemas/batch_condition"
         cell_count:
           description: The number of cells in the Dataset.
+          nullable: true
+          type: integer
+        primary_cell_count:
+          description: The number of primary cells in the Dataset.
           nullable: true
           type: integer
         cell_type:
@@ -1156,6 +1164,10 @@ components:
           $ref: "#/components/schemas/batch_condition"
         cell_count:
           description: The number of cells in the Dataset.
+          nullable: true
+          type: integer
+        primary_cell_count:
+          description: The number of primary cells in the Dataset.
           nullable: true
           type: integer
         cell_type:

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -222,7 +222,6 @@ def reshape_dataset_for_curation_api(
 
     ds["dataset_id"] = dataset_version.dataset_id.id
     ds["dataset_version_id"] = dataset_version.version_id.id
-    ds["primary_cell_count"] = dataset_version.metadata.primary_cell_count
     # Get none preview specific dataset fields
     if not preview:
         ds["assets"] = extract_dataset_assets(dataset_version)
@@ -305,6 +304,7 @@ class EntityColumns:
         "development_stage",
         "cell_type",
         "cell_count",
+        "primary_cell_count",
         "x_approximate_distribution",
         "batch_condition",
         "mean_genes_per_cell",

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -222,6 +222,7 @@ def reshape_dataset_for_curation_api(
 
     ds["dataset_id"] = dataset_version.dataset_id.id
     ds["dataset_version_id"] = dataset_version.version_id.id
+    ds["primary_cell_count"] = dataset_version.metadata.primary_cell_count
     # Get none preview specific dataset fields
     if not preview:
         ds["assets"] = extract_dataset_assets(dataset_version)

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -213,7 +213,7 @@ def reshape_dataset_for_curation_api(
     # Metadata can be None if the dataset isn't still fully processed, so we account for that
     if dataset_version.metadata is not None:
         for column in columns:
-            col = getattr(dataset_version.metadata, column)
+            col = getattr(dataset_version.metadata, column, None)
             if isinstance(col, OntologyTermId):
                 col = [asdict(col)]
             elif isinstance(col, list) and len(col) != 0 and isinstance(col[0], OntologyTermId):

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -172,7 +172,7 @@ class DatasetMetadata:
     development_stage: List[OntologyTermId]
     cell_type: List[OntologyTermId]
     cell_count: int
-    primary_cell_count: int
+    primary_cell_count: Optional[int] = None
     mean_genes_per_cell: float
     batch_condition: List[str]
     suspension_type: List[str]

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -172,6 +172,7 @@ class DatasetMetadata:
     development_stage: List[OntologyTermId]
     cell_type: List[OntologyTermId]
     cell_count: int
+    primary_cell_count: int
     mean_genes_per_cell: float
     batch_condition: List[str]
     suspension_type: List[str]

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -172,13 +172,13 @@ class DatasetMetadata:
     development_stage: List[OntologyTermId]
     cell_type: List[OntologyTermId]
     cell_count: int
-    primary_cell_count: Optional[int] = None
     mean_genes_per_cell: float
     batch_condition: List[str]
     suspension_type: List[str]
     donor_id: List[str]
     is_primary_data: str
     x_approximate_distribution: Optional[str]
+    primary_cell_count: Optional[int] = None
 
 
 @dataclass

--- a/backend/layers/processing/process_download_validate.py
+++ b/backend/layers/processing/process_download_validate.py
@@ -150,6 +150,7 @@ class ProcessDownloadValidate(ProcessingLogic):
             self_reported_ethnicity=_get_term_pairs("self_reported_ethnicity"),
             development_stage=_get_term_pairs("development_stage"),
             cell_count=adata.shape[0],
+            primary_cell_count=adata.obs["is_primary_data"].astype("int").sum(),
             mean_genes_per_cell=numerator / denominator,
             is_primary_data=_get_is_primary_data(),
             cell_type=_get_term_pairs("cell_type"),

--- a/backend/layers/processing/process_download_validate.py
+++ b/backend/layers/processing/process_download_validate.py
@@ -150,7 +150,7 @@ class ProcessDownloadValidate(ProcessingLogic):
             self_reported_ethnicity=_get_term_pairs("self_reported_ethnicity"),
             development_stage=_get_term_pairs("development_stage"),
             cell_count=adata.shape[0],
-            primary_cell_count=adata.obs["is_primary_data"].astype("int").sum(),
+            primary_cell_count=int(adata.obs["is_primary_data"].astype("int").sum()),
             mean_genes_per_cell=numerator / denominator,
             is_primary_data=_get_is_primary_data(),
             cell_type=_get_term_pairs("cell_type"),

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -725,6 +725,8 @@ paths:
                         type: string
                     cell_count:
                       type: integer
+                    primary_cell_count:
+                      type: integer
                     cell_type:
                       $ref: "#/components/schemas/ontology_element_array"
                     cell_type_ancestors:

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -808,6 +808,8 @@ paths:
                         type: string
                     cell_count:
                       type: integer
+                    primary_cell_count:
+                      type: integer
                     cell_type:
                       $ref: "#/components/schemas/ontology_element_array"
                     cell_type_ancestors:
@@ -1185,6 +1187,8 @@ components:
         cell_type:
           $ref: "#/components/schemas/ontology_element_array"
         cell_count:
+          type: integer
+        primary_cell_count:
           type: integer
         X_approximate_distribution:
           $ref: "#/components/schemas/distribution"

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -187,6 +187,7 @@ def _dataset_to_response(
             "assay": None if dataset.metadata is None else _ontology_term_ids_to_response(dataset.metadata.assay),
             "batch_condition": None if dataset.metadata is None else dataset.metadata.batch_condition,
             "cell_count": None if dataset.metadata is None else dataset.metadata.cell_count,
+            "primary_cell_count": None if dataset.metadata is None else dataset.metadata.primary_cell_count,
             "cell_type": None
             if dataset.metadata is None
             else _ontology_term_ids_to_response(dataset.metadata.cell_type),

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1035,6 +1035,7 @@ class TestGetCollectionVersionID(BaseAPIPortalTest):
                     "collection_id": f"{first_version.collection_id.id}",
                     "collection_version_id": f"{first_version.version_id.id}",
                     "cell_count": 10,
+                    "primary_cell_count": 5,
                     "cell_type": [{"label": "test_cell_type_label", "ontology_term_id": "test_cell_type_term_id"}],
                     "dataset_id": f"{first_version.datasets[0].dataset_id.id}",
                     "dataset_version_id": f"{first_version.datasets[0].version_id.id}",

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -269,7 +269,6 @@ class TestPostCollection(BaseAPIPortalTest):
             self.assertEqual(len(response.json["invalid_parameters"]), num_expected_errors)
 
     def test__create_collection__strip_string_fields(self):
-
         collection_metadata = dict(
             name="collection   ",
             description="   description",
@@ -728,6 +727,7 @@ class TestGetCollectionID(BaseAPIPortalTest):
 
         # test
         res = self.app.get(f"/curation/v1/collections/{collection_version.collection_id}")
+
         self.assertEqual(200, res.status_code)
         res_body = res.json
         del res_body["created_at"]  # too finicky; ignore

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -82,6 +82,7 @@ class TestCollection(BaseAPIPortalTest):
                     "assay": [{"label": "test_assay_label", "ontology_term_id": "test_assay_term_id"}],
                     "batch_condition": ["test_batch_1", "test_batch_2"],
                     "cell_count": 10,
+                    "primary_cell_count": 5,
                     "cell_type": [{"label": "test_cell_type_label", "ontology_term_id": "test_cell_type_term_id"}],
                     "collection_id": collection.collection_id.id,
                     "created_at": mock.ANY,
@@ -132,6 +133,7 @@ class TestCollection(BaseAPIPortalTest):
                     "assay": [{"label": "test_assay_label", "ontology_term_id": "test_assay_term_id"}],
                     "batch_condition": ["test_batch_1", "test_batch_2"],
                     "cell_count": 10,
+                    "primary_cell_count": 5,
                     "cell_type": [{"label": "test_cell_type_label", "ontology_term_id": "test_cell_type_term_id"}],
                     "collection_id": collection.collection_id.id,
                     "created_at": mock.ANY,
@@ -1661,6 +1663,7 @@ class TestDataset(BaseAPIPortalTest):
                 actual_dataset["development_stage"], convert_ontology(persisted_dataset.metadata.development_stage)
             )
             self.assertEqual(actual_dataset["cell_count"], persisted_dataset.metadata.cell_count)
+            self.assertEqual(actual_dataset["primary_cell_count"], persisted_dataset.metadata.primary_cell_count)
             self.assertEqual(actual_dataset["cell_type"], convert_ontology(persisted_dataset.metadata.cell_type))
             self.assertEqual(actual_dataset["is_primary_data"], persisted_dataset.metadata.is_primary_data)
             self.assertEqual(actual_dataset["mean_genes_per_cell"], persisted_dataset.metadata.mean_genes_per_cell)

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -142,6 +142,7 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
             ],
             cell_type=[OntologyTermId(label="test_cell_type_label", ontology_term_id="test_cell_type_term_id")],
             cell_count=10,
+            primary_cell_count=5,
             schema_version="3.0.0",
             mean_genes_per_cell=0.5,
             batch_condition=["test_batch_1", "test_batch_2"],
@@ -228,7 +229,6 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
         published_at: datetime = None,
         num_datasets: int = 2,
     ) -> Tuple[CollectionVersionWithDatasets, CollectionVersionWithDatasets]:
-
         # Published with a published revision.
         published_version = self.initialize_published_collection(owner, curator_name, published_at, num_datasets)
         revision = self.business_logic.create_collection_version(published_version.collection_id)
@@ -245,7 +245,6 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
         published_at: datetime = None,
         num_datasets: int = 2,
     ) -> Tuple[CollectionVersionWithDatasets, CollectionVersionWithDatasets]:
-
         # Published with an unpublished revision
         published_version = self.initialize_published_collection(owner, curator_name, published_at, num_datasets)
         revision = self.business_logic.create_collection_version(published_version.collection_id)

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -58,7 +58,6 @@ class DatasetData:
 
 
 class BaseTest(unittest.TestCase):
-
     business_logic: BusinessLogic
     crossref_provider: CrossrefProviderInterface  # Can be mocked from the tests
     uri_provider: UriProviderInterface
@@ -125,6 +124,7 @@ class BaseTest(unittest.TestCase):
             ],
             cell_type=[OntologyTermId(label="test_cell_type_label", ontology_term_id="test_cell_type_term_id")],
             cell_count=10,
+            primary_cell_count=5,
             schema_version="3.0.0",
             mean_genes_per_cell=0.5,
             batch_condition=["test_batch_1", "test_batch_2"],
@@ -180,7 +180,6 @@ class BaseTest(unittest.TestCase):
         collection = self.business_logic.create_collection(owner, curator_name, metadata)
 
         for _ in range(add_datasets):
-
             metadata = copy.deepcopy(self.sample_dataset_metadata)
             metadata.schema_version = dataset_schema_version
             # TODO: generate a real dataset, with artifact and processing status

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -18,7 +18,6 @@ class TestProcessingDownloadValidate(BaseProcessingTest):
 
     @patch("scanpy.read_h5ad")
     def test_extract_metadata(self, mock_read_h5ad):
-
         df = pandas.DataFrame(
             np.random.randint(10, size=(50001, 5)) * 50, columns=list("ABCDE"), index=(str(i) for i in range(50001))
         )
@@ -143,6 +142,7 @@ class TestProcessingDownloadValidate(BaseProcessingTest):
         self.assertEqual(extracted_metadata.schema_version, "3.0.0")
 
         self.assertEqual(extracted_metadata.cell_count, 50001)
+        self.assertEqual(extracted_metadata.primary_cell_count, 0)
 
         filter = np.where(adata.var.feature_biotype == "gene")[0]
         self.assertAlmostEqual(extracted_metadata.mean_genes_per_cell, np.count_nonzero(adata.X[:, filter]) / 50001)


### PR DESCRIPTION
## Reason for Change

 - [this is part of the work to automate the hero numbers on the landing page](https://docs.google.com/document/d/1UIw-nyNmRF6ob46WLOnxXhyT46J-jcEglzJ9bxGV2BU/edit).

## Changes

- add primary cell count field to curation and data portal apis
- update extract metadata with primary cell count

## Testing steps

- tests pass
- @brianraymor to check [rdev](https://primary-cell-count-backend.rdev.single-cell.czi.technology/)