### PR TITLE
feat: use the string "tissue agnostic" instead of "all tissues"

### DIFF
--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/MarkerGeneTables/constants.ts
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/MarkerGeneTables/constants.ts
@@ -2,6 +2,8 @@ export const HOMO_SAPIENS = "Homo sapiens";
 
 export const ALL_TISSUES = "All Tissues";
 
+export const TISSUE_AGNOSTIC = "Tissue Agnostic";
+
 export const NO_ORGAN_ID = "";
 
 export const CELL_GUIDE_CARD_CANONICAL_MARKER_GENES_TABLE =

--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/MarkerGeneTables/hooks/canonical_markers.ts
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/MarkerGeneTables/hooks/canonical_markers.ts
@@ -3,7 +3,12 @@ import {
   CanonicalMarkersQueryResponse,
   CanonicalMarkersQueryResponseEntry,
 } from "src/common/queries/cellGuide";
-import { ALL_TISSUES, HOMO_SAPIENS } from "../constants";
+import {
+  ALL_TISSUES,
+  HOMO_SAPIENS,
+  NO_ORGAN_ID,
+  TISSUE_AGNOSTIC,
+} from "../constants";
 import { isTissueIdDescendantOfAncestorTissueId } from "src/views/CellGuide/common/utils";
 
 export interface CanonicalMarkerGeneTableData {
@@ -71,17 +76,15 @@ function _getReferenceData(
 function _passSelectionCriteria({
   markerGene,
   allTissuesLabelToIdMap,
-  selectedOrganLabel,
   selectedOrganId,
 }: {
   markerGene: CanonicalMarkersQueryResponseEntry;
   allTissuesLabelToIdMap: Map<string, string>;
-  selectedOrganLabel: string;
   selectedOrganId: string;
 }): boolean {
   // There are marker genes tissues labeled as "All Tissues"
   // so select them only when selectedOrganLabel is "All Tissues"
-  if (selectedOrganLabel === ALL_TISSUES) {
+  if (selectedOrganId === NO_ORGAN_ID) {
     return markerGene.tissue === ALL_TISSUES;
   }
 
@@ -117,9 +120,10 @@ export function useCanonicalMarkerGenesTableRowsAndFilters({
 
     const rows: CanonicalMarkerGeneTableData[] = [];
 
+    const organLabel = TISSUE_AGNOSTIC ? ALL_TISSUES : selectedOrganLabel;
     const publicationTitlesToIndex = _getPublicationTitlesToIndex(
       genes,
-      selectedOrganLabel
+      organLabel
     );
 
     for (const markerGene of genes) {
@@ -127,7 +131,6 @@ export function useCanonicalMarkerGenesTableRowsAndFilters({
         !_passSelectionCriteria({
           markerGene: markerGene,
           allTissuesLabelToIdMap: allTissuesLabelToIdMap,
-          selectedOrganLabel: selectedOrganLabel,
           selectedOrganId: selectedOrganId,
         })
       )

--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/MarkerGeneTables/hooks/computational_markers.ts
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/MarkerGeneTables/hooks/computational_markers.ts
@@ -5,7 +5,7 @@ import {
 } from "src/common/queries/cellGuide";
 import { FMG_GENE_STRENGTH_THRESHOLD } from "src/views/WheresMyGene/common/constants";
 import { isTissueIdDescendantOfAncestorTissueId } from "src/views/CellGuide/common/utils";
-import { ALL_TISSUES } from "../constants";
+import { ALL_TISSUES, NO_ORGAN_ID } from "../constants";
 
 export interface ComputationalMarkerGeneTableData {
   symbol: string;
@@ -30,12 +30,10 @@ function _applyOrderedSelectionCriteria({
   markerGene,
   allTissuesLabelToIdMap,
   selectedOrganismLabel,
-  selectedOrganLabel,
   selectedOrganId,
 }: {
   markerGene: ComputationalMarkersQueryResponseEntry;
   selectedOrganismLabel: string;
-  selectedOrganLabel: string;
   selectedOrganId: string;
   allTissuesLabelToIdMap: Map<string, string>;
 }): { pass: boolean; errorCode: selectionCriteriaErrorCode } {
@@ -60,7 +58,7 @@ function _applyOrderedSelectionCriteria({
   // as ALL_TISSUES. Select them only when selectedOrganLabel is "All Tissues"
   let pass = false;
 
-  if (selectedOrganLabel === ALL_TISSUES) {
+  if (selectedOrganId === NO_ORGAN_ID) {
     pass = tissue_ontology_term_label === ALL_TISSUES;
   } else {
     const tissueId = allTissuesLabelToIdMap.get(tissue_ontology_term_label);
@@ -95,13 +93,11 @@ export function useComputationalMarkerGenesTableRowsAndFilters({
   genes,
   allTissuesLabelToIdMap,
   selectedOrganismLabel,
-  selectedOrganLabel,
   selectedOrganId,
 }: {
   genes: ComputationalMarkersQueryResponse;
   allTissuesLabelToIdMap: Map<string, string>;
   selectedOrganismLabel: string;
-  selectedOrganLabel: string;
   selectedOrganId: string;
 }): {
   computationalMarkerGeneTableData: ComputationalMarkerGeneTableData[];
@@ -122,7 +118,6 @@ export function useComputationalMarkerGenesTableRowsAndFilters({
         markerGene: markerGene,
         allTissuesLabelToIdMap: allTissuesLabelToIdMap,
         selectedOrganismLabel: selectedOrganismLabel,
-        selectedOrganLabel: selectedOrganLabel,
         selectedOrganId: selectedOrganId,
       });
 
@@ -159,11 +154,5 @@ export function useComputationalMarkerGenesTableRowsAndFilters({
       computationalMarkerGeneTableData: rows,
       allFilteredByLowMarkerScore: allFilteredByLowMarkerScore,
     };
-  }, [
-    genes,
-    allTissuesLabelToIdMap,
-    selectedOrganismLabel,
-    selectedOrganLabel,
-    selectedOrganId,
-  ]);
+  }, [genes, allTissuesLabelToIdMap, selectedOrganismLabel, selectedOrganId]);
 }

--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/MarkerGeneTables/index.tsx
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/MarkerGeneTables/index.tsx
@@ -320,7 +320,6 @@ const MarkerGeneTables = ({
     useComputationalMarkerGenesTableRowsAndFilters({
       genes: computationalMarkerGenes,
       allTissuesLabelToIdMap: allTissuesLabelToIdMap,
-      selectedOrganLabel: organName,
       selectedOrganId: organId,
       selectedOrganismLabel: organismName,
     });

--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/SourceDataTable/hooks/useDataSourceFilter.ts
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/SourceDataTable/hooks/useDataSourceFilter.ts
@@ -3,7 +3,7 @@ import {
   SourceCollectionsQueryResponse,
   SourceCollectionsQueryResponseEntry,
 } from "src/common/queries/cellGuide";
-import { ALL_TISSUES } from "../../MarkerGeneTables/constants";
+import { NO_ORGAN_ID } from "../../MarkerGeneTables/constants";
 import { filterDescendantsOfAncestorTissueId } from "src/views/CellGuide/common/utils";
 
 // The predicate function used by the filter function to filter the list of
@@ -11,12 +11,10 @@ import { filterDescendantsOfAncestorTissueId } from "src/views/CellGuide/common/
 function _passSelectionCriteria({
   collection,
   selectedOrganismLabel,
-  selectedOrganLabel,
   selectedOrganId,
 }: {
   collection: SourceCollectionsQueryResponseEntry;
   selectedOrganismLabel: string;
-  selectedOrganLabel: string;
   selectedOrganId: string;
 }): boolean {
   const collectionOrganismLabels = collection.organism.map(
@@ -28,7 +26,7 @@ function _passSelectionCriteria({
 
   if (!collectionOrganismLabels.includes(selectedOrganismLabel)) return false;
 
-  if (selectedOrganLabel === ALL_TISSUES) {
+  if (selectedOrganId === NO_ORGAN_ID) {
     return true;
   }
 
@@ -43,12 +41,10 @@ function _passSelectionCriteria({
 function _filterCollections({
   collections,
   selectedOrganismLabel,
-  selectedOrganLabel,
   selectedOrganId,
 }: {
   collections: SourceCollectionsQueryResponse;
   selectedOrganismLabel: string;
-  selectedOrganLabel: string;
   selectedOrganId: string;
 }): SourceCollectionsQueryResponse {
   const filteredCollections: SourceCollectionsQueryResponse = [];
@@ -58,7 +54,6 @@ function _filterCollections({
       _passSelectionCriteria({
         collection: collection,
         selectedOrganismLabel: selectedOrganismLabel,
-        selectedOrganLabel: selectedOrganLabel,
         selectedOrganId: selectedOrganId,
       })
     )
@@ -92,12 +87,10 @@ export function useDataSourceFilter({
   collections,
   selectedOrganismLabel,
   selectedOrganId,
-  selectedOrganLabel,
 }: {
   collections: SourceCollectionsQueryResponse;
   selectedOrganismLabel: string;
   selectedOrganId: string;
-  selectedOrganLabel: string;
 }): SourceCollectionsQueryResponseEntry[] {
   return useMemo(() => {
     if (!collections) return [];
@@ -105,9 +98,8 @@ export function useDataSourceFilter({
     const filteredCollections = _filterCollections({
       collections,
       selectedOrganismLabel,
-      selectedOrganLabel,
       selectedOrganId,
     });
     return _sortCollections(filteredCollections);
-  }, [collections, selectedOrganismLabel, selectedOrganLabel, selectedOrganId]);
+  }, [collections, selectedOrganismLabel, selectedOrganId]);
 }

--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/SourceDataTable/index.tsx
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/SourceDataTable/index.tsx
@@ -68,7 +68,6 @@ const ROWS_PER_PAGE = 10;
 
 const SourceDataTable = ({
   cellTypeId,
-  organName,
   organId,
   organismName,
   skinnyMode,
@@ -95,7 +94,6 @@ const SourceDataTable = ({
   const filteredCollections = useDataSourceFilter({
     collections: collections ?? [],
     selectedOrganismLabel: organismName,
-    selectedOrganLabel: organName,
     selectedOrganId: organId,
   });
 

--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/SourceDataTable/index.tsx
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/SourceDataTable/index.tsx
@@ -52,7 +52,6 @@ const tableColumns: Array<keyof TableRow> = [
 
 interface Props {
   cellTypeId: string;
-  organName: string;
   organId: string;
   organismName: string;
   skinnyMode: boolean;

--- a/frontend/src/views/CellGuide/components/CellGuideCard/index.tsx
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/index.tsx
@@ -45,6 +45,7 @@ import { useOrganAndOrganismFilterListForCellType } from "./components/MarkerGen
 import {
   ALL_TISSUES,
   NO_ORGAN_ID,
+  TISSUE_AGNOSTIC,
 } from "./components/MarkerGeneTables/constants";
 import {
   DefaultDropdownMenuOption,
@@ -150,14 +151,14 @@ export default function CellGuideCard({
   const sdsOrgansList = useMemo(
     () =>
       Array.from(organsMap.keys()).map((organ) => ({
-        name: organ,
+        name: organ === ALL_TISSUES ? TISSUE_AGNOSTIC : organ,
       })),
     [organsMap]
   );
 
   const [selectedOrgan, setSelectedOrgan] = useState<DefaultDropdownMenuOption>(
     sdsOrgansList.find(
-      (organ) => organ.name === ALL_TISSUES
+      (organ) => organ.name === TISSUE_AGNOSTIC
     ) as DefaultDropdownMenuOption
   );
 
@@ -166,8 +167,11 @@ export default function CellGuideCard({
   const handleChangeOrgan = (option: DefaultDropdownMenuOption | null) => {
     if (!option) return;
     setSelectedOrgan(option);
-    setSelectedOrganId(organsMap.get(option.name) ?? "");
-    track(EVENTS.CG_SELECT_TISSUE, { tissue: option.name });
+    const optionName =
+      option.name === TISSUE_AGNOSTIC ? ALL_TISSUES : option.name;
+    setSelectedOrganId(organsMap.get(optionName) ?? "");
+    // Continue tracking the analytics event as All Tissues
+    track(EVENTS.CG_SELECT_TISSUE, { tissue: optionName });
   };
 
   const [selectedOrganism, setSelectedOrganism] =
@@ -366,7 +370,6 @@ export default function CellGuideCard({
             <div ref={sectionRef3} id="section-3" data-testid="section-3" />
             <SourceDataTable
               cellTypeId={cellTypeId}
-              organName={selectedOrgan.name}
               organId={selectedOrganId}
               organismName={selectedOrganism.name}
               skinnyMode={skinnyMode}


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/5671

## Changes

updates only the view layer mapping `organsMap` to `sdsOrgansList`, which we use for display in the dropdown. also adds some logic to `handleChangeOrgan` to make sure we're mapping back from "tissue agnostic" to "all tissues" for setting the selected organ id + tracking the analytics event

## Testing steps

checked T cell which actually has canonical/computational markers now!

## Notes for Reviewer
