### PR TITLE
fix: 5703 XAxis label overflow

### DIFF
--- a/frontend/src/components/common/SideBar/index.tsx
+++ b/frontend/src/components/common/SideBar/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { Button, Icon } from "@czi-sds/components";
 import {
   Position,
@@ -8,6 +8,7 @@ import {
   SideBarPositioner,
   ToggleButtonText,
 } from "src/components/common/SideBar/style";
+import { noop } from "src/common/constants/utils";
 
 const COLLAPSED_WIDTH_PX = 36;
 export const FILTERS_PANEL_EXPANDED_WIDTH_PX = 240;
@@ -31,6 +32,7 @@ export interface Props {
   disabled?: boolean;
   wmgSideBar?: boolean;
   truncatedLabel?: string;
+  onWidthChange?: (width: number) => void;
 }
 
 export default function SideBar({
@@ -47,6 +49,7 @@ export default function SideBar({
   disabled,
   wmgSideBar,
   truncatedLabel = "",
+  onWidthChange = noop,
 }: Props): JSX.Element {
   // seve: wmgSideBar does not have isOpen prop, so we need to set default to true/open
   const [isExpanded, setIsExpanded] = useState(isOpen || !!wmgSideBar);
@@ -65,6 +68,10 @@ export default function SideBar({
       onToggle(nextExpanded);
     }
   };
+
+  useEffect(() => {
+    onWidthChange(sideBarWidth);
+  }, [sideBarWidth, onWidthChange]);
 
   return (
     <SideBarWrapperComponent

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -2,7 +2,7 @@ import isEqual from "lodash/isEqual";
 import { CompareId, X_AXIS_CHART_HEIGHT_PX } from "../constants";
 import { CellType, SORT_BY } from "../types";
 import { EMPTY_ARRAY } from "src/common/constants/utils";
-import { GENE_SEARCH_BAR_HEIGHT_PX } from "src/views/WheresMyGeneV2/components/GeneSearchBar/style";
+import { GENE_SEARCH_BAR_HEIGHT_PX } from "src/views/WheresMyGeneV2/common/constants";
 
 export interface PayloadAction<Payload> {
   type: keyof typeof REDUCERS;

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/XAxisChart/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/XAxisChart/index.tsx
@@ -39,6 +39,7 @@ import GeneSearchBar from "src/views/WheresMyGeneV2/components/GeneSearchBar";
 
 interface Props {
   geneNames: string[];
+  sidebarWidth: number;
 }
 
 export const GENE_LABEL_HOVER_CONTAINER_ID = "gene-hover-container";
@@ -115,7 +116,10 @@ function GeneButton({
   );
 }
 
-export default function XAxisChart({ geneNames }: Props): JSX.Element {
+export default function XAxisChart({
+  geneNames,
+  sidebarWidth,
+}: Props): JSX.Element {
   const { genesToDelete, handleGeneClick } = useDeleteGenes();
   const [heatmapWidth, setHeatmapWidth] = useState(getHeatmapWidth(geneNames));
   const { xAxisHeight } = useContext(StateContext);
@@ -136,7 +140,10 @@ export default function XAxisChart({ geneNames }: Props): JSX.Element {
       left={Y_AXIS_CHART_WIDTH_PX + CHART_PADDING_PX}
       height={xAxisHeight}
     >
-      <GeneSearchBar className={EXCLUDE_IN_SCREENSHOT_CLASS_NAME} />
+      <GeneSearchBar
+        sidebarWidth={sidebarWidth}
+        className={EXCLUDE_IN_SCREENSHOT_CLASS_NAME}
+      />
       <XAxisContainer
         data-testid="gene-labels"
         width={heatmapWidth}

--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/XAxisChart/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/XAxisChart/style.ts
@@ -1,25 +1,44 @@
 import styled from "@emotion/styled";
 import { SELECTED_STYLE } from "../../style";
 import { HEAT_MAP_BASE_CELL_WIDTH_PX } from "../../utils";
-import { GENE_SEARCH_BAR_HEIGHT_PX } from "src/views/WheresMyGeneV2/components/GeneSearchBar/style";
+import { GENE_SEARCH_BAR_HEIGHT_PX } from "src/views/WheresMyGeneV2/common/constants";
+import { spacesXxxs } from "src/common/theme";
+import { CommonThemeProps } from "@czi-sds/components";
 
 export const ECHART_AXIS_LABEL_COLOR_HEX = "#000000";
 export const ECHART_AXIS_LABEL_FONT_SIZE_PX = 12;
 export const GENE_INFO_BUTTON_PADDING_PX = 12;
 
-interface XAxisContainerProps {
+interface XAxisContainerProps extends CommonThemeProps {
   height: number;
   width: number;
+}
+
+function xAxisOffset(props: CommonThemeProps) {
+  /**
+   * (thuang): This offset is to make sure the x-axis label doesn't overlap the
+   * gene search bar.
+   */
+  return spacesXxxs?.(props) || 0;
 }
 
 export const XAxisContainer = styled.div<XAxisContainerProps>`
   ${xAxisWidth}
   background-color: white;
-  height: ${(props) => props.height - GENE_SEARCH_BAR_HEIGHT_PX}px;
+  height: ${(props) => {
+    /**
+     * (thuang): This offset is to make sure the x-axis label doesn't overlap the
+     * gene search bar.
+     */
+    const offset = xAxisOffset(props);
+
+    return props.height - GENE_SEARCH_BAR_HEIGHT_PX - offset;
+  }}px;
   position: absolute;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  margin-top: ${(props) => GENE_SEARCH_BAR_HEIGHT_PX + xAxisOffset(props)}px;
 `;
 
 interface XAxisWrapperProps {
@@ -44,7 +63,6 @@ export const XAxisLabel = styled.div`
   display: flex;
   justify-content: end;
   align-items: center;
-  margin-bottom: 2px;
 `;
 
 export const XAxisGeneName = styled.span`

--- a/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/index.tsx
@@ -177,7 +177,11 @@ export default memo(function HeatMap({
         {isLoadingAPI || isAnyTissueLoading(isLoading) ? <Loader /> : null}
         <XAxisWrapper id="x-axis-wrapper">
           <XAxisMask data-testid="x-axis-mask" height={xAxisHeight} />
-          <XAxisChart geneNames={sortedGeneNames} />
+          <XAxisChart
+            geneNames={sortedGeneNames}
+            // (thuang): Dummy value here, since we're deleting this file
+            sidebarWidth={0}
+          />
         </XAxisWrapper>
         <YAxisWrapper top={xAxisHeight}>
           {selectedTissues.map((tissue) => {

--- a/frontend/src/views/WheresMyGene/components/Main/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/Main/index.tsx
@@ -321,7 +321,14 @@ export default function WheresMyGene(): JSX.Element {
           )}
 
           <Top id="top-legend">
-            <GeneSearchBar className={EXCLUDE_IN_SCREENSHOT_CLASS_NAME} />
+            <GeneSearchBar
+              /**
+               * (thuang): Since this WMGv1 file is going to be deleted, I'm just
+               * passing a dummy value
+               */
+              sidebarWidth={0}
+              className={EXCLUDE_IN_SCREENSHOT_CLASS_NAME}
+            />
             <Legend
               selectedCellTypes={cellTypesByTissueName}
               selectedGenes={selectedGenes}

--- a/frontend/src/views/WheresMyGeneV2/common/constants.ts
+++ b/frontend/src/views/WheresMyGeneV2/common/constants.ts
@@ -1,0 +1,1 @@
+export const GENE_SEARCH_BAR_HEIGHT_PX = 32;

--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/index.tsx
@@ -94,8 +94,10 @@ const ListboxComponent = React.forwardRef<HTMLDivElement, ListboxProps>(
 
 export default function GeneSearchBar({
   className,
+  sidebarWidth,
 }: {
   className?: string;
+  sidebarWidth: number;
 }): JSX.Element {
   const dispatch = useContext(DispatchContext);
   const { selectedGenes, selectedOrganismId } = useContext(StateContext);
@@ -198,10 +200,15 @@ export default function GeneSearchBar({
   };
 
   return (
-    <Container {...{ className }}>
+    <Container sidebarWidth={sidebarWidth} {...{ className }}>
       <ActionWrapper>
         <AutocompleteWrapper>
           <Autocomplete
+            /**
+             * (thuang): Use React Portal to avoid z-index issues, causing partial
+             * of the dropdown to be behind the XAxisChart
+             */
+            disablePortal={false}
             value={selectedGeneOptions}
             multiple
             fullWidth

--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/style.ts
@@ -2,13 +2,34 @@ import styled from "@emotion/styled";
 import { fontBodyXxs } from "@czi-sds/components";
 import { gray500 } from "src/common/theme";
 import { Button } from "@czi-sds/components";
+import { HEADER_HEIGHT_PX } from "src/components/LandingHeader/style";
+import {
+  CONTENT_WRAPPER_LEFT_RIGHT_PADDING_PX,
+  CONTENT_WRAPPER_TOP_BOTTOM_PADDING_PX,
+} from "src/components/Layout/style";
+import { LEGEND_HEIGHT_PX } from "src/views/WheresMyGene/components/InfoPanel/components/Legend/style";
+import { Y_AXIS_CHART_WIDTH_PX } from "src/views/WheresMyGene/components/HeatMap/utils";
+import { GENE_SEARCH_BAR_HEIGHT_PX } from "src/views/WheresMyGeneV2/common/constants";
 
-export const GENE_SEARCH_BAR_HEIGHT_PX = 32;
+interface ContainerProps {
+  sidebarWidth: number;
+}
 
 export const Container = styled.div`
   height: ${GENE_SEARCH_BAR_HEIGHT_PX}px;
   width: fit-content;
-  margin-bottom: 8px;
+  position: fixed;
+  top: ${HEADER_HEIGHT_PX +
+  CONTENT_WRAPPER_TOP_BOTTOM_PADDING_PX +
+  LEGEND_HEIGHT_PX}px;
+  /**
+   * (thuang): Dynamically calculate the left offset based on the sidebar
+   * expand/collapse width.
+   */
+  left: ${({ sidebarWidth }: ContainerProps) =>
+    sidebarWidth +
+    CONTENT_WRAPPER_LEFT_RIGHT_PADDING_PX +
+    Y_AXIS_CHART_WIDTH_PX}px;
 `;
 
 export const AutocompleteWrapper = styled.div`

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/index.tsx
@@ -103,6 +103,7 @@ interface Props {
   >;
   expandedTissues: Set<string>;
   setExpandedTissues: Dispatch<SetStateAction<Set<string>>>;
+  sidebarWidth: number;
 }
 
 export default memo(function HeatMap({
@@ -123,6 +124,7 @@ export default memo(function HeatMap({
   setTissuesByName,
   expandedTissues,
   setExpandedTissues,
+  sidebarWidth,
 }: Props): JSX.Element {
   const {
     xAxisHeight,
@@ -439,7 +441,10 @@ export default memo(function HeatMap({
           {isLoadingAPI || isAnyTissueLoading(isLoading) ? <Loader /> : null}
           <XAxisWrapper id="x-axis-wrapper">
             <XAxisMask data-testid="x-axis-mask" height={xAxisHeight} />
-            <XAxisChart geneNames={sortedGeneNames} />
+            <XAxisChart
+              geneNames={sortedGeneNames}
+              sidebarWidth={sidebarWidth}
+            />
           </XAxisWrapper>
           <YAxisWrapper top={0}>
             {allTissueCellTypes.map(

--- a/frontend/src/views/WheresMyGeneV2/components/Main/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/Main/index.tsx
@@ -16,7 +16,9 @@ import {
   useGeneExpressionSummariesByTissueName,
   usePrimaryFilterDimensions,
 } from "src/common/queries/wheresMyGene";
-import SideBar from "src/components/common/SideBar";
+import SideBar, {
+  FILTERS_PANEL_EXPANDED_WIDTH_PX,
+} from "src/components/common/SideBar";
 import {
   DispatchContext,
   StateContext,
@@ -273,6 +275,11 @@ export default function WheresMyGene(): JSX.Element {
     dispatch(addGeneInfoGene(gene));
   };
 
+  // Sidebar width
+  const [sidebarWidth, setSidebarWidth] = useState(
+    FILTERS_PANEL_EXPANDED_WIDTH_PX
+  );
+
   return (
     <>
       <Head>
@@ -285,6 +292,7 @@ export default function WheresMyGene(): JSX.Element {
         SideBarPositionerComponent={SideBarPositioner}
         testId="filters-panel"
         wmgSideBar
+        onWidthChange={setSidebarWidth}
       >
         <Filters
           isLoading={isLoading}
@@ -391,6 +399,11 @@ export default function WheresMyGene(): JSX.Element {
             tissuesByName={tissuesByName}
             expandedTissues={expandedTissues}
             setExpandedTissues={setExpandedTissues}
+            /**
+             * (thuang): This is needed to reposition gene search bar when the
+             * sidebar width expands/collapses
+             */
+            sidebarWidth={sidebarWidth}
           />
         </Wrapper>
       </View>


### PR DESCRIPTION
## Reason for Change

- #5703 

## Changes

1. Update GeneSearchBar to be `position: fixed`, so it can be sticky even when we scroll the x axis
1. To support fixed position, we actually need to pass the expand/collapse sidebar width to the search bar, so it can update the `left: px` value dynamically

## Testing steps

1.  Go to: https://localhost:3000/gene-expression?genes=TSPAN6%2CTNMD%2CDPM1%2CSCYL3%2CC1orf112%2CFGR%2CCFH%2CFUCA2%2CGCLC%2CNFYA%2CSTPG1%2CNIPAL3%2CLAS1L%2CENPP4%2CSEMA3F%2CCFTR%2CANKIB1%2CCYP51A1%2CKRIT1%2CRAD52%2CMYH16%2CBAD%2CLAP3%2CCD99%2CHS3ST1%2CAOC1%2CWNT16%2CHECW1%2CMAD1L1%2CLASP1%2CSNX11%2CTMEM176A%2CM6PR%2CKLHL13%2CCYP26B1%2CICA1%2CDBNDD1%2CALS2%2CCASP10%2CCFLAR%2CTFPI%2CNDUFAF7%2CRBM5%2CMTMR7%2CSLC7A2%2CARF5%2CPOLDIP2%2CAK2%2CCD38%2CFKBP4%2CKDM1A%2CRBM6%2CCAMKK1%2CRECQL%2CVPS50%2CHSPB6%2CARHGAP33%2CNDUFAB1&ver=2
2. Scroll the x axis to the right, and you should no longer see overflow
3. Click on gene search dropdown, and it should not be blocked by the x axis label

BEFORE:
![Screenshot 2023-09-06 at 4 47 05 PM](https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/b5a02789-fc90-4c83-9420-697b439345ab)

<img width="980" alt="Screenshot 2023-09-07 at 2 55 34 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/68a1b0c6-68d2-49ab-828b-3993159c6687">


AFTER:
<img width="945" alt="Screenshot 2023-09-07 at 12 29 08 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/e84d144d-1019-4569-b347-c647e38f712e">

VIDEO:

https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/334a5de7-b282-4b4b-b0a6-b90a45dc0738

## Notes for Reviewer
