### PR TITLE
chore: remove primary cell count from API

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -977,10 +977,6 @@ components:
           description: The number of cells in the Dataset.
           nullable: true
           type: integer
-        primary_cell_count:
-          description: The number of primary cells in the Dataset.
-          nullable: true
-          type: integer
         cell_type:
           description: |
             [cell type label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.1.0/schema.md#cell_type)
@@ -1067,10 +1063,6 @@ components:
           $ref: "#/components/schemas/batch_condition"
         cell_count:
           description: The number of cells in the Dataset.
-          nullable: true
-          type: integer
-        primary_cell_count:
-          description: The number of primary cells in the Dataset.
           nullable: true
           type: integer
         cell_type:
@@ -1164,10 +1156,6 @@ components:
           $ref: "#/components/schemas/batch_condition"
         cell_count:
           description: The number of cells in the Dataset.
-          nullable: true
-          type: integer
-        primary_cell_count:
-          description: The number of primary cells in the Dataset.
           nullable: true
           type: integer
         cell_type:

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -304,7 +304,6 @@ class EntityColumns:
         "development_stage",
         "cell_type",
         "cell_count",
-        "primary_cell_count",
         "x_approximate_distribution",
         "batch_condition",
         "mean_genes_per_cell",

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -725,8 +725,6 @@ paths:
                         type: string
                     cell_count:
                       type: integer
-                    primary_cell_count:
-                      type: integer
                     cell_type:
                       $ref: "#/components/schemas/ontology_element_array"
                     cell_type_ancestors:
@@ -807,8 +805,6 @@ paths:
                       items:
                         type: string
                     cell_count:
-                      type: integer
-                    primary_cell_count:
                       type: integer
                     cell_type:
                       $ref: "#/components/schemas/ontology_element_array"
@@ -1187,8 +1183,6 @@ components:
         cell_type:
           $ref: "#/components/schemas/ontology_element_array"
         cell_count:
-          type: integer
-        primary_cell_count:
           type: integer
         X_approximate_distribution:
           $ref: "#/components/schemas/distribution"

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -187,7 +187,6 @@ def _dataset_to_response(
             "assay": None if dataset.metadata is None else _ontology_term_ids_to_response(dataset.metadata.assay),
             "batch_condition": None if dataset.metadata is None else dataset.metadata.batch_condition,
             "cell_count": None if dataset.metadata is None else dataset.metadata.cell_count,
-            "primary_cell_count": None if dataset.metadata is None else dataset.metadata.primary_cell_count,
             "cell_type": None
             if dataset.metadata is None
             else _ontology_term_ids_to_response(dataset.metadata.cell_type),

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -707,6 +707,7 @@ class TestGetCollectionID(BaseAPIPortalTest):
                 "x_approximate_distribution": "NORMAL",
             }
         )
+        del expect_dataset["primary_cell_count"]  # not used for any APIs
         expected_body = asdict(collection_version.metadata)
         expected_body.update(
             **{

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1035,7 +1035,6 @@ class TestGetCollectionVersionID(BaseAPIPortalTest):
                     "collection_id": f"{first_version.collection_id.id}",
                     "collection_version_id": f"{first_version.version_id.id}",
                     "cell_count": 10,
-                    "primary_cell_count": 5,
                     "cell_type": [{"label": "test_cell_type_label", "ontology_term_id": "test_cell_type_term_id"}],
                     "dataset_id": f"{first_version.datasets[0].dataset_id.id}",
                     "dataset_version_id": f"{first_version.datasets[0].version_id.id}",

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -82,7 +82,6 @@ class TestCollection(BaseAPIPortalTest):
                     "assay": [{"label": "test_assay_label", "ontology_term_id": "test_assay_term_id"}],
                     "batch_condition": ["test_batch_1", "test_batch_2"],
                     "cell_count": 10,
-                    "primary_cell_count": 5,
                     "cell_type": [{"label": "test_cell_type_label", "ontology_term_id": "test_cell_type_term_id"}],
                     "collection_id": collection.collection_id.id,
                     "created_at": mock.ANY,
@@ -133,7 +132,6 @@ class TestCollection(BaseAPIPortalTest):
                     "assay": [{"label": "test_assay_label", "ontology_term_id": "test_assay_term_id"}],
                     "batch_condition": ["test_batch_1", "test_batch_2"],
                     "cell_count": 10,
-                    "primary_cell_count": 5,
                     "cell_type": [{"label": "test_cell_type_label", "ontology_term_id": "test_cell_type_term_id"}],
                     "collection_id": collection.collection_id.id,
                     "created_at": mock.ANY,
@@ -1663,7 +1661,6 @@ class TestDataset(BaseAPIPortalTest):
                 actual_dataset["development_stage"], convert_ontology(persisted_dataset.metadata.development_stage)
             )
             self.assertEqual(actual_dataset["cell_count"], persisted_dataset.metadata.cell_count)
-            self.assertEqual(actual_dataset["primary_cell_count"], persisted_dataset.metadata.primary_cell_count)
             self.assertEqual(actual_dataset["cell_type"], convert_ontology(persisted_dataset.metadata.cell_type))
             self.assertEqual(actual_dataset["is_primary_data"], persisted_dataset.metadata.is_primary_data)
             self.assertEqual(actual_dataset["mean_genes_per_cell"], persisted_dataset.metadata.mean_genes_per_cell)

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -142,7 +142,6 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
             ],
             cell_type=[OntologyTermId(label="test_cell_type_label", ontology_term_id="test_cell_type_term_id")],
             cell_count=10,
-            primary_cell_count=5,
             schema_version="3.0.0",
             mean_genes_per_cell=0.5,
             batch_condition=["test_batch_1", "test_batch_2"],

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -124,7 +124,6 @@ class BaseTest(unittest.TestCase):
             ],
             cell_type=[OntologyTermId(label="test_cell_type_label", ontology_term_id="test_cell_type_term_id")],
             cell_count=10,
-            primary_cell_count=5,
             schema_version="3.0.0",
             mean_genes_per_cell=0.5,
             batch_condition=["test_batch_1", "test_batch_2"],


### PR DESCRIPTION
## Reason for Change

- #5713 
- Follow-up work will need to add an endpoint to compute the hero numbers.

## Changes

- add
- remove
- modify

## Testing steps

- Uploaded example dataset to rdev[LINK] and confirmed that `primary_cell_count` is not present any of the DP or Discover API responses.

## Notes for Reviewer
