### PR TITLE
chore: add script to backfill primary cell count (backfill completed)

### DIFF
--- a/scripts/cxg_admin.py
+++ b/scripts/cxg_admin.py
@@ -296,7 +296,13 @@ def backfill_processing_status_for_datasets(ctx):
 @click.pass_context
 def backfill_primary_cell_count_for_datasets(ctx: click.Context, primary_cell_count_mapping_file: str):
     """
-    Backfills the primary cell count for datasets
+    Backfills the primary cell count for datasets.
+
+    Keys should be dataset version IDs and values should be primary cell counts for the input mapping
+    file.
+
+    Run with:
+    ./scripts/cxg_admin.py --deployment dev backfill-primary-cell-count-for-datasets mapping_file.json
     """
     with open(primary_cell_count_mapping_file) as f:
         primary_cell_count_mapping = json.load(f)

--- a/scripts/cxg_admin.py
+++ b/scripts/cxg_admin.py
@@ -22,6 +22,7 @@ from backend.layers.thirdparty.s3_provider import S3Provider
 from backend.layers.thirdparty.step_function_provider import StepFunctionProvider
 from backend.layers.thirdparty.uri_provider import UriProvider
 from scripts.cxg_admin_scripts import (
+    backfill_primary_cell_count,
     dataset_details,
     deletions,
     migrate,
@@ -288,6 +289,24 @@ def backfill_processing_status_for_datasets(ctx):
     Backfills the `dataset_processing_status` table for datasets that do not have a matching record.
     """
     migrate.backfill_processing_status_for_datasets(ctx)
+
+
+@cli.command()
+@click.argument("primary_cell_count_mapping_file")
+@click.pass_context
+def backfill_primary_cell_count_for_datasets(ctx: click.Context, primary_cell_count_mapping_file: str):
+    """
+    Backfills the primary cell count a public Collection specified by collection_id.
+    To run:
+        ./scripts/cxg_admin.py --deployment prod tombstone-collection 01234567-89ab-cdef-0123-456789abcdef
+
+    :param ctx: command context
+    :param collection_id: uuid that identifies the Collection to tombstone
+    """
+    with open(primary_cell_count_mapping_file) as f:
+        primary_cell_count_mapping = json.load(f)
+
+    backfill_primary_cell_count.backfill_primary_cell_count(ctx, primary_cell_count_mapping)
 
 
 # Commands to reprocess dataset artifacts (seurat or cxg)

--- a/scripts/cxg_admin.py
+++ b/scripts/cxg_admin.py
@@ -307,7 +307,9 @@ def backfill_primary_cell_count_for_datasets(ctx: click.Context, primary_cell_co
     with open(primary_cell_count_mapping_file) as f:
         primary_cell_count_mapping = json.load(f)
 
-    backfill_primary_cell_count.backfill_primary_cell_count(ctx, primary_cell_count_mapping)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        backfill_primary_cell_count.backfill_primary_cell_count(ctx, primary_cell_count_mapping)
 
 
 # Commands to reprocess dataset artifacts (seurat or cxg)

--- a/scripts/cxg_admin.py
+++ b/scripts/cxg_admin.py
@@ -296,12 +296,7 @@ def backfill_processing_status_for_datasets(ctx):
 @click.pass_context
 def backfill_primary_cell_count_for_datasets(ctx: click.Context, primary_cell_count_mapping_file: str):
     """
-    Backfills the primary cell count a public Collection specified by collection_id.
-    To run:
-        ./scripts/cxg_admin.py --deployment prod tombstone-collection 01234567-89ab-cdef-0123-456789abcdef
-
-    :param ctx: command context
-    :param collection_id: uuid that identifies the Collection to tombstone
+    Backfills the primary cell count for datasets
     """
     with open(primary_cell_count_mapping_file) as f:
         primary_cell_count_mapping = json.load(f)

--- a/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
+++ b/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
@@ -12,7 +12,7 @@ from backend.layers.common.entities import DatasetMetadata, DatasetVersionId
 
 def backfill_primary_cell_count(ctx: Context, mapping: dict[str, int]) -> None:
     business_logic: BusinessLogic = ctx.obj["business_logic"]
-    dataset_versions = business_logic.get_dataset_versions_by_id([DatasetVersionId(key) for key in map])
+    dataset_versions = business_logic.get_dataset_versions_by_id([DatasetVersionId(key) for key in mapping])
     for dv in dataset_versions:
         dataset_metadata = DatasetMetadata(**dv.dataset_metadata)
         dataset_metadata.primary_cell_count = mapping.get(dv.id, dataset_metadata.primary_cell_count)

--- a/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
+++ b/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
@@ -7,13 +7,12 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..."))  # no
 sys.path.insert(0, pkg_root)  # noqa
 
 from backend.layers.business.business import BusinessLogic
-from backend.layers.common.entities import DatasetMetadata, DatasetVersionId
+from backend.layers.common.entities import DatasetId
 
 
 def backfill_primary_cell_count(ctx: Context, mapping: dict[str, int]) -> None:
     business_logic: BusinessLogic = ctx.obj["business_logic"]
-    dataset_versions = business_logic.get_dataset_versions_by_id([DatasetVersionId(key) for key in mapping])
-    for dv in dataset_versions:
-        dataset_metadata = DatasetMetadata(**dv.dataset_metadata)
-        dataset_metadata.primary_cell_count = mapping.get(dv.id, dataset_metadata.primary_cell_count)
-        business_logic.set_dataset_metadata(dv.id, dataset_metadata)
+    for key in mapping:
+        dv = business_logic.get_dataset_version_from_canonical(DatasetId(key))
+        dv.metadata.primary_cell_count = mapping.get(str(dv.dataset_id), dv.metadata.primary_cell_count)
+        business_logic.set_dataset_metadata(dv.dataset_id, dv.metadata)

--- a/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
+++ b/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
@@ -13,14 +13,8 @@ from backend.layers.common.entities import DatasetId
 def backfill_primary_cell_count(ctx: Context, mapping: dict[str, int]) -> None:
     business_logic: BusinessLogic = ctx.obj["business_logic"]
     for i, key in enumerate(mapping):
-        try:
-            dv = business_logic.get_dataset_version_from_canonical(DatasetId(key))
+        dv = business_logic.get_dataset_version_from_canonical(DatasetId(key))
+        if dv is not None:
             dv.metadata.primary_cell_count = mapping.get(str(dv.dataset_id), dv.metadata.primary_cell_count)
             print(key, dv.metadata.primary_cell_count, f"({i+1}/{len(mapping)})")
             business_logic.set_dataset_metadata(dv.version_id, dv.metadata)
-        except KeyboardInterrupt:
-            print("Interrupted by user")
-            break
-        except Exception as e:
-            print(f"Error: {e}")
-            continue

--- a/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
+++ b/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+from click import Context
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..."))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from backend.layers.business.business import BusinessLogic
+from backend.layers.common.entities import DatasetMetadata, DatasetVersionId
+
+
+def backfill_primary_cell_count(ctx: Context, mapping: dict[str, int]) -> None:
+    business_logic: BusinessLogic = ctx.obj["business_logic"]
+    dataset_versions = business_logic.get_dataset_versions_by_id([DatasetVersionId(key) for key in map])
+    for dv in dataset_versions:
+        dataset_metadata = DatasetMetadata(**dv.dataset_metadata)
+        dataset_metadata.primary_cell_count = mapping.get(dv.id, dataset_metadata.primary_cell_count)
+        business_logic.set_dataset_metadata(dv.id, dataset_metadata)

--- a/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
+++ b/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
@@ -13,7 +13,15 @@ from backend.layers.common.entities import DatasetId
 def backfill_primary_cell_count(ctx: Context, mapping: dict[str, int]) -> None:
     business_logic: BusinessLogic = ctx.obj["business_logic"]
     for i, key in enumerate(mapping):
-        dv = business_logic.get_dataset_version_from_canonical(DatasetId(key))
-        dv.metadata.primary_cell_count = mapping.get(str(dv.dataset_id), dv.metadata.primary_cell_count)
-        print(key, dv.metadata.primary_cell_count, f"({i+1}/{len(mapping)})")
-        business_logic.set_dataset_metadata(dv.dataset_id, dv.metadata)
+        try:
+            dv = business_logic.get_dataset_version_from_canonical(DatasetId(key))
+            dv.metadata.primary_cell_count = mapping.get(str(dv.dataset_id), dv.metadata.primary_cell_count)
+            print(key, dv.metadata.primary_cell_count, f"({i+1}/{len(mapping)})")
+            print(dv.metadata)
+            business_logic.set_dataset_metadata(dv.version_id, dv.metadata)
+        except KeyboardInterrupt:
+            print("Interrupted by user")
+            break
+        except Exception as e:
+            print(f"Error: {e}")
+            continue

--- a/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
+++ b/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
@@ -12,7 +12,8 @@ from backend.layers.common.entities import DatasetId
 
 def backfill_primary_cell_count(ctx: Context, mapping: dict[str, int]) -> None:
     business_logic: BusinessLogic = ctx.obj["business_logic"]
-    for key in mapping:
+    for i, key in enumerate(mapping):
         dv = business_logic.get_dataset_version_from_canonical(DatasetId(key))
         dv.metadata.primary_cell_count = mapping.get(str(dv.dataset_id), dv.metadata.primary_cell_count)
+        print(key, dv.metadata.primary_cell_count, f"({i+1}/{len(mapping)})")
         business_logic.set_dataset_metadata(dv.dataset_id, dv.metadata)

--- a/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
+++ b/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
@@ -3,6 +3,8 @@ import sys
 
 from click import Context
 
+from backend.layers.thirdparty.cloudfront_provider import CloudfrontProvider
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..."))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
@@ -18,3 +20,5 @@ def backfill_primary_cell_count(ctx: Context, mapping: dict[str, int]) -> None:
             dv.metadata.primary_cell_count = mapping.get(str(dv.dataset_id), dv.metadata.primary_cell_count)
             print(key, dv.metadata.primary_cell_count, f"({i+1}/{len(mapping)})")
             business_logic.set_dataset_metadata(dv.version_id, dv.metadata)
+    cloudfront_provider: CloudfrontProvider = ctx.obj["cloudfront_provider"]
+    cloudfront_provider.create_invalidation_for_index_paths()

--- a/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
+++ b/scripts/cxg_admin_scripts/backfill_primary_cell_count.py
@@ -17,7 +17,6 @@ def backfill_primary_cell_count(ctx: Context, mapping: dict[str, int]) -> None:
             dv = business_logic.get_dataset_version_from_canonical(DatasetId(key))
             dv.metadata.primary_cell_count = mapping.get(str(dv.dataset_id), dv.metadata.primary_cell_count)
             print(key, dv.metadata.primary_cell_count, f"({i+1}/{len(mapping)})")
-            print(dv.metadata)
             business_logic.set_dataset_metadata(dv.version_id, dv.metadata)
         except KeyboardInterrupt:
             print("Interrupted by user")


### PR DESCRIPTION
## Reason for Change

- Automating the hero numbers on the landing page requires all datasets to be populated with primary cell count.
- #5705 already added primary cell count to the persistence layer so new uploads will be populated with the primary cell count