### PR TITLE
feat(landing): hook up hero numbers to datasets/index

### DIFF
--- a/frontend/src/common/queries/filter.ts
+++ b/frontend/src/common/queries/filter.ts
@@ -111,6 +111,7 @@ export type ProcessedCollectionResponse = (
 export interface DatasetResponse {
   assay: Ontology[];
   cell_count: number | null;
+  primary_cell_count: number | null;
   cell_type: Ontology[];
   cell_type_ancestors: string[];
   collection_id: string;


### PR DESCRIPTION
## Reason for Change

- The primary cell counts were added to the DB and exposed in datasets/index.
- Future work will move this logic into a backend endpoint.
- This work hooks up the landing page to the datasets/index and aggregates the required hero numbers

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

<img width="617" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/16548075/34776288-9dcb-482f-b2b7-7dd8325d3a52">

