### PR TITLE
fix: secondary filters in gene expression

### DIFF
--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -1115,6 +1115,7 @@ function useWMGFiltersQueryRequestBody(
     ethnicities,
     publications,
     sexes,
+    filteredCellTypeIds,
   ]);
 }
 

--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -1072,7 +1072,8 @@ function useWMGQueryRequestBody(version: 1 | 2) {
 function useWMGFiltersQueryRequestBody(
   version: 1 | 2 = 2
 ): FiltersQuery | null {
-  const { selectedOrganismId, selectedFilters } = useContext(StateContext);
+  const { selectedOrganismId, selectedFilters, filteredCellTypeIds } =
+    useContext(StateContext);
 
   const { data } = usePrimaryFilterDimensions(version);
 
@@ -1101,6 +1102,7 @@ function useWMGFiltersQueryRequestBody(
         sex_ontology_term_ids: sexes,
         tissue_ontology_term_ids: tissues,
         publication_citations: publications,
+        cell_type_ontology_term_ids: filteredCellTypeIds,
       },
     };
   }, [

--- a/frontend/src/views/WheresMyGene/common/store/actions.ts
+++ b/frontend/src/views/WheresMyGene/common/store/actions.ts
@@ -7,6 +7,7 @@ import {
   AddCellInfoCellTypePayload,
   LoadStateFromURLPayload,
   REDUCERS,
+  SetFilteredCellTypesPayload,
   State,
 } from "./reducer";
 
@@ -198,11 +199,6 @@ export function setXAxisHeight(
     payload,
     type: "setXAxisHeight",
   };
-}
-
-interface SetFilteredCellTypesPayload {
-  filteredCellTypes: State["filteredCellTypes"];
-  filteredCellTypeIds: State["filteredCellTypeIds"];
 }
 
 export function setFilteredCellTypes(

--- a/frontend/src/views/WheresMyGene/common/store/actions.ts
+++ b/frontend/src/views/WheresMyGene/common/store/actions.ts
@@ -200,8 +200,13 @@ export function setXAxisHeight(
   };
 }
 
+interface SetFilteredCellTypesPayload {
+  filteredCellTypes: State["filteredCellTypes"];
+  filteredCellTypeIds: State["filteredCellTypeIds"];
+}
+
 export function setFilteredCellTypes(
-  payload: State["filteredCellTypes"]
+  payload: SetFilteredCellTypesPayload
 ): GetActionTypeOfReducer<(typeof REDUCERS)["setFilteredCellTypes"]> {
   return {
     payload,

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -3,12 +3,17 @@ import { CompareId, X_AXIS_CHART_HEIGHT_PX } from "../constants";
 import { CellType, SORT_BY } from "../types";
 import { EMPTY_ARRAY } from "src/common/constants/utils";
 import { GENE_SEARCH_BAR_HEIGHT_PX } from "src/views/WheresMyGeneV2/common/constants";
-import { SetFilteredCellTypesPayload } from "src/views/WheresMyGene/common/store/actions";
 
 export interface PayloadAction<Payload> {
   type: keyof typeof REDUCERS;
   payload: Payload;
 }
+
+export interface SetFilteredCellTypesPayload {
+  filteredCellTypes: State["filteredCellTypes"];
+  filteredCellTypeIds: State["filteredCellTypeIds"];
+}
+
 export interface State {
   genesToDelete: string[];
   selectedGenes: string[];

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -3,6 +3,7 @@ import { CompareId, X_AXIS_CHART_HEIGHT_PX } from "../constants";
 import { CellType, SORT_BY } from "../types";
 import { EMPTY_ARRAY } from "src/common/constants/utils";
 import { GENE_SEARCH_BAR_HEIGHT_PX } from "src/views/WheresMyGeneV2/common/constants";
+import { SetFilteredCellTypesPayload } from "src/views/WheresMyGene/common/store/actions";
 
 export interface PayloadAction<Payload> {
   type: keyof typeof REDUCERS;
@@ -38,6 +39,7 @@ export interface State {
   compare?: CompareId;
   xAxisHeight: number;
   filteredCellTypes: string[];
+  filteredCellTypeIds: string[];
 }
 
 const EMPTY_FILTERS: State["selectedFilters"] = {
@@ -68,6 +70,7 @@ export const INITIAL_STATE: State = {
   },
   xAxisHeight: X_AXIS_CHART_HEIGHT_PX + GENE_SEARCH_BAR_HEIGHT_PX,
   filteredCellTypes: [],
+  filteredCellTypeIds: [],
 };
 
 export const REDUCERS = {
@@ -418,10 +421,11 @@ function setXAxisHeight(state: State, action: PayloadAction<number>): State {
 
 function setFilteredCellTypes(
   state: State,
-  action: PayloadAction<State["filteredCellTypes"]>
+  action: PayloadAction<SetFilteredCellTypesPayload>
 ): State {
   return {
     ...state,
-    filteredCellTypes: action.payload,
+    filteredCellTypes: action.payload.filteredCellTypes,
+    filteredCellTypeIds: action.payload.filteredCellTypeIds,
   };
 }

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/index.tsx
@@ -130,6 +130,7 @@ export default memo(function HeatMap({
     xAxisHeight,
     selectedFilters: { tissues: filteredTissueIds },
     filteredCellTypes,
+    filteredCellTypeIds,
   } = useContext(StateContext);
 
   const selectedCellTypeOptions = useMemo(() => {
@@ -305,10 +306,17 @@ export default memo(function HeatMap({
     rawNewFilteredCellTypes: DefaultAutocompleteOption[]
   ) => {
     if (!dispatch) return;
+
+    const cellTypeNames = rawNewFilteredCellTypes.map(
+      (cellType) => cellType.name
+    );
+    const cellTypeIds = cellTypeNames.map((name) => cellTypesByName[name].id);
+
     dispatch(
-      setFilteredCellTypes(
-        rawNewFilteredCellTypes.map((cellType) => cellType.name)
-      )
+      setFilteredCellTypes({
+        filteredCellTypes: cellTypeNames,
+        filteredCellTypeIds: cellTypeIds,
+      })
     );
   };
   useEffect(() => {
@@ -364,6 +372,7 @@ export default memo(function HeatMap({
   }, [
     cellTypesByName,
     filteredCellTypes,
+    filteredCellTypeIds,
     filteredTissueIds,
     initialDisplayedCellTypeIds,
     setExpandedTissues,
@@ -373,10 +382,20 @@ export default memo(function HeatMap({
 
   const handleCellTypeDelete = (cellTypeToDelete: string) => () => {
     if (!dispatch) return;
-    const newValue = filteredCellTypes.filter(
+    const cellTypeIdToDelete = cellTypesByName[cellTypeToDelete].id;
+    const newCellTypeNames = filteredCellTypes.filter(
       (cellType) => !(cellTypeToDelete === cellType)
     );
-    dispatch(setFilteredCellTypes(newValue));
+    const newCellTypeIds = filteredCellTypeIds.filter(
+      (cellTypeId) => !(cellTypeIdToDelete === cellTypeId)
+    );
+
+    dispatch(
+      setFilteredCellTypes({
+        filteredCellTypes: newCellTypeNames,
+        filteredCellTypeIds: newCellTypeIds,
+      })
+    );
   };
 
   useTrackHeatMapLoaded({

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/index.tsx
@@ -380,11 +380,11 @@ export default memo(function HeatMap({
     tissuesByName,
   ]);
 
-  const handleCellTypeDelete = (cellTypeToDelete: string) => () => {
+  const handleCellTypeDelete = (cellTypeNameToDelete: string) => () => {
     if (!dispatch) return;
-    const cellTypeIdToDelete = cellTypesByName[cellTypeToDelete].id;
+    const cellTypeIdToDelete = cellTypesByName[cellTypeNameToDelete].id;
     const newCellTypeNames = filteredCellTypes.filter(
-      (cellType) => !(cellTypeToDelete === cellType)
+      (cellType) => !(cellTypeNameToDelete === cellType)
     );
     const newCellTypeIds = filteredCellTypeIds.filter(
       (cellTypeId) => !(cellTypeIdToDelete === cellTypeId)


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/5716

## Changes

adds a new field filteredCellTypeIds to the state, which we then pass in to WMG under `cell_type_ontology_ids`

## Testing steps


https://github.com/chanzuckerberg/single-cell-data-portal/assets/5653616/6327a7a0-ccf3-4c24-b470-546fef7b9053



## Notes for Reviewer
