### PR TITLE
fix(cellguide): update tooltip to read "in all tissues" instead of "in tissue agnostic"

### DIFF
--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -47,6 +47,10 @@ import {
   CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_TOOLTIP,
   MINIMUM_NUMBER_OF_HIDDEN_CHILDREN_FOR_DUMMY_NODE,
 } from "src/views/CellGuide/components/common/OntologyDagView/constants";
+import {
+  ALL_TISSUES,
+  TISSUE_AGNOSTIC,
+} from "../../CellGuideCard/components/MarkerGeneTables/constants";
 
 interface BaseTreeProps {
   skinnyMode?: boolean;
@@ -88,10 +92,12 @@ const initialTransformMatrixDefault = {
 export default function OntologyDagView({
   cellTypeId,
   tissueId,
-  tissueName,
+  tissueName: tissueNameRaw,
   inputWidth,
   inputHeight,
 }: TreeProps) {
+  const tissueName =
+    tissueNameRaw === TISSUE_AGNOSTIC ? ALL_TISSUES : tissueNameRaw;
   const [width, setWidth] = useState(inputWidth);
   const [height, setHeight] = useState(inputHeight);
 


### PR DESCRIPTION
## Reason for Change

- #5671 

Tooltip now reads as before the regression:
<img width="425" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/16548075/c10b3b9b-7e03-4e48-b73d-95a33729f4a6">

## Testing steps
 - tested locally