### PR TITLE
fix: spacing and styling for svg

### DIFF
--- a/frontend/src/views/WheresMyGene/common/constants.ts
+++ b/frontend/src/views/WheresMyGene/common/constants.ts
@@ -22,6 +22,7 @@ export const getCompareOptionNameById = (id?: CompareId) => {
 
 // This is used as the default/initial height of the x-axis
 export const X_AXIS_CHART_HEIGHT_PX = 80;
+export const X_AXIS_CHART_HEIGHT_PX_SVG = 30;
 
 // This is the height of the container for the gene delete and hover icons
 // Increasing this value adds more space between the gene label and icons

--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SaveExport/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SaveExport/index.tsx
@@ -15,6 +15,7 @@ import {
   getCompareOptionNameById,
   HEATMAP_CONTAINER_ID,
   X_AXIS_CHART_HEIGHT_PX,
+  X_AXIS_CHART_HEIGHT_PX_SVG,
 } from "src/views/WheresMyGene/common/constants";
 import { CellType, ChartProps } from "src/views/WheresMyGene/common/types";
 
@@ -374,8 +375,9 @@ function generateSvg({
     // If tissue is NOT expanded, then just add padding
 
     const heatmapHeight = expandedTissues.has(tissuesByName[tissueName].id)
-      ? getHeatmapHeight(selectedCellTypes[tissueName]) + X_AXIS_CHART_HEIGHT_PX
-      : X_AXIS_CHART_HEIGHT_PX;
+      ? getHeatmapHeight(selectedCellTypes[tissueName]) +
+        X_AXIS_CHART_HEIGHT_PX_SVG
+      : X_AXIS_CHART_HEIGHT_PX_SVG;
 
     // Render elements to SVG
     const yAxisSvg = renderYAxis({

--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SaveExport/svgUtils.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SaveExport/svgUtils.ts
@@ -22,6 +22,7 @@ import {
 
 export const NAME_SPACE_URI = "http://www.w3.org/2000/svg";
 const FONT_FAMILY = "sans-serif";
+const FONT_WEIGHT = "bold";
 const LABEL_ROTATION = "rotate(-90)";
 
 export function renderLegend({
@@ -337,8 +338,9 @@ export function renderYAxis({
       const label =
         labelCount.querySelector(`.${TISSUE_NAME_LABEL_CLASS_NAME}`)
           ?.textContent ||
-        labelCount.querySelector(`.${CELL_TYPE_NAME_LABEL_CLASS_NAME}`)
-          ?.textContent;
+        ` ` +
+          labelCount.querySelector(`.${CELL_TYPE_NAME_LABEL_CLASS_NAME}`)
+            ?.textContent;
 
       const count = labelCount.querySelector(`.${CELL_COUNT_LABEL_CLASS_NAME}`)
         ?.textContent;
@@ -351,6 +353,7 @@ export function renderYAxis({
         fill: ECHART_AXIS_LABEL_COLOR_HEX,
         "font-family": FONT_FAMILY,
         "font-size": ECHART_AXIS_LABEL_FONT_SIZE_PX,
+        "font-weight": FONT_WEIGHT,
         x: 0,
         /**
          * (thuang): Add `HEAT_MAP_BASE_CELL_PX / 2` top margin, so we render the


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/5656

## Changes

- added constant for svg spacing
- added font weight attribute
- slight indentation for expanded cell types

## Testing steps

- select genes, click the download button, select svg

## Notes for Reviewer

https://github.com/chanzuckerberg/single-cell-data-portal/assets/7976579/95643b85-44b1-4992-8b54-79d5c91f9b15