### PR TITLE
fix(cellguide): work around foreignObject bug in safari

### DIFF
--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/components/Legend/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/components/Legend/index.tsx
@@ -10,6 +10,7 @@ import {
   MarkerScoreWrapper,
   NoDescendantsLine,
   StyledBorder,
+  StyledNodeWrapper,
 } from "./style";
 import { StyledPie } from "../../common/style";
 import { CELL_GUIDE_ONTOLOGY_VIEW_LEGEND_TEST_ID } from "./constants";
@@ -19,7 +20,6 @@ import {
   nodePieChartCircleScaler,
   secondaryColor,
 } from "../../common/constants";
-import { NodeWrapper } from "../Node/components/RectOrCircle/style";
 interface LegendProps {
   selectedGene: string | undefined;
   isTissue?: boolean;
@@ -36,10 +36,10 @@ export default function Legend({ selectedGene, isTissue }: LegendProps) {
   const descendantsLegendComponent = (
     <LegendItemWrapper>
       <FlexColumn>
-        <NodeWrapper>
+        <StyledNodeWrapper>
           <NoDescendantsLine size={size} />
           <StyledBorder width={1} height={size * 2} />
-        </NodeWrapper>
+        </StyledNodeWrapper>
         No Descendants
       </FlexColumn>
     </LegendItemWrapper>

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/components/Legend/style.ts
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/components/Legend/style.ts
@@ -6,7 +6,7 @@ import {
   tertiaryColor,
 } from "../../common/constants";
 import { spacesL, spacesM } from "src/common/theme";
-import { Border } from "../Node/components/RectOrCircle/style";
+import { Border, NodeWrapper } from "../Node/components/RectOrCircle/style";
 
 const SQUARE_SIZE = 14;
 export const LegendWrapper = styled.div`
@@ -88,4 +88,8 @@ export const NoDescendantsLine = styled.div<NoDescendantsProps>`
 
 export const StyledBorder = styled(Border)`
   border-left: 2px solid ${secondaryColor};
+`;
+
+export const StyledNodeWrapper = styled(NodeWrapper)`
+  position: relative;
 `;

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/components/Node/components/RectOrCircle/style.ts
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/components/Node/components/RectOrCircle/style.ts
@@ -5,7 +5,6 @@ import { secondaryColor } from "../../../../common/constants";
 export const NodeWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  position: relative;
 `;
 
 interface BorderProps extends CommonThemeProps {


### PR DESCRIPTION
## Reason for Change

foreignObject is apparently broken in safari ([context](https://stackoverflow.com/questions/51313873/svg-foreignobject-not-working-properly-on-safari)). It breaks when one of its child elements has `position` set. See screenshot
<img width="913" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/16548075/91451a9b-bc07-4a49-8d20-62a221128fba">

This fixes that bug by removing `position: relative` from `NodeWrapper` (which is unnecessary in the SVG) and adding back it for the legend!