### PR TITLE
fix(functional tests): check status before parsing

### DIFF
--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -140,8 +140,8 @@ class TestRevisions(BaseFunctionalTestCase):
 
         # Start a new revision
         res = self.session.post(f"{self.api}/dp/v1/collections/{canonical_collection_id}", headers=headers)
-        revision_id = res.json()["id"]
         self.assertStatusCode(201, res)
+        revision_id = res.json()["id"]
 
         # Get datasets for the collection (before uploading)
         public_datasets_before = self.session.get(f"{self.api}/dp/v1/collections/{canonical_collection_id}").json()[


### PR DESCRIPTION
## Reason for Change

- check the status of the request response before parsing it.
## Changes

- Modify test_revision_flow subtest to verify the status before parsing the response

## Testing steps

- This is modifying a tests to give more useful information than before. The test is already failing. This will help us figure out why.

## Notes for Reviewer
