### PR TITLE
fix(cicd): Use chamber to pass secrets to the smoke test

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -166,12 +166,17 @@ jobs:
           DEPLOYMENT_STAGE: ${{ github.event.deployment.environment }}
         ### config.js set-up required due to transient test dependencies on API_URL
         run: |
+          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          mkdir -p .local/bin
+          curl -Ls https://github.com/segmentio/chamber/releases/download/v2.9.1/chamber-v2.9.1-linux-amd64 > .local/bin/chamber &&
+          chmod +x .local/bin/chamber
+          PATH="$PATH:$(pwd)/.local/bin"
           if [ "${DEPLOYMENT_STAGE}" == "stage" ]; then
             export DEPLOYMENT_STAGE=staging
           fi
           if [ "${DEPLOYMENT_STAGE}" != "prod" ]; then
             pip3 install -r scripts/smoke_tests/requirements.txt
-            python3 -m scripts.smoke_tests.setup
+            backend-smoke-test
           fi
           cd frontend
           npm ci

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -176,7 +176,7 @@ jobs:
           fi
           if [ "${DEPLOYMENT_STAGE}" != "prod" ]; then
             pip3 install -r scripts/smoke_tests/requirements.txt
-            backend-smoke-test
+            make backend-smoke-test
           fi
           cd frontend
           npm ci

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,10 @@ local-functional-test: ## Run functional tests in the dev environment
 		-e DEPLOYMENT_STAGE  -e STACK_NAME -e API_BASE_URL $${EXTRA_ARGS} \
 		backend bash -c "cd /single-cell-data-portal && make container-functionaltest"
 
+backend-smoke-test:
+	chamber -b secretsmanager exec corpora/backend/$${DEPLOYMENT_STAGE}/auth0-secret -- \
+		python3 -m scripts.smoke_tests.setup
+
 .PHONY: local-smoke-test
 local-smoke-test: ## Run frontend/e2e tests in the dev environment
 	docker-compose $(COMPOSE_OPTS) run --rm -T frontend make smoke-test-with-local-dev


### PR DESCRIPTION


## Reason for Change

- smoke tests needs AWS secrets to run. Install chamber in GHA to retrieve secrets.

## Changes

- Add make recipe to make it easier to verify backend smoke-tests work.

## Testing steps

- Ran `$ DEPLOYMENT_STAGE=dev make backend-smoke-test` 

## Notes for Reviewer
