### PR TITLE
feat: added get asset with permanent url.

### DIFF
--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -41,7 +41,7 @@ def extract_dataset_assets(dataset_version: DatasetVersion):
         filesize = get_business_logic().s3_provider.get_file_size(asset.uri)
         if filesize is None:
             filesize = -1
-        url = get_business_logic().generate_permanent_url(dataset_version.version_id, asset)
+        url = get_business_logic().generate_permanent_url(dataset_version.version_id, asset.type)
         result = {
             "filesize": filesize,
             "filetype": asset.type.upper(),

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -12,6 +12,7 @@ from backend.layers.common.entities import (
     CollectionVersionId,
     CollectionVersionWithDatasets,
     CollectionVersionWithPublishedDatasets,
+    DatasetArtifact,
     DatasetArtifactType,
     DatasetId,
     DatasetProcessingStatus,
@@ -33,7 +34,6 @@ def get_collections_base_url():
 
 
 def extract_dataset_assets(dataset_version: DatasetVersion):
-    base_url = CorporaConfig().dataset_assets_base_url
     asset_list = list()
     for asset in dataset_version.artifacts:
         if asset.type not in allowed_dataset_asset_types:
@@ -41,7 +41,7 @@ def extract_dataset_assets(dataset_version: DatasetVersion):
         filesize = get_business_logic().s3_provider.get_file_size(asset.uri)
         if filesize is None:
             filesize = -1
-        url = f"{base_url}/{dataset_version.version_id.id}.{asset.type}"
+        url = get_business_logic().generate_permanent_url(dataset_version.version_id, asset)
         result = {
             "filesize": filesize,
             "filetype": asset.type.upper(),

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from backend.common.corpora_config import CorporaConfig
 from backend.common.utils.http_exceptions import ForbiddenHTTPException, GoneHTTPException, NotFoundHTTPException
 from backend.layers.auth.user_info import UserInfo
+from backend.layers.business.business import BusinessLogic
 from backend.layers.common.entities import (
     CollectionId,
     CollectionVersion,
@@ -40,7 +41,7 @@ def extract_dataset_assets(dataset_version: DatasetVersion):
         filesize = get_business_logic().s3_provider.get_file_size(asset.uri)
         if filesize is None:
             filesize = -1
-        url = get_business_logic().generate_permanent_url(dataset_version.version_id, asset.type)
+        url = BusinessLogic.generate_permanent_url(dataset_version.version_id, asset.type)
         result = {
             "filesize": filesize,
             "filetype": asset.type.upper(),

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -12,7 +12,6 @@ from backend.layers.common.entities import (
     CollectionVersionId,
     CollectionVersionWithDatasets,
     CollectionVersionWithPublishedDatasets,
-    DatasetArtifact,
     DatasetArtifactType,
     DatasetId,
     DatasetProcessingStatus,

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -104,12 +104,12 @@ class BusinessLogic(BusinessLogicInterface):
         super().__init__()
 
     @staticmethod
-    def generate_permanent_url(dataset_version_id: DatasetVersionId, asset: DatasetArtifact):
+    def generate_permanent_url(dataset_version_id: DatasetVersionId, asset_type: DatasetArtifactType):
         """
         Return the permanent URL for the given asset.
         """
         base_url = CorporaConfig().dataset_assets_base_url
-        url = f"{base_url}/{dataset_version_id.id}.{asset.type}"
+        url = f"{base_url}/{dataset_version_id.id}.{asset_type}"
         return url
 
     def _get_publisher_metadata(self, doi: str, errors: list) -> Optional[dict]:
@@ -538,7 +538,7 @@ class BusinessLogic(BusinessLogicInterface):
             raise ArtifactNotFoundException(f"Artifact {artifact_id} not found in dataset {dataset_version_id}")
 
         file_size = self.s3_provider.get_file_size(artifact.uri)
-        url = self.generate_permanent_url(dataset_version_id, artifact)
+        url = self.generate_permanent_url(dataset_version_id, artifact.type)
 
         return DatasetArtifactDownloadData(file_size, url)
 

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -5,14 +5,13 @@ from collections import defaultdict
 from datetime import datetime
 from functools import reduce
 from typing import Dict, Iterable, List, Optional, Set, Tuple
-from backend.common.corpora_config import CorporaConfig
 
 from backend.layers.business.business_interface import BusinessLogicInterface
 from backend.layers.business.entities import (
     CollectionMetadataUpdate,
     CollectionQueryFilter,
     DatasetArtifactDownloadData,
-    DatasetArtifactDownloadDataDeprecated,
+    DeprecatedDatasetArtifactDownloadData,
 )
 from backend.layers.business.exceptions import (
     ArtifactNotFoundException,
@@ -108,9 +107,10 @@ class BusinessLogic(BusinessLogicInterface):
         """
         Return the permanent URL for the given asset.
         """
+        from backend.common.corpora_config import CorporaConfig
+
         base_url = CorporaConfig().dataset_assets_base_url
-        url = f"{base_url}/{dataset_version_id.id}.{asset_type}"
-        return url
+        return f"{base_url}/{dataset_version_id.id}.{asset_type}"
 
     def _get_publisher_metadata(self, doi: str, errors: list) -> Optional[dict]:
         """
@@ -402,6 +402,8 @@ class BusinessLogic(BusinessLogicInterface):
             file_info = self.uri_provider.get_file_info(url)
             file_size = file_info.size
 
+        from backend.common.corpora_config import CorporaConfig
+
         max_file_size_gb = CorporaConfig().upload_max_file_size_gb * 2**30
 
         if file_size is not None and file_size > max_file_size_gb:
@@ -542,10 +544,10 @@ class BusinessLogic(BusinessLogicInterface):
 
         return DatasetArtifactDownloadData(file_size, url)
 
-    # Superseded by get_dataset_artifact_download_data. Remove with #5697.
+    # TODO: Superseded by get_dataset_artifact_download_data. Remove with #5697.
     def get_dataset_artifact_download_data_deprecated(
         self, dataset_version_id: DatasetVersionId, artifact_id: DatasetArtifactId
-    ) -> DatasetArtifactDownloadDataDeprecated:
+    ) -> DeprecatedDatasetArtifactDownloadData:
         """
         Returns download data for an artifact, including a presigned URL
         """
@@ -560,7 +562,7 @@ class BusinessLogic(BusinessLogicInterface):
         file_size = self.s3_provider.get_file_size(artifact.uri)
         presigned_url = self.s3_provider.generate_presigned_url(artifact.uri)
 
-        return DatasetArtifactDownloadDataDeprecated(file_name, file_type, file_size, presigned_url)
+        return DeprecatedDatasetArtifactDownloadData(file_name, file_type, file_size, presigned_url)
 
     def get_dataset_status(self, dataset_version_id: DatasetVersionId) -> DatasetStatus:
         """

--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -4,7 +4,7 @@ from backend.layers.business.entities import (
     CollectionMetadataUpdate,
     CollectionQueryFilter,
     DatasetArtifactDownloadData,
-    DatasetArtifactDownloadDataDeprecated,
+    DeprecatedDatasetArtifactDownloadData,
 )
 from backend.layers.common.entities import (
     CanonicalCollection,
@@ -136,10 +136,10 @@ class BusinessLogicInterface:
     ) -> DatasetArtifactDownloadData:
         pass
 
-    # Superseded by get_dataset_artifact_download_data. Remove with #5697.
+    # TODO: Superseded by get_dataset_artifact_download_data. Remove with #5697.
     def get_dataset_artifact_download_data_deprecated(
         self, dataset_version_id: DatasetVersionId, artifact_id: DatasetArtifactId
-    ) -> DatasetArtifactDownloadDataDeprecated:
+    ) -> DeprecatedDatasetArtifactDownloadData:
         pass
 
     def update_dataset_version_status(

--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -4,6 +4,7 @@ from backend.layers.business.entities import (
     CollectionMetadataUpdate,
     CollectionQueryFilter,
     DatasetArtifactDownloadData,
+    DatasetArtifactDownloadDataDeprecated,
 )
 from backend.layers.common.entities import (
     CanonicalCollection,
@@ -133,6 +134,12 @@ class BusinessLogicInterface:
     def get_dataset_artifact_download_data(
         self, dataset_version_id: DatasetVersionId, artifact_id: DatasetArtifactId
     ) -> DatasetArtifactDownloadData:
+        pass
+
+    # Superseded by get_dataset_artifact_download_data. Remove with #5697.
+    def get_dataset_artifact_download_data_deprecated(
+        self, dataset_version_id: DatasetVersionId, artifact_id: DatasetArtifactId
+    ) -> DatasetArtifactDownloadDataDeprecated:
         pass
 
     def update_dataset_version_status(

--- a/backend/layers/business/entities.py
+++ b/backend/layers/business/entities.py
@@ -14,6 +14,13 @@ class CollectionQueryFilter:
 
 @dataclass
 class DatasetArtifactDownloadData:
+    file_size: int
+    url: str
+
+
+# Superseded by DatasetArtifactDownloadData. Remove with #5697.
+@dataclass
+class DatasetArtifactDownloadDataDeprecated:
     file_name: str
     file_type: DatasetArtifactType
     file_size: int

--- a/backend/layers/business/entities.py
+++ b/backend/layers/business/entities.py
@@ -18,9 +18,9 @@ class DatasetArtifactDownloadData:
     url: str
 
 
-# Superseded by DatasetArtifactDownloadData. Remove with #5697.
+# TODO: Superseded by DatasetArtifactDownloadData. Remove with #5697.
 @dataclass
-class DatasetArtifactDownloadDataDeprecated:
+class DeprecatedDatasetArtifactDownloadData:
     file_name: str
     file_type: DatasetArtifactType
     file_size: int

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -552,7 +552,7 @@ paths:
         - datasets
       summary: Request to download a dataset asset
       description: >-
-        Request to download a file which on success will return a permanent URL to download the dataset.
+        Request to download a file which on success returns a permanent URL to download the dataset.
       operationId: backend.portal.api.portal_api.get_dataset_asset
       parameters:
         - $ref: "#/components/parameters/path_dataset_id"
@@ -574,7 +574,7 @@ paths:
                   file_size:
                     type: number
                   url:
-                    type: string                    
+                    type: string
         "401":
           $ref: "#/components/responses/401"
         "403":

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -547,6 +547,40 @@ paths:
           $ref: "#/components/responses/404"
 
   /v1/datasets/{dataset_id}/asset/{asset_id}:
+    get:
+      tags:
+        - datasets
+      summary: Request to download a dataset asset
+      description: >-
+        Request to download a file which on success will return a permanent URL to download the dataset.
+      operationId: backend.portal.api.portal_api.get_dataset_asset
+      parameters:
+        - $ref: "#/components/parameters/path_dataset_id"
+        - name: asset_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dataset_id:
+                    $ref: "#/components/schemas/dataset_id"
+                  file_size:
+                    type: number
+                  url:
+                    type: string                    
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       tags:
         - datasets

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -647,6 +647,33 @@ def upload_relink(collection_id: str, body: dict, token_info: dict):
     return make_response({"dataset_id": dataset_id.id}, 202)
 
 
+def get_dataset_asset(dataset_id: str, asset_id: str):
+    """
+    Request to download a file which on success will return a permanent URL to download the dataset.
+    """
+
+    version = get_business_logic().get_dataset_version(DatasetVersionId(dataset_id))
+    if version is None:
+        raise NotFoundHTTPException(detail=f"'dataset/{dataset_id}' not found.")
+
+    try:
+        download_data = get_business_logic().get_dataset_artifact_download_data(
+            DatasetVersionId(dataset_id), DatasetArtifactId(asset_id)
+        )
+    except ArtifactNotFoundException:
+        raise NotFoundHTTPException(detail=f"'dataset/{dataset_id}/asset/{asset_id}' not found.") from None
+
+    if download_data.file_size is None:
+        raise ServerErrorHTTPException() from None
+
+    if download_data.url is None:
+        raise ServerErrorHTTPException()
+
+    response = {"dataset_id": dataset_id, "file_size": download_data.file_size, "url": download_data.url}
+
+    return make_response(response, 200)
+
+
 def post_dataset_asset(dataset_id: str, asset_id: str):
     """
     Requests to download a dataset asset, by generating a presigned_url.
@@ -657,7 +684,7 @@ def post_dataset_asset(dataset_id: str, asset_id: str):
         raise NotFoundHTTPException(detail=f"'dataset/{dataset_id}' not found.")
 
     try:
-        download_data = get_business_logic().get_dataset_artifact_download_data(
+        download_data = get_business_logic().get_dataset_artifact_download_data_deprecated(
             DatasetVersionId(dataset_id), DatasetArtifactId(asset_id)
         )
     except ArtifactNotFoundException:

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -669,7 +669,11 @@ def get_dataset_asset(dataset_id: str, asset_id: str):
     if download_data.url is None:
         raise ServerErrorHTTPException()
 
-    response = {"dataset_id": dataset_id, "file_size": download_data.file_size, "url": download_data.url}
+    response = {
+        "dataset_id": dataset_id,
+        "file_size": download_data.file_size,
+        "url": download_data.url,
+    }
 
     return make_response(response, 200)
 

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -649,7 +649,7 @@ def upload_relink(collection_id: str, body: dict, token_info: dict):
 
 def get_dataset_asset(dataset_id: str, asset_id: str):
     """
-    Request to download a file which on success will return a permanent URL to download the dataset.
+    Request to download a file which on success returns a permanent URL to download the dataset.
     """
 
     version = get_business_logic().get_dataset_version(DatasetVersionId(dataset_id))

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 
 from furl import furl
 
-from backend.layers.business.entities import DatasetArtifactDownloadData
+from backend.layers.business.entities import DatasetArtifactDownloadData, DatasetArtifactDownloadDataDeprecated
 from backend.layers.common.entities import (
     CollectionId,
     CollectionVersionId,
@@ -1523,10 +1523,60 @@ class TestCollectionsCurators(BaseAPIPortalTest):
 
 # TODO: these tests all require the generation of a dataset
 class TestDataset(BaseAPIPortalTest):
+    def test__get_dataset_asset__OK(self):
+        file_size = 1000
+        permanent_url = "http://url.url"
+        self.business_logic.get_dataset_artifact_download_data = Mock(
+            return_value=DatasetArtifactDownloadData(file_size, permanent_url)
+        )
+        version = self.generate_dataset(
+            artifacts=[DatasetArtifactUpdate(DatasetArtifactType.H5AD, "http://mock.uri/asset.h5ad")]
+        )
+        dataset_version_id = version.dataset_version_id
+        artifact_id = version.artifact_ids[0]
+
+        test_url = furl(path=f"/dp/v1/datasets/{dataset_version_id}/asset/{artifact_id}")
+        response = self.app.get(test_url.url, headers=dict(host="localhost"))
+        self.assertEqual(200, response.status_code)
+
+        actual_body = json.loads(response.data)
+        self.assertEqual(actual_body["url"], permanent_url)
+        self.assertEqual(actual_body["file_size"], file_size)
+
+    def test__get_dataset_asset__file_SERVER_ERROR(self):
+        """
+        `get_dataset_asset` should throw 500 if url or file_size aren't returned from the server
+        """
+        version = self.generate_dataset(
+            artifacts=[DatasetArtifactUpdate(DatasetArtifactType.H5AD, "http://mock.uri/asset.h5ad")]
+        )
+        dataset_version_id = version.dataset_version_id
+        artifact_id = version.artifact_ids[0]
+
+        test_url = furl(path=f"/dp/v1/datasets/{dataset_version_id}/asset/{artifact_id}")
+        response = self.app.get(test_url.url, headers=dict(host="localhost"))
+        self.assertEqual(500, response.status_code)
+
+    def test__get_dataset_asset__dataset_NOT_FOUND(self):
+        fake_id = DatasetVersionId()
+        test_url = furl(path=f"/dp/v1/datasets/{fake_id}/asset/{fake_id}")
+        response = self.app.get(test_url.url, headers=dict(host="localhost"))
+        self.assertEqual(404, response.status_code)
+        body = json.loads(response.data)
+        self.assertEqual(f"'dataset/{fake_id}' not found.", body["detail"])
+
+    def test__get_dataset_asset__asset_NOT_FOUND(self):
+        dataset = self.generate_dataset()
+        test_url = furl(path=f"/dp/v1/datasets/{dataset.dataset_version_id}/asset/fake_asset")
+        response = self.app.get(test_url.url, headers=dict(host="localhost"))
+        self.assertEqual(404, response.status_code)
+        body = json.loads(response.data)
+        self.assertEqual(f"'dataset/{dataset.dataset_version_id}/asset/fake_asset' not found.", body["detail"])
+
     # ✅
     def test__post_dataset_asset__OK(self):
-        self.business_logic.get_dataset_artifact_download_data = Mock(
-            return_value=DatasetArtifactDownloadData(
+        self.business_logic.get_dataset_artifact_download_data_deprecated = Mock(
+            return_value=DatasetArtifactDownloadDataDeprecated(
                 "asset.h5ad", DatasetArtifactType.H5AD, 1000, "http://presigned.url"
             )
         )

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 
 from furl import furl
 
-from backend.layers.business.entities import DatasetArtifactDownloadData, DatasetArtifactDownloadDataDeprecated
+from backend.layers.business.entities import DatasetArtifactDownloadData, DeprecatedDatasetArtifactDownloadData
 from backend.layers.common.entities import (
     CollectionId,
     CollectionVersionId,
@@ -1576,7 +1576,7 @@ class TestDataset(BaseAPIPortalTest):
     # ✅
     def test__post_dataset_asset__OK(self):
         self.business_logic.get_dataset_artifact_download_data_deprecated = Mock(
-            return_value=DatasetArtifactDownloadDataDeprecated(
+            return_value=DeprecatedDatasetArtifactDownloadData(
                 "asset.h5ad", DatasetArtifactType.H5AD, 1000, "http://presigned.url"
             )
         )

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -12,6 +12,7 @@ from backend.layers.business.business import (
     CollectionMetadataUpdate,
     CollectionQueryFilter,
     DatasetArtifactDownloadData,
+    DatasetArtifactDownloadDataDeprecated,
 )
 from backend.layers.business.exceptions import (
     CollectionCreationException,
@@ -1221,14 +1222,37 @@ class TestGetDataset(BaseBusinessLogicTestCase):
         self.assertIsNotNone(artifact)
 
         expected_file_size = 12345
+        expected_permanent_url = "http://fake.permanent/url"
+
+        self.s3_provider.get_file_size = Mock(return_value=expected_file_size)
+        self.business_logic.generate_permanent_url = Mock(return_value=expected_permanent_url)
+
+        # TODO: requires mocking of the S3 provider. implement later
+        download_data = self.business_logic.get_dataset_artifact_download_data(dataset.version_id, artifact.id)
+        expected_download_data = DatasetArtifactDownloadData(expected_file_size, expected_permanent_url)
+        self.assertEqual(download_data, expected_download_data)
+
+    # Superseded. Remove with #5697.
+    def test_get_dataset_artifact_download_data_deprecated_ok(self):
+        """
+        Calling `get_dataset_artifact_download_dat_deprecated` should yield downloadable data
+        """
+        published_version = self.initialize_published_collection()
+        dataset = published_version.datasets[0]
+        artifact = next(artifact for artifact in dataset.artifacts if artifact.type == DatasetArtifactType.H5AD)
+        self.assertIsNotNone(artifact)
+
+        expected_file_size = 12345
         expected_presigned_url = "http://fake.presigned/url"
 
         self.s3_provider.get_file_size = Mock(return_value=expected_file_size)
         self.s3_provider.generate_presigned_url = Mock(return_value=expected_presigned_url)
 
         # TODO: requires mocking of the S3 provider. implement later
-        download_data = self.business_logic.get_dataset_artifact_download_data(dataset.version_id, artifact.id)
-        expected_download_data = DatasetArtifactDownloadData(
+        download_data = self.business_logic.get_dataset_artifact_download_data_deprecated(
+            dataset.version_id, artifact.id
+        )
+        expected_download_data = DatasetArtifactDownloadDataDeprecated(
             f"{dataset.version_id}.h5ad", DatasetArtifactType.H5AD, expected_file_size, expected_presigned_url
         )
         self.assertEqual(download_data, expected_download_data)

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -12,7 +12,7 @@ from backend.layers.business.business import (
     CollectionMetadataUpdate,
     CollectionQueryFilter,
     DatasetArtifactDownloadData,
-    DatasetArtifactDownloadDataDeprecated,
+    DeprecatedDatasetArtifactDownloadData,
 )
 from backend.layers.business.exceptions import (
     CollectionCreationException,
@@ -1252,7 +1252,7 @@ class TestGetDataset(BaseBusinessLogicTestCase):
         download_data = self.business_logic.get_dataset_artifact_download_data_deprecated(
             dataset.version_id, artifact.id
         )
-        expected_download_data = DatasetArtifactDownloadDataDeprecated(
+        expected_download_data = DeprecatedDatasetArtifactDownloadData(
             f"{dataset.version_id}.h5ad", DatasetArtifactType.H5AD, expected_file_size, expected_presigned_url
         )
         self.assertEqual(download_data, expected_download_data)


### PR DESCRIPTION
## Reason for Change
- #5758

## Changes
- Added GET dataset asset endpoint that reuses existing Discover API functionality to calculate file size and permanent URL. (Supersedes POST dataset asset endpoint that generates pre-signed URL.)
- Modified Discover API's `extract_dataset_assets`: moved permanent URL builder code to business layer for reuse.

## Testing steps
- Added unit tests to `test_portal_api` and `test_business` test suites.
- Tested in rdev by hitting new GET endpoint and:
  - confirming file size matches existing POST file size for same asset, and,
  - confirming permanent URL yields download.
