### PR TITLE
feat(cicd): allow all conventional commit types

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,11 +15,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5.2.0
-        with:
-          types: |
-            fix
-            feat
-            chore
-            docs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Reason for Change

- The default has more options and reduce the configuration we need to manager.

## Changes
- allow all conventional commit types
