### PR TITLE
feat(cellguide): add ontology tree states for every cell type

### DIFF
--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/constants.ts
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/constants.ts
@@ -13,3 +13,5 @@ export const CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_HOVER_CONTAINER =
 export const CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_DEACTIVATE_MARKER_GENE_MODE =
   "cell-guide-card-ontology-dag-view-deactivate-marker-gene-mode";
 export const MINIMUM_NUMBER_OF_HIDDEN_CHILDREN_FOR_DUMMY_NODE = 3;
+
+export const ANIMAL_CELL_ID = "CL:0000548";


### PR DESCRIPTION
## Reason for Change

- #5809

## Changes

- updated the pipeline to build the ontology graph from "cell" as the root (`CL:0000000`).
- updated the frontend to set the root to be `CL:0000548__0` (animal cell) if the target cell type is a descendant of animal cell.

## Testing steps

- Added E2E test case for "abnormal cell" ontology dag view. If this test passes, it means that the tree view exists for abnormal cell (which is not a descendant of animal cell).