### PR TITLE
chore: Reduce e2e shard count from 20 to 10

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -211,30 +211,8 @@ jobs:
       matrix:
         # Only run Chrome for now, since GHA only has 250 workers and will cancel jobs if it runs out
         project: [chromium]
-        shardCurrent:
-          [
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-          ]
-        shardTotal: [20]
+        shardCurrent: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shardTotal: [10]
 
     defaults:
       run:


### PR DESCRIPTION
## Reason for Change

E2E tests are timing out on a lot of commits on PRs (here is an example from a [PR for datadog integration](https://github.com/chanzuckerberg/single-cell-data-portal/pull/5788)) and [main branch](https://github.com/chanzuckerberg/single-cell-data-portal/commits/main). 

There is some [planned work](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/5793) to rethink how sharding is done because we hypothesize that the GHA servers can't handle the concurrent load of the current number of shards.

This PR attempts a short term fix by reducing the shard count from 20 to 10, hoping that the GHA servers won't timeout but will take longer to complete E2E tests.

## Changes

- Reduce number of shards used for e2e tests

## Testing steps

- Manual testing by merging this PR to `main` and checking that the e2e tests pass more reliably on GHA runs of subsequent commits in `main` and PR branches

## Notes for Reviewer
