### PR TITLE
fix: remove debugging line in ontology tree unit test

### DIFF
--- a/tests/unit/cellguide_pipeline/test_ontology_tree.py
+++ b/tests/unit/cellguide_pipeline/test_ontology_tree.py
@@ -30,7 +30,6 @@ class OntologyTreeBuilderTests(unittest.TestCase):
             tree_builder = OntologyTreeBuilder(cell_counts_df)
 
             ontology_graph = convert_dataclass_to_dict_and_strip_nones(tree_builder.get_ontology_tree())
-            return ontology_graph, expected__ontology_graph
             self.assertTrue(compare_dicts(ontology_graph, expected__ontology_graph))
 
             all_states_per_cell_type = convert_dataclass_to_dict_and_strip_nones(


### PR DESCRIPTION
## Reason for Change

- Accidentally merged in a debugging line added to one of the cellguide pipeline unit tests in #5825 