### PR TITLE
fix(cellguide): server side props for seo description (#5832)

### DIFF
--- a/frontend/src/common/queries/cellGuide.ts
+++ b/frontend/src/common/queries/cellGuide.ts
@@ -341,14 +341,9 @@ export const USE_GPT_SEO_DESCRIPTION_QUERY = {
   id: "cell-guide-gpt-seo-description-query",
 };
 
-interface GptSeoDescriptionQueryResponse {
-  name: string;
-  description: string;
-}
-
 export const fetchGptSeoDescription = async (
   entityId: string
-): Promise<GptSeoDescriptionQueryResponse> => {
+): Promise<string> => {
   entityId = entityId.replace(":", "_");
   // This function is used server-side to fetch the GPT SEO description.
   const url = `${CELLGUIDE_DATA_URL_WITH_RDEV_SUFFIX}/${QUERY_MAPPING[

--- a/frontend/src/pages/cellguide/[cellTypeId].tsx
+++ b/frontend/src/pages/cellguide/[cellTypeId].tsx
@@ -25,15 +25,10 @@ export const getServerSideProps: GetServerSideProps<{
 }> = async (context) => {
   const { params } = context;
   const { cellTypeId: rawCellTypeId } = params ?? {};
-  const cellType = await fetchGptSeoDescription(rawCellTypeId as string);
+  const seoDescription = await fetchGptSeoDescription(rawCellTypeId as string);
   const cellTypeMetadata = await fetchCellTypeMetadata();
   const cellTypeId = (rawCellTypeId as string).replace("_", ":");
-  const synonyms = cellTypeMetadata[cellTypeId].synonyms;
-  const { name, description: seoDescription } = cellType ?? {
-    name: "",
-    description: "",
-  };
-
+  const { synonyms, name } = cellTypeMetadata[cellTypeId];
   return { props: { seoDescription, name, synonyms } };
 };
 


### PR DESCRIPTION
## Reason for Change

- CellGuide pipeline was updated to generate SEO descriptions as strings, not dictionaries. Because SEO descriptions are only generated when new cell types are added, most of the SEO descriptions are still dictionaries. Newer cell types (like [this
one](https://cellxgene.cziscience.com/cellguide/CL_4030026)) store the SEO descriptions as strings, leading to an error in parsing the server side props and undefined names.
- This PR updates the frontend server to get the cell type names from the `celltype_metadata.json` and updates the CellGuide query module to expect strings for the GPT SEO description.
- Once this is deployed, the old GPT SEO descriptions will be migrated to the correct format (strings).

## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- add
- remove
- modify

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Notes for Reviewer
