### PR TITLE
test: Fix e2e filter test

### DIFF
--- a/frontend/tests/features/wheresMyGene/landingPageFilter.test.ts
+++ b/frontend/tests/features/wheresMyGene/landingPageFilter.test.ts
@@ -146,10 +146,23 @@ describe("Left side bar", () => {
   });
 
   async function countRecords(page: Page, testId: string) {
-    await page.getByTestId(testId).getByRole("button").click();
-    await expect(page.locator("option")).not.toHaveCount(0);
-    const numberOfRecords = await page.getByRole("option").count();
-    await page.keyboard.press("Escape");
-    return numberOfRecords;
+    const optionLocator = page.getByRole("option");
+
+    let count = 0;
+
+    await tryUntil(
+      async () => {
+        await page.getByTestId(testId).getByRole("button").click();
+
+        count = await optionLocator.count();
+
+        await page.keyboard.press("Escape");
+
+        expect(count).toBeGreaterThan(0);
+      },
+      { page }
+    );
+
+    return count;
   }
 });


### PR DESCRIPTION
## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

1. Update locator to use `page.getByRole("option")`, since `page.locator("option")` was getting 3 local development only React Query tool elements

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Notes for Reviewer
