### PR TITLE
feat: added consortia to collections index.

### DIFF
--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -482,6 +482,8 @@ def get_user_collection_index(token_info):
                 collection.publisher_metadata
             )
 
+        transformed_collection["consortia"] = collection.metadata.consortia
+
         if collection.is_unpublished_version():
             transformed_collection["id"] = collection.version_id.id
         else:

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -431,6 +431,8 @@ def get_collection_index():
         transformed_collection["published_at"] = collection.canonical_collection.originally_published_at
         transformed_collection["revised_at"] = collection.published_at
 
+        transformed_collection["consortia"] = collection.metadata.consortia
+
         response.append(transformed_collection)
 
     return make_response(jsonify(response), 200)

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -817,6 +817,7 @@ class TestCollection(BaseAPIPortalTest):
         self.assertEqual(actual_collection["id"], collection.collection_id.id)
         self.assertEqual(actual_collection["name"], collection.metadata.name)
         self.assertNotIn("description", actual_collection)
+        self.assertEqual(actual_collection["consortia"], collection.metadata.consortia)
         # Both `published_at` and `revised_at` should point to the same timestamp
         self.assertEqual(actual_collection["published_at"], collection.published_at.timestamp())
         self.assertEqual(actual_collection["revised_at"], collection.published_at.timestamp())

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -939,6 +939,10 @@ class TestCollection(BaseAPIPortalTest):
             else:
                 self.assertEqual(collection["access_type"], "READ")
 
+        # Confirm consortia is included in the response
+        actual_collection = body[-1]  # last collection is private, owned by the user
+        self.assertEqual(actual_collection["consortia"], private_collection.metadata.consortia)
+
     # ✅
     def test__create_collection__InvalidParameters_DOI(self):
         tests = [


### PR DESCRIPTION
## Reason for Change

- #5858

## Changes

- Added `consortia` to collections index and user collections index responses.

## Testing steps

- Updated unit tests.
- Tested manually in [rdev](https://mim-consortia-e2e-i-frontend.rdev.single-cell.czi.technology/collections).
