### PR TITLE
feat: Auto merge and deploy to staging branch

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -10,7 +10,7 @@ on:
 # add a concurrency group to prevent multiple builds from running at the same time
 concurrency:
   group: $${{ github.ref }}-environment
-  cancel-in-progress: true
+  cancel-in-progress: false
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -7,6 +7,10 @@ on:
       - staging
       - prod
 
+# add a concurrency group to prevent multiple builds from running at the same time
+concurrency:
+  group: $${{ github.ref }}-environment
+  cancel-in-progress: true
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -5,7 +5,7 @@ on: deployment
 # add a concurrency group to prevent multiple builds from running at the same time
 concurrency:
   group: $${{ github.ref }}-environment
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -2,6 +2,11 @@ name: Deploy Happy
 
 on: deployment
 
+# add a concurrency group to prevent multiple builds from running at the same time
+concurrency:
+  group: $${{ github.ref }}-environment
+  cancel-in-progress: true
+
 env:
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1

--- a/.github/workflows/merge-main-into-staging.yml
+++ b/.github/workflows/merge-main-into-staging.yml
@@ -1,0 +1,21 @@
+name: Merge main into staging
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Merge main into staging
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git checkout staging
+          git pull
+          git merge --no-ff main -m "Merge main into staging"
+          git push

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -9,20 +9,23 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout code from psridharan/issue-5461
+        uses: actions/checkout@v2
+        with:
+          ref: psridharan/issue-5461
+      - name: Checkout code from psridharan/test-auto-merge-2
         uses: actions/checkout@v2
         with:
           ref: psridharan/test-auto-merge-2
-      - name: Fetch latest changes to psridharan/issue-5461
-        run: git fetch origin psridharan/issue-5461
       - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge-2
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           echo "Checkout psridharan/test-auto-merge-2"
           git checkout psridharan/test-auto-merge-2
-          echo "Current checkout branch is: $(git branch --show-current)"
-          echo "HEAD commit in current checkout branch is: $(git log -1 --format='%H')"
+          echo "Current checked out receiving branch is: $(git branch --show-current)"
+          echo "HEAD commit in current checked out receiving branch: $(git branch --show-current) is: $(git log -1 --format='%H')"
+          echo "HEAD commit in incoming branch psridharan/issue-5461 is: $(git log -1 --format='%H' psridharan/issue-5461)"
           echo "About to merge psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git merge --verbose --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -3,39 +3,37 @@ name: Trigger release candidate build and deploy
 on:
   push:
     branches:
-      - psridharan/issue-5461
+      - main
 
 jobs:
   merge:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout psridharan/issue-5461 into psridharan/test-auto-merge-2
+      - name: Checkout main branch and staging branch
         uses: actions/checkout@v2
         with:
-          ref: psridharan/issue-5461
-          fetch-depth: 0
-      - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge-2
+          ref: main
+          fetch-depth: 0 # fetch all history to make merges work correctly
+      - name: Merge main branch into staging branch
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
-          echo "BEFORE CHECKOUT: Listing current checked out branches:"
+          echo "Listing locally available branches BEFORE 'staging' branch is checked out:"
           echo "$(git branch --list)"
 
-          echo "Checking out psridharan/test-auto-merge-2"
-          git checkout psridharan/test-auto-merge-2
+          echo "Checking out 'staging' branch"
+          git checkout staging
           echo "Confirming checked out branch receiving merge is: $(git branch --show-current)"
 
-          echo "AFTER CHECKOUT: Listing current checked out branches:"
+          echo "Listing locally available branches AFTER 'staging' branch is checked out:"
           echo "$(git branch --list)"
 
-          echo "Current checked out receiving branch is: $(git branch --show-current)"
           echo "HEAD commit in current checked out receiving branch: $(git branch --show-current) is: $(git log -1 --format='%H')"
 
-          echo "HEAD commit in incoming branch psridharan/issue-5461 is:"
-          echo "$(git log -1 --format='%H' psridharan/issue-5461)"
+          echo "HEAD commit in incoming branch: 'main' is: $(git log -1 --format='%H' main)"
 
-          echo "About to merge psridharan/issue-5461 into psridharan/test-auto-merge-2"
-          git merge --verbose --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
+          echo "About to merge 'main' branch into 'staging' branch"
+          git merge --verbose --no-ff main -m "Merging main branch into staging branch"
 
-          git push origin psridharan/test-auto-merge-2
+          git push origin staging

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -17,8 +17,9 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git branch --show-current
-          git log -1 --format='%H'
-          git rev-parse psridharan/issue-5461
+          echo "Current checkout branch is: $(git branch --show-current)"
+          echo "HEAD commit in current checkout branch is: $(git log -1 --format='%H')"
+          echo "HEAD commit in psridharan/issue-5461 branch is: "
+          echo "$(git rev-parse psridharan/issue-5461)"
           git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -19,7 +19,9 @@ jobs:
           git config user.email "actions@github.com"
           echo "Current checkout branch is: $(git branch --show-current)"
           echo "HEAD commit in current checkout branch is: $(git log -1 --format='%H')"
+          echo "Checking branches available in the repo:"
+          echo "$(git branch)"
           echo "HEAD commit in psridharan/issue-5461 branch is: "
-          echo "$(git rev-parse origin/psridharan/issue-5461)"
+          echo "$(git rev-parse psridharan/issue-5461)"
           git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -20,6 +20,6 @@ jobs:
           echo "Current checkout branch is: $(git branch --show-current)"
           echo "HEAD commit in current checkout branch is: $(git log -1 --format='%H')"
           echo "HEAD commit in psridharan/issue-5461 branch is: "
-          echo "$(git rev-parse psridharan/issue-5461)"
+          echo "$(git rev-parse origin/psridharan/issue-5461)"
           git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -9,8 +9,12 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     steps:
-      - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge-2
+      - name: Checkout psridharan/issue-5461 into psridharan/test-auto-merge-2
         uses: actions/checkout@v2
+        with:
+          ref: psridharan/issue-5461
+          fetch-depth: 0
+      - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge-2
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
@@ -18,19 +22,12 @@ jobs:
           echo "BEFORE CHECKOUT: Listing current checked out branches:"
           echo "$(git branch --list)"
 
-          echo "Checking out psridharan/issue-5461"
-          git checkout psridharan/issue-5461
-          echo "Confirming checked out branch-to-merge is: $(git branch --show-current)"
-
           echo "Checking out psridharan/test-auto-merge-2"
           git checkout psridharan/test-auto-merge-2
           echo "Confirming checked out branch receiving merge is: $(git branch --show-current)"
 
           echo "AFTER CHECKOUT: Listing current checked out branches:"
           echo "$(git branch --list)"
-
-          echo "Checkout psridharan/test-auto-merge-2"
-          git checkout psridharan/test-auto-merge-2
 
           echo "Current checked out receiving branch is: $(git branch --show-current)"
           echo "HEAD commit in current checked out receiving branch: $(git branch --show-current) is: $(git log -1 --format='%H')"

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -23,7 +23,5 @@ jobs:
           git fetch origin psridharan/issue-5461
           echo "Checking branches available in the repo:"
           echo "$(git branch)"
-          echo "HEAD commit in psridharan/issue-5461 branch is: "
-          echo "$(git rev-parse psridharan/issue-5461)"
           git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -21,6 +21,8 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
+          echo "Listing current checked out branches:"
+          echo "$(git branch)"
           echo "Checkout psridharan/test-auto-merge-2"
           git checkout psridharan/test-auto-merge-2
           echo "Current checked out receiving branch is: $(git branch --show-current)"

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -19,6 +19,8 @@ jobs:
           git config user.email "actions@github.com"
           echo "Current checkout branch is: $(git branch --show-current)"
           echo "HEAD commit in current checkout branch is: $(git log -1 --format='%H')"
+          echo "Running git fetch..."
+          git fetch
           echo "Checking branches available in the repo:"
           echo "$(git branch)"
           echo "HEAD commit in psridharan/issue-5461 branch is: "

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -19,8 +19,8 @@ jobs:
           git config user.email "actions@github.com"
           echo "Current checkout branch is: $(git branch --show-current)"
           echo "HEAD commit in current checkout branch is: $(git log -1 --format='%H')"
-          echo "Running git fetch..."
-          git fetch
+          echo "Running git fetch origin psridharan/issue-5461"
+          git fetch origin psridharan/issue-5461
           echo "Checking branches available in the repo:"
           echo "$(git branch)"
           echo "HEAD commit in psridharan/issue-5461 branch is: "

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: psridharan/test-auto-merge
-      - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge
+          ref: psridharan/test-auto-merge-2
+      - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge-2
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge"
+          git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -17,5 +17,8 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
+          git branch --show-current
+          git log -1 --format='%H'
+          git rev-parse psridharan/issue-5461
           git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -1,4 +1,4 @@
-name: Merge main into staging
+name: Trigger release candidate build and deploy
 
 on:
   push:
@@ -11,11 +11,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          ref: staging
       - name: Merge main into staging
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           git checkout staging
-          git pull
-          git merge --no-ff main -m "Merge main into staging"
+          git merge --no-ff main -m "Trigger release candidate build and deploy"
           git push

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -17,11 +17,10 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          echo "Current checkout branch is: $(git branch --show-current)"
-          echo "HEAD commit in current checkout branch is: $(git log -1 --format='%H')"
           echo "Running git fetch origin psridharan/issue-5461"
           git fetch origin psridharan/issue-5461
-          echo "Checking branches available in the repo:"
-          echo "$(git branch)"
+          echo "Current checkout branch is: $(git branch --show-current)"
+          echo "HEAD commit in current checkout branch is: $(git log -1 --format='%H')"
+          echo "About to merge psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           echo "Listing current checked out branches:"
-          echo "$(git branch)"
+          echo "$(git branch --list)"
           echo "Checkout psridharan/test-auto-merge-2"
           git checkout psridharan/test-auto-merge-2
           echo "Current checked out receiving branch is: $(git branch --show-current)"

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -9,18 +9,20 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code from psridharan/issue-5461
+      - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          ref: psridharan/issue-5461
-      - name: Checkout code from psridharan/test-auto-merge-2
-        uses: actions/checkout@v2
-        with:
-          ref: psridharan/test-auto-merge-2
       - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge-2
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
+          echo "Checking out psridharan/issue-5461"
+          git checkout psridharan/issue-5461
+          git pull
+          echo "Confirming checked out branch-to-merge is: $(git branch --show-current)"
+          echo "Checking out psridharan/test-auto-merge-2"
+          git checkout psridharan/test-auto-merge-2
+          git pull
+          echo "Confirming checked out branch receiving merge is: $(git branch --show-current)"
           echo "Listing current checked out branches:"
           echo "$(git branch --list)"
           echo "Checkout psridharan/test-auto-merge-2"

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -3,7 +3,7 @@ name: Trigger release candidate build and deploy
 on:
   push:
     branches:
-      - main
+      - psridharan/issue-5461
 
 jobs:
   merge:
@@ -12,11 +12,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: staging
-      - name: Merge main into staging
+          ref: psridharan/test-auto-merge
+      - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git checkout staging
-          git merge --no-ff main -m "Trigger release candidate build and deploy"
+          git checkout psridharan/test-auto-merge
+          git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge"
           git push

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -17,5 +17,5 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git merge psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
+          git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -17,6 +17,5 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git checkout psridharan/test-auto-merge
           git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge"
           git push

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -25,7 +25,8 @@ jobs:
           git checkout psridharan/test-auto-merge-2
           echo "Current checked out receiving branch is: $(git branch --show-current)"
           echo "HEAD commit in current checked out receiving branch: $(git branch --show-current) is: $(git log -1 --format='%H')"
-          echo "HEAD commit in incoming branch psridharan/issue-5461 is: $(git log -1 --format='%H' psridharan/issue-5461)"
+          echo "HEAD commit in incoming branch psridharan/issue-5461 is:"
+          echo "$(git log -1 --format='%H' psridharan/issue-5461)"
           echo "About to merge psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git merge --verbose --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -13,14 +13,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: psridharan/test-auto-merge-2
+      - name: Fetch latest changes to psridharan/issue-5461
+        run: git fetch origin psridharan/issue-5461
       - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge-2
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          echo "Running git fetch origin psridharan/issue-5461"
-          git fetch origin psridharan/issue-5461
+          echo "Checkout psridharan/test-auto-merge-2"
+          git checkout psridharan/test-auto-merge-2
           echo "Current checkout branch is: $(git branch --show-current)"
           echo "HEAD commit in current checkout branch is: $(git log -1 --format='%H')"
           echo "About to merge psridharan/issue-5461 into psridharan/test-auto-merge-2"
-          git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
+          git merge --verbose --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -15,22 +15,31 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
+
+          echo "BEFORE CHECKOUT: Listing current checked out branches:"
+          echo "$(git branch --list)"
+
           echo "Checking out psridharan/issue-5461"
           git checkout psridharan/issue-5461
-          git pull
           echo "Confirming checked out branch-to-merge is: $(git branch --show-current)"
+
           echo "Checking out psridharan/test-auto-merge-2"
           git checkout psridharan/test-auto-merge-2
-          git pull
           echo "Confirming checked out branch receiving merge is: $(git branch --show-current)"
-          echo "Listing current checked out branches:"
+
+          echo "AFTER CHECKOUT: Listing current checked out branches:"
           echo "$(git branch --list)"
+
           echo "Checkout psridharan/test-auto-merge-2"
           git checkout psridharan/test-auto-merge-2
+
           echo "Current checked out receiving branch is: $(git branch --show-current)"
           echo "HEAD commit in current checked out receiving branch: $(git branch --show-current) is: $(git log -1 --format='%H')"
+
           echo "HEAD commit in incoming branch psridharan/issue-5461 is:"
           echo "$(git log -1 --format='%H' psridharan/issue-5461)"
+
           echo "About to merge psridharan/issue-5461 into psridharan/test-auto-merge-2"
           git merge --verbose --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
+
           git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -31,6 +31,6 @@ jobs:
           echo "Latest commit on 'main' branch is: $(git log -1 --format='%H' main)"
 
           echo "About to merge 'main' branch into 'staging' branch"
-          git merge --verbose --no-ff main -m "Merging main branch into staging branch"
+          git merge --verbose main -m "Merging main branch into staging branch"
 
           git push origin staging

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -17,5 +17,5 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git merge --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
-          git push
+          git merge psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"
+          git push origin psridharan/test-auto-merge-2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -9,9 +9,8 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge-2
+        uses: actions/checkout@v2
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -19,9 +19,6 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
-          echo "Listing locally available branches BEFORE 'staging' branch is checked out:"
-          echo "$(git branch --list)"
-
           echo "Checking out 'staging' branch"
           git checkout staging
           echo "Confirming checked out branch receiving merge is: $(git branch --show-current)"
@@ -29,9 +26,9 @@ jobs:
           echo "Listing locally available branches AFTER 'staging' branch is checked out:"
           echo "$(git branch --list)"
 
-          echo "HEAD commit in current checked out receiving branch: $(git branch --show-current) is: $(git log -1 --format='%H')"
+          echo "Latest commit on 'staging' branch is: $(git log -1 --format='%H' staging)"
 
-          echo "HEAD commit in incoming branch: 'main' is: $(git log -1 --format='%H' main)"
+          echo "Latest commit on 'main' branch is: $(git log -1 --format='%H' main)"
 
           echo "About to merge 'main' branch into 'staging' branch"
           git merge --verbose --no-ff main -m "Merging main branch into staging branch"


### PR DESCRIPTION
## Reason for Change

- #5461

The idea is that we can leverage our existing workflow where a commit to `staging` branch creates a deployment to the `stage` environment. So, whenever new commits to `main` come in, we merge the commit to `staging` thus kicking off a deployment to `stage` environment.

Additionally, github action's [concurrency group feature is utilized](https://docs.github.com/en/actions/using-jobs/using-concurrency) to eliminate race conditions involving multiple builds and deployments run at the same time. Here, we cancel scheduled builds and deployments as well as currently running builds and deployments in favor of the newest build/deployment job.

## Changes

- add merging `main` branch to `staging` branch on new commits to `main`
- add GHA concurrency group feature

## Testing steps

- The following workflow was used to test a merge between 2 branches not named `[dev, staging, prod]`. Specifically the following github workflow merges commits from `psridharan/issue-5461` into `psridharan/test-auto-merge-2` triggered by a pushes to `psridharan/issue-5461`:

```
name: Trigger release candidate build and deploy

on:
  push:
    branches:
      - psridharan/issue-5461

jobs:
  merge:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout psridharan/issue-5461 into psridharan/test-auto-merge-2
        uses: actions/checkout@v2
        with:
          ref: psridharan/issue-5461
          fetch-depth: 0
      - name: Merge psridharan/issue-5461 into psridharan/test-auto-merge-2
        run: |
          git config user.name "GitHub Actions"
          git config user.email "actions@github.com"

          echo "BEFORE CHECKOUT: Listing current checked out branches:"
          echo "$(git branch --list)"

          echo "Checking out psridharan/test-auto-merge-2"
          git checkout psridharan/test-auto-merge-2
          echo "Confirming checked out branch receiving merge is: $(git branch --show-current)"

          echo "AFTER CHECKOUT: Listing current checked out branches:"
          echo "$(git branch --list)"

          echo "Current checked out receiving branch is: $(git branch --show-current)"
          echo "HEAD commit in current checked out receiving branch: $(git branch --show-current) is: $(git log -1 --format='%H')"

          echo "HEAD commit in incoming branch psridharan/issue-5461 is:"
          echo "$(git log -1 --format='%H' psridharan/issue-5461)"

          echo "About to merge psridharan/issue-5461 into psridharan/test-auto-merge-2"
          git merge --verbose --no-ff psridharan/issue-5461 -m "Merging psridharan/issue-5461 into psridharan/test-auto-merge-2"

          git push origin psridharan/test-auto-merge-2
```

- Here is the DEBUG log output that inspects the state before the `git merge` operation:

```
BEFORE CHECKOUT: Listing current checked out branches:
* psridharan/issue-5461
Checking out psridharan/test-auto-merge-2
Switched to a new branch 'psridharan/test-auto-merge-2'
branch 'psridharan/test-auto-merge-2' set up to track 'origin/psridharan/test-auto-merge-2'.
Confirming checked out branch receiving merge is: psridharan/test-auto-merge-2
AFTER CHECKOUT: Listing current checked out branches:
  psridharan/issue-5461
* psridharan/test-auto-merge-2
Current checked out receiving branch is: psridharan/test-auto-merge-2
HEAD commit in current checked out receiving branch: psridharan/test-auto-merge-2 is: baf69efb5f6f94c2d6645e3eedaf4d8703852ccc
HEAD commit in incoming branch psridharan/issue-5461 is:
4b12fc3e[27](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/6386570986/job/17333448676?pr=5860#step:3:28)50f6af67bae5ca[28](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/6386570986/job/17333448676?pr=5860#step:3:29)354502e9e[33](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/6386570986/job/17333448676?pr=5860#step:3:34)bba
About to merge psridharan/issue-5461 into psridharan/test-auto-merge-2
Merge made by the 'ort' strategy.
 .../build-images-and-create-deployment.yml         |  4 +++
 .github/workflows/deploy-happy-stack.yml           |  5 +++
 .../trigger-release-candidate-build-and-deploy.yml | 41 ++++++++++++++++++++++
 3 files changed, 50 insertions(+)
 create mode 100644 .github/workflows/trigger-release-candidate-build-and-deploy.yml
To https://github.com/chanzuckerberg/single-cell-data-portal
   baf69efb5f6..64a[37](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/6386570986/job/17333448676?pr=5860#step:3:38)11d333  psridharan/test-auto-merge-2 -> psridharan/test-auto-merge-2
```

Attached is an image that shows the auto-merge

<img width="1709" alt="Screenshot 2023-10-02 at 4 31 47 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/5581819/85fb42b1-cce7-4ce9-81dd-f63a7db21ef3">


## Notes for Reviewer
