### PR TITLE
chore: scale dev backend instances to 4

### DIFF
--- a/.happy/terraform/envs/dev/main.tf
+++ b/.happy/terraform/envs/dev/main.tf
@@ -20,7 +20,7 @@ module stack {
   cg_batch_container_memory_limit  = 92000
   backend_memory               = 8192
   frontend_memory              = 4096
-  backend_instance_count       = 2
+  backend_instance_count       = 4
   backend_workers              = 1
   wait_for_steady_state = var.wait_for_steady_state
 }


### PR DESCRIPTION
Unblock e2e tests with even more resources.