### PR TITLE
fix: Add concurrency to rdev managing GHAs

### DIFF
--- a/.github/workflows/rdev-delete-for-pr.yml
+++ b/.github/workflows/rdev-delete-for-pr.yml
@@ -7,11 +7,6 @@ on:
     types:
       - closed
 
-# add a concurrency group to prevent the rdev from being updated multiple times
-concurrency:
-  group: pr-${{ github.event.number }}
-  cancel-in-progress: true
-
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.
@@ -26,6 +21,10 @@ permissions:
 
 jobs:
   delete-rdev:
+    # Cancel any updates to the rdev for this PR
+    concurrency:
+      group: pr-${{ github.event.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-22.04
     steps:
       - name: Configure AWS Credentials

--- a/.github/workflows/rdev-delete-for-pr.yml
+++ b/.github/workflows/rdev-delete-for-pr.yml
@@ -21,10 +21,10 @@ permissions:
 
 jobs:
   delete-rdev:
-    # Cancel any rdev updates and tear down the stack.
+    # prevent the rdev from being updated in concurrent GHA
     concurrency:
       group: pr-${{ github.event.number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     runs-on: ubuntu-22.04
     steps:
       - name: Configure AWS Credentials

--- a/.github/workflows/rdev-delete-for-pr.yml
+++ b/.github/workflows/rdev-delete-for-pr.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   delete-rdev:
-    # Cancel any updates to the rdev for this PR
+    # Cancel any rdev updates and tear down the stack.
     concurrency:
       group: pr-${{ github.event.number }}
       cancel-in-progress: true

--- a/.github/workflows/rdev-delete-for-pr.yml
+++ b/.github/workflows/rdev-delete-for-pr.yml
@@ -7,6 +7,11 @@ on:
     types:
       - closed
 
+# add a concurrency group to prevent the rdev from being updated multiple times
+concurrency:
+  group: pr-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.

--- a/.github/workflows/rdev-delete-for-pr.yml
+++ b/.github/workflows/rdev-delete-for-pr.yml
@@ -19,12 +19,13 @@ permissions:
   id-token: write
   contents: read
 
+# prevent the rdev from being updated in concurrent GHA
+concurrency:
+  group: pr-${{ github.event.number }}
+  cancel-in-progress: false
+
 jobs:
   delete-rdev:
-    # prevent the rdev from being updated in concurrent GHA
-    concurrency:
-      group: pr-${{ github.event.number }}
-      cancel-in-progress: false
     runs-on: ubuntu-22.04
     steps:
       - name: Configure AWS Credentials

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -146,3 +146,5 @@ jobs:
         run: |
           pip3 install -r tests/functional/requirements.txt
           DEPLOYMENT_STAGE=rdev STACK_NAME=${{ env.STACK_NAME }} make functional-test
+
+# comment

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -8,7 +8,6 @@ on:
       - open
       - synchronize
       - reopened
-      - closed
 
 # add a concurrency group to prevent the rdev from being updated multiple times
 concurrency:

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -145,5 +145,3 @@ jobs:
         run: |
           pip3 install -r tests/functional/requirements.txt
           DEPLOYMENT_STAGE=rdev STACK_NAME=${{ env.STACK_NAME }} make functional-test
-
-# comment

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -9,6 +9,11 @@ on:
       - synchronize
       - reopened
 
+# prevent the rdev from being updated in concurrent GHA
+concurrency:
+  group: pr-${{ github.event.number }}
+  cancel-in-progress: false
+
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.
@@ -64,10 +69,6 @@ jobs:
 
   deploy-rdev:
     runs-on: ubuntu-22.04
-    # prevent the rdev from being updated in concurrent GHA
-    concurrency:
-      group: pr-${{ github.event.number }}
-      cancel-in-progress: false
     needs:
       - build-images
     steps:

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -9,11 +9,6 @@ on:
       - synchronize
       - reopened
 
-# add a concurrency group to prevent the rdev from being updated multiple times
-concurrency:
-  group: pr-${{ github.event.number }}
-  cancel-in-progress: false
-
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.
@@ -69,6 +64,10 @@ jobs:
 
   deploy-rdev:
     runs-on: ubuntu-22.04
+    # add a concurrency group to prevent the rdev from being updated multiple times
+    concurrency:
+      group: pr-${{ github.event.number }}
+      cancel-in-progress: false
     needs:
       - build-images
     steps:

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -8,6 +8,12 @@ on:
       - open
       - synchronize
       - reopened
+      - closed
+
+# add a concurrency group to prevent the rdev from being updated multiple times
+concurrency:
+  group: pr-${{ github.event.number }}
+  cancel-in-progress: false
 
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -64,7 +64,7 @@ jobs:
 
   deploy-rdev:
     runs-on: ubuntu-22.04
-    # add a concurrency group to prevent the rdev from being updated multiple times
+    # prevent the rdev from being updated in concurrent GHA
     concurrency:
       group: pr-${{ github.event.number }}
       cancel-in-progress: false

--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -112,7 +112,7 @@ class H5ADDataFile:
                 * follows ScanPy embedding naming conventions
                 * with all values finite or NaN (no +Inf or -Inf)
             """
-
+            # TODO is this in the cellxgene_cli validator and can this be removed from here?
             is_valid = isinstance(embedding_name, str) and embedding_name.startswith("X_") and len(embedding_name) > 2
             is_valid = is_valid and isinstance(embedding_array, np.ndarray) and embedding_array.dtype.kind in "fiu"
             is_valid = is_valid and embedding_array.shape[0] == adata.n_obs and embedding_array.shape[1] >= 2

--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -112,7 +112,7 @@ class H5ADDataFile:
                 * follows ScanPy embedding naming conventions
                 * with all values finite or NaN (no +Inf or -Inf)
             """
-            # TODO is this in the cellxgene_cli validator and can this be removed from here?
+
             is_valid = isinstance(embedding_name, str) and embedding_name.startswith("X_") and len(embedding_name) > 2
             is_valid = is_valid and isinstance(embedding_array, np.ndarray) and embedding_array.dtype.kind in "fiu"
             is_valid = is_valid and embedding_array.shape[0] == adata.n_obs and embedding_array.shape[1] >= 2


### PR DESCRIPTION
## Reason for Change

-  There is a chance the rdev environment can get into an unknown state if multiple happy updates are run on the same environment concurrently. This PR adds some locking to prevent happy from running for the same rdev in different GHA at the same time. 

## Changes

- add concurrency locking of the happy update/delete jobs to prevent concurrent happy modification.

## Testing steps

- Created an rdev using a PR. Adding additional commits and check that the GHA triggered by the latest commit waited for the previous GHA to finish.

## Notes for Reviewer
