### PR TITLE
fix: bump processing scanpy version 1.6.0 -> 1.9.3

### DIFF
--- a/requirements-processing.txt
+++ b/requirements-processing.txt
@@ -29,7 +29,7 @@ requests>=2.22.0
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
 ruff==0.0.239 # Must be kept in sync with ruff version in .pre-commit-config.yaml
 s3fs==0.4.2
-scanpy==1.6.0
+scanpy==1.9.3
 SQLAlchemy>=1.4.0,<1.5
 SQLAlchemy-Utils>=0.36.8
 tenacity


### PR DESCRIPTION
## Reason for Change

- #5907

## Changes

- modify scanpy version in processing requirements. 1.6.0 -> 1.9.3

## Testing steps

- Processing tests are no longer broken

## Notes for Reviewer
