### PR TITLE
test(wmg): additional test coverage for tissue auto expand 5827

### DIFF
--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -10,6 +10,26 @@ const TISSUE_FILTER_TEST_ID = "tissue-filter";
 const CELL_TYPE_FILTER_TEST_ID = "celltype-filter";
 const CELL_TYPE_FILTERS = ["B cell", "B-1a B cell", "B-1b B cell"];
 const CELL_TYPE_TEST_ID = "cell-type-name";
+const SEX_FILTER_TEST_ID = "sex-filter";
+const SEX_FILTER_LABEL = "Sex";
+const SEX_FILTER_SELECTION = "female";
+const PUBLICATION_FILTER_TEST_ID = "publication-filter";
+const PUBLICATION_FILTER_LABEL = "Publication";
+const PUBLICATION_FILTER_SELECTION = [
+  "Ahern et al. Cell 2022",
+  "Arutyunyan et al. Nature 2023",
+];
+const SELF_REPORTED_ETHNICITY_FILTER_TEST_ID = "self-reported-ethnicity-filter";
+const SELF_REPORTED_ETHNICITY_FILTER_LABEL = "Self-Reported Ethnicity";
+const SELF_REPORTED_ETHNICITY_FILTER_SELECTION = "African";
+const SELF_REPORTED_ETHNICITY_TISSUE = ["breast"];
+const DISEASE_FILTER_TEST_ID = "disease-filter";
+const DISEASE_FILTER_LABEL = "Disease";
+const DISEASE_FILTER_SELECTION = "influenza";
+const DATASET_FILTER_TEST_ID = "dataset-filter";
+const DATASET_FILTER_LABEL = "Dataset";
+const DATASET_FILTER_SELECTION =
+  "Combined samples HTAN MSK - Single cell profiling reveals novel tumor and myeloid subpopulations in small cell lung cancer";
 
 const { describe } = test;
 
@@ -25,6 +45,7 @@ describe("WMG tissue auto-expand", () => {
     await filterTissues(page);
     await checkTissues(page);
   });
+
   /**
    * Filter first two tissues from the left panel, collapse the first
    * tissue, add third tissue from the left panel. Expect the first tissue
@@ -39,6 +60,7 @@ describe("WMG tissue auto-expand", () => {
     await filterTissues(page, FILTERED_TISSUES.slice(2, 3));
     await checkTissues(page, FILTERED_TISSUES, FILTERED_TISSUES.slice(1, 3));
   });
+
   /**
    * Filter two tissues, expect tissues to be expanded. Remove both tissues
    * from filter. Expect showing all tissues in collapsed state.
@@ -52,6 +74,7 @@ describe("WMG tissue auto-expand", () => {
     await filterTissues(page);
     await checkTissues(page, [], []);
   });
+
   /**
    * Filter two tissues, expect tissues to be expanded. Expect tissue list
    * to only show tissues that contain "B cell" and automatically expanded.
@@ -70,6 +93,7 @@ describe("WMG tissue auto-expand", () => {
     await removeCellFilter(page);
     await expect(checkCellTypes(page)).rejects.toThrow();
   });
+
   /**
    * Filter cell type auto expansion - override tissue filter collapse state
    * Filter first 2 tissues in left panel, collapse both tissues, filter "B
@@ -88,6 +112,7 @@ describe("WMG tissue auto-expand", () => {
     await checkTissues(page, tissues);
     await checkCellTypes(page, cells);
   });
+
   /**
    * Filter 3 tissues, filter top 3 cell types
    * (B cell, B-1a B cell, and B-1b B cell). Expect both tissues expanded.
@@ -106,7 +131,182 @@ describe("WMG tissue auto-expand", () => {
     await checkTissues(page, ["lung"], []);
     await checkCellTypes(page, cells);
   });
+
+  /**
+   * Tissue auto expansion - cross filter with Sex filter selected
+   * Filter Female from Sex filter. Filter Abdomen and Blood from the Tissue
+   * filter - those should be expanded, Add Cell type filtering,
+   * only B Cell type should appear and expanded.
+   */
+  test("Tissue auto expansion - cross filter with Sex filter selected", async ({
+    page,
+  }) => {
+    const tissues = FILTERED_TISSUES.slice(0, 1);
+    await loadPageAndTissues(page);
+    await filterSelection(
+      page,
+      SEX_FILTER_TEST_ID,
+      SEX_FILTER_LABEL,
+      SEX_FILTER_SELECTION
+    );
+    await filterTissues(page, tissues);
+    await filterCellType(page, 1);
+    await checkTissues(page, tissues);
+  });
+
+  /**
+   * Tissue auto expansion - cross filter with Sex filter, check expansion
+   * Filter 3 Tissues ["abdomen", "axilla", "blood"]. Collapse Abdomen. Select
+   * Female from the Sex filter. Tissue filter should now only have Abdomen and
+   * Blood selected. Only Abdomen and Blood should be visible. Abdomen should
+   * remain collapsed. Remove Sex filter. Tissue filter should now only have
+   * Abdomen and Blood selected. Only Abdomen and Blood should be visible.
+   * Abdomen should remain collapsed.
+   */
+  test("Tissue auto expansion - cross filter with Sex filter, check expansion", async ({
+    page,
+  }) => {
+    const filteredTissues = FILTERED_TISSUES.slice();
+    const expandedTissues = filteredTissues.slice();
+    await loadPageAndTissues(page);
+    await filterTissues(page, filteredTissues);
+    await collapseTissue(page, filteredTissues[0]);
+    expandedTissues.splice(0, 2);
+    await filterSelection(
+      page,
+      SEX_FILTER_TEST_ID,
+      SEX_FILTER_LABEL,
+      SEX_FILTER_SELECTION
+    );
+    filteredTissues.splice(1, 1); // remove axilla
+    await expect(page.getByTestId(TISSUE_NODE_TEST_ID)).toHaveCount(2);
+    await checkTissues(page, filteredTissues, expandedTissues);
+  });
+
+  /**
+   * Tissue auto expansion - cross filter with Publication filter selected
+   * Filter 'Ahren et al. Cell 2022' from the Publication filter. Filter Blood
+   * from the tissue filter. Blood should be expanded. Collapse Blood. add Cell
+   * filter for B Cell. Only B Cell should appear and Blood should be expanded.
+   */
+  test("Tissue auto expansion - cross filter with Publication filter selected", async ({
+    page,
+  }) => {
+    const tissues = FILTERED_TISSUES.slice(2, 3);
+    await loadPageAndTissues(page);
+    await filterSelection(
+      page,
+      PUBLICATION_FILTER_TEST_ID,
+      PUBLICATION_FILTER_LABEL,
+      PUBLICATION_FILTER_SELECTION[0]
+    );
+    await filterTissues(page, tissues);
+    await collapseTissue(page, tissues[0]);
+    await filterCellType(page, 1);
+    await checkTissues(page, tissues);
+    await checkCellTypes(page);
+  });
+
+  /**
+   * Tissue auto expansion - cross filter with Publication filter, check expansion
+   * Filter 3 Tissues ["abdomen", "axilla", "blood"]. Collapse Brain. Filter
+   * 'Ahren et al. Neuron 2021' from the Publication filter. Only Brain should remain
+   * visible and collapsed. Add Cell filter for B Cell. Only B Cell should be
+   * visible under expanded Blood tissue node
+   */
+  test("Tissue auto expansion - cross filter with Publication filter, check expansion", async ({
+    page,
+  }) => {
+    await loadPageAndTissues(page);
+    await filterTissues(page);
+    await collapseTissue(page, FILTERED_TISSUES[2]);
+    await filterSelection(
+      page,
+      PUBLICATION_FILTER_TEST_ID,
+      PUBLICATION_FILTER_LABEL,
+      PUBLICATION_FILTER_SELECTION[1]
+    );
+    await expect(page.getByTestId(TISSUE_NODE_TEST_ID)).toHaveCount(1);
+    await checkTissues(page, FILTERED_TISSUES.slice(2, 3), []);
+  });
+
+  /**
+   * Tissue auto expansion - cross filter with Self-Reported Ethnicity filter
+   * Expand Breast. Select African from Ethnicity filter. Breast should remain expanded.
+   * Add Nose to the Tissue filter. Nose should appear expanded.
+   */
+  test("Tissue auto expansion - cross filter with Self-Reported Ethnicity filter", async ({
+    page,
+  }) => {
+    await loadPageAndTissues(page);
+    await expandTissue(page, SELF_REPORTED_ETHNICITY_TISSUE[0]);
+    await filterSelection(
+      page,
+      SELF_REPORTED_ETHNICITY_FILTER_TEST_ID,
+      SELF_REPORTED_ETHNICITY_FILTER_LABEL,
+      SELF_REPORTED_ETHNICITY_FILTER_SELECTION
+    );
+    await filterTissues(page, SELF_REPORTED_ETHNICITY_TISSUE);
+    await checkTissues(page, SELF_REPORTED_ETHNICITY_TISSUE);
+  });
+
+  /**
+   * Tissue auto expansion - cross filter with Disease filter
+   * Filter 3 Tissues ["abdomen", "axilla", "brain"]. From the Disease filter select influenza.
+   * Blood should appear only and expanded. Add cell type filter for B Cell. Only B Cell should
+   * appear under Blood and expanded. Remove influenza. Blood should remain expanded and cell count
+   * increase.
+   */
+  test("Tissue auto expansion - cross filter with Disease filter", async ({
+    page,
+  }) => {
+    const tissues = FILTERED_TISSUES.slice(2, 3);
+    await loadPageAndTissues(page);
+    await filterTissues(page);
+    await filterSelection(
+      page,
+      DISEASE_FILTER_TEST_ID,
+      DISEASE_FILTER_LABEL,
+      DISEASE_FILTER_SELECTION
+    );
+    await checkTissues(page, tissues);
+    await filterCellType(page, 1);
+    await checkCellTypes(page);
+    await checkTissues(page, tissues);
+    await removeCellFilter(page);
+    await checkTissues(page, tissues);
+  });
+
+  /**
+   * Tissue auto expansion - cross filter with Dataset filter
+   * Filter 3 Tissues ["abdomen", "axilla", "Brain"]. From the Dataset filter select Combined Samples.
+   * Axilla and Brain should appear only and expanded. Add cell type filter for B Cell. Only B Cell
+   * should appear under Axilla and Brain and expanded. Remove B Cell. Remove Combined Samples. Brain
+   */
+  test("Tissue auto expansion - cross filter with Dataset filter", async ({
+    page,
+  }) => {
+    let tissues = FILTERED_TISSUES.slice(0, 2);
+    tissues = [...tissues, "brain"];
+
+    await loadPageAndTissues(page);
+    await filterTissues(page, tissues);
+    await filterSelection(
+      page,
+      DATASET_FILTER_TEST_ID,
+      DATASET_FILTER_LABEL,
+      DATASET_FILTER_SELECTION
+    );
+    tissues.splice(0, 1);
+    await checkTissues(page, tissues);
+    await filterCellType(page, 1);
+    await checkCellTypes(page);
+    await checkTissues(page, tissues);
+    await removeCellFilter(page);
+    await checkTissues(page, tissues);
+  });
 });
+
 /**
  * *******************************************
  * Helper Functions
@@ -126,10 +326,14 @@ async function loadPageAndTissues(page: Page) {
  * clickIntoFilter
  * Click into the filter and wait for the tooltip to be visible
  */
-async function clickIntoFilter(page: Page, filterName: string) {
+async function clickIntoFilter(
+  page: Page,
+  filterName: string,
+  filterLabel = TISSUE_FILTER_LABEL
+) {
   await page
     .getByTestId(filterName)
-    .getByRole("button", { name: TISSUE_FILTER_LABEL, exact: true })
+    .getByRole("button", { name: filterLabel, exact: true })
     .click();
   await page.getByRole("tooltip").waitFor();
 }
@@ -214,4 +418,20 @@ async function removeCellFilter(page: Page) {
     .getByTestId(`cell-type-tag-${CELL_TYPE_FILTERS[0]}`)
     .getByTestId("CancelIcon")
     .click();
+}
+
+/**
+ * filterSelection
+ * Filter the selection from the filter
+ */
+async function filterSelection(
+  page: Page,
+  filterTestId: string,
+  filterLabel: string,
+  selection: string
+) {
+  await clickIntoFilter(page, filterTestId, filterLabel);
+  await page.getByRole("option", { name: selection, exact: true }).isVisible();
+  await page.getByRole("option", { name: selection, exact: true }).click();
+  await page.keyboard.press("Escape");
 }

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -22,7 +22,7 @@ const PUBLICATION_FILTER_SELECTION = [
 const SELF_REPORTED_ETHNICITY_FILTER_TEST_ID = "self-reported-ethnicity-filter";
 const SELF_REPORTED_ETHNICITY_FILTER_LABEL = "Self-Reported Ethnicity";
 const SELF_REPORTED_ETHNICITY_FILTER_SELECTION = "African";
-const SELF_REPORTED_ETHNICITY_TISSUE = ["breast"];
+const SELF_REPORTED_ETHNICITY_TISSUE = ["breast", "nose"];
 const DISEASE_FILTER_TEST_ID = "disease-filter";
 const DISEASE_FILTER_LABEL = "Disease";
 const DISEASE_FILTER_SELECTION = "influenza";
@@ -241,7 +241,7 @@ describe("WMG tissue auto-expand", () => {
   /**
    * Tissue auto expansion - cross filter with Self-Reported Ethnicity filter
    * Expand Breast. Select African from Ethnicity filter. Breast should remain expanded.
-   * Add Nose to the Tissue filter. Nose should appear expanded.
+   * Add Breast and Nose to the Tissue filter. Both should appear expanded.
    */
   test("Tissue auto expansion - cross filter with Self-Reported Ethnicity filter", async ({
     page,

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -268,7 +268,7 @@ describe("WMG tissue auto-expand", () => {
   test("Tissue auto expansion - cross filter with Disease filter", async ({
     page,
   }) => {
-    const tissues = FILTERED_TISSUES.slice(2, 3);
+    const tissues = ["blood"];
     await loadPageAndTissues(page);
     await filterTissues(page);
     await filterSelection(
@@ -294,9 +294,7 @@ describe("WMG tissue auto-expand", () => {
   test("Tissue auto expansion - cross filter with Dataset filter", async ({
     page,
   }) => {
-    let tissues = FILTERED_TISSUES.slice(0, 2);
-    tissues = [...tissues, "brain"];
-
+    const tissues = ["abdomen", "axilla", "brain"];
     await loadPageAndTissues(page);
     await filterTissues(page, tissues);
     await filterSelection(

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -345,24 +345,7 @@ async function clickIntoFilter(
 }
 
 /**
- * filterCellType
- * Filter cell type 'B cell' and exit filter mode
- */
-// async function filterCellType(page: Page, count = 3) {
-//   await page
-//     .getByTestId(CELL_TYPE_FILTER_TEST_ID)
-//     .getByRole("combobox")
-//     .click();
-//   for (let i = 0; i < count; i++) {
-//     await page
-//       .getByRole("option", { name: CELL_TYPE_FILTERS[i], exact: true })
-//       .click();
-//   }
-//   await page.keyboard.press("Escape");
-// }
-
-/**
- * filterCellType
+ * filterCellTypes
  * Add cell types to the cell type filter
  */
 async function filterCellTypes(page: Page, cellTypes: string[]) {

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -31,10 +31,12 @@ const DATASET_FILTER_LABEL = "Dataset";
 const DATASET_FILTER_SELECTION =
   "Combined samples HTAN MSK - Single cell profiling reveals novel tumor and myeloid subpopulations in small cell lung cancer";
 const DATASET_FILTER_SELECTED = "Combined samples";
+const DATASET_FILTER_FILTERED_TISSUES = ["axilla", "brain"];
 const EXPECTED_FILTERED_TISSUES_WITH_SEX_FILTER = ["abdomen", "blood"];
 const EXPECTED_EXPANDED_TISSUES = ["blood"];
 const EXPECTED_VISIBLE_CELL = ["B Cell"];
 const EXPECTED_FILTERED_TISSUES_WITH_DATASET_FILTER = ["axilla", "brain"];
+const EXPECTED_FILTERED_TISSUES_WITH_DISEASE_FILTER = ["blood"];
 
 const { describe } = test;
 
@@ -92,7 +94,7 @@ describe("WMG tissue auto-expand", () => {
   }) => {
     await loadPageAndTissues(page);
     await filterTissues(page);
-    await filterCellType(page, 1);
+    await filterCellTypes(page, CELL_TYPE_FILTERS.slice(0, 1));
     await checkTissues(page);
     await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
     await removeCellFilter(page);
@@ -114,7 +116,7 @@ describe("WMG tissue auto-expand", () => {
     await filterTissues(page, tissues);
     await collapseTissue(page, tissues[0]);
     await collapseTissue(page, tissues[1]);
-    await filterCellType(page, 1);
+    await filterCellTypes(page, CELL_TYPE_FILTERS.slice(0, 1));
     await checkTissues(page, tissues);
     await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
   });
@@ -131,7 +133,7 @@ describe("WMG tissue auto-expand", () => {
     const cells = CELL_TYPE_FILTERS.slice(1, 3);
     await loadPageAndTissues(page);
     await filterTissues(page);
-    await filterCellType(page);
+    await filterCellTypes(page, CELL_TYPE_FILTERS);
     await checkTissues(page);
     await removeCellFilter(page);
     await checkTissues(page, ["lung"], []);
@@ -155,7 +157,7 @@ describe("WMG tissue auto-expand", () => {
       SEX_FILTER_SELECTION
     );
     await filterTissues(page, EXPECTED_FILTERED_TISSUES_WITH_SEX_FILTER);
-    await filterCellType(page, 1);
+    await filterCellTypes(page, CELL_TYPE_FILTERS.slice(0, 1));
     await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_SEX_FILTER);
     await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
   });
@@ -210,7 +212,7 @@ describe("WMG tissue auto-expand", () => {
     );
     await filterTissues(page, tissues);
     await collapseTissue(page, tissues[0]);
-    await filterCellType(page, 1);
+    await filterCellTypes(page, CELL_TYPE_FILTERS.slice(0, 1));
     await checkTissues(page, tissues);
     await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
   });
@@ -268,7 +270,6 @@ describe("WMG tissue auto-expand", () => {
   test("Tissue auto expansion - cross filter with Disease filter", async ({
     page,
   }) => {
-    const tissues = ["blood"];
     await loadPageAndTissues(page);
     await filterTissues(page);
     await filterSelection(
@@ -277,12 +278,12 @@ describe("WMG tissue auto-expand", () => {
       DISEASE_FILTER_LABEL,
       DISEASE_FILTER_SELECTION
     );
-    await checkTissues(page, tissues);
-    await filterCellType(page, 1);
+    await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_DISEASE_FILTER);
+    await filterCellTypes(page, CELL_TYPE_FILTERS.slice(0, 1));
     await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
-    await checkTissues(page, tissues);
+    await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_DISEASE_FILTER);
     await removeCellFilter(page);
-    await checkTissues(page, tissues);
+    await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_DISEASE_FILTER);
   });
 
   /**
@@ -294,9 +295,8 @@ describe("WMG tissue auto-expand", () => {
   test("Tissue auto expansion - cross filter with Dataset filter", async ({
     page,
   }) => {
-    const tissues = ["abdomen", "axilla", "brain"];
     await loadPageAndTissues(page);
-    await filterTissues(page, tissues);
+    await filterTissues(page, DATASET_FILTER_FILTERED_TISSUES);
     await filterSelection(
       page,
       DATASET_FILTER_TEST_ID,
@@ -305,7 +305,7 @@ describe("WMG tissue auto-expand", () => {
       DATASET_FILTER_SELECTED
     );
     await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_DATASET_FILTER);
-    await filterCellType(page, 1);
+    await filterCellTypes(page, CELL_TYPE_FILTERS.slice(0, 1));
     await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
     await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_DATASET_FILTER);
     await removeCellFilter(page);
@@ -348,16 +348,33 @@ async function clickIntoFilter(
  * filterCellType
  * Filter cell type 'B cell' and exit filter mode
  */
-async function filterCellType(page: Page, count = 3) {
+// async function filterCellType(page: Page, count = 3) {
+//   await page
+//     .getByTestId(CELL_TYPE_FILTER_TEST_ID)
+//     .getByRole("combobox")
+//     .click();
+//   for (let i = 0; i < count; i++) {
+//     await page
+//       .getByRole("option", { name: CELL_TYPE_FILTERS[i], exact: true })
+//       .click();
+//   }
+//   await page.keyboard.press("Escape");
+// }
+
+/**
+ * filterCellType
+ * Add cell types to the cell type filter
+ */
+async function filterCellTypes(page: Page, cellTypes: string[]) {
   await page
     .getByTestId(CELL_TYPE_FILTER_TEST_ID)
     .getByRole("combobox")
     .click();
-  for (let i = 0; i < count; i++) {
-    await page
-      .getByRole("option", { name: CELL_TYPE_FILTERS[i], exact: true })
-      .click();
+
+  for (const cellType of cellTypes) {
+    await page.getByRole("option", { name: cellType, exact: true }).click();
   }
+
   await page.keyboard.press("Escape");
 }
 

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -34,6 +34,7 @@ const DATASET_FILTER_SELECTED = "Combined samples";
 const EXPECTED_FILTERED_TISSUES_WITH_SEX_FILTER = ["abdomen", "blood"];
 const EXPECTED_EXPANDED_TISSUES = ["blood"];
 const EXPECTED_VISIBLE_CELL = ["B Cell"];
+const EXPECTED_FILTERED_TISSUES_WITH_DATASET_FILTER = ["axilla", "brain"];
 
 const { describe } = test;
 
@@ -305,13 +306,12 @@ describe("WMG tissue auto-expand", () => {
       DATASET_FILTER_SELECTION,
       DATASET_FILTER_SELECTED
     );
-    tissues.splice(0, 1);
-    await checkTissues(page, tissues);
+    await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_DATASET_FILTER);
     await filterCellType(page, 1);
     await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
-    await checkTissues(page, tissues);
+    await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_DATASET_FILTER);
     await removeCellFilter(page);
-    await checkTissues(page, tissues);
+    await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_DATASET_FILTER);
   });
 });
 

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -33,6 +33,7 @@ const DATASET_FILTER_SELECTION =
 const DATASET_FILTER_SELECTED = "Combined samples";
 const EXPECTED_FILTERED_TISSUES_WITH_SEX_FILTER = ["abdomen", "blood"];
 const EXPECTED_EXPANDED_TISSUES = ["blood"];
+const EXPECTED_VISIBLE_CELL = ["B Cell"];
 
 const { describe } = test;
 
@@ -92,11 +93,7 @@ describe("WMG tissue auto-expand", () => {
     await filterTissues(page);
     await filterCellType(page, 1);
     await checkTissues(page);
-    await checkElementVisible(
-      page,
-      CELL_TYPE_FILTERS.slice(0, 1),
-      CELL_TYPE_TEST_ID
-    );
+    await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
     await removeCellFilter(page);
     await expect(
       checkElementVisible(page, CELL_TYPE_FILTERS, CELL_TYPE_TEST_ID)
@@ -112,7 +109,7 @@ describe("WMG tissue auto-expand", () => {
     page,
   }) => {
     const tissues = FILTERED_TISSUES.slice(0, 2);
-    const cells = CELL_TYPE_FILTERS.slice(0, 1);
+    const cells = EXPECTED_VISIBLE_CELL;
     await loadPageAndTissues(page);
     await filterTissues(page, tissues);
     await collapseTissue(page, tissues[0]);
@@ -150,7 +147,6 @@ describe("WMG tissue auto-expand", () => {
   test("Tissue auto expansion - cross filter with Sex filter selected", async ({
     page,
   }) => {
-    const tissues = FILTERED_TISSUES.slice(0, 1);
     await loadPageAndTissues(page);
     await filterSelection(
       page,
@@ -158,9 +154,10 @@ describe("WMG tissue auto-expand", () => {
       SEX_FILTER_LABEL,
       SEX_FILTER_SELECTION
     );
-    await filterTissues(page, tissues);
+    await filterTissues(page, EXPECTED_FILTERED_TISSUES_WITH_SEX_FILTER);
     await filterCellType(page, 1);
-    await checkTissues(page, tissues);
+    await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_SEX_FILTER);
+    await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
   });
 
   /**
@@ -215,11 +212,7 @@ describe("WMG tissue auto-expand", () => {
     await collapseTissue(page, tissues[0]);
     await filterCellType(page, 1);
     await checkTissues(page, tissues);
-    await checkElementVisible(
-      page,
-      CELL_TYPE_FILTERS.slice(0, 1),
-      CELL_TYPE_TEST_ID
-    );
+    await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
   });
 
   /**
@@ -286,11 +279,7 @@ describe("WMG tissue auto-expand", () => {
     );
     await checkTissues(page, tissues);
     await filterCellType(page, 1);
-    await checkElementVisible(
-      page,
-      CELL_TYPE_FILTERS.slice(0, 1),
-      CELL_TYPE_TEST_ID
-    );
+    await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
     await checkTissues(page, tissues);
     await removeCellFilter(page);
     await checkTissues(page, tissues);
@@ -320,11 +309,7 @@ describe("WMG tissue auto-expand", () => {
     tissues.splice(0, 1);
     await checkTissues(page, tissues);
     await filterCellType(page, 1);
-    await checkElementVisible(
-      page,
-      CELL_TYPE_FILTERS.slice(0, 1),
-      CELL_TYPE_TEST_ID
-    );
+    await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
     await checkTissues(page, tissues);
     await removeCellFilter(page);
     await checkTissues(page, tissues);

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -109,14 +109,13 @@ describe("WMG tissue auto-expand", () => {
     page,
   }) => {
     const tissues = FILTERED_TISSUES.slice(0, 2);
-    const cells = EXPECTED_VISIBLE_CELL;
     await loadPageAndTissues(page);
     await filterTissues(page, tissues);
     await collapseTissue(page, tissues[0]);
     await collapseTissue(page, tissues[1]);
     await filterCellType(page, 1);
     await checkTissues(page, tissues);
-    await checkElementVisible(page, cells, CELL_TYPE_TEST_ID);
+    await checkElementVisible(page, EXPECTED_VISIBLE_CELL, CELL_TYPE_TEST_ID);
   });
 
   /**

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -31,6 +31,8 @@ const DATASET_FILTER_LABEL = "Dataset";
 const DATASET_FILTER_SELECTION =
   "Combined samples HTAN MSK - Single cell profiling reveals novel tumor and myeloid subpopulations in small cell lung cancer";
 const DATASET_FILTER_SELECTED = "Combined samples";
+const EXPECTED_FILTERED_TISSUES_WITH_SEX_FILTER = ["abdomen", "blood"];
+const EXPECTED_EXPANDED_TISSUES = ["blood"];
 
 const { describe } = test;
 
@@ -90,7 +92,11 @@ describe("WMG tissue auto-expand", () => {
     await filterTissues(page);
     await filterCellType(page, 1);
     await checkTissues(page);
-    await checkElementVisible(page, CELL_TYPE_FILTERS, CELL_TYPE_TEST_ID);
+    await checkElementVisible(
+      page,
+      CELL_TYPE_FILTERS.slice(0, 1),
+      CELL_TYPE_TEST_ID
+    );
     await removeCellFilter(page);
     await expect(
       checkElementVisible(page, CELL_TYPE_FILTERS, CELL_TYPE_TEST_ID)
@@ -169,21 +175,23 @@ describe("WMG tissue auto-expand", () => {
   test("Tissue auto expansion - cross filter with Sex filter, check expansion", async ({
     page,
   }) => {
-    const filteredTissues = FILTERED_TISSUES.slice();
-    const expandedTissues = filteredTissues.slice();
     await loadPageAndTissues(page);
-    await filterTissues(page, filteredTissues);
-    await collapseTissue(page, filteredTissues[0]);
-    expandedTissues.splice(0, 2);
+    await filterTissues(page, FILTERED_TISSUES);
+    await collapseTissue(page, FILTERED_TISSUES[0]);
     await filterSelection(
       page,
       SEX_FILTER_TEST_ID,
       SEX_FILTER_LABEL,
       SEX_FILTER_SELECTION
     );
-    filteredTissues.splice(1, 1); // remove axilla
-    await expect(page.getByTestId(TISSUE_NODE_TEST_ID)).toHaveCount(2);
-    await checkTissues(page, filteredTissues, expandedTissues);
+    await expect(page.getByTestId(TISSUE_NODE_TEST_ID)).toHaveCount(
+      EXPECTED_FILTERED_TISSUES_WITH_SEX_FILTER.length
+    );
+    await checkTissues(
+      page,
+      EXPECTED_FILTERED_TISSUES_WITH_SEX_FILTER,
+      EXPECTED_EXPANDED_TISSUES
+    );
   });
 
   /**
@@ -207,7 +215,11 @@ describe("WMG tissue auto-expand", () => {
     await collapseTissue(page, tissues[0]);
     await filterCellType(page, 1);
     await checkTissues(page, tissues);
-    await checkElementVisible(page, CELL_TYPE_FILTERS, CELL_TYPE_TEST_ID);
+    await checkElementVisible(
+      page,
+      CELL_TYPE_FILTERS.slice(0, 1),
+      CELL_TYPE_TEST_ID
+    );
   });
 
   /**
@@ -274,7 +286,11 @@ describe("WMG tissue auto-expand", () => {
     );
     await checkTissues(page, tissues);
     await filterCellType(page, 1);
-    await checkElementVisible(page, CELL_TYPE_FILTERS, CELL_TYPE_TEST_ID);
+    await checkElementVisible(
+      page,
+      CELL_TYPE_FILTERS.slice(0, 1),
+      CELL_TYPE_TEST_ID
+    );
     await checkTissues(page, tissues);
     await removeCellFilter(page);
     await checkTissues(page, tissues);
@@ -304,7 +320,11 @@ describe("WMG tissue auto-expand", () => {
     tissues.splice(0, 1);
     await checkTissues(page, tissues);
     await filterCellType(page, 1);
-    await checkElementVisible(page, CELL_TYPE_FILTERS, CELL_TYPE_TEST_ID);
+    await checkElementVisible(
+      page,
+      CELL_TYPE_FILTERS.slice(0, 1),
+      CELL_TYPE_TEST_ID
+    );
     await checkTissues(page, tissues);
     await removeCellFilter(page);
     await checkTissues(page, tissues);
@@ -422,7 +442,9 @@ async function checkElementVisible(
       const elements = await (
         await page.getByTestId(testId).allInnerTexts()
       ).map((str) => str.toLowerCase());
-      expect(elements).toEqual(expect.arrayContaining(filteredElements));
+      expect(elements).toEqual(
+        expect.arrayContaining(filteredElements.map((str) => str.toLowerCase()))
+      );
     },
     { page }
   );

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -200,7 +200,7 @@ describe("WMG tissue auto-expand", () => {
   test("Tissue auto expansion - cross filter with Publication filter selected", async ({
     page,
   }) => {
-    const tissues = FILTERED_TISSUES.slice(2, 3);
+    const tissues = ["blood"];
     await loadPageAndTissues(page);
     await filterSelection(
       page,
@@ -217,8 +217,8 @@ describe("WMG tissue auto-expand", () => {
 
   /**
    * Tissue auto expansion - cross filter with Publication filter, check expansion
-   * Filter 3 Tissues ["abdomen", "axilla", "blood"]. Collapse Brain. Filter
-   * 'Ahren et al. Neuron 2021' from the Publication filter. Only Brain should remain
+   * Filter 3 Tissues ["abdomen", "axilla", "blood"]. Collapse Blood. Filter
+   * 'Ahren et al. Neuron 2021' from the Publication filter. Only Blood should remain
    * visible and collapsed. Add Cell filter for B Cell. Only B Cell should be
    * visible under expanded Blood tissue node
    */
@@ -227,7 +227,7 @@ describe("WMG tissue auto-expand", () => {
   }) => {
     await loadPageAndTissues(page);
     await filterTissues(page);
-    await collapseTissue(page, FILTERED_TISSUES[2]);
+    await collapseTissue(page, "blood");
     await filterSelection(
       page,
       PUBLICATION_FILTER_TEST_ID,
@@ -235,7 +235,7 @@ describe("WMG tissue auto-expand", () => {
       PUBLICATION_FILTER_SELECTION[1]
     );
     await expect(page.getByTestId(TISSUE_NODE_TEST_ID)).toHaveCount(1);
-    await checkTissues(page, FILTERED_TISSUES.slice(2, 3), []);
+    await checkTissues(page, ["blood"], []);
   });
 
   /**


### PR DESCRIPTION
## Reason for Change

This PR is Part 2 of Tissue Auto Expand test coverage. Part 1 was merged [here](https://github.com/chanzuckerberg/single-cell-data-portal/pull/5884).

[Add extensive test coverage for tissue expansion 5827
](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/5827)

