### PR TITLE
feat: Add network guard

### DIFF
--- a/frontend/src/common/networkGuard.ts
+++ b/frontend/src/common/networkGuard.ts
@@ -1,0 +1,67 @@
+import { isSSR } from "src/common/utils/isSSR";
+
+export const TOO_MANY_REQUESTS_ERROR_MESSAGE_PREFIX =
+  "Too many requests detected. Canceling the current and all future requests. Request count: ";
+
+let requestCount = 0;
+const TIMEOUT_MS = 5 * 1000; // 5 seconds in milliseconds
+const maxRequests = 20;
+let timeoutExpiration = 0;
+let hasReachedMaxRequests = false;
+
+type FetchArgs = [input: RequestInfo | URL, init?: RequestInit | undefined];
+
+export function networkGuard() {
+  if (isSSR()) return;
+
+  // Intercept network requests
+  const originalFetch = window.fetch;
+
+  window.fetch = newFetch;
+
+  function newFetch(...args: FetchArgs) {
+    requestCount++;
+
+    if (!timeoutExpiration) {
+      setTimeoutExpiration();
+    }
+
+    /**
+     * (thuang): Check if the time window has expired
+     * WARNING: If we've reached the max number of requests, we will no longer
+     * reset the `requestCount`, and thus no new requests will be made until the
+     * page is refreshed.
+     */
+    if (!hasReachedMaxRequests && Date.now() > timeoutExpiration) {
+      resetRequestCount();
+      setTimeoutExpiration();
+    }
+
+    hasReachedMaxRequests = requestCount > maxRequests;
+
+    /**
+     * (thuang): Check if the number of requests exceeds the limit
+     */
+    if (hasReachedMaxRequests) {
+      const message = tooManyRequestsErrorMessage(requestCount);
+
+      console.error(message);
+      throw Error(message);
+    }
+
+    return originalFetch.apply(window, args);
+  }
+}
+
+// Function to reset the request counter after the time window
+function resetRequestCount() {
+  requestCount = 0;
+}
+
+function setTimeoutExpiration() {
+  timeoutExpiration = Date.now() + TIMEOUT_MS;
+}
+
+function tooManyRequestsErrorMessage(requestCount: number) {
+  return TOO_MANY_REQUESTS_ERROR_MESSAGE_PREFIX + requestCount;
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { EVENTS } from "src/common/analytics/events";
 import { checkFeatureFlags } from "src/common/featureFlags";
+import { networkGuard } from "src/common/networkGuard";
 import { theme } from "src/common/theme";
 import DefaultLayout from "src/components/Layout/components/defaultLayout";
 import configs from "src/configs/configs";
@@ -30,6 +31,7 @@ declare global {
 const queryClient = new QueryClient();
 
 checkFeatureFlags();
+networkGuard();
 
 type NextPageWithLayout = NextPage & {
   Layout?: FC;

--- a/frontend/src/views/WheresMyGene/components/Filters/components/Compare/connect.ts
+++ b/frontend/src/views/WheresMyGene/components/Filters/components/Compare/connect.ts
@@ -43,6 +43,8 @@ export const useConnect = ({ areFiltersDisabled }: Props) => {
    * Warning(thuang): `handleChange` CANNOT depend on `optionLabel`, since a new
    * handleChange passed to SDS Dropdown will trigger another onChange event with the old value,
    * causing infinite loop
+   * Action Item: We can depend on `optionLabel` again after https://github.com/chanzuckerberg/sci-components/pull/620
+   * is released
    */
   const handleChange = useCallback(
     (value: DefaultDropdownMenuOption | null) => {
@@ -60,7 +62,7 @@ export const useConnect = ({ areFiltersDisabled }: Props) => {
         )
       );
     },
-    [dispatch, optionLabelRef]
+    [dispatch]
   );
   return {
     handleChange,

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -4,6 +4,8 @@
 
 1. Do **NOT** import `.tsx` files in your tests, otherwise we'll get weird parsing errors, due to Playwright parser not parsing SVG files at the moment.
 
+1. Use `test` from `import { test } from "tests/common/test"` instead of `import { test } from "@playwright/test"`
+
 ## How to run E2E tests from your local machine
 
 See the [#how](#how) section

--- a/frontend/tests/common/playwright.global.preSetup.ts
+++ b/frontend/tests/common/playwright.global.preSetup.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test } from "tests/common/test";
 import { getAccessToken } from "tests/utils/helpers";
 
 const { describe } = test;

--- a/frontend/tests/common/test.ts
+++ b/frontend/tests/common/test.ts
@@ -1,0 +1,27 @@
+import { test as base, expect } from "@playwright/test";
+import { TOO_MANY_REQUESTS_ERROR_MESSAGE_PREFIX } from "src/common/networkGuard";
+
+/**
+ * (thuang): Use this `test` object instead of the one from playwright/test
+ */
+export const test = base.extend<{ saveLogs: void }>({
+  page: async ({ page }, use) => {
+    const errors: string[] = [];
+
+    page.on("console", (message) => {
+      if (message.type() !== "error") return;
+
+      const text = message.text();
+
+      if (text.includes(TOO_MANY_REQUESTS_ERROR_MESSAGE_PREFIX)) {
+        errors.push(text);
+        console.error(text);
+        throw Error(text);
+      }
+    });
+
+    await use(page);
+
+    expect(errors).toHaveLength(0);
+  },
+});

--- a/frontend/tests/features/cellGuide/cellGuide.test.ts
+++ b/frontend/tests/features/cellGuide/cellGuide.test.ts
@@ -1,4 +1,4 @@
-import { test, Page, expect, Locator } from "@playwright/test";
+import { Page, expect, Locator } from "@playwright/test";
 import { ROUTES } from "src/common/constants/routes";
 import {
   goToPage,
@@ -67,6 +67,7 @@ import {
   CELLGUIDE_INFO_SIDEBAR_TEST_ID,
   CELLGUIDE_VIEW_PAGE_SIDEBAR_BUTTON_TEST_ID,
 } from "src/views/CellGuide/components/CellGuideInfoSideBar/constants";
+import { test } from "tests/common/test";
 
 const { describe } = test;
 

--- a/frontend/tests/features/collection/util.test.ts
+++ b/frontend/tests/features/collection/util.test.ts
@@ -3,8 +3,9 @@
  */
 
 // App dependencies
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { getDOIPath } from "src/views/Collection/utils";
+import { test } from "tests/common/test";
 
 const { describe } = test;
 

--- a/frontend/tests/features/filter/filter.test.ts
+++ b/frontend/tests/features/filter/filter.test.ts
@@ -3,7 +3,7 @@
  */
 
 // App dependencies
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { PublisherMetadata } from "src/common/entities";
 import {
   buildSummaryCitation,
@@ -13,6 +13,7 @@ import {
   createPublicationDateValues,
 } from "src/common/queries/filter";
 import { PUBLICATION_DATE_VALUES } from "src/components/common/Filter/common/constants";
+import { test } from "tests/common/test";
 
 const { describe } = test;
 

--- a/frontend/tests/features/filter/selectUtils.test.ts
+++ b/frontend/tests/features/filter/selectUtils.test.ts
@@ -2,8 +2,9 @@
  * Test suite for select filter-related utils.
  */
 
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { buildAnalyticsPayload } from "src/common/hooks/useCategoryFilter/common/selectUtils";
+import { test } from "tests/common/test";
 
 const { describe } = test;
 

--- a/frontend/tests/features/filter/useCategoryFilter.test.ts
+++ b/frontend/tests/features/filter/useCategoryFilter.test.ts
@@ -46,7 +46,7 @@
  */
 
 // App dependencies
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { Row } from "react-table";
 import { buildNextOntologyCategoryFilters } from "src/common/hooks/useCategoryFilter/common/curatedOntologyUtils";
 import {
@@ -79,6 +79,7 @@ import {
   SelectCategoryValue,
   SelectCategoryValueView,
 } from "src/components/common/Filter/common/entities";
+import { test } from "tests/common/test";
 
 const { describe } = test;
 

--- a/frontend/tests/features/filter/utils.test.ts
+++ b/frontend/tests/features/filter/utils.test.ts
@@ -2,7 +2,7 @@
  * Test suite for filter-related utils.
  */
 
-import { expect, test } from "@playwright/test";
+import test, { expect } from "@playwright/test";
 import { DEVELOPMENT_STAGE_ONTOLOGY_TERM_SET } from "src/components/common/Filter/common/constants";
 import {
   findOntologyNodeById,

--- a/frontend/tests/features/home/homePage.test.ts
+++ b/frontend/tests/features/home/homePage.test.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, Page } from "@playwright/test";
 import { ROUTES } from "src/common/constants/routes";
 import { TEST_URL } from "tests/common/constants";
 import { goToPage, tryUntil } from "tests/utils/helpers";
@@ -10,6 +10,7 @@ import {
   LANDING_PAGE_CELLTYPES_HERO_NUM_ID,
   LANDING_PAGE_DATASETS_HERO_NUM_ID,
 } from "src/views/Landing/constants";
+import { test } from "tests/common/test";
 
 const { describe } = test;
 const COLLECTIONS_LINK_ID = "collections-link";

--- a/frontend/tests/features/terms/tosAndPrivacy.test.ts
+++ b/frontend/tests/features/terms/tosAndPrivacy.test.ts
@@ -1,7 +1,8 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { ROUTES } from "src/common/constants/routes";
 import { goToPage } from "tests/utils/helpers";
 import { TEST_URL } from "../../common/constants";
+import { test } from "tests/common/test";
 
 const { describe } = test;
 

--- a/frontend/tests/features/wheresMyGene/cellTooltip.test.ts
+++ b/frontend/tests/features/wheresMyGene/cellTooltip.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { expandTissue, getCellTypeNames, goToPage } from "tests/utils/helpers";
 import { TEST_URL } from "tests/common/constants";
 import { ROUTES } from "src/common/constants/routes";
@@ -6,6 +6,7 @@ import {
   CELL_TYPE_NAME_LABEL_CLASS_NAME,
   CELL_TYPE_ROW_CLASS_NAME,
 } from "src/views/WheresMyGeneV2/components/HeatMap/components/YAxisChart/constants";
+import { test } from "tests/common/test";
 const { describe } = test;
 
 describe("cell tooltip", () => {

--- a/frontend/tests/features/wheresMyGene/downloadCsv.test.ts
+++ b/frontend/tests/features/wheresMyGene/downloadCsv.test.ts
@@ -1,4 +1,3 @@
-import { test } from "@playwright/test";
 import { goToWMG } from "../../utils/wmgUtils";
 import {
   subDirectory,
@@ -12,6 +11,7 @@ import {
   SHARED_LINK_NO_FILTER,
   SHARED_LINK_NO_GROUP,
 } from "tests/common/constants";
+import { test } from "tests/common/test";
 
 const { describe } = test;
 describe("CSV download tests", () => {

--- a/frontend/tests/features/wheresMyGene/landingPage.test.ts
+++ b/frontend/tests/features/wheresMyGene/landingPage.test.ts
@@ -1,9 +1,10 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, Page } from "@playwright/test";
 import { TEST_URL } from "../../common/constants";
 import { ROUTES } from "src/common/constants/routes";
 import { ADD_GENE_BTN } from "tests/common/constants";
 import { getById } from "tests/utils/selectors";
 import { tryUntil } from "tests/utils/helpers";
+import { test } from "tests/common/test";
 
 const { describe } = test;
 const ALERT = "Send us feedback with this quick survey";

--- a/frontend/tests/features/wheresMyGene/manageGene.test.ts
+++ b/frontend/tests/features/wheresMyGene/manageGene.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "tests/common/test";
 import {
   ADD_GENE_SEARCH_PLACEHOLDER_TEXT,
   searchAndAddGene,

--- a/frontend/tests/features/wheresMyGene/rightSideBar.test.ts
+++ b/frontend/tests/features/wheresMyGene/rightSideBar.test.ts
@@ -1,10 +1,11 @@
 /**
  * Test suite for select filter-related utils.
  */
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { goToWMG } from "../../utils/wmgUtils";
 import { selectFirstOption } from "tests/utils/helpers";
 import { getById } from "tests/utils/selectors";
+import { test } from "tests/common/test";
 
 const { describe } = test;
 

--- a/frontend/tests/features/wheresMyGene/shareLink.test.ts
+++ b/frontend/tests/features/wheresMyGene/shareLink.test.ts
@@ -1,7 +1,8 @@
-import { Page, expect, test } from "@playwright/test";
+import { Page, expect } from "@playwright/test";
 import { LATEST_SHARE_LINK_VERSION } from "src/views/WheresMyGeneV2/components/GeneSearchBar/components/ShareButton/utils";
 
 import { TEST_URL } from "tests/common/constants";
+import { test } from "tests/common/test";
 import { tryUntil } from "tests/utils/helpers";
 
 import { goToWMG, addTissuesAndGenes } from "tests/utils/wmgUtils";

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -1,5 +1,6 @@
-import { expect, test, Page } from "@playwright/test";
+import { expect, Page } from "@playwright/test";
 import { toInteger } from "lodash";
+import { test } from "tests/common/test";
 import { collapseTissue, expandTissue, tryUntil } from "tests/utils/helpers";
 import { goToWMG } from "tests/utils/wmgUtils";
 

--- a/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test, Locator } from "@playwright/test";
+import { expect, Page, Locator } from "@playwright/test";
 import { ROUTES } from "src/common/constants/routes";
 import type { RawPrimaryFilterDimensionsResponse } from "src/common/queries/wheresMyGene";
 import { FMG_GENE_STRENGTH_THRESHOLD } from "src/views/WheresMyGene/common/constants";
@@ -26,6 +26,7 @@ import {
   CELL_TYPE_NAME_LABEL_CLASS_NAME,
   TISSUE_NAME_LABEL_CLASS_NAME,
 } from "src/views/WheresMyGeneV2/components/HeatMap/components/YAxisChart/constants";
+import { test } from "tests/common/test";
 
 const HOMO_SAPIENS_TERM_ID = "NCBITaxon:9606";
 


### PR DESCRIPTION
## Reason for Change

- #5940

## Changes

1. Add a network guard in `window.fetch()` to catch excessive API calls
2. Add network guard in every e2e test to detect excessive API calls, so we're aware of it in test logs

## Testing steps

1. Temporarily change `handleChange()` in frontend/src/views/WheresMyGene/components/Filters/components/Compare/connect.ts to depend on `optionLabel`, which will generate a new `handleChange` function every time `optionLabel` changes. Which is the crux of the infinite loop
2. Navigate to https://localhost:3000/gene-expression?compare=disease&sexes=PATO%3A0000383&tissues=blood%2Clung&genes=DPM1%2CTNMD%2CTSPAN6&ver=2
3. Observe console that it will now throw many "Too many API calls" errors, but the `network` tab will stop making requests

## Notes for Reviewer
