### PR TITLE
test: use smoke test account to seed db for smoke tests

### DIFF
--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -173,9 +173,30 @@ jobs:
         run: |
           ./scripts/populate_rdev_with_wmg_data.sh ${{ env.STACK_NAME }}
 
+  seed-database-e2e-tests:
+    runs-on: ubuntu-22.04
+    needs:
+      - deploy-rdev
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Seed database for e2e tests
+        run: |
+          pip3 install -r scripts/smoke_tests/requirements.txt
+          STACK_NAME=${{ env.STACK_NAME }} DEPLOYMENT_STAGE=rdev python3 -m scripts.smoke_tests.setup
+
   run-e2e-tests:
     needs:
       - seed-wmg-cellguide-rdev
+      - seed-database-e2e-tests
     timeout-minutes: 30
     name: e2e-tests ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
     runs-on: ubuntu-22.04
@@ -319,6 +340,7 @@ jobs:
         working-directory: frontend
     needs:
       - seed-wmg-cellguide-rdev
+      - seed-database-e2e-tests
     steps:
       - uses: actions/setup-node@v2
         with:

--- a/frontend/tests/features/collection/revision.test.ts
+++ b/frontend/tests/features/collection/revision.test.ts
@@ -31,7 +31,7 @@ describe("Collection Revision @loggedIn", () => {
    * TODO(#5666): Enable this test once #5666 is resolved
    * https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/5666
    */
-  test.skip("starts a revision", async ({ page }) => {
+  test("starts a revision", async ({ page }) => {
     const collectionName = await startRevision(page);
 
     const publishButton = await page.$(getTestID("publish-collection-button"));
@@ -74,7 +74,8 @@ describe("Collection Revision @loggedIn", () => {
    * TODO(#5666): Enable this test once #5666 is resolved
    * https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/5666
    */
-  test.skip("allows editing", async ({ page }) => {
+
+  test("allows editing", async ({ page }) => {
     await startRevision(page);
 
     const collectionName = await getInnerText(

--- a/scripts/smoke_tests/setup.py
+++ b/scripts/smoke_tests/setup.py
@@ -12,7 +12,7 @@ TEST_ACCT_CONTACT_NAME = "Smoke Test User"
 
 class SmokeTestsInitializer(BaseFunctionalTestCase):
     def __init__(self):
-        super().setUpClass()
+        super().setUpClass(smoke_tests=True)
         super().setUp()
         self.headers = {"Cookie": f"cxguser={self.curator_cookie}", "Content-Type": "application/json"}
 

--- a/tests/functional/backend/common.py
+++ b/tests/functional/backend/common.py
@@ -38,7 +38,7 @@ class BaseFunctionalTestCase(unittest.TestCase):
     deployment_stage: str
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls, smoke_tests: bool = False):
         super().setUpClass()
         cls.deployment_stage = os.environ["DEPLOYMENT_STAGE"]
         cls.config = CorporaAuthConfig()
@@ -54,7 +54,11 @@ class BaseFunctionalTestCase(unittest.TestCase):
         cls.session.mount("https://", HTTPAdapter(max_retries=retry_config))
         if cls.deployment_stage == "rdev":
             cls.get_oauth2_proxy_access_token()
-        token = cls.get_auth_token(cls.config.functest_account_username, cls.config.functest_account_password)
+        if smoke_tests:
+            username, password = cls.config.test_account_username, cls.config.test_account_password
+        else:
+            username, password = cls.config.functest_account_username, cls.config.functest_account_password
+        token = cls.get_auth_token(username, password)
         cls.curator_cookie = cls.make_cookie(token)
         cls.api = API_URL.get(cls.deployment_stage)
         cls.test_collection_id = "005d611a-14d5-4fbf-846e-571a1f874f70"


### PR DESCRIPTION
This commit modifies the BaseFunctionalTestCase class to allow the caller to specify a `smoke_tests` flag. If True, the class will initialized (seed) the data using the test account for smoke tests, which is user@example.com, instead of the test account for functional tests, which is functest@example.com

## Reason for Change

- #5666 

## Changes

- Use the test user account `user@example.com` (rather than the functional test user account `functest@example.com`) to seed the database ahead of smoke tests
- Reinstate the e2e tests that are dependent on the seeded Collections being created with the test user account `user@example.com`

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Notes for Reviewer
