### PR TITLE
fix: Edit collection is broken (#5950)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@blueprintjs/core": "^4.20.2",
         "@blueprintjs/icons": "^4.16.0",
         "@blueprintjs/select": "^4.9.24",
-        "@czi-sds/components": "^18.1.0",
+        "@czi-sds/components": "^18.1.2",
         "@czi-sds/data-viz": "^0.3.0",
         "@emotion/css": "^11.11.2",
         "@emotion/react": "^11.11.1",
@@ -1484,9 +1484,9 @@
       "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ=="
     },
     "node_modules/@czi-sds/components": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@czi-sds/components/-/components-18.1.0.tgz",
-      "integrity": "sha512-at3HNjDyu2QBXuMxlvGxtiy1iUYGzrOcrXmAWkhEau+2zA50qvePHcsNVjwj45maZSaeXQNEWdiB6YCdIi6DdQ==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@czi-sds/components/-/components-18.1.2.tgz",
+      "integrity": "sha512-AHWj87km/4XB7K4cGnFOwlyPBgKOHJ3K2zU8qwNvY5ghOnpctdt434c+oby3/njUg4uJZFmP83DjiyToDqB9/g==",
       "peerDependencies": {
         "@emotion/core": "^11.0.0",
         "@emotion/css": "^11.11.0",
@@ -17189,9 +17189,9 @@
       "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ=="
     },
     "@czi-sds/components": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@czi-sds/components/-/components-18.1.0.tgz",
-      "integrity": "sha512-at3HNjDyu2QBXuMxlvGxtiy1iUYGzrOcrXmAWkhEau+2zA50qvePHcsNVjwj45maZSaeXQNEWdiB6YCdIi6DdQ==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@czi-sds/components/-/components-18.1.2.tgz",
+      "integrity": "sha512-AHWj87km/4XB7K4cGnFOwlyPBgKOHJ3K2zU8qwNvY5ghOnpctdt434c+oby3/njUg4uJZFmP83DjiyToDqB9/g==",
       "requires": {}
     },
     "@czi-sds/data-viz": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "@blueprintjs/core": "^4.20.2",
     "@blueprintjs/icons": "^4.16.0",
     "@blueprintjs/select": "^4.9.24",
-    "@czi-sds/components": "^18.1.0",
+    "@czi-sds/components": "^18.1.2",
     "@czi-sds/data-viz": "^0.3.0",
     "@emotion/css": "^11.11.2",
     "@emotion/react": "^11.11.1",

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -1,6 +1,6 @@
 import { Classes, Intent } from "@blueprintjs/core";
 import { useRouter } from "next/router";
-import { FC, useCallback, useEffect, useRef, useState } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import { ROUTES } from "src/common/constants/routes";
 import { Collection, COLLECTION_LINK_TYPE } from "src/common/entities";
 import { useUserInfo } from "src/common/queries/auth";
@@ -124,14 +124,6 @@ const Content: FC<Props> = (props) => {
   } = data || {};
 
   const [consortia, setConsortia] = useState<DefaultDropdownMenuOption[]>([]);
-
-  // Handles change to selection of consortia.
-  const handleConsortiaChange = useCallback(
-    (selectedConsortia: DropdownValue) => {
-      setConsortia(sortConsortia(selectedConsortia));
-    },
-    []
-  );
 
   useEffect(() => {
     if (collectionConsortia) {
@@ -392,6 +384,14 @@ const Content: FC<Props> = (props) => {
     }
 
     onClose();
+  }
+
+  /**
+   * Handles change to selection of consortia.
+   * @param selectedConsortia - Selected consortia.
+   */
+  function handleConsortiaChange(selectedConsortia: DropdownValue) {
+    setConsortia(sortConsortia(selectedConsortia));
   }
 
   function handleInputChange({ isValid: isValidFromInput, name }: Value) {

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -1,6 +1,6 @@
 import { Classes, Intent } from "@blueprintjs/core";
 import { useRouter } from "next/router";
-import { FC, useEffect, useRef, useState } from "react";
+import { FC, useCallback, useEffect, useRef, useState } from "react";
 import { ROUTES } from "src/common/constants/routes";
 import { Collection, COLLECTION_LINK_TYPE } from "src/common/entities";
 import { useUserInfo } from "src/common/queries/auth";
@@ -124,6 +124,14 @@ const Content: FC<Props> = (props) => {
   } = data || {};
 
   const [consortia, setConsortia] = useState<DefaultDropdownMenuOption[]>([]);
+
+  // Handles change to selection of consortia.
+  const handleConsortiaChange = useCallback(
+    (selectedConsortia: DropdownValue) => {
+      setConsortia(sortConsortia(selectedConsortia));
+    },
+    []
+  );
 
   useEffect(() => {
     if (collectionConsortia) {
@@ -384,14 +392,6 @@ const Content: FC<Props> = (props) => {
     }
 
     onClose();
-  }
-
-  /**
-   * Handles change to selection of consortia.
-   * @param selectedConsortia - Selected consortia.
-   */
-  function handleConsortiaChange(selectedConsortia: DropdownValue) {
-    setConsortia(sortConsortia(selectedConsortia));
   }
 
   function handleInputChange({ isValid: isValidFromInput, name }: Value) {


### PR DESCRIPTION
## Reason for Change

- #5950

## Changes

- ~Modified the consortia dropdown `onChange` function `handleConsortiaChange` to a memoized function.~
- Updated `czi-sds` package to `v18.1.2`.

*Background*

Currently, editing a collection is unavailable due to a bug that causes the page to freeze or return an error: "Application error: a client-side exception has occurred (see the browser console for more information)".

The bug was introduced with an upgrade of `czi-sds` package version; specifically the package upgrade introduced a defect in the consortia dropdown functionality in the [create / edit collection](https://github.com/chanzuckerberg/single-cell-data-portal/blob/fe226f5f20ef7ff5690ddf47e3add9bae082a040/frontend/src/components/CreateCollectionModal/components/Content/index.tsx#L217) component.

Between versions `15.4.2` and `18.1.0`, a modification was made where a hook's dependency array was updated to include the prop `onChange` (`v15.4.2`: [L112-114](https://github.com/chanzuckerberg/sci-components/blob/bf8c991055bf4715ded0ebee4d325ac0276650f6/packages/components/src/core/Dropdown/index.tsx#L112), `v18.10`: [L112-114](https://github.com/chanzuckerberg/sci-components/blob/%40czi-sds/components%4018.1.0/packages/components/src/core/Dropdown/index.tsx#L112)).

Thanks to a recent `czi-sds` [commit](https://github.com/chanzuckerberg/sci-components/commit/8d9ffda2992a112f1e489dabcf10315f0561f167) by @tihuan 🎉 , this hook has been removed, and the update functionality now resides in the `setValueAndCallOnChange` function [here](https://github.com/chanzuckerberg/sci-components/blob/main/packages/components/src/core/Dropdown/index.tsx#L315). The purpose of this commit was to address infinite loop issues.

~Until the `czi-sds` library publishes this update, we can memoize the dropdown function `handleConsortiaChange` to prevent an infinite loop when editing a collection.~

~See https://pr-5957-frontend.rdev.single-cell.czi.technology/collections.~

`czi-sds` library has published the update! Thank you!

See https://5950-package-update-frontend.rdev.single-cell.czi.technology/collections.

## Testing steps

- Edit a private collection, or a private revision collection.
- User should be able to edit and save collection.
- User should not see `Application error: a client-side exception has occurred (see the browser console for more information)` nor experience an error such as the page / edit modal freezing - caused by an infinite loop.