### PR TITLE
fix: properly fetch previous prod release tag to produce changelog diff for prod release notes

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -109,6 +109,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.deployment.sha }}
+      - name: Get most recent tag
+        id: "fetch_tag"
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          echo "PREVIOUS_TAG=$(git describe --tags $(git rev-list --tags=sha\* --max-count=1))" >> $GITHUB_OUTPUT
       - name: Push Tag with latest prod commit SHA
         uses: rickstaa/action-create-tag@v1
         id: "tag_create"
@@ -119,16 +125,7 @@ jobs:
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4
         with:
-          configurationJson: |
-            {
-              "tag_resolver": {
-                "method": "sort",
-                "filter": {
-                  "pattern": "sha-(.+)",
-                  "flags": "gu"
-                }
-              }
-            }
+          fromTag: ${{ steps.fetch_tag.outputs.PREVIOUS_TAG }}
       - name: Produce Github Release for Prod Deployments
         uses: softprops/action-gh-release@v1
         if: steps.tag_create.outputs.tag_exists == 'false'


### PR DESCRIPTION
## Reason for Change

- #5487
- Changelog diff builder GHA wasn't properly retrieving the most recent prod release tag when comparing to the new tag; thus, changelog diffs were not being generated correctly.

## Changes

- workflow fetches the most recent prod tag release (those matching the pattern `sha-*`) and passes it directly to the changelog builder github action, rather than relying on its built-in tag resolver (which can only fetch tags in lexicographic or semver order, rather than by date)
- changelog builder github action will check the diff between the new tag and the previous tag we fetch/pass in and generate release notes accordingly

## Testing steps

## Notes for Reviewer
