### PR TITLE
chore: Disable redeploying the dev environment for pentest

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -86,6 +86,8 @@ jobs:
             echo "DEPLOYMENT_STAGE=dev" >> $GITHUB_ENV
           fi
       - uses: avakar/create-deployment@v1
+        #  TODO remove if conidition after pentest on October 31st 2023
+        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod'
         with:
           auto_merge: false
           environment: ${{ env.DEPLOYMENT_STAGE }}


### PR DESCRIPTION
## Reason for Change
To freeze the dev environment while pentesting happens.

## Changes

- only deploy staging and prod in GHA

## Notes for Reviewer
This will be reverted after pentesting concludes