### PR TITLE
feat: 5848 FE add deployed version

### DIFF
--- a/frontend/src/common/constants/routes.ts
+++ b/frontend/src/common/constants/routes.ts
@@ -15,4 +15,5 @@ export enum ROUTES {
   WMG_DOCS_DATA_PROCESSING = "/docs/04__Analyze%20Public%20Data/4_2__Gene%20Expression%20Documentation/4_2_3__Gene%20Expression%20Data%20Processing",
   SITEMAP = "/sitemap",
   CELL_GUIDE = "/cellguide",
+  DEPLOYED_VERSION = "/api/deployed_version",
 }

--- a/frontend/src/pages/api/deployed_version.ts
+++ b/frontend/src/pages/api/deployed_version.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import HTTP_STATUS_CODE from "src/common/constants/HTTP_STATUS_CODE";
+
+type ResponseData = {
+  "Data Portal"?: string;
+  error?: string;
+};
+
+export default function handler(
+  _: NextApiRequest,
+  response: NextApiResponse<ResponseData>
+) {
+  const commit = process.env.COMMIT_SHA || "";
+
+  if (!commit) {
+    response.status(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR).json({
+      error: "Commit SHA is not defined",
+    });
+  }
+
+  response.status(HTTP_STATUS_CODE.OK).json({
+    "Data Portal": commit,
+  });
+}

--- a/frontend/tests/features/api/deployedVersion.test.ts
+++ b/frontend/tests/features/api/deployedVersion.test.ts
@@ -1,0 +1,23 @@
+import { expect } from "@playwright/test";
+import { ROUTES } from "src/common/constants/routes";
+import { goToPage, tryUntil } from "tests/utils/helpers";
+import { TEST_URL } from "../../common/constants";
+import { test } from "tests/common/test";
+
+const { describe } = test;
+
+describe("api/deployed_version", () => {
+  test("Returns commit SHA", async ({ page }) => {
+    await goToPage(`${TEST_URL}${ROUTES.DEPLOYED_VERSION}`, page);
+
+    await tryUntil(
+      async () => {
+        const commitSha = await page.textContent("body");
+        const regex = /(?<="Data Portal":")\w+/;
+        const match = regex.exec(commitSha || "");
+        expect(match).toBeTruthy();
+      },
+      { page }
+    );
+  });
+});


### PR DESCRIPTION
## Reason for Change

- #5848 

## Changes

1. Add `COMMIT_SHA` to `/api/deployed_version`, so we can query it like so: https://pr-6002-frontend.rdev.single-cell.czi.technology/api/deployed_version
2. Add e2e test for this

## Testing steps

1. Navigate to https://pr-6002-frontend.rdev.single-cell.czi.technology/api/deployed_version, you should see something like: `{"Data Portal":"0d27c97a65ef30d8afa8df3920f4c75a8aff0c43"}`

