### PR TITLE
feat: Trigger staging deployment on auto-merge to staging branch

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -8,16 +8,18 @@ on:
       - prod
   repository_dispatch:
     types: [build-images]
-# add a concurrency group to prevent multiple builds from running at the same time
-concurrency:
-  group: $${{ github.ref }}-environment
-  cancel-in-progress: false
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1
   DOCKER_REPO: ${{ secrets.ECR_REPO }}/
+  GITHUB_BRANCH: ${{ github.event.client_payload.ref || github.ref }}
+
+# add a concurrency group to prevent multiple builds from running at the same time
+concurrency:
+  group: $${{ env.GITHUB_BRANCH }}-environment
+  cancel-in-progress: false
 
 permissions:
   id-token: write
@@ -69,7 +71,7 @@ jobs:
           mention: "here"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-        if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
+        if: failure() && (env.GITHUB_BRANCH == 'refs/heads/main' || env.GITHUB_BRANCH == 'refs/heads/staging' || env.GITHUB_BRANCH == 'refs/heads/prod')
 
   create_deployment:
     needs:
@@ -79,16 +81,16 @@ jobs:
       - name: Generate payload
         run: |
           echo "payload={\"tag\":\"sha-${GITHUB_SHA:0:8}\"}" >> $GITHUB_ENV
-          if [[ "${{ github.ref }}" == "refs/heads/prod" ]]; then
+          if [[ "${{ env.GITHUB_BRANCH }}" == "refs/heads/prod" ]]; then
             echo "DEPLOYMENT_STAGE=prod" >> $GITHUB_ENV
-          elif [[ "${{ github.ref }}" == "refs/heads/staging" ]]; then
+          elif [[ "${{ env.GITHUB_BRANCH }}" == "refs/heads/staging" ]]; then
             echo "DEPLOYMENT_STAGE=stage" >> $GITHUB_ENV
           else
             echo "DEPLOYMENT_STAGE=dev" >> $GITHUB_ENV
           fi
       - uses: avakar/create-deployment@v1
         #  TODO remove if conidition after pentest on October 31st 2023
-        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod'
+        if: env.GITHUB_BRANCH == 'refs/heads/staging' || env.GITHUB_BRANCH == 'refs/heads/prod'
         with:
           auto_merge: false
           environment: ${{ env.DEPLOYMENT_STAGE }}

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -6,7 +6,8 @@ on:
       - main
       - staging
       - prod
-
+  repository_dispatch:
+    types: [build-images]
 # add a concurrency group to prevent multiple builds from running at the same time
 concurrency:
   group: $${{ github.ref }}-environment

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -1,6 +1,9 @@
 name: Deploy Happy
 
-on: deployment
+on:
+  deployment:
+  repository_dispatch:
+    types: [deploy-images]
 
 # add a concurrency group to prevent multiple builds from running at the same time
 concurrency:

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -1,9 +1,6 @@
 name: Deploy Happy
 
-on:
-  deployment:
-  repository_dispatch:
-    types: [deploy-images]
+on: deployment
 
 # add a concurrency group to prevent multiple builds from running at the same time
 concurrency:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -7,6 +7,14 @@ on:
   push:
     branches:
       - "main"
+      - staging
+  repository_dispatch:
+    types: [run-unit-tests]
+
+# add a concurrency group to prevent multiple builds from running at the same time
+concurrency:
+  group: $${{ github.ref }}-environment
+  cancel-in-progress: false
 
 env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -7,9 +7,6 @@ on:
   push:
     branches:
       - "main"
-      - staging
-  repository_dispatch:
-    types: [run-unit-tests]
 
 # add a concurrency group to prevent multiple builds from running at the same time
 concurrency:

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -34,6 +34,8 @@ jobs:
 
           git push origin staging
 
+      # TODO(prathap): remove this dummy comment
+      #
       # We need to use repository_dispatch because by default github actions
       # prevents actions triggered by 'GITHUB_TOKEN' from triggering other
       # workflows. Details are here:

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -34,8 +34,6 @@ jobs:
 
           git push origin staging
 
-      # TODO(prathap): remove this dummy comment
-      #
       # We need to use repository_dispatch because by default github actions
       # prevents actions triggered by 'GITHUB_TOKEN' from triggering other
       # workflows. Details are here:

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -6,10 +6,10 @@ on:
       - main
 
 jobs:
-  merge:
+  continuous_deploy_to_staging:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main branch and staging branch
+      - name: Checkout main branch
         uses: actions/checkout@v2
         with:
           ref: main
@@ -34,3 +34,21 @@ jobs:
           git merge --verbose main -m "Merging main branch into staging branch"
 
           git push origin staging
+      - name: Trigger repository_dispatch to build images
+        if: success()
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: build-images
+      - name: Trigger repository_dispatch to deploy images
+        if: success()
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: deploy-images
+      - name: Trigger repository_dispatch to run unit tests
+        if: success()
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: run-unit-tests

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -39,9 +39,10 @@ jobs:
       # workflows. Details are here:
       # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
       #https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch
-      - name: Trigger repository_dispatch to build images
+      - name: Trigger repository_dispatch to build images for staging
         if: success()
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: build-images
+          client-payload: '{"ref": "refs/heads/staging"}'

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -3,7 +3,7 @@ name: Trigger release candidate build and deploy
 on:
   push:
     branches:
-      - psridharan/trigger-stage-deploy # main
+      - main
 
 jobs:
   continuous_deploy_to_staging:
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout main branch
         uses: actions/checkout@v2
         with:
-          ref: psridharan/trigger-stage-deploy # main
+          ref: main
           fetch-depth: 0 # fetch all history to make merges work correctly
       - name: Merge main branch into staging branch
         run: |
@@ -27,31 +27,21 @@ jobs:
           echo "$(git branch --list)"
 
           echo "Latest commit on 'staging' branch is: $(git log -1 --format='%H' staging)"
+          echo "Latest commit on 'main' branch is: $(git log -1 --format='%H' main)"
 
-          # echo "Latest commit on 'main' branch is: $(git log -1 --format='%H' main)"
-          echo "Latest commit on 'psridharan/trigger-stage-deploy' branch is: $(git log -1 --format='%H' psridharan/trigger-stage-deploy)"
-
-          # echo "About to merge 'main' branch into 'staging' branch"
-          echo "About to merge 'psridharan/trigger-stage-deploy' branch into 'staging' branch"
-          # git merge --verbose main -m "Merging main branch into staging branch"
-          git merge --verbose psridharan/trigger-stage-deploy -m "Merging psridharan/trigger-stage-deploy branch into staging branch"
+          echo "About to merge 'main' branch into 'staging' branch"
+          git merge --verbose main -m "Merging main branch into staging branch"
 
           git push origin staging
+
+      # We need to use repository_dispatch because by default github actions
+      # prevents actions triggered by 'GITHUB_TOKEN' from triggering other
+      # workflows. Details are here:
+      # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      #https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch
       - name: Trigger repository_dispatch to build images
         if: success()
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: build-images
-      #- name: Trigger repository_dispatch to deploy images
-      #  if: success()
-      #  uses: peter-evans/repository-dispatch@v2
-      #  with:
-      #    token: ${{ secrets.GITHUB_TOKEN }}
-      #    event-type: deploy-images
-      #- name: Trigger repository_dispatch to run unit tests
-      #  if: success()
-      #  uses: peter-evans/repository-dispatch@v2
-      #  with:
-      #    token: ${{ secrets.GITHUB_TOKEN }}
-      #    event-type: run-unit-tests

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -37,12 +37,12 @@ jobs:
           git merge --verbose psridharan/trigger-stage-deploy -m "Merging psridharan/trigger-stage-deploy branch into staging branch"
 
           git push origin staging
-      #- name: Trigger repository_dispatch to build images
-      #  if: success()
-      #  uses: peter-evans/repository-dispatch@v2
-      #  with:
-      #    token: ${{ secrets.GITHUB_TOKEN }}
-      #    event-type: build-images
+      - name: Trigger repository_dispatch to build images
+        if: success()
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: build-images
       #- name: Trigger repository_dispatch to deploy images
       #  if: success()
       #  uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -3,7 +3,7 @@ name: Trigger release candidate build and deploy
 on:
   push:
     branches:
-      - main
+      - psridharan/trigger-stage-deploy # main
 
 jobs:
   continuous_deploy_to_staging:
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout main branch
         uses: actions/checkout@v2
         with:
-          ref: main
+          ref: psridharan/trigger-stage-deploy # main
           fetch-depth: 0 # fetch all history to make merges work correctly
       - name: Merge main branch into staging branch
         run: |
@@ -28,27 +28,30 @@ jobs:
 
           echo "Latest commit on 'staging' branch is: $(git log -1 --format='%H' staging)"
 
-          echo "Latest commit on 'main' branch is: $(git log -1 --format='%H' main)"
+          # echo "Latest commit on 'main' branch is: $(git log -1 --format='%H' main)"
+          echo "Latest commit on 'psridharan/trigger-stage-deploy' branch is: $(git log -1 --format='%H' psridharan/trigger-stage-deploy)"
 
-          echo "About to merge 'main' branch into 'staging' branch"
-          git merge --verbose main -m "Merging main branch into staging branch"
+          # echo "About to merge 'main' branch into 'staging' branch"
+          echo "About to merge 'psridharan/trigger-stage-deploy' branch into 'staging' branch"
+          # git merge --verbose main -m "Merging main branch into staging branch"
+          git merge --verbose psridharan/trigger-stage-deploy -m "Merging psridharan/trigger-stage-deploy branch into staging branch"
 
           git push origin staging
-      - name: Trigger repository_dispatch to build images
-        if: success()
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: build-images
-      - name: Trigger repository_dispatch to deploy images
-        if: success()
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: deploy-images
-      - name: Trigger repository_dispatch to run unit tests
-        if: success()
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: run-unit-tests
+      #- name: Trigger repository_dispatch to build images
+      #  if: success()
+      #  uses: peter-evans/repository-dispatch@v2
+      #  with:
+      #    token: ${{ secrets.GITHUB_TOKEN }}
+      #    event-type: build-images
+      #- name: Trigger repository_dispatch to deploy images
+      #  if: success()
+      #  uses: peter-evans/repository-dispatch@v2
+      #  with:
+      #    token: ${{ secrets.GITHUB_TOKEN }}
+      #    event-type: deploy-images
+      #- name: Trigger repository_dispatch to run unit tests
+      #  if: success()
+      #  uses: peter-evans/repository-dispatch@v2
+      #  with:
+      #    token: ${{ secrets.GITHUB_TOKEN }}
+      #    event-type: run-unit-tests


### PR DESCRIPTION
## Reason for Change

- #5461 
- Use `repository_dispatch` to trigger a `stage` environment deploy after `main` is auto-merged to `staging` branch

## Changes

- add `repository_dispatch` calls to workflow

## Testing steps

- Manually done on this PR branch or `main`

## Notes for Reviewer
