### PR TITLE
fix(wmg): newsletter test revert to empty string

### DIFF
--- a/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
@@ -540,7 +540,7 @@ describe("Where's My Gene", () => {
         validationMessage.getByText(FAILED_EMAIL_VALIDATION_STRING)
       ).toBeTruthy();
 
-      emailInput.fill(" ");
+      emailInput.fill("");
       expect(subscribeButton.isDisabled());
 
       // Bad email 2
@@ -551,7 +551,7 @@ describe("Where's My Gene", () => {
         validationMessage.getByText(FAILED_EMAIL_VALIDATION_STRING)
       ).toBeTruthy();
 
-      emailInput.fill(" ");
+      emailInput.fill("");
       expect(subscribeButton.isDisabled());
 
       // Bad email 3


### PR DESCRIPTION
## Reason for Change

## Changes

revert temp fix for newsletter validate email from 
`emailInput.fill(" ")`  to `emailInput.fill("")`

