### PR TITLE
feat: Test repository_dispatch call for github actions

### DIFF
--- a/.github/workflows/test-receiving-repository-dispatch.yml
+++ b/.github/workflows/test-receiving-repository-dispatch.yml
@@ -1,0 +1,19 @@
+name: Test Receiving Repository Dispatch
+
+on:
+  repository_dispatch:
+    types: [test-repository-dispatch]
+
+env:
+  GITHUB_BRANCH: ${{ github.event.client_payload.ref || github.ref }}
+
+jobs:
+  test_repository_dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test Print Branch Name
+        run: |
+          echo "About to print branch name using env.GITHUB_BRANCH:"
+          echo "${{ env.GITHUB_BRANCH }}"
+          echo "About to print branch name using plain GITHUB_BRANCH:"
+          echo $GITHUB_BRANCH

--- a/.github/workflows/test-sending-repository-dispatch.yml
+++ b/.github/workflows/test-sending-repository-dispatch.yml
@@ -1,0 +1,17 @@
+name: Test Receiving Repository Dispatch
+
+on:
+  push:
+    branches:
+      - psridharan/trigger-stage-deploy
+
+jobs:
+  test_sending_repository_dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test Sending Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: test-repository-dispatch
+          client-payload: '{"ref": "refs/heads/staging"}'

--- a/.github/workflows/test-sending-repository-dispatch.yml
+++ b/.github/workflows/test-sending-repository-dispatch.yml
@@ -1,4 +1,4 @@
-name: Test Receiving Repository Dispatch
+name: Test Sending Repository Dispatch
 
 on:
   push:


### PR DESCRIPTION
## Reason for Change

- This to test `repository_dispatch` call

## Changes

## Testing steps

- Manual testing by pushing to another feature branch `psridharan/trigger-stage-deploy` and seeing that the `repository_dispatch` event gets sent by the `psridharan/trigger-stage-deploy` branch

## Notes for Reviewer
