### PR TITLE
chore: Test repository_dispatch trigger on push to main

### DIFF
--- a/.github/workflows/test-sending-repository-dispatch.yml
+++ b/.github/workflows/test-sending-repository-dispatch.yml
@@ -3,7 +3,7 @@ name: Test Sending Repository Dispatch
 on:
   push:
     branches:
-      - "*"
+      - main
 
 jobs:
   test_sending_repository_dispatch:


### PR DESCRIPTION
## Reason for Change

Testing `repository_dispatch` invocation by pushing to `main`

## Changes

- add
- remove
- modify

## Testing steps

- On merge to `main` we should see the sending and receiving of `repository_dispatch` call on the `Actions` page

## Notes for Reviewer
