### PR TITLE
fix: Get the ref to checkout from repository_dispatch payload

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -52,6 +52,7 @@ jobs:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
         with:
+          ref: ${{ env.GITHUB_BRANCH }}
           fetch-depth: 1
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2


### PR DESCRIPTION
## Reason for Change

When `repository_dispatch` event is sent for event `build-images`, the `build-images-and-create-deployment.yml` file has a step to checkout the current `${{ github.ref }}`. This turns out the be the `main` branch because it is the branch _that emitted the `repository_dispatch` event_. 

_That is not what we want!_. For the `build-images` event, the `payload` contains a `ref`. This `ref` turns out to be `staging` because the event is emitted in workflow that is the starting point for a `stage` deploy.

## Changes


## Testing steps

Manually test in `main`

## Notes for Reviewer
