### PR TITLE
fix: 5416 GE quick fixes

### DIFF
--- a/frontend/src/views/WheresMyGene/components/HeatMap/components/YAxisChart/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/components/YAxisChart/style.ts
@@ -5,6 +5,7 @@ import { ECHART_AXIS_LABEL_COLOR_HEX } from "../XAxisChart/style";
 import { SELECTED_STYLE } from "../../style";
 import { MARGIN_BETWEEN_HEATMAPS } from "src/views/WheresMyGene/common/constants";
 import { fontWeightSemibold, gray500 } from "src/common/theme";
+import { CommonThemeProps } from "@czi-sds/components";
 
 export const Y_AXIS_TISSUE_WIDTH_PX = 30;
 
@@ -55,6 +56,10 @@ export const CellTypeLabelStyle = styled.div`
   text-align: left;
 `;
 
+interface TissueHeaderLabelStyleProps extends CommonThemeProps {
+  expanded: boolean;
+}
+
 export const TissueHeaderLabelStyle = styled.div`
   margin: auto;
   font: normal 12px sans-serif;
@@ -62,7 +67,9 @@ export const TissueHeaderLabelStyle = styled.div`
   width: 100%;
   color: ${ECHART_AXIS_LABEL_COLOR_HEX};
   text-align: left;
-  font-weight: ${fontWeightSemibold};
+  ${(props: TissueHeaderLabelStyleProps) => {
+    return props.expanded && `font-weight: ${fontWeightSemibold(props)}`;
+  }}
 `;
 
 export const HiddenCellTypeLabelStyle = styled.div`

--- a/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
+++ b/frontend/src/views/WheresMyGene/components/HeatMap/style.ts
@@ -10,7 +10,7 @@ import {
 import { LEGEND_MARGIN_BOTTOM_PX } from "../../style";
 import { X_AXIS_CHART_HEIGHT_PX } from "../../common/constants";
 import { Autocomplete } from "@mui/material";
-import { Tag } from "@czi-sds/components";
+import { TagFilter } from "@czi-sds/components";
 import { spacesS } from "src/common/theme";
 
 export const CHART_PADDING_PX = 10;
@@ -64,7 +64,7 @@ export const StyledAutocomplete = styled(Autocomplete)`
   }
 `;
 
-export const StyledTag = styled(Tag)`
+export const StyledTag = styled(TagFilter)`
   max-width: 258px;
 `;
 // Copied to frontend/src/views/WheresMyGeneV2/components/HeatMap/style.ts

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/components/YAxisChart/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/components/YAxisChart/index.tsx
@@ -184,15 +184,13 @@ const TissueHeaderButton = ({
           color="gray"
           sdsType="static"
         />
-        <TissueHeaderLabelStyle>
-          <div>
-            <TissueLabel
-              className={TISSUE_NAME_LABEL_CLASS_NAME}
-              data-testid={TISSUE_NAME_LABEL_CLASS_NAME}
-            >
-              {capitalize(formattedName)}
-            </TissueLabel>
-          </div>
+        <TissueHeaderLabelStyle expanded={expanded}>
+          <TissueLabel
+            className={TISSUE_NAME_LABEL_CLASS_NAME}
+            data-testid={TISSUE_NAME_LABEL_CLASS_NAME}
+          >
+            {capitalize(formattedName)}
+          </TissueLabel>
         </TissueHeaderLabelStyle>
       </FlexRow>
       <CellCountLabelStyle

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -440,7 +440,7 @@ async function checkElementVisible(
 async function removeCellFilter(page: Page) {
   await page
     .getByTestId(`cell-type-tag-${CELL_TYPE_FILTERS[0]}`)
-    .getByTestId("CancelIcon")
+    .getByTestId("ClearIcon")
     .click();
 }
 

--- a/frontend/tests/utils/wmgUtils.ts
+++ b/frontend/tests/utils/wmgUtils.ts
@@ -296,7 +296,7 @@ export async function searchAndAddFilterCellType(page: Page, cellType: string) {
 export async function removeFilteredCellType(page: Page, cellType: string) {
   const beforeCellTypeNames = await getCellTypeNames(page);
   const cellTypeTag = page.getByTestId(`cell-type-tag-${cellType}`);
-  const deleteIcon = cellTypeTag.getByTestId("CancelIcon");
+  const deleteIcon = cellTypeTag.getByTestId("ClearIcon");
   await deleteIcon.click();
   const afterCellTypeNames = await getCellTypeNames(page);
   expect(afterCellTypeNames.length).toBeLessThan(beforeCellTypeNames.length);


### PR DESCRIPTION
## Reason for Change

- #5416 

## Changes

1. Use `TagFilter` for cell type filter tag
2. Update tissue label font weight based on `expanded`

## Testing steps

1. Go to rdev
2. Select some cell types and see the new styled tags
3. Collapse a tissue, the tissue name should no longer be bold

<img width="850" alt="Screenshot 2023-10-18 at 9 24 31 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/8af37678-381d-46fa-9ac0-c728c17059f5">


## Notes for Reviewer
