### PR TITLE
chore: TEST workflow_run trigger on push_tests

### DIFF
--- a/.github/workflows/test-workflow-run-after-push-tests-pass.yml
+++ b/.github/workflows/test-workflow-run-after-push-tests-pass.yml
@@ -1,0 +1,25 @@
+name: Test Run Workflow After Push Tests Execution
+
+on:
+  workflow_run:
+    workflows:
+      - "Push Tests"
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  test_workflow_run_push_tests_success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Test Workflow Triggered on Push Tests SUCCESS
+        run: echo "Hello! Push Tests succeeded!"
+
+  test_workflow_run_push_tests_failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Test Workflow Triggered on Push Tests FAILED
+        run: echo "Hello! Push Tests succeeded!"


### PR DESCRIPTION
## Reason for Change

- Pertains to #5461 

Test that a workflow only runs on `main` branch after `push_tests.yml` runs `main` branch

## Changes

- add
- remove
- modify

## Testing steps

Manual testing on `main` branch

## Notes for Reviewer
