### PR TITLE
chore: Remove staging branch trigger to build images

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -4,10 +4,9 @@ on:
   push:
     branches:
       - main
-      - staging
       - prod
   repository_dispatch:
-    types: [build-images]
+    types: [build-images-for-staging]
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -51,7 +51,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: build-images
+          event-type: build-images-for-staging
           client-payload: '{"ref": "refs/heads/staging"}'
 
       - name: Send slack notification if main not merged into staging


### PR DESCRIPTION
## Reason for Change

- Pertains to #5461 

Remove `staging` branch as a trigger to `build-images-and-create-deployment.yml` because `trigger-release-candidate-build-and-deploy.yml` will invoke a _staging deploy_ through continous deployment mechanism

## Changes

## Testing steps

Manual testing in `main` branch

## Notes for Reviewer
