### PR TITLE
fix: 5936 cell type share link auto expand

### DIFF
--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -1031,9 +1031,11 @@ function useWMGQueryRequestBody(version: 1 | 2) {
       return null;
     }
     const gene_ontology_term_ids = selectedGenes.map((geneName) => {
-      return organismGenesByName[geneName].id;
+      return organismGenesByName[geneName]?.id;
     });
+
     if (!gene_ontology_term_ids.length) gene_ontology_term_ids.push(".");
+
     const tissue_ontology_term_ids = selectedTissues?.map((tissueName) => {
       return tissuesByName[tissueName].id;
     });

--- a/frontend/src/common/utils/removeParams.ts
+++ b/frontend/src/common/utils/removeParams.ts
@@ -1,4 +1,12 @@
-export function removeParams(params: Array<string> | string): void {
+import { NextRouter } from "next/router";
+
+export function removeParams({
+  params,
+  router,
+}: {
+  params: Array<string> | string;
+  router: NextRouter;
+}): void {
   if (!params || !params.length) return;
 
   if (typeof params === "string") params = [params];
@@ -13,5 +21,5 @@ export function removeParams(params: Array<string> | string): void {
   const query = urlParams.toString();
   const newURL = pathname + (query ? "?" + query : "");
 
-  window.history.replaceState(null, "", newURL);
+  router.replace(newURL);
 }

--- a/frontend/src/components/Collections/common/utils.ts
+++ b/frontend/src/components/Collections/common/utils.ts
@@ -24,7 +24,7 @@ export function useExplainTombstoned(): void {
         message:
           "This collection was withdrawn. You’ve been redirected to Collections.",
       });
-      removeParams("tombstoned_collection_id");
+      removeParams({ params: "tombstoned_collection_id", router });
     }
-  }, [tombstoned_collection_id, isReady]);
+  }, [tombstoned_collection_id, isReady, router]);
 }

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -10,6 +10,7 @@ import { BOOLEAN } from "src/common/localStorage/set";
 import { useUserInfo } from "src/common/queries/auth";
 import { removeParams } from "src/common/utils/removeParams";
 import { StyledButton } from "./style";
+import { useRouter } from "next/router";
 
 const AsyncContent = loadable(
   () =>
@@ -34,6 +35,8 @@ const CreateCollection: FC<{
   id?: Collection["id"];
   Button?: React.ElementType;
 }> = ({ className, id, Button }) => {
+  const router = useRouter();
+
   const isCurator = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
   const urlParams = new URLSearchParams(window.location.search);
   const param = urlParams.get(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
@@ -84,7 +87,9 @@ const CreateCollection: FC<{
 
   function toggleOpen() {
     setIsOpen(!isOpen);
-    if (shouldModuleOpen) removeParams(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
+    if (shouldModuleOpen) {
+      removeParams({ params: QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT, router });
+    }
   }
 };
 

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -64,9 +64,9 @@ const Collection: FC = () => {
       message:
         "A dataset was withdrawn. You've been redirected to the parent collection.",
     });
-    removeParams("tombstoned_dataset_id");
+    removeParams({ params: "tombstoned_dataset_id", router });
     setHasShownWithdrawToast(true);
-  }, [tombstoned_dataset_id, collection, hasShownWithdrawToast]);
+  }, [tombstoned_dataset_id, collection, hasShownWithdrawToast, router]);
 
   useEffect(() => {
     if (isTombstonedCollection(collection)) {

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -422,7 +422,7 @@ function loadStateFromURL(
 ): State {
   const { payload } = action;
 
-  const { compare, filters, genes, tissues } = payload;
+  const { compare, filters, genes, tissues, cellTypes, organism } = payload;
 
   return {
     ...state,
@@ -430,8 +430,8 @@ function loadStateFromURL(
     selectedFilters: { ...state.selectedFilters, ...filters },
     selectedGenes: genes,
     selectedTissues: tissues,
-    selectedOrganismId: payload.organism,
-    filteredCellTypes: payload.cellTypes ?? [],
+    selectedOrganismId: organism,
+    filteredCellTypes: cellTypes ?? [],
     expandedTissueIds: filters.tissues ?? [],
   };
 }

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -472,11 +472,6 @@ function setFilteredCellTypes(
     payload: { filteredCellTypes, filteredCellTypeIds },
   } = action;
 
-  // DEBUG
-  // DEBUG
-  // DEBUG
-  console.log("$$$$$$$$$$$$$ reducer filteredCellTypes", filteredCellTypes);
-
   track(EVENTS.WMG_SELECT_CELL_TYPE, {
     cell_types: filteredCellTypeIds,
   });

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -106,11 +106,6 @@ export const REDUCERS = {
 export function reducer(state: State, action: PayloadAction<unknown>): State {
   const { type } = action;
 
-  // DEBUG
-  // DEBUG
-  // DEBUG
-  console.log("🎄 state", state);
-
   const handler = REDUCERS[type];
 
   if (!handler) {
@@ -426,6 +421,8 @@ function loadStateFromURL(
   state: State,
   action: PayloadAction<LoadStateFromURLPayload>
 ): State {
+  const { expandedTissueIds } = state;
+
   const { payload } = action;
 
   const { compare, filters, genes, tissues, cellTypes, organism, cellTypeIds } =
@@ -440,7 +437,7 @@ function loadStateFromURL(
     selectedOrganismId: organism,
     filteredCellTypes: cellTypes ?? EMPTY_ARRAY,
     filteredCellTypeIds: cellTypeIds ?? EMPTY_ARRAY,
-    expandedTissueIds: filters.tissues ?? EMPTY_ARRAY,
+    expandedTissueIds: filters.tissues ?? expandedTissueIds,
   };
 }
 

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -467,6 +467,11 @@ function setFilteredCellTypes(
     payload: { filteredCellTypes, filteredCellTypeIds },
   } = action;
 
+  // DEBUG
+  // DEBUG
+  // DEBUG
+  console.log("$$$$$$$$$$$$$ reducer filteredCellTypes", filteredCellTypes);
+
   track(EVENTS.WMG_SELECT_CELL_TYPE, {
     cell_types: filteredCellTypeIds,
   });

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -106,6 +106,11 @@ export const REDUCERS = {
 export function reducer(state: State, action: PayloadAction<unknown>): State {
   const { type } = action;
 
+  // DEBUG
+  // DEBUG
+  // DEBUG
+  console.log("🎄 state", state);
+
   const handler = REDUCERS[type];
 
   if (!handler) {
@@ -414,6 +419,7 @@ export interface LoadStateFromURLPayload {
   tissues?: State["selectedTissues"];
   genes: State["selectedGenes"];
   cellTypes?: State["filteredCellTypes"];
+  cellTypeIds?: State["filteredCellTypeIds"];
 }
 
 function loadStateFromURL(
@@ -422,7 +428,8 @@ function loadStateFromURL(
 ): State {
   const { payload } = action;
 
-  const { compare, filters, genes, tissues, cellTypes, organism } = payload;
+  const { compare, filters, genes, tissues, cellTypes, organism, cellTypeIds } =
+    payload;
 
   return {
     ...state,
@@ -431,8 +438,9 @@ function loadStateFromURL(
     selectedGenes: genes,
     selectedTissues: tissues,
     selectedOrganismId: organism,
-    filteredCellTypes: cellTypes ?? [],
-    expandedTissueIds: filters.tissues ?? [],
+    filteredCellTypes: cellTypes ?? EMPTY_ARRAY,
+    filteredCellTypeIds: cellTypeIds ?? EMPTY_ARRAY,
+    expandedTissueIds: filters.tissues ?? EMPTY_ARRAY,
   };
 }
 

--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/ShareButton/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/ShareButton/index.tsx
@@ -4,6 +4,7 @@ import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
 import { EMPTY_OBJECT, noop } from "src/common/constants/utils";
 import { isSSR } from "src/common/utils/isSSR";
+import { useRouter } from "next/router";
 
 import { EXCLUDE_IN_SCREENSHOT_CLASS_NAME } from "../SaveExport";
 import {
@@ -32,6 +33,7 @@ import { useTissueMetadata } from "src/common/queries/cellGuide";
 export default function ShareButton(): JSX.Element {
   const state = useContext(StateContext);
   const { data: tissues } = useTissueMetadata();
+  const router = useRouter();
 
   const {
     selectedFilters,
@@ -127,11 +129,12 @@ export default function ShareButton(): JSX.Element {
     if (params) {
       // If we later want to display a toast on successful load from url, this function returns true/false
       const loadedState = loadStateFromQueryParams({
-        params,
-        selectedFilters,
-        dispatch,
-        tissues,
         cellTypesByName,
+        dispatch,
+        params,
+        router,
+        selectedFilters,
+        tissues,
       });
 
       if (loadedState) {
@@ -159,6 +162,7 @@ export default function ShareButton(): JSX.Element {
     compare,
     mapCellTypesToIDs,
     tissues,
+    router,
   ]);
 
   return (

--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/ShareButton/utils.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/ShareButton/utils.tsx
@@ -1,3 +1,4 @@
+import { NextRouter } from "next/router";
 import { Dispatch } from "react";
 import { TissueMetadataQueryResponse } from "src/common/queries/cellGuide";
 import { isSSR } from "src/common/utils/isSSR";
@@ -76,17 +77,19 @@ const stripEmptyFilters = (
 };
 
 export const loadStateFromQueryParams = ({
-  params,
-  selectedFilters,
-  dispatch,
-  tissues,
   cellTypesByName,
+  dispatch,
+  params,
+  router,
+  selectedFilters,
+  tissues,
 }: {
   params: URLSearchParams;
   selectedFilters: State["selectedFilters"];
   dispatch: Dispatch<PayloadAction<LoadStateFromURLPayload>>;
   tissues?: TissueMetadataQueryResponse;
   cellTypesByName: { [name: string]: CellType };
+  router: NextRouter;
 }): LoadStateFromURLPayload | null => {
   if (isSSR()) return null;
 
@@ -153,7 +156,7 @@ export const loadStateFromQueryParams = ({
    * (thuang): Please makes sure we only remove params AFTER pushing all params
    * to `paramsToRemove`
    */
-  removeParams(paramsToRemove);
+  removeParams({ params: paramsToRemove, router });
 
   const payload = {
     compare: newCompare,

--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/ShareButton/utils.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/ShareButton/utils.tsx
@@ -143,6 +143,10 @@ export const loadStateFromQueryParams = ({
         return false;
       }) || [];
 
+  const newFilteredCellTypeIds = newFilteredCellTypes.map(
+    (cellTypeName) => cellTypesByName[cellTypeName].id
+  );
+
   if (newFilteredCellTypes.length > 0) paramsToRemove.push("cellTypes");
 
   // Check for compare
@@ -164,6 +168,7 @@ export const loadStateFromQueryParams = ({
     organism: newSelectedOrganism,
     genes: newSelectedGenes,
     cellTypes: newFilteredCellTypes,
+    cellTypeIds: newFilteredCellTypeIds,
   };
 
   dispatch(loadStateFromURL(payload));

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/connect.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/connect.ts
@@ -268,30 +268,30 @@ export function useConnect({
     [cellTypesByName, displayedTissueIds, dispatch, filteredCellTypes]
   );
 
-  const previousFilteredCellTypes = useRef(filteredCellTypes);
+  // const previousFilteredCellTypes = useRef(filteredCellTypes);
 
-  useEffect(() => {
-    if (previousFilteredCellTypes.current === filteredCellTypes) return;
+  // useEffect(() => {
+  //   if (previousFilteredCellTypes.current === filteredCellTypes) return;
 
-    // DEBUG
-    // DEBUG
-    // DEBUG
-    console.log(
-      "#### Calling handleFilteredCellTypesChange filteredCellTypes",
-      filteredCellTypes
-    );
+  //   // DEBUG
+  //   // DEBUG
+  //   // DEBUG
+  //   console.log(
+  //     "#### Calling handleFilteredCellTypesChange filteredCellTypes",
+  //     filteredCellTypes
+  //   );
 
-    handleFilteredCellTypesChange(
-      null,
-      filteredCellTypes.map((name) => ({ name }))
-    );
+  //   handleFilteredCellTypesChange(
+  //     null,
+  //     filteredCellTypes.map((name) => ({ name }))
+  //   );
 
-    previousFilteredCellTypes.current = filteredCellTypes;
-  }, [
-    previousFilteredCellTypes,
-    filteredCellTypes,
-    handleFilteredCellTypesChange,
-  ]);
+  //   previousFilteredCellTypes.current = filteredCellTypes;
+  // }, [
+  //   previousFilteredCellTypes,
+  //   filteredCellTypes,
+  //   handleFilteredCellTypesChange,
+  // ]);
 
   const handleCellTypeDelete = (cellTypeNameToDelete: string) => () => {
     const cellTypeIdToDelete = cellTypesByName[cellTypeNameToDelete].id;
@@ -353,6 +353,14 @@ export function useConnect({
     displayedCellTypes,
     selectedCellTypes: filteredCellTypes,
   });
+
+  // DEBUG
+  // DEBUG
+  // DEBUG
+  console.log(
+    "📞📞📞📞 calling useHandleExpandedTissueIds filteredCellTypeIds",
+    filteredCellTypeIds
+  );
 
   useHandleExpandedTissueIds({
     filteredCellTypeIds,

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/connect.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/connect.ts
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router";
 import {
   useCallback,
   useContext,

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/connect.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/connect.ts
@@ -239,23 +239,11 @@ export function useConnect({
         (name) => cellTypesByName[name].id
       );
 
-      // DEBUG
-      // DEBUG
-      // DEBUG
-      console.log("-------filteredCellTypes", filteredCellTypes);
-      console.log("-------rawNewFilteredCellTypes", rawNewFilteredCellTypes);
-      console.log("-------newCellTypeNames", newCellTypeNames);
-
       /**
        * (thuang): Don't dispatch if the new filtered cell types are the same.
        * Otherwise, it will cause infinite loop.
        */
       if (String(filteredCellTypes) === String(newCellTypeNames)) return;
-
-      // DEBUG
-      // DEBUG
-      // DEBUG
-      console.log("🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆 DISPATCHING");
 
       dispatch?.(
         setFilteredCellTypes({
@@ -267,31 +255,6 @@ export function useConnect({
     },
     [cellTypesByName, displayedTissueIds, dispatch, filteredCellTypes]
   );
-
-  // const previousFilteredCellTypes = useRef(filteredCellTypes);
-
-  // useEffect(() => {
-  //   if (previousFilteredCellTypes.current === filteredCellTypes) return;
-
-  //   // DEBUG
-  //   // DEBUG
-  //   // DEBUG
-  //   console.log(
-  //     "#### Calling handleFilteredCellTypesChange filteredCellTypes",
-  //     filteredCellTypes
-  //   );
-
-  //   handleFilteredCellTypesChange(
-  //     null,
-  //     filteredCellTypes.map((name) => ({ name }))
-  //   );
-
-  //   previousFilteredCellTypes.current = filteredCellTypes;
-  // }, [
-  //   previousFilteredCellTypes,
-  //   filteredCellTypes,
-  //   handleFilteredCellTypesChange,
-  // ]);
 
   const handleCellTypeDelete = (cellTypeNameToDelete: string) => () => {
     const cellTypeIdToDelete = cellTypesByName[cellTypeNameToDelete].id;
@@ -353,14 +316,6 @@ export function useConnect({
     displayedCellTypes,
     selectedCellTypes: filteredCellTypes,
   });
-
-  // DEBUG
-  // DEBUG
-  // DEBUG
-  console.log(
-    "📞📞📞📞 calling useHandleExpandedTissueIds filteredCellTypeIds",
-    filteredCellTypeIds
-  );
 
   useHandleExpandedTissueIds({
     filteredCellTypeIds,

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/connect.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/connect.ts
@@ -1,0 +1,422 @@
+import { useRouter } from "next/router";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { EMPTY_ARRAY, EMPTY_OBJECT } from "src/common/constants/utils";
+import {
+  CellTypeRow,
+  OntologyTerm,
+  generateTermsByKey,
+  usePrimaryFilterDimensions,
+} from "src/common/queries/wheresMyGene";
+import {
+  DispatchContext,
+  StateContext,
+} from "src/views/WheresMyGene/common/store";
+import {
+  useSortedGeneNames,
+  useTissueNameToCellTypeIdToGeneNameToCellTypeGeneExpressionSummaryDataMap,
+} from "src/views/WheresMyGene/components/HeatMap/hooks/useSortedGeneNames";
+import {
+  useHandleExpandedTissueIds,
+  useTrackHeatMapLoaded,
+} from "src/views/WheresMyGeneV2/components/HeatMap/hooks";
+
+import { Props } from "./types";
+import { DefaultAutocompleteOption } from "@czi-sds/components";
+import {
+  CellType,
+  GeneExpressionSummary,
+  SORT_BY,
+  Tissue,
+} from "src/views/WheresMyGene/common/types";
+import {
+  addCellInfoCellType,
+  setFilteredCellTypes,
+  toggleExpandedTissueId,
+} from "src/views/WheresMyGene/common/store/actions";
+import { useSortedCellTypesByTissueName } from "src/views/WheresMyGene/components/HeatMap/hooks/useSortedCellTypesByTissueName";
+import { cloneDeep } from "lodash";
+
+export function useConnect({
+  cellTypes,
+  cellTypeSortBy,
+  genes,
+  geneSortBy,
+  selectedGeneExpressionSummariesByTissueName,
+  setTissuesByName,
+  tissuesByName,
+}: Props) {
+  const {
+    expandedTissueIds,
+    filteredCellTypeIds,
+    filteredCellTypes,
+    selectedFilters: { tissues: filteredTissueIds },
+    xAxisHeight,
+  } = useContext(StateContext);
+
+  const selectedCellTypeOptions = useMemo(() => {
+    return filteredCellTypes.map((cellType) => ({
+      name: cellType,
+    }));
+  }, [filteredCellTypes]);
+
+  // Loading state per tissue
+  const [isLoading, setIsLoading] = useState(setInitialIsLoading(cellTypes));
+  const chartWrapperRef = useRef<HTMLDivElement>(null);
+  const dispatch = useContext(DispatchContext);
+
+  const { data } = usePrimaryFilterDimensions(); //temp explicit version
+
+  // Get tissueName to ID map for use in find marker genes
+  useEffect(() => {
+    let result: { [name: string]: OntologyTerm } = EMPTY_OBJECT;
+
+    if (data) {
+      const { tissues } = data;
+
+      result = generateTermsByKey(tissues, "name");
+    }
+
+    setTissuesByName(result);
+  }, [data, setTissuesByName]);
+
+  const cellTypesByName = useMemo(() => {
+    const result: { [name: string]: CellType } = {};
+
+    Object.values(cellTypes).forEach((cellTypes) => {
+      cellTypes.forEach((cellType) => {
+        result[cellType.cellTypeName] = cellType;
+      });
+    });
+
+    return result;
+  }, [cellTypes]);
+
+  const generateMarkerGenes = (cellType: CellType, tissueID: string) => {
+    dispatch?.(addCellInfoCellType({ cellType, tissueID }));
+  };
+
+  const tissueNameToCellTypeIdToGeneNameToCellTypeGeneExpressionSummaryDataMap =
+    useTissueNameToCellTypeIdToGeneNameToCellTypeGeneExpressionSummaryDataMap(
+      selectedGeneExpressionSummariesByTissueName
+    );
+
+  const sortedGeneNames = useSortedGeneNames({
+    genes,
+    geneSortBy,
+    selectedCellTypes: cellTypes,
+    tissueNameToCellTypeIdToGeneNameToCellTypeGeneExpressionSummaryDataMap,
+  });
+
+  const sortedCellTypesByTissueName = useSortedCellTypesByTissueName({
+    cellTypeSortBy,
+    genes,
+    selectedCellTypes: cellTypes,
+    tissueNameToCellTypeIdToGeneNameToCellTypeGeneExpressionSummaryDataMap,
+  });
+
+  const geneNameToIndex = useMemo(() => {
+    const result: { [key: string]: number } = {};
+
+    for (const [index, gene] of Object.entries(sortedGeneNames)) {
+      result[gene] = Number(index);
+    }
+
+    return result;
+  }, [sortedGeneNames]);
+
+  const orderedSelectedGeneExpressionSummariesByTissueName = useMemo(() => {
+    const result: { [tissueName: string]: GeneExpressionSummary[] } = {};
+
+    for (const [tissueName, geneExpressionSummary] of Object.entries(
+      selectedGeneExpressionSummariesByTissueName
+    )) {
+      // (thuang): sort() mutates the array, so we need to clone it
+      result[tissueName] = cloneDeep(
+        geneExpressionSummary.sort((a, b) => {
+          if (!a || !b) return -1;
+
+          return geneNameToIndex[a.name] - geneNameToIndex[b.name];
+        })
+      );
+    }
+
+    return result;
+  }, [selectedGeneExpressionSummariesByTissueName, geneNameToIndex]);
+
+  /**
+   * (thuang): Tissues to display after applying filters
+   */
+  const displayedTissues = useMemo(() => {
+    return Object.values(tissuesByName)
+      .filter(({ id }) => {
+        return !filteredTissueIds.length || filteredTissueIds.includes(id);
+      })
+      .filter(({ name }) => {
+        if (!filteredCellTypes.length) return true;
+
+        const tissueCellTypes = sortedCellTypesByTissueName[name];
+
+        return tissueCellTypes?.some((cellType) => {
+          return filteredCellTypes.includes(cellType.cellTypeName);
+        });
+      });
+  }, [
+    filteredTissueIds,
+    filteredCellTypes,
+    sortedCellTypesByTissueName,
+    tissuesByName,
+  ]);
+
+  const displayedTissueIds = useMemo(() => {
+    return displayedTissues.map(({ id }) => id);
+  }, [displayedTissues]);
+
+  /**
+   * (thuang): Derive displayed cell types from `displayedTissues`,
+   * `expandedTissueIds`, and `filteredCellTypes`
+   */
+  const displayedCellTypes = useMemo(() => {
+    const result = new Set<string>();
+
+    displayedTissues.forEach(({ id, name }) => {
+      result.add(id + id);
+
+      if (expandedTissueIds.includes(id)) {
+        const tissueCellTypes = sortedCellTypesByTissueName[name];
+
+        tissueCellTypes?.forEach((cellType) => {
+          if (
+            !filteredCellTypes.length ||
+            filteredCellTypes.includes(cellType.cellTypeName)
+          ) {
+            result.add(id + cellType.cellTypeName);
+          }
+        });
+      }
+    });
+
+    return result;
+  }, [
+    displayedTissues,
+    expandedTissueIds,
+    filteredCellTypes,
+    sortedCellTypesByTissueName,
+  ]);
+
+  const handleExpandCollapse = useCallback(
+    (tissueId: string, tissueName: Tissue) => {
+      dispatch?.(toggleExpandedTissueId({ tissueId, tissueName }));
+    },
+    [dispatch]
+  );
+
+  const uniqueCellTypes = useMemo(() => {
+    const result: Set<string> = new Set<string>();
+    Object.values(sortedCellTypesByTissueName).forEach((cellTypes) => {
+      cellTypes.forEach((cellType) => {
+        if (!cellType.cellTypeName.includes("UBERON:"))
+          result.add(cellType.cellTypeName);
+      });
+    });
+    return [...result].sort().map((cellType) => ({ name: cellType }));
+  }, [sortedCellTypesByTissueName]);
+
+  const handleFilteredCellTypesChange = useCallback(
+    (_: unknown, rawNewFilteredCellTypes: DefaultAutocompleteOption[]) => {
+      if (!Object.keys(cellTypesByName).length) return;
+
+      const newCellTypeNames = rawNewFilteredCellTypes.map(
+        (cellType) => cellType.name
+      );
+      const cellTypeIds = newCellTypeNames.map(
+        (name) => cellTypesByName[name].id
+      );
+
+      // DEBUG
+      // DEBUG
+      // DEBUG
+      console.log("-------filteredCellTypes", filteredCellTypes);
+      console.log("-------rawNewFilteredCellTypes", rawNewFilteredCellTypes);
+      console.log("-------newCellTypeNames", newCellTypeNames);
+
+      /**
+       * (thuang): Don't dispatch if the new filtered cell types are the same.
+       * Otherwise, it will cause infinite loop.
+       */
+      if (String(filteredCellTypes) === String(newCellTypeNames)) return;
+
+      // DEBUG
+      // DEBUG
+      // DEBUG
+      console.log("🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆 DISPATCHING");
+
+      dispatch?.(
+        setFilteredCellTypes({
+          filteredCellTypes: newCellTypeNames,
+          filteredCellTypeIds: cellTypeIds,
+          displayedTissueIds,
+        })
+      );
+    },
+    [cellTypesByName, displayedTissueIds, dispatch, filteredCellTypes]
+  );
+
+  const previousFilteredCellTypes = useRef(filteredCellTypes);
+
+  useEffect(() => {
+    if (previousFilteredCellTypes.current === filteredCellTypes) return;
+
+    // DEBUG
+    // DEBUG
+    // DEBUG
+    console.log(
+      "#### Calling handleFilteredCellTypesChange filteredCellTypes",
+      filteredCellTypes
+    );
+
+    handleFilteredCellTypesChange(
+      null,
+      filteredCellTypes.map((name) => ({ name }))
+    );
+
+    previousFilteredCellTypes.current = filteredCellTypes;
+  }, [
+    previousFilteredCellTypes,
+    filteredCellTypes,
+    handleFilteredCellTypesChange,
+  ]);
+
+  const handleCellTypeDelete = (cellTypeNameToDelete: string) => () => {
+    const cellTypeIdToDelete = cellTypesByName[cellTypeNameToDelete].id;
+    const newCellTypeNames = filteredCellTypes.filter(
+      (cellType) => !(cellTypeNameToDelete === cellType)
+    );
+    const newCellTypeIds = filteredCellTypeIds.filter(
+      (cellTypeId) => !(cellTypeIdToDelete === cellTypeId)
+    );
+
+    dispatch?.(
+      setFilteredCellTypes({
+        filteredCellTypes: newCellTypeNames,
+        filteredCellTypeIds: newCellTypeIds,
+        displayedTissueIds,
+      })
+    );
+  };
+
+  /**
+   * All tissue cell types to render in YAxisCharts
+   */
+  const allTissueCellTypes = useMemo(() => {
+    return displayedTissues
+      .sort((a, b) => {
+        // sort tissues alphabetically
+        return a.name.localeCompare(b.name);
+      })
+      .flatMap((tissue: OntologyTerm) => {
+        const { id, name } = tissue;
+
+        const tissueCellTypes = getTissueCellTypes({
+          cellTypeSortBy,
+          cellTypes,
+          sortedCellTypesByTissueName,
+          tissue: name,
+          tissueID: id,
+          displayedCellTypes,
+        });
+
+        return tissueCellTypes.length > 0
+          ? {
+              tissueId: id,
+              tissueName: name,
+              tissueCellTypes,
+            }
+          : [];
+      });
+  }, [
+    cellTypeSortBy,
+    cellTypes,
+    sortedCellTypesByTissueName,
+    displayedCellTypes,
+    displayedTissues,
+  ]);
+
+  useTrackHeatMapLoaded({
+    selectedGenes: genes,
+    displayedCellTypes,
+    selectedCellTypes: filteredCellTypes,
+  });
+
+  useHandleExpandedTissueIds({
+    filteredCellTypeIds,
+    filteredTissueIds,
+    displayedTissueIds,
+    dispatch,
+  });
+
+  return {
+    allTissueCellTypes,
+    chartWrapperRef,
+    expandedTissueIds,
+    filteredCellTypes,
+    generateMarkerGenes,
+    handleCellTypeDelete,
+    handleExpandCollapse,
+    handleFilteredCellTypesChange,
+    isLoading,
+    orderedSelectedGeneExpressionSummariesByTissueName,
+    selectedCellTypeOptions,
+    setIsLoading,
+    sortedGeneNames,
+    uniqueCellTypes,
+    useHandleExpandedTissueIds,
+    useTrackHeatMapLoaded,
+    xAxisHeight,
+  };
+}
+
+function setInitialIsLoading(cellTypes: Props["cellTypes"]) {
+  return Object.keys(cellTypes).reduce((isLoading, tissue) => {
+    return { ...isLoading, [tissue]: false };
+  }, {});
+}
+
+function getTissueCellTypes({
+  cellTypes,
+  sortedCellTypesByTissueName,
+  tissue,
+  tissueID,
+  cellTypeSortBy,
+  displayedCellTypes,
+}: {
+  cellTypes: { [tissue: Tissue]: CellTypeRow[] };
+  sortedCellTypesByTissueName: { [tissue: string]: CellTypeRow[] };
+  tissue: Tissue;
+  tissueID: string;
+  cellTypeSortBy: SORT_BY;
+  displayedCellTypes: Set<string>;
+}) {
+  const tissueCellTypes = cellTypes[tissue];
+
+  if (!tissueCellTypes || tissueCellTypes.length === 0) return EMPTY_ARRAY;
+
+  const sortedTissueCellTypes = sortedCellTypesByTissueName[tissue];
+
+  let ret =
+    (cellTypeSortBy === SORT_BY.CELL_ONTOLOGY
+      ? tissueCellTypes
+      : sortedTissueCellTypes) || EMPTY_ARRAY;
+
+  ret = ret.filter((cellType) =>
+    displayedCellTypes.has(tissueID + cellType.cellTypeName)
+  );
+
+  return ret;
+}

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/hooks.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/hooks.ts
@@ -67,16 +67,14 @@ export function useHandleExpandedTissueIds({
   const [prevFilteredTissueIds, setPrevFilteredTissueIds] =
     useState(filteredTissueIds);
 
-  // DEBUG
-  // DEBUG
-  // DEBUG
-  console.log("-👀---------displayedTissueIds", displayedTissueIds);
-  console.log("-👀---------prevFilteredCellTypeIds", prevFilteredCellTypeIds);
-  console.log("-👀---------filteredCellTypeIds", filteredCellTypeIds);
-  console.log("-👀---------prevFilteredTissueIds", prevFilteredTissueIds);
-  console.log("-👀---------filteredTissueIds", filteredTissueIds);
-
   useEffect(() => {
+    /**
+     * (thuang): When we enter the cell type filter mode from share link with cellTypes param
+     */
+    if (!prevFilteredCellTypeIds.length && filteredCellTypeIds.length) {
+      expandTissues();
+    }
+
     /**
      * (thuang): When we exit the tissue filter mode, but still have cell type filter,
      * we want to expand all the tissues.

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/hooks.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/hooks.ts
@@ -67,6 +67,15 @@ export function useHandleExpandedTissueIds({
   const [prevFilteredTissueIds, setPrevFilteredTissueIds] =
     useState(filteredTissueIds);
 
+  // DEBUG
+  // DEBUG
+  // DEBUG
+  console.log("-👀---------displayedTissueIds", displayedTissueIds);
+  console.log("-👀---------prevFilteredCellTypeIds", prevFilteredCellTypeIds);
+  console.log("-👀---------filteredCellTypeIds", filteredCellTypeIds);
+  console.log("-👀---------prevFilteredTissueIds", prevFilteredTissueIds);
+  console.log("-👀---------filteredTissueIds", filteredTissueIds);
+
   useEffect(() => {
     /**
      * (thuang): When we exit the tissue filter mode, but still have cell type filter,

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/types.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/types.ts
@@ -1,0 +1,40 @@
+import { Dispatch, SetStateAction } from "react";
+
+import { CellTypeRow, OntologyTerm } from "src/common/queries/wheresMyGene";
+import { State } from "src/views/WheresMyGene/common/store";
+
+import {
+  ChartProps,
+  GeneExpressionSummary,
+  SORT_BY,
+  Tissue,
+} from "src/views/WheresMyGene/common/types";
+
+export interface Props {
+  className?: string;
+  cellTypes: { [tissue: Tissue]: CellTypeRow[] };
+  genes: State["selectedGenes"];
+  selectedGeneExpressionSummariesByTissueName: {
+    [tissueName: string]: GeneExpressionSummary[];
+  };
+  scaledMeanExpressionMax: number;
+  scaledMeanExpressionMin: number;
+  isLoadingAPI: boolean;
+  isScaled: boolean;
+  cellTypeSortBy: SORT_BY;
+  geneSortBy: SORT_BY;
+  echartsRendererMode: "svg" | "canvas";
+  setAllChartProps: Dispatch<
+    SetStateAction<{
+      [tissue: string]: ChartProps;
+    }>
+  >;
+  allChartProps: { [tissue: string]: ChartProps };
+  tissuesByName: { [name: string]: OntologyTerm };
+  setTissuesByName: Dispatch<
+    SetStateAction<{
+      [name: string]: OntologyTerm;
+    }>
+  >;
+  sidebarWidth: number;
+}

--- a/frontend/tests/features/wheresMyGene/downloadCsv.test.ts
+++ b/frontend/tests/features/wheresMyGene/downloadCsv.test.ts
@@ -23,7 +23,8 @@ describe("CSV download tests", () => {
     const tissues = ["blood", "lung"];
     const fileTypes = ["csv"];
     const folder = subDirectory();
-    //download  csv file
+
+    // download  csv file
     await downloadAndVerifyFiles(page, fileTypes, tissues, folder);
     // verify csv file
     await verifyCsv({

--- a/frontend/tests/features/wheresMyGene/shareLink.test.ts
+++ b/frontend/tests/features/wheresMyGene/shareLink.test.ts
@@ -250,7 +250,7 @@ async function verifyShareLink({
     encodedLink += encodeLink(param, String(data));
   }
 
-  //cellTypes
+  // cellTypes
   if (cellTypes !== undefined) {
     const param = "cellTypes";
 

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -2,7 +2,10 @@ import { expect, Page } from "@playwright/test";
 import { toInteger } from "lodash";
 import { test } from "tests/common/test";
 import { collapseTissue, expandTissue, tryUntil } from "tests/utils/helpers";
-import { goToWMG } from "tests/utils/wmgUtils";
+import {
+  goToWMG,
+  WMG_WITH_SEEDED_GENES_AND_CELL_TYPES,
+} from "tests/utils/wmgUtils";
 
 const FILTERED_TISSUES = ["abdomen", "axilla", "blood"];
 const TISSUE_NODE_TEST_ID = "tissue-name";
@@ -38,6 +41,9 @@ const EXPECTED_EXPANDED_TISSUES = ["blood"];
 const EXPECTED_VISIBLE_CELL = ["B Cell"];
 const EXPECTED_FILTERED_TISSUES_WITH_DATASET_FILTER = ["axilla", "brain"];
 const EXPECTED_FILTERED_TISSUES_WITH_DISEASE_FILTER = ["blood"];
+const EXPECTED_FILTERED_TISSUES_WITH_SHARE_LINK = ["lung"];
+
+const WAIT_FOR_REQUEST_TIMEOUT_MS = 30 * 1000; // 30 seconds
 
 const { describe } = test;
 
@@ -312,6 +318,42 @@ describe("WMG tissue auto-expand", () => {
     await removeCellFilter(page);
     await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_DATASET_FILTER);
   });
+
+  test("Share link with genes and cellTypes", async ({ page }) => {
+    await Promise.all([
+      /**
+       * (thuang): This test asserts that the app does use the cellTypes passed
+       * in the share link in a `/filters` request.
+       * If this `waitForRequest` times out, it's likely because the app is NOT
+       * sending a request with the cellTypes passed in the share link.
+       */
+      page.waitForRequest(
+        (request) => {
+          if (!request.url().includes("wmg/v2/filters")) return false;
+
+          const requestBody = JSON.parse(request.postData() || "{}");
+
+          const requestCellTypeIds = JSON.stringify(
+            requestBody.filter.cell_type_ontology_term_ids
+          );
+
+          return (
+            requestCellTypeIds ===
+            JSON.stringify(WMG_WITH_SEEDED_GENES_AND_CELL_TYPES.cellTypeIds)
+          );
+        },
+        { timeout: WAIT_FOR_REQUEST_TIMEOUT_MS }
+      ),
+      loadPageAndTissues(page, WMG_WITH_SEEDED_GENES_AND_CELL_TYPES.URL),
+    ]);
+
+    await checkElementVisible(
+      page,
+      WMG_WITH_SEEDED_GENES_AND_CELL_TYPES.cellTypes,
+      CELL_TYPE_TEST_ID
+    );
+    await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_SHARE_LINK);
+  });
 });
 
 /**
@@ -324,8 +366,8 @@ describe("WMG tissue auto-expand", () => {
  * loadPageAndTissues
  * Load the WMG page and wait for the tissue nodes to be visible
  */
-async function loadPageAndTissues(page: Page) {
-  await goToWMG(page);
+async function loadPageAndTissues(page: Page, url?: string) {
+  await goToWMG(page, url);
   await expect(page.getByTestId(TISSUE_NODE_TEST_ID)).not.toHaveCount(0);
 }
 
@@ -364,7 +406,7 @@ async function filterCellTypes(page: Page, cellTypes: string[]) {
 
 /**
  * filterTissues
- * Filter the tissuesfrom the left panel
+ * Filter the tissues from the left panel
  */
 async function filterTissues(
   page: Page,

--- a/frontend/tests/utils/wmgUtils.ts
+++ b/frontend/tests/utils/wmgUtils.ts
@@ -29,6 +29,23 @@ export const WMG_WITH_SEEDED_GENES = {
   genes: WMG_SEED_GENES,
 };
 
+const WMG_SEED_CELL_TYPES = ["B-1a B cell"];
+/**
+ * B-1a B cell's ontology id is: CL:0000820
+ */
+const WMG_SEED_CELL_TYPE_IDS = ["CL:0000820"];
+
+export const WMG_WITH_SEEDED_GENES_AND_CELL_TYPES = {
+  URL:
+    `${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}?` +
+    `genes=${encodeURIComponent(WMG_SEED_GENES.join(","))}&` +
+    `cellTypes=${encodeURIComponent(WMG_SEED_CELL_TYPES.join(","))}&` +
+    "ver=2",
+  genes: WMG_SEED_GENES,
+  cellTypes: WMG_SEED_CELL_TYPES,
+  cellTypeIds: WMG_SEED_CELL_TYPE_IDS,
+};
+
 const WAIT_FOR_RESPONSE_TIMEOUT_MS = 10 * 1000;
 
 /**

--- a/frontend/tests/utils/wmgUtils.ts
+++ b/frontend/tests/utils/wmgUtils.ts
@@ -46,6 +46,20 @@ export const WMG_WITH_SEEDED_GENES_AND_CELL_TYPES = {
   cellTypeIds: WMG_SEED_CELL_TYPE_IDS,
 };
 
+const WMG_SEED_TISSUES = ["blood", "lung"];
+const WMG_SEED_TISSUE_IDS = ["UBERON:0000178", "UBERON:0002048"];
+
+export const WMG_WITH_SEEDED_GENES_AND_TISSUES = {
+  URL:
+    `${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}?` +
+    `genes=${encodeURIComponent(WMG_SEED_GENES.join(","))}&` +
+    `tissues=${encodeURIComponent(WMG_SEED_TISSUE_IDS.join(","))}&` +
+    "ver=2",
+  genes: WMG_SEED_GENES,
+  tissues: WMG_SEED_TISSUES,
+  tissueIds: WMG_SEED_TISSUE_IDS,
+};
+
 const WAIT_FOR_RESPONSE_TIMEOUT_MS = 10 * 1000;
 
 /**


### PR DESCRIPTION
## Reason for Change

- #5936 

## Changes

1. CellTypes in share link will now auto expand tissues
2. BONUS: Fix extra bug that cellTypes in share link doesn't result in cellTypeIds in `/filters` API request
3. Add corresponding tests to cover both bugs above
4. EXTRA BONUS: Refactor Heatmap component to use Ronen Pattern™️ 

## Testing steps

1. Visit https://pr-6050-frontend.rdev.single-cell.czi.technology/gene-expression?genes=TSPAN6%2CTNMD%2CDPM1&ver=2&cellTypes=B+cell%2CB-1a+B+cell
2. The tissues should be expanded like so:

<img width="1064" alt="Screenshot 2023-10-20 at 8 41 53 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/dbe5413e-bb59-4aef-9bae-d11740c6a97b">

3. API call should include cellTypeIds too

<img width="1554" alt="Screenshot 2023-10-20 at 8 42 36 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/503bed51-5864-4d27-b530-bcf279ce8001">


## Notes for Reviewer
