### PR TITLE
test: Update collection revision e2e test timeout

### DIFF
--- a/frontend/tests/features/collection/revision.test.ts
+++ b/frontend/tests/features/collection/revision.test.ts
@@ -158,6 +158,11 @@ describe("Collection Revision @loggedIn", () => {
   });
 });
 
+/**
+ * (thuang): Wait for 1 min instead of the default 3 minutes, so we fail faster
+ */
+const WAIT_FOR_MIN_USABLE_COLLECTION_TIMEOUT_MS = 1 * 60 * 1000; // 1 minute
+
 async function startRevision(page: Page): Promise<string> {
   const MIN_USABLE_COLLECTION_COUNT = 4;
 
@@ -183,16 +188,23 @@ async function startRevision(page: Page): Promise<string> {
           { page }
         );
       } catch {
-        await page
-          .getByTestId(COLLECTION_ROW_WRITE_REVISION_ID)
-          .first()
-          .getByTestId(COLLECTION_VIEW_REVISION)
-          .click();
-        await deleteRevision(page);
+        const hasAnyRevision =
+          (await page.getByTestId(COLLECTION_ROW_WRITE_REVISION_ID).count()) >
+          0;
+
+        if (hasAnyRevision) {
+          await page
+            .getByTestId(COLLECTION_ROW_WRITE_REVISION_ID)
+            .first()
+            .getByTestId(COLLECTION_VIEW_REVISION)
+            .click();
+          await deleteRevision(page);
+        }
+
         throw new Error("No available collection");
       }
     },
-    { page }
+    { page, timeoutMs: WAIT_FOR_MIN_USABLE_COLLECTION_TIMEOUT_MS }
   );
 
   // (thuang): We randomly select a collection row to start a revision


### PR DESCRIPTION
## Reason for Change

1. e2e collection revision test was timing out at 30 mins, because there's a bug in the waitUntil block logic that triggers a 5 min wait every time it can't find a suitable collection

## Notes for Reviewer
