### PR TITLE
chore(wmg): improve default wmg cube schema

### DIFF
--- a/backend/wmg/data/schemas/cube_schema_default.py
+++ b/backend/wmg/data/schemas/cube_schema_default.py
@@ -56,6 +56,7 @@ expression_summary_schema = tiledb.ArraySchema(
     sparse=True,
     allows_duplicates=True,
     attrs=expression_summary_physical_attrs,
-    cell_order="hilbert",
-    capacity=100000,
+    cell_order="row-major",
+    tile_order="row-major",
+    capacity=10000,
 )

--- a/scripts/populate_rdev_with_cellguide_data.sh
+++ b/scripts/populate_rdev_with_cellguide_data.sh
@@ -61,6 +61,7 @@ if [ -n "$LATEST_SNAPSHOT_IDENTIFIER" ]; then
   aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/gpt_descriptions s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/gpt_descriptions
   aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/validated_descriptions s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/validated_descriptions
   if [ "$POPULATE_ONLY_GPT" = false ]; then
+    aws s3 rm s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/${LATEST_SNAPSHOT_IDENTIFIER} --recursive
     aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/${LATEST_SNAPSHOT_IDENTIFIER} s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/${LATEST_SNAPSHOT_IDENTIFIER}
     aws s3 cp s3://cellguide-data-public-${SRC_DEPLOYMENT}/latest_snapshot_identifier s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/latest_snapshot_identifier
   fi

--- a/scripts/populate_rdev_with_wmg_data.sh
+++ b/scripts/populate_rdev_with_wmg_data.sh
@@ -57,6 +57,7 @@ fi
 
 LATEST_SNAPSHOT_IDENTIFIER=$(aws s3 cp s3://cellxgene-wmg-${SRC_DEPLOYMENT}/snapshots/${SNAPSHOT_VERSION}/latest_snapshot_identifier -)
 if [ -n "$LATEST_SNAPSHOT_IDENTIFIER" ]; then
+  aws s3 rm s3://env-rdev-wmg/${STACK_NAME}/snapshots/${SNAPSHOT_VERSION}/${LATEST_SNAPSHOT_IDENTIFIER} --recursive
   aws s3 sync s3://cellxgene-wmg-${SRC_DEPLOYMENT}/snapshots/${SNAPSHOT_VERSION}/${LATEST_SNAPSHOT_IDENTIFIER} s3://env-rdev-wmg/${STACK_NAME}/snapshots/${SNAPSHOT_VERSION}/${LATEST_SNAPSHOT_IDENTIFIER}
 
   # Check the exit code of the last command (AWS CLI)


### PR DESCRIPTION
## Reason for Change

- Using hilbert ordering for the expression summary default cube was bad for performance once after the WMGv2 changes to the backend. This reverts the schema to be row-ordered like the full expression summary cube.
