### PR TITLE
feat(wmg): performance improvements

### DIFF
--- a/backend/common/utils/rollup.py
+++ b/backend/common/utils/rollup.py
@@ -46,15 +46,21 @@ def find_descendants_per_cell_type(cell_types):
     descendants_per_cell_type : list
         List of lists of descendants for each cell type in the input list.
     """
-
+    lookup_table = {}
+    cell_types_set = set(cell_types)
     relatives_per_cell_type = []
     for cell_type in cell_types:
-        relatives = descendants(cell_type)
-        relatives_per_cell_type.append(relatives)
+        if ";;" in cell_type:
+            prefix, suffix = cell_type.split(";;")
+            suffix = ";;" + suffix
+        else:
+            prefix = cell_type
+            suffix = ""
+        if cell_type not in lookup_table:
+            relatives = [f"{i}{suffix}" for i in descendants(prefix)]
+            lookup_table[cell_type] = list(cell_types_set.intersection(relatives))
 
-    for i, children in enumerate(relatives_per_cell_type):
-        # remove descendent cell types that are not cell types in the WMG data
-        relatives_per_cell_type[i] = list(set(children).intersection(cell_types))
+        relatives_per_cell_type.append(lookup_table[cell_type])
 
     return relatives_per_cell_type
 

--- a/backend/common/utils/rollup.py
+++ b/backend/common/utils/rollup.py
@@ -34,7 +34,16 @@ def ancestors(cell_type):
 
 def find_descendants_per_cell_type(cell_types):
     """
-    Find the ancestors or descendants for each cell type in the input list.
+    Find the descendants for each cell type in the input list.
+    Terms are only considered descendants if they are present in the input list.
+
+    Terms can be suffixed with ";;{A_0}--{B_0}--..." to indicate that only descendants within the same
+    group specified by the suffix should be considered. For example, if the term is
+    "CL:0000540;;{tissue_0}--{disease_0}" then only descendants with the same tissue_0 and disease_0
+    will be considered.
+
+    This is useful for rolling up cell types within groups (e.g. tissues) but not across groups.
+
 
     Parameters
     ----------
@@ -46,10 +55,15 @@ def find_descendants_per_cell_type(cell_types):
     descendants_per_cell_type : list
         List of lists of descendants for each cell type in the input list.
     """
+    # a lookup table to avoid redundant ontology lookups
     lookup_table = {}
+
+    # a set of all cell types in the input list
+    # used to compute intersections with descendants
     cell_types_set = set(cell_types)
     relatives_per_cell_type = []
     for cell_type in cell_types:
+        # if the input cell types are suffixed, only consider descendants within the same group
         if ";;" in cell_type:
             prefix, suffix = cell_type.split(";;")
             suffix = ";;" + suffix
@@ -57,7 +71,9 @@ def find_descendants_per_cell_type(cell_types):
             prefix = cell_type
             suffix = ""
         if cell_type not in lookup_table:
+            # find descendants of cell type and re-suffix them
             relatives = [f"{i}{suffix}" for i in descendants(prefix)]
+            # only consider descendants (+suffixes) that are in the input list
             lookup_table[cell_type] = list(cell_types_set.intersection(relatives))
 
         relatives_per_cell_type.append(lookup_table[cell_type])

--- a/backend/wmg/api/common/rollup.py
+++ b/backend/wmg/api/common/rollup.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame
 
-from backend.common.utils.rollup import rollup_across_cell_type_descendants
+from backend.common.utils.rollup import rollup_across_cell_type_descendants, rollup_across_cell_type_descendants_array
 
 ######################### PUBLIC FUNCTIONS IN ALPHABETIC ORDER ##################################
 
@@ -62,9 +62,7 @@ def rollup(gene_expression_df, cell_counts_grouped_df) -> Tuple[DataFrame, DataF
 ######################### PRIVATE FUNCTIONS IN ALPHABETIC ORDER ##################################
 
 
-def _add_missing_combinations_to_gene_expression_df_for_rollup(
-    gene_expression_df, universal_set_cell_counts_df
-) -> DataFrame:
+def _rollup_gene_expression(gene_expression_df, universal_set_cell_counts_df) -> DataFrame:
     """
     Augments the input gene expression dataframe to include
     (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>)
@@ -85,53 +83,58 @@ def _add_missing_combinations_to_gene_expression_df_for_rollup(
         and likely greater size than the input gene expression dataframe that includes combinations
         for which numeric values should be aggregated during the rollup operation.
     """
-    # extract group-by terms and queried genes from the input dataframes
-    # if a queried gene is not present in the input dot plot dataframe, we can safely
-    # ignore it as it need not be rolled up anyway.
-    group_by_terms = list(universal_set_cell_counts_df.index.names)
-    genes = list(set(gene_expression_df["gene_ontology_term_id"]))
+    if gene_expression_df.shape[0] == 0:
+        return gene_expression_df
 
-    # get the names of the numeric columns
     numeric_columns = list(
         gene_expression_df.columns[[np.issubdtype(dtype, np.number) for dtype in gene_expression_df.dtypes]]
     )
 
-    # exclude n_cells_tissue as we do not wish to roll it up
-    if "n_cells_tissue" in numeric_columns:
-        numeric_columns.remove("n_cells_tissue")
-
-    # get the total number of cells per tissue to populate the n_cells_tissue in the added entries
-    n_cells_tissue_dict = gene_expression_df.groupby("tissue_ontology_term_id").first()["n_cells_tissue"].to_dict()
-
-    # get the set of available combinations of group-by terms from the aggregated cell counts
+    group_by_terms = list(universal_set_cell_counts_df.index.names)
     available_combinations = set(universal_set_cell_counts_df.index.values)
 
-    # for each gene, get the set of available combinations of group-by terms from the input expression dataframe
-    entries_to_add = []
-    for gene in genes:
-        gene_expression_df_per_gene = gene_expression_df[gene_expression_df["gene_ontology_term_id"] == gene]
-        available_combinations_per_gene = set(zip(*gene_expression_df_per_gene[group_by_terms].values.T))
+    numeric_columns.remove("n_cells_tissue")
 
-        # get the combinations that are missing in the input expression dataframe
-        # these combinations have no data but can be rescued by the roll-up operation
-        missing_combinations = available_combinations.difference(available_combinations_per_gene)
-        for combo in missing_combinations:
-            entry = {dim: combo[i] for i, dim in enumerate(group_by_terms)}
+    pivoted = gene_expression_df.pivot_table(
+        index=group_by_terms, columns=["gene_ontology_term_id"], fill_value=0, values=numeric_columns, aggfunc="sum"
+    )
+    genes = np.array(pivoted["sum"].columns.tolist())
+    missing_combinations = list(available_combinations.difference(pivoted.index.values))
+    dense_tables = np.stack(
+        [
+            np.vstack((pivoted[col].values, np.zeros((len(missing_combinations), len(genes)))))
+            for col in numeric_columns
+        ],
+        axis=2,
+    )
 
-            # If a tissue, T1, DOES NOT have ANY of the QUERIED GENES expressed, then entirely
-            # omit all combos that contain tissue T1 from the candidate list of combos
-            # that should be considered for rollup. Otherwise, include combos containing T1
-            # in the candidate list of combos for rollup.
-            if entry["tissue_ontology_term_id"] in n_cells_tissue_dict:
-                entry.update({col: 0 for col in numeric_columns})
-                entry["n_cells_tissue"] = n_cells_tissue_dict[entry["tissue_ontology_term_id"]]
-                entry["gene_ontology_term_id"] = gene
-                entries_to_add.append(entry)
+    multi_index = pd.MultiIndex.from_tuples(pivoted.index.tolist() + missing_combinations, names=group_by_terms)
+    group_by_terms.remove("cell_type_ontology_term_id")
+    group_by_terms = ["cell_type_ontology_term_id"] + group_by_terms
 
-    # add the missing entries to the input expression dataframe
-    gene_expression_with_missing_combos_df = pd.concat((gene_expression_df, pd.DataFrame(entries_to_add)), axis=0)
+    multi_index = multi_index.reorder_levels(group_by_terms)
 
-    return gene_expression_with_missing_combos_df
+    multi_index_array = np.vstack(multi_index.values)
+
+    cell_types_for_rollup = np.char.add(multi_index_array[:, 0], ";;")
+    for col in range(1, multi_index_array.shape[1]):
+        if col > 1:
+            cell_types_for_rollup = np.char.add(cell_types_for_rollup, "--")
+        cell_types_for_rollup = np.char.add(cell_types_for_rollup, multi_index_array[:, col])
+
+    dense_tables = rollup_across_cell_type_descendants_array(dense_tables, cell_types_for_rollup)
+
+    row, col = dense_tables[:, :, 0].nonzero()
+
+    new_df = pd.DataFrame(index=multi_index[row], data=genes[col], columns=["gene_ontology_term_id"]).reset_index()
+    for i, col_name in enumerate(numeric_columns):
+        new_df[col_name] = dense_tables[row, col, i]
+
+    # get the total number of cells per tissue to populate the n_cells_tissue in the added entries
+    n_cells_tissue = gene_expression_df.groupby("tissue_ontology_term_id").first()["n_cells_tissue"]
+
+    new_df["n_cells_tissue"] = n_cells_tissue[new_df["tissue_ontology_term_id"]].values
+    return new_df[gene_expression_df.columns]
 
 
 def _build_cell_count_groups_universal_set(cell_counts_grouped_df) -> DataFrame:
@@ -208,11 +211,9 @@ def _rollup_cell_counts(cell_counts_grouped_df) -> DataFrame:
 
     if cell_counts_grouped_df.shape[0] > 0:
         universal_set_cell_counts_grouped_df = _build_cell_count_groups_universal_set(cell_counts_grouped_df)
+        index_names = universal_set_cell_counts_grouped_df.index.names
 
-        # Add index columns to the universal_set_cell_counts_grouped_df so that these columns can be
-        # DIRECTLY accessed in the dataframe during the rollup operation while traversing the cell type descendants
-        for col in universal_set_cell_counts_grouped_df.index.names:
-            universal_set_cell_counts_grouped_df[col] = universal_set_cell_counts_grouped_df.index.get_level_values(col)
+        universal_set_cell_counts_grouped_df = universal_set_cell_counts_grouped_df.reset_index()
 
         # rollup cell counts across cell type descendants
         rolled_up_cell_counts_grouped_df = rollup_across_cell_type_descendants(universal_set_cell_counts_grouped_df)
@@ -220,61 +221,6 @@ def _rollup_cell_counts(cell_counts_grouped_df) -> DataFrame:
         rolled_up_cell_counts_grouped_df = rolled_up_cell_counts_grouped_df[
             rolled_up_cell_counts_grouped_df["n_cells_cell_type"] > 0
         ]
-        # Remove columns that were added to the cell counts dataframe for the purpose of rollup.
-        # This is make it congruent with the structure of the input cell counts dataframe
-        rolled_up_cell_counts_grouped_df.drop(columns=rolled_up_cell_counts_grouped_df.index.names, inplace=True)
+        rolled_up_cell_counts_grouped_df.set_index(index_names, inplace=True)
 
     return rolled_up_cell_counts_grouped_df
-
-
-def _rollup_gene_expression(gene_expression_df, universal_set_cell_counts_df) -> DataFrame:
-    """
-    Roll up numeric values across cell type descendants in the input gene expression dataframe.
-
-    Accumulate gene expression values up the cell type ontology ancestor paths for every
-    (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id, <compare_dimension>)
-    combination in the input gene expression dataframe. The compare dimension is an optional
-    field and in the case that it is missing, then accumulation happens for every
-    (gene_ontology_term_id, tissue_ontology_term_id, cell_type_ontology_term_id) combination.
-
-    For example:
-
-    If (G1, T1, C1) has gene expression values in the input expression dataframe,
-    and the tissue labeled T1 has another cell labeled C2 where C2 is an ANCESTOR of C1,
-    then the rolled up gene expression dataframe must include CUMULATIVE gene expression values for the
-    combination (G1, T1, C2) by adding in the gene expression for (G1, T1, C1).
-
-    Parameters
-    ----------
-    gene_expression_df : pandas DataFrame
-        Tidy gene expression dataframe containing the dimensions across which the numeric columns will be
-        aggregated.
-
-    universal_set_cell_counts_df : pandas DataFrame
-        Multi-indexed cell counts dataframe that contains "The Universal Set Of GroupBy Ontology Terms".
-
-    Returns
-    -------
-    rolled_up_gene_expression_df : pandas DataFrame
-        Tidy gene expression dataframe with the same columns as the input gene expression dataframe,
-        and likely greater size than the input gene expression dataframe, but with the numeric
-        columns aggregated across the cell type's descendants.
-    """
-    rolled_up_gene_expression_df = gene_expression_df
-
-    if gene_expression_df.shape[0] > 0:
-        # For each gene in the query, add missing combinations (tissue, cell type, compare dimension)
-        # to the expression dataframe
-        gene_expression_with_missing_combos_df = _add_missing_combinations_to_gene_expression_df_for_rollup(
-            gene_expression_df, universal_set_cell_counts_df
-        )
-
-        # Roll up expression dataframe
-        rolled_up_gene_expression_df = rollup_across_cell_type_descendants(
-            gene_expression_with_missing_combos_df, ignore_cols=["n_cells_tissue"]
-        )
-
-        # Filter out the entries that were added to the dataframe that remain zero after roll-up
-        rolled_up_gene_expression_df = rolled_up_gene_expression_df[rolled_up_gene_expression_df["sum"] > 0]
-
-    return rolled_up_gene_expression_df

--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -100,7 +100,7 @@ def query():
                     term_id_labels=dict(
                         genes=build_gene_id_label_mapping(criteria.gene_ontology_term_ids),
                         cell_types=build_ordered_cell_types_by_tissue(
-                            rolled_cell_counts_grouped_df, snapshot.cell_type_orderings, compare
+                            rolled_cell_counts_grouped_df, cell_counts_grouped_df, snapshot.cell_type_orderings, compare
                         ),
                     ),
                 )
@@ -393,11 +393,13 @@ def fill_out_structured_cell_type_compare(cell_type_agg_compare, structured_resu
 
 # getting only cell type metadata, no genes
 def build_ordered_cell_types_by_tissue(
+    rolled_cell_counts_cell_type_agg: DataFrame,
     cell_counts_cell_type_agg: DataFrame,
     cell_type_orderings: dict,
     compare: str,
 ) -> Dict[str, Dict[str, Dict[str, Any]]]:
     cell_counts_cell_type_agg = cell_counts_cell_type_agg.reset_index()
+    rolled_cell_counts_cell_type_agg = rolled_cell_counts_cell_type_agg.reset_index()
     # Create nested dicts with tissue_ontology_term_id keys, cell_type_ontology_term_id respectively
     structured_result: Dict[str, Dict[str, Dict[str, Any]]] = defaultdict(lambda: defaultdict(dict))
 
@@ -406,7 +408,7 @@ def build_ordered_cell_types_by_tissue(
     fill_out_structured_tissue_agg(tissue_agg, structured_result)
 
     # Populate aggregated cell counts for each (tissue, cell_type) combination
-    cell_type_agg = cell_counts_cell_type_agg.groupby(
+    cell_type_agg = rolled_cell_counts_cell_type_agg.groupby(
         ["tissue_ontology_term_id", "cell_type_ontology_term_id"], as_index=False
     ).sum(numeric_only=True)
 
@@ -415,7 +417,7 @@ def build_ordered_cell_types_by_tissue(
     # Populate aggregated cell counts for each (tissue, cell_type, <compare_dimension>) combination
     if compare:
         fill_out_structured_cell_type_compare(
-            cell_counts_cell_type_agg, structured_result, cell_type_orderings, compare
+            rolled_cell_counts_cell_type_agg, structured_result, cell_type_orderings, compare
         )
 
     return structured_result

--- a/backend/wmg/data/snapshot.py
+++ b/backend/wmg/data/snapshot.py
@@ -64,7 +64,7 @@ class WmgSnapshot:
 
     # Pandas DataFrame containing per-tissue ordering of cell types.
     # Columns are "tissue_ontology_term_id", "cell_type_ontology_term_id", "order"
-    cell_type_orderings: Optional[DataFrame] = field(default=None)
+    cell_type_orderings: Optional[dict] = field(default=None)
 
     # precomputed list of ids for all gene and tissue ontology term ids per organism
     primary_filter_dimensions: Optional[Dict] = field(default=None)
@@ -195,7 +195,9 @@ def _load_snapshot(*, snapshot_schema_version: str, snapshot_id: str, read_versi
         expression_summary_default_cube=_open_cube(f"{snapshot_base_uri}/{EXPRESSION_SUMMARY_DEFAULT_CUBE_NAME}"),
         marker_genes_cube=_open_cube(f"{snapshot_base_uri}/{MARKER_GENES_CUBE_NAME}"),
         cell_counts_cube=_open_cube(f"{snapshot_base_uri}/{CELL_COUNTS_CUBE_NAME}"),
-        cell_type_orderings=cell_type_orderings,
+        cell_type_orderings=cell_type_orderings.set_index(["tissue_ontology_term_id", "cell_type_ontology_term_id"])[
+            "order"
+        ].to_dict(),
         primary_filter_dimensions=primary_filter_dimensions,
         filter_relationships=filter_relationships,
         dataset_metadata=dataset_metadata,

--- a/tests/unit/backend/wmg/api/test_v2.py
+++ b/tests/unit/backend/wmg/api/test_v2.py
@@ -23,6 +23,7 @@ from tests.unit.backend.wmg.fixtures.test_snapshot import (
     create_temp_wmg_snapshot,
     exclude_all_but_one_gene_per_organism,
     exclude_dev_stage_and_ethnicity_for_secondary_filter_test,
+    forward_cell_type_ordering,
     load_realistic_test_snapshot,
     reverse_cell_type_ordering,
 )
@@ -40,7 +41,7 @@ def generate_expected_term_id_labels_dictionary(
     cell_count_tissue_cell_type: int,
     compare_terms: list[str],
     cell_counts_tissue_cell_type_compare_dim: int,
-    cell_ordering_func=reverse_cell_type_ordering,
+    cell_ordering_func=forward_cell_type_ordering,
 ) -> dict:
     """
     Generates aggregated cell counts and cell ordering expected to be returned by /wmg/v2/query endpoint.
@@ -210,6 +211,7 @@ def generate_test_inputs_and_expected_outputs(
     me: float,
     cell_count_per_row_cell_counts_cube: int,
     compare_dim=None,
+    cell_ordering_func=forward_cell_type_ordering,
 ) -> tuple:
     """
     Generates test inputs and expected outputs for the /wmg/v2/query endpoint.
@@ -269,6 +271,7 @@ def generate_test_inputs_and_expected_outputs(
         cell_count_tissue_cell_type=cell_count_tissue_cell_type,
         compare_terms=compare_terms,
         cell_counts_tissue_cell_type_compare_dim=cell_counts_tissue_cell_type_compare_dim,
+        cell_ordering_func=cell_ordering_func,
     )
     expected_expression_summary = generate_expected_expression_summary_dictionary(
         genes=genes,
@@ -464,7 +467,6 @@ class WmgApiV2Tests(unittest.TestCase):
                 "expression_summary": expected_expression_summary,
                 "term_id_labels": expected_term_id_labels,
             }
-
             self.assert_equality_nested_dict_with_floats(
                 expected=expected_response, actual=json.loads(response.data), key_path=[]
             )
@@ -582,7 +584,7 @@ class WmgApiV2Tests(unittest.TestCase):
             organism = "organism_ontology_term_id_0"
 
             (request, _, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
-                genes, organism, dim_size, 1.0, 10
+                genes, organism, dim_size, 1.0, 10, cell_ordering_func=reverse_cell_type_ordering
             )
 
             response = self.app.post("/wmg/v2/query", json=request)
@@ -618,7 +620,7 @@ class WmgApiV2Tests(unittest.TestCase):
             organism = "organism_ontology_term_id_0"
 
             (request, _, expected_term_id_labels) = generate_test_inputs_and_expected_outputs(
-                genes, organism, dim_size, 1.0, expected_count
+                genes, organism, dim_size, 1.0, expected_count, cell_ordering_func=reverse_cell_type_ordering
             )
 
             response = self.app.post("/wmg/v2/query", json=request)

--- a/tests/unit/backend/wmg/fixtures/test_snapshot.py
+++ b/tests/unit/backend/wmg/fixtures/test_snapshot.py
@@ -269,7 +269,11 @@ def create_temp_wmg_snapshot(
             cell_counts_fn=cell_counts_generator_fn,
         )
 
-        cell_type_orderings = build_cell_orderings(cell_counts_cube_dir, cell_ordering_generator_fn)
+        cell_type_orderings = (
+            build_cell_orderings(cell_counts_cube_dir, cell_ordering_generator_fn)
+            .set_index(["tissue_ontology_term_id", "cell_type_ontology_term_id"])["order"]
+            .to_dict()
+        )
         primary_filter_dimensions = build_precomputed_primary_filters()
 
         with tiledb.open(expression_summary_cube_dir, ctx=create_ctx()) as expression_summary_cube, tiledb.open(


### PR DESCRIPTION
## Performance improvements
There are two performance improvements included in this PR.

 - Update build_ordered_cell_types_by_tissue to iterative over numpy arrays instead of pandas DataFrame rows.
   - This reduces runtime from 8s to 50ms for large queries.
 - Re-write the gene expression rollup function. Instead of rolling up a tidy pandas dataframe, the dataframe is reshaped into a 2D numpy array per numeric column, where the rows correspond to groups excluding gene and the columns correspond to genes. Rollup is performed on this 2D array and then reshaped into a pandas dataframe.
   - This also includes a performance optimization to find_descendants_per_cell_type where a hash table is used to store descendants for cell types so that the operation does not need to be needlessly repeated.
   - This reduces runtime for queries, especially large ones with compare dimension selected (e.g. 11s before to 3s after). it also dramatically reduces memory used (e.g. 5GB before to 500MB after).

## Reason for Change

- #6036
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- add
- remove
- modify

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Notes for Reviewer
