### PR TITLE
fix: happy validating terraform that doesn't exist for single-cell

### DIFF
--- a/.github/workflows/clean_happy_rdev.yml
+++ b/.github/workflows/clean_happy_rdev.yml
@@ -22,9 +22,8 @@ jobs:
           role-duration-seconds: 1800
           role-session-name: HappyCleanupSingleCellDPRdevStacks
       - name: Clean up stale happy stacks
-        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.1.5
+        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.5.0
         with:
-          happy_version: 0.108.0
           tfe_token: ${{secrets.TFE_TOKEN}}
           # the default stale period to delete a stack is 2 weeks
           # override like this:

--- a/.github/workflows/clean_happy_rdev.yml
+++ b/.github/workflows/clean_happy_rdev.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Clean up stale happy stacks
         uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.1.5
         with:
+          happy_version: 0.108.0
           tfe_token: ${{secrets.TFE_TOKEN}}
           # the default stale period to delete a stack is 2 weeks
           # override like this:


### PR DESCRIPTION
## Summary

This PR fixes a broken JSON field when trying to get the stacks using jq. This was fixed in the latest version of this action, so we are just updating the action. Here is the fix notes: https://github.com/chanzuckerberg/github-actions/pull/212. The action will still print an error about validations, but this is just a print statement and shouldn't affect anything.

## Reason for Change

- https://czi-tech.atlassian.net/browse/ONCALL-635?atlOrigin=eyJpIjoiNWE3YzUyZmVhMTNjNGE1OTliOGE3MGMyYTY1NGQyMWMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ
- The cleanup aciton stopped working

## Testing steps

* Used a local ubuntu image to test the `jq` string does what we expect. Looks like with this update, there are at least 4 stacks that should be cleaned.

## Notes for Reviewer
