### PR TITLE
fix: 5777 switch organism bug

### DIFF
--- a/frontend/src/common/theme.ts
+++ b/frontend/src/common/theme.ts
@@ -270,6 +270,9 @@ export const gray500 = grey500;
 export const grey600 = (props: CommonThemeProps) => getColors(props)?.gray[600];
 export const gray600 = grey600;
 
+export const greyWhite = () => "#fffff";
+export const grayWhite = greyWhite;
+
 themeOptions.colors.gray = { ...themeOptions.colors.gray, "400": "#999999" };
 
 export const beta100 = (props: CommonThemeProps) => getColors(props)?.beta[100];

--- a/frontend/src/components/common/Button/index.tsx
+++ b/frontend/src/components/common/Button/index.tsx
@@ -1,6 +1,56 @@
 import styled from "@emotion/styled";
-import { buttonStyle } from "src/components/Collections/components/Dataset/common/style";
+import {
+  ButtonProps as RawButtonProps,
+  CommonThemeProps,
+  Button as RawButton,
+  fontBodyS,
+} from "@czi-sds/components";
+import {
+  grayWhite,
+  spacesM,
+  spacesXs,
+  textPrimary,
+  textSecondary,
+} from "src/common/theme";
 
-export const Button = styled.button`
-  ${buttonStyle}
+type ButtonProps = RawButtonProps & CommonThemeProps;
+
+export const Button = styled(RawButton)`
+  ${squarePrimary}
+  ${minimalSecondary}
 `;
+
+function squarePrimary(props: ButtonProps) {
+  const { sdsStyle, sdsType } = props;
+
+  if (sdsStyle !== "square" || sdsType !== "primary") return;
+
+  return `
+    ${commonStyle()}
+    min-width: 80px;
+    color: ${grayWhite()};
+    padding: ${spacesXs(props)}px ${spacesM(props)}px;
+  `;
+}
+
+function minimalSecondary(props: ButtonProps) {
+  const { sdsStyle, sdsType } = props;
+
+  if (sdsStyle !== "minimal" || sdsType !== "secondary") return;
+
+  return `
+    ${commonStyle()}
+    color: ${textSecondary(props)};
+
+    &:hover {
+      color: ${textPrimary(props)};
+    }
+  `;
+}
+
+function commonStyle() {
+  return `
+    ${fontBodyS}
+    font-weight: 500;
+  `;
+}

--- a/frontend/src/views/WheresMyGene/common/store/reducer.ts
+++ b/frontend/src/views/WheresMyGene/common/store/reducer.ts
@@ -164,13 +164,12 @@ function selectOrganism(
     return state;
   }
 
+  const { snapshotId } = state;
+
   return {
-    ...state,
-    selectedGenes: [],
+    ...INITIAL_STATE,
+    snapshotId,
     selectedOrganismId: action.payload,
-    selectedTissues: EMPTY_ARRAY,
-    selectedFilters: EMPTY_FILTERS,
-    cellInfoCellType: null,
   };
 }
 

--- a/frontend/src/views/WheresMyGene/common/store/selectors.ts
+++ b/frontend/src/views/WheresMyGene/common/store/selectors.ts
@@ -1,0 +1,47 @@
+import {
+  INITIAL_STATE,
+  State,
+} from "src/views/WheresMyGene/common/store/reducer";
+
+export function selectHasCustomFiltersOrGenesSelected(state: State): boolean {
+  const {
+    selectedFilters,
+    selectedGenes,
+    compare,
+    sortBy,
+    filteredCellTypes,
+    filteredCellTypeIds,
+  } = state;
+
+  // check if any arrays in selectedFilters is not empty using .some()
+  const hasCustomFilters = Object.values(selectedFilters).some(
+    (filter) => filter.length
+  );
+
+  return (
+    hasCustomFilters ||
+    selectedGenes.length > 0 ||
+    Boolean(compare) ||
+    !isSortByDefault(sortBy) ||
+    filteredCellTypes.length > 0 ||
+    filteredCellTypeIds.length > 0
+  );
+}
+
+/**
+ * (thuang): Returns true if the sortBy value is the same as the default value.
+ */
+function isSortByDefault(sortBy: State["sortBy"]): boolean {
+  const {
+    cellTypes: initialCellTypes,
+    genes: initialGenes,
+    scaled: initialScaled,
+  } = INITIAL_STATE.sortBy;
+  const { cellTypes, genes, scaled } = sortBy;
+
+  return (
+    cellTypes === initialCellTypes &&
+    genes === initialGenes &&
+    scaled === initialScaled
+  );
+}

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/index.tsx
@@ -1,0 +1,43 @@
+import {
+  Dialog as RawDialog,
+  DialogContent,
+  DialogActions,
+} from "@czi-sds/components";
+import { ActionButton, CancelButton, StyledDialogTitle } from "./style";
+
+interface Props {
+  handleCancel: () => void;
+  handleConfirm: () => void;
+  isOpen: boolean;
+}
+
+export default function Dialog({ handleCancel, handleConfirm, isOpen }: Props) {
+  return (
+    <RawDialog sdsSize="xs" canClickOutsideClose={false} open={isOpen}>
+      <StyledDialogTitle title="Change organism?" data-testid="dialog-title" />
+      <DialogContent data-testid="dialog-content">
+        This will reset the dot plot and remove all selected genes and filters.
+      </DialogContent>
+      <DialogActions data-testid="dialog-actions" buttonPosition="right">
+        <>
+          <CancelButton
+            isAllCaps={false}
+            sdsStyle="minimal"
+            sdsType="secondary"
+            onClick={handleCancel}
+          >
+            Cancel
+          </CancelButton>
+          <ActionButton
+            color="error"
+            sdsStyle="square"
+            sdsType="primary"
+            onClick={handleConfirm}
+          >
+            Confirm
+          </ActionButton>
+        </>
+      </DialogActions>
+    </RawDialog>
+  );
+}

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/index.tsx
@@ -1,9 +1,11 @@
-import { Dialog as RawDialog, DialogContent } from "@czi-sds/components";
+import { Dialog as RawDialog } from "@czi-sds/components";
 import {
   ActionButton,
   StyledDialogAction,
+  StyledDialogContent,
   StyledDialogPaper,
   StyledDialogTitle,
+  Title,
 } from "./style";
 import { Button } from "src/components/common/Button";
 
@@ -21,10 +23,13 @@ export default function Dialog({ handleCancel, handleConfirm, isOpen }: Props) {
       canClickOutsideClose={false}
       open={isOpen}
     >
-      <StyledDialogTitle title="Change organism?" data-testid="dialog-title" />
-      <DialogContent data-testid="dialog-content">
+      <StyledDialogTitle
+        title={(<Title>Change organism?</Title>) as unknown as string}
+        data-testid="dialog-title"
+      />
+      <StyledDialogContent data-testid="dialog-content">
         This will reset the dot plot and remove all selected genes and filters.
-      </DialogContent>
+      </StyledDialogContent>
       <StyledDialogAction data-testid="dialog-actions" buttonPosition="right">
         <>
           <Button

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/index.tsx
@@ -1,9 +1,11 @@
+import { Dialog as RawDialog, DialogContent } from "@czi-sds/components";
 import {
-  Dialog as RawDialog,
-  DialogContent,
-  DialogActions,
-} from "@czi-sds/components";
-import { ActionButton, CancelButton, StyledDialogTitle } from "./style";
+  ActionButton,
+  StyledDialogAction,
+  StyledDialogPaper,
+  StyledDialogTitle,
+} from "./style";
+import { Button } from "src/components/common/Button";
 
 interface Props {
   handleCancel: () => void;
@@ -13,21 +15,26 @@ interface Props {
 
 export default function Dialog({ handleCancel, handleConfirm, isOpen }: Props) {
   return (
-    <RawDialog sdsSize="xs" canClickOutsideClose={false} open={isOpen}>
+    <RawDialog
+      PaperComponent={StyledDialogPaper}
+      sdsSize="xs"
+      canClickOutsideClose={false}
+      open={isOpen}
+    >
       <StyledDialogTitle title="Change organism?" data-testid="dialog-title" />
       <DialogContent data-testid="dialog-content">
         This will reset the dot plot and remove all selected genes and filters.
       </DialogContent>
-      <DialogActions data-testid="dialog-actions" buttonPosition="right">
+      <StyledDialogAction data-testid="dialog-actions" buttonPosition="right">
         <>
-          <CancelButton
+          <Button
             isAllCaps={false}
             sdsStyle="minimal"
             sdsType="secondary"
             onClick={handleCancel}
           >
             Cancel
-          </CancelButton>
+          </Button>
           <ActionButton
             color="error"
             sdsStyle="square"
@@ -37,7 +44,7 @@ export default function Dialog({ handleCancel, handleConfirm, isOpen }: Props) {
             Confirm
           </ActionButton>
         </>
-      </DialogActions>
+      </StyledDialogAction>
     </RawDialog>
   );
 }

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/style.ts
@@ -1,7 +1,9 @@
 import {
   DialogActions,
+  DialogContent,
   DialogPaper,
   DialogTitle,
+  fontBodyXs,
   fontHeaderL,
 } from "@czi-sds/components";
 import styled from "@emotion/styled";
@@ -19,8 +21,20 @@ export const StyledDialogTitle = styled(DialogTitle)`
   margin-bottom: ${spacesDefault}px;
 `;
 
+/**
+ * (thuang): SDS DialogTitle currently doesn't support
+ * swapping out their Title component, so this is a workaround
+ */
+export const Title = styled("p")`
+  ${fontHeaderL}
+`;
+
 export const StyledDialogPaper = styled(DialogPaper)`
   padding: ${spacesXl}px !important;
+`;
+
+export const StyledDialogContent = styled(DialogContent)`
+  ${fontBodyXs}
 `;
 
 /**

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/style.ts
@@ -1,30 +1,34 @@
 import {
-  Button,
+  DialogActions,
+  DialogPaper,
   DialogTitle,
-  fontBodyS,
   fontHeaderL,
 } from "@czi-sds/components";
 import styled from "@emotion/styled";
-import { error500, spacesDefault, textSecondary } from "src/common/theme";
-
-const FONT_WEIGHT_500 = 500;
+import { error500, spacesDefault, spacesXl, spacesXxs } from "src/common/theme";
+import { Button } from "src/components/common/Button";
 
 export const ActionButton = styled(Button)`
-  ${fontBodyS}
-  font-weight: ${FONT_WEIGHT_500};
-
   &:hover {
     background-color: ${error500};
   }
 `;
 
-export const CancelButton = styled(Button)`
-  ${fontBodyS}
-  color: ${textSecondary};
-  font-weight: ${FONT_WEIGHT_500};
-`;
-
 export const StyledDialogTitle = styled(DialogTitle)`
   ${fontHeaderL}
   margin-bottom: ${spacesDefault}px;
+`;
+
+export const StyledDialogPaper = styled(DialogPaper)`
+  padding: ${spacesXl}px !important;
+`;
+
+/**
+ * (thuang): We want the word to word space between buttons to be
+ * 16px, so reducing margin-left to spacesXxs gives us that
+ */
+export const StyledDialogAction = styled(DialogActions)`
+  &.MuiDialogActions-spacing > :not(:first-of-type) {
+    margin-left: ${spacesXxs}px;
+  }
 `;

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/style.ts
@@ -1,0 +1,30 @@
+import {
+  Button,
+  DialogTitle,
+  fontBodyS,
+  fontHeaderL,
+} from "@czi-sds/components";
+import styled from "@emotion/styled";
+import { error500, spacesDefault, textSecondary } from "src/common/theme";
+
+const FONT_WEIGHT_500 = 500;
+
+export const ActionButton = styled(Button)`
+  ${fontBodyS}
+  font-weight: ${FONT_WEIGHT_500};
+
+  &:hover {
+    background-color: ${error500};
+  }
+`;
+
+export const CancelButton = styled(Button)`
+  ${fontBodyS}
+  color: ${textSecondary};
+  font-weight: ${FONT_WEIGHT_500};
+`;
+
+export const StyledDialogTitle = styled(DialogTitle)`
+  ${fontHeaderL}
+  margin-bottom: ${spacesDefault}px;
+`;

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/connect.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/connect.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Organism as IOrganism } from "src/views/WheresMyGene/common/types";
 import { useAvailableOrganisms } from "src/common/queries/wheresMyGene";
 import {
@@ -8,12 +8,23 @@ import {
 import { selectOrganism } from "src/views/WheresMyGene/common/store/actions";
 import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
+import { selectHasCustomFiltersOrGenesSelected } from "src/views/WheresMyGene/common/store/selectors";
 
 export const useConnect = () => {
   const dispatch = useContext(DispatchContext);
-  const { selectedOrganismId } = useContext(StateContext);
+  const state = useContext(StateContext);
+  const { selectedOrganismId } = state;
 
   const { data: organisms } = useAvailableOrganisms(2);
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const [pendingOrganism, setPendingOrganism] = useState<IOrganism | null>(
+    null
+  );
+
+  const hasCustomFiltersOrGenesSelected =
+    selectHasCustomFiltersOrGenesSelected(state);
 
   // (thuang): Default to "Homo sapiens" on first load
   useEffect(() => {
@@ -43,11 +54,59 @@ export const useConnect = () => {
   function handleOnChange(organism: IOrganism | null): void {
     if (!dispatch || !organism || selectedOrganismId === organism.id) return;
 
-    track(EVENTS.WMG_SELECT_ORGANISM, { payload: organism?.name });
-
-    dispatch(selectOrganism(organism?.id || null));
+    setPendingOrganism(organism);
   }
 
+  const handleDialogConfirm = useCallback(() => {
+    track(EVENTS.WMG_SELECT_ORGANISM, { payload: pendingOrganism?.name });
+
+    dispatch?.(selectOrganism(pendingOrganism?.id || null));
+
+    setIsDialogOpen(false);
+    setPendingOrganism(null);
+  }, [dispatch, pendingOrganism]);
+
+  function handleDialogCancel() {
+    setPendingOrganism(null);
+    setIsDialogOpen(false);
+  }
+
+  useEffect(() => {
+    if (!pendingOrganism) return;
+
+    if (hasCustomFiltersOrGenesSelected) {
+      setIsDialogOpen(true);
+    } else {
+      handleDialogConfirm();
+    }
+  }, [pendingOrganism, hasCustomFiltersOrGenesSelected, handleDialogConfirm]);
+
   const organism = organismsById[selectedOrganismId || ""];
-  return { organisms, organism, handleOnChange };
+
+  /**
+   * FIXME(thuang): We need to pass `value` to Dropdown this way instead of using
+   * `Dropdown.props.value`, because when we cancel the confirm dialog, the
+   * internal Dropdown selected value is still staying as the new value instead of
+   * reverting back to the old value, even though the old value is still being
+   * passed to Dropdown.
+   * To fix this, SDS Dropdown needs to detect that it's in a controlled state,
+   * if so, it should use the value passed to it instead of the internal state.
+   */
+  const DropdownMenuProps = useMemo(
+    () => ({
+      value: organism,
+    }),
+    [organism]
+  );
+
+  return {
+    handleDialogCancel,
+    handleDialogConfirm,
+    handleOnChange,
+    isDialogOpen,
+    organism,
+    organisms,
+    setIsDialogOpen,
+    DropdownMenuProps,
+  };
 };

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/index.tsx
@@ -2,9 +2,19 @@ import { EMPTY_ARRAY } from "src/common/constants/utils";
 import { StyledDropdown, Wrapper, Label } from "../common/style";
 import { InputDropdownProps, Props, tempOnChange } from "./types";
 import { useConnect } from "./connect";
+import Dialog from "./components/Dialog";
 
 export default function Organism({ isLoading }: Props): JSX.Element {
-  const { organisms, organism, handleOnChange } = useConnect();
+  const {
+    handleDialogCancel,
+    handleDialogConfirm,
+    handleOnChange,
+    isDialogOpen,
+    organism,
+    organisms,
+    DropdownMenuProps,
+  } = useConnect();
+
   return (
     <Wrapper>
       <Label>Organism</Label>
@@ -14,7 +24,12 @@ export default function Organism({ isLoading }: Props): JSX.Element {
         onChange={handleOnChange as tempOnChange}
         InputDropdownProps={{ ...InputDropdownProps, disabled: isLoading }}
         data-testid="add-organism"
-        value={organism}
+        DropdownMenuProps={DropdownMenuProps}
+      />
+      <Dialog
+        isOpen={isDialogOpen}
+        handleCancel={handleDialogCancel}
+        handleConfirm={handleDialogConfirm}
       />
     </Wrapper>
   );

--- a/frontend/tests/common/constants.ts
+++ b/frontend/tests/common/constants.ts
@@ -57,3 +57,11 @@ export const GENE_DELETE_BUTTON = "gene-delete-button";
 export const SOURCE_DATA_BUTTON_ID = "source-data-button";
 export const SOURCE_DATA_LIST_SELECTOR = `[data-testid="source-data-list"]`;
 export const DOWNLOAD_BUTTON_ID = "download-button";
+export const COMPARE_DROPDOWN_ID = "compare-dropdown";
+export const SEX_FILTER_TEST_ID = "sex-filter";
+export const PUBLICATION_FILTER_TEST_ID = "publication-filter";
+export const DISEASE_FILTER_TEST_ID = "disease-filter";
+export const DATASET_FILTER_TEST_ID = "dataset-filter";
+export const CELL_TYPE_FILTER_TEST_ID = "celltype-filter";
+export const SELF_REPORTED_ETHNICITY_FILTER_TEST_ID =
+  "self-reported-ethnicity-filter";

--- a/frontend/tests/features/wheresMyGene/selectOrganism.test.ts
+++ b/frontend/tests/features/wheresMyGene/selectOrganism.test.ts
@@ -1,0 +1,251 @@
+import { Page, expect } from "playwright/test";
+import { ROUTES } from "src/common/constants/routes";
+import {
+  ADD_TISSUE_ID,
+  CELL_TYPE_FILTER_TEST_ID,
+  COMPARE_DROPDOWN_ID,
+  DATASET_FILTER_TEST_ID,
+  DISEASE_FILTER_TEST_ID,
+  PUBLICATION_FILTER_TEST_ID,
+  SELF_REPORTED_ETHNICITY_FILTER_TEST_ID,
+  SEX_FILTER_TEST_ID,
+  TEST_URL,
+} from "tests/common/constants";
+import { test } from "tests/common/test";
+import { tryUntil } from "tests/utils/helpers";
+import { WMG_WITH_SEEDED_GENES, goToWMG } from "tests/utils/wmgUtils";
+
+const { describe } = test;
+
+const TISSUE_NAME_TEST_ID = "tissue-name";
+const MOUSE_NAME = "Mus musculus";
+
+describe("Select organism", () => {
+  test("Switch organism to `Mus musculus` with no customization", async ({
+    page,
+  }) => {
+    const { tissueNameCount: beforeTissueNameCount } = await setup({ page });
+
+    const targetOption = page.getByText(MOUSE_NAME);
+
+    await tryUntil(
+      async () => {
+        await page.getByTestId("add-organism").click();
+        await expect(targetOption).toBeVisible();
+      },
+      { page }
+    );
+
+    await targetOption.click();
+
+    await tryUntil(
+      async () => {
+        expect(await page.getByTestId(TISSUE_NAME_TEST_ID).count()).not.toBe(
+          beforeTissueNameCount
+        );
+      },
+      { page }
+    );
+  });
+
+  describe("Switch organism to `Mus musculus` with customizations", () => {
+    test("With genes selected, it prompts confirm modal on change", async ({
+      page,
+    }) => {
+      await verifyConfirmModal({ page, url: WMG_WITH_SEEDED_GENES.URL });
+    });
+
+    test("With dataset `22 integrated samples` selected, it prompts confirm modal on change", async ({
+      page,
+    }) => {
+      await verifyConfirmModal({
+        page,
+        url:
+          `${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}?` +
+          "datasets=9d8e5dca-03a3-457d-b7fb-844c75735c83&ver=2",
+        testId: DATASET_FILTER_TEST_ID,
+        text: "22 integrated samples",
+      });
+    });
+
+    test("With disease `normal` selected, it prompts confirm modal on change", async ({
+      page,
+    }) => {
+      await verifyConfirmModal({
+        page,
+        url:
+          `${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}?` +
+          "diseases=PATO%3A0000461&ver=2",
+        testId: DISEASE_FILTER_TEST_ID,
+        text: "normal",
+      });
+    });
+
+    test("With ethnicity `unknown` selected, it prompts confirm modal on change", async ({
+      page,
+    }) => {
+      await verifyConfirmModal({
+        page,
+        url:
+          `${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}?` +
+          "ethnicities=unknown&ver=2",
+        testId: SELF_REPORTED_ETHNICITY_FILTER_TEST_ID,
+        text: "unknown",
+      });
+    });
+
+    test("With publication `Ahern et al.` selected, it prompts confirm modal on change", async ({
+      page,
+    }) => {
+      await verifyConfirmModal({
+        page,
+        url:
+          `${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}?` +
+          "publications=Ahern+et+al.+Cell+2022&ver=2",
+        testId: PUBLICATION_FILTER_TEST_ID,
+        text: "Ahern et al.",
+      });
+    });
+
+    test("With sex `unknown` selected, it prompts confirm modal on change", async ({
+      page,
+    }) => {
+      await verifyConfirmModal({
+        page,
+        url: `${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}?` + "sexes=unknown&ver=2",
+        testId: SEX_FILTER_TEST_ID,
+        text: "unknown",
+      });
+    });
+
+    test("With tissue `lung` selected, it prompts confirm modal on change", async ({
+      page,
+    }) => {
+      await verifyConfirmModal({
+        page,
+        url:
+          `${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}?` +
+          "tissues=UBERON%3A0002048&ver=2",
+        testId: ADD_TISSUE_ID,
+        text: "lung",
+      });
+    });
+
+    test("With groupBy `disease` selected, it prompts confirm modal on change", async ({
+      page,
+    }) => {
+      await verifyConfirmModal({
+        page,
+        url:
+          `${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}?` +
+          /**
+           * (thuang): Somehow compare share link needs a gene to work
+           */
+          "compare=disease&genes=TSPAN6&ver=2",
+        testId: COMPARE_DROPDOWN_ID,
+        text: "Disease",
+        /**
+         * (thuang): Explicitly remove the seeded gene, so we can test just the groupBy
+         */
+        removeGene: "TSPAN6",
+      });
+    });
+
+    test("With cellType `B cell` selected, it prompts confirm modal on change", async ({
+      page,
+    }) => {
+      await verifyConfirmModal({
+        page,
+        url:
+          `${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}?` +
+          /**
+           * (thuang): Somehow compare share link needs a gene to work
+           */
+          "cellTypes=B+cell&genes=TSPAN6&ver=2",
+        testId: CELL_TYPE_FILTER_TEST_ID,
+        text: "B cell",
+        /**
+         * (thuang): Explicitly remove the seeded gene, so we can test just the cellType
+         */
+        removeGene: "TSPAN6",
+      });
+    });
+  });
+});
+
+async function verifyConfirmModal({
+  page,
+  url,
+  testId,
+  text,
+  removeGene,
+}: {
+  page: Page;
+  url?: string;
+  testId?: string;
+  text?: string;
+  removeGene?: string;
+}) {
+  const { tissueNameCount: beforeTissueNameCount } = await setup({
+    page,
+    url,
+  });
+
+  if (testId && text) {
+    await tryUntil(
+      async () => {
+        await expect(page.getByTestId(testId).getByText(text)).toBeVisible();
+      },
+      { page }
+    );
+  }
+
+  if (removeGene) {
+    await page.getByTestId("gene-name-" + removeGene).hover();
+    await page.getByTestId("gene-delete-icon-" + removeGene).click();
+  }
+
+  const targetOption = page.getByText(MOUSE_NAME);
+
+  await tryUntil(
+    async () => {
+      await page.getByTestId("add-organism").click();
+      await expect(targetOption).toBeVisible();
+    },
+    { page }
+  );
+
+  await targetOption.click();
+
+  await expect(page.getByRole("dialog")).toBeVisible();
+
+  await page.getByText("Confirm").click();
+
+  await tryUntil(
+    async () => {
+      expect(await page.getByTestId("tissue-name").count()).not.toBe(
+        beforeTissueNameCount
+      );
+    },
+    { page }
+  );
+}
+
+async function setup({ page, url }: { page: Page; url?: string }): Promise<{
+  tissueNameCount: number;
+}> {
+  await goToWMG(page, url);
+
+  const tissueNameSelector = page.getByTestId(TISSUE_NAME_TEST_ID);
+
+  await tryUntil(
+    async () => {
+      expect(await tissueNameSelector.count()).toBeGreaterThan(0);
+    },
+    { page }
+  );
+
+  return {
+    tissueNameCount: await tissueNameSelector.count(),
+  };
+}

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -1,5 +1,14 @@
 import { expect, Page } from "@playwright/test";
 import { toInteger } from "lodash";
+import {
+  ADD_TISSUE_ID,
+  CELL_TYPE_FILTER_TEST_ID,
+  DATASET_FILTER_TEST_ID,
+  DISEASE_FILTER_TEST_ID,
+  PUBLICATION_FILTER_TEST_ID,
+  SELF_REPORTED_ETHNICITY_FILTER_TEST_ID,
+  SEX_FILTER_TEST_ID,
+} from "tests/common/constants";
 import { test } from "tests/common/test";
 import { collapseTissue, expandTissue, tryUntil } from "tests/utils/helpers";
 import { goToWMG } from "tests/utils/wmgUtils";
@@ -7,27 +16,24 @@ import { goToWMG } from "tests/utils/wmgUtils";
 const FILTERED_TISSUES = ["axilla", "blood", "brain"];
 const TISSUE_NODE_TEST_ID = "tissue-name";
 const TISSUE_FILTER_LABEL = "Tissue";
-const TISSUE_FILTER_TEST_ID = "tissue-filter";
-const CELL_TYPE_FILTER_TEST_ID = "celltype-filter";
+
 const CELL_TYPE_FILTERS = ["B cell", "B-1a B cell", "B-1b B cell"];
 const CELL_TYPE_TEST_ID = "cell-type-name";
-const SEX_FILTER_TEST_ID = "sex-filter";
 const SEX_FILTER_LABEL = "Sex";
 const SEX_FILTER_SELECTION = "female";
-const PUBLICATION_FILTER_TEST_ID = "publication-filter";
 const PUBLICATION_FILTER_LABEL = "Publication";
 const PUBLICATION_FILTER_SELECTION = [
   "Ahern et al. (2022) Cell",
   "Arutyunyan et al. (2023) Nature",
 ];
-const SELF_REPORTED_ETHNICITY_FILTER_TEST_ID = "self-reported-ethnicity-filter";
+
 const SELF_REPORTED_ETHNICITY_FILTER_LABEL = "Self-Reported Ethnicity";
 const SELF_REPORTED_ETHNICITY_FILTER_SELECTION = "African";
 const SELF_REPORTED_ETHNICITY_TISSUE = ["breast", "nose"];
-const DISEASE_FILTER_TEST_ID = "disease-filter";
+
 const DISEASE_FILTER_LABEL = "Disease";
 const DISEASE_FILTER_SELECTION = "influenza";
-const DATASET_FILTER_TEST_ID = "dataset-filter";
+
 const DATASET_FILTER_LABEL = "Dataset";
 const DATASET_FILTER_SELECTION =
   "Combined samples HTAN MSK - Single cell profiling reveals novel tumor and myeloid subpopulations in small cell lung cancer";
@@ -364,13 +370,13 @@ async function filterCellTypes(page: Page, cellTypes: string[]) {
 
 /**
  * filterTissues
- * Filter the tissuesfrom the left panel
+ * Filter the tissues from the left panel
  */
 async function filterTissues(
   page: Page,
   filteredTissues: string[] = FILTERED_TISSUES
 ) {
-  await clickIntoFilter(page, TISSUE_FILTER_TEST_ID);
+  await clickIntoFilter(page, ADD_TISSUE_ID);
   for (const tissue of filteredTissues) {
     await page.getByRole("option", { name: tissue, exact: true }).click();
   }

--- a/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
@@ -9,7 +9,7 @@ import {
   tryUntil,
   waitForLoadingSpinnerToResolve,
 } from "tests/utils/helpers";
-import { TEST_URL } from "../../common/constants";
+import { COMPARE_DROPDOWN_ID, TEST_URL } from "../../common/constants";
 import { TISSUE_DENY_LIST } from "../../fixtures/wheresMyGene/tissueRollup";
 
 import {
@@ -59,8 +59,6 @@ const GENE_INFO_BUTTON_CELL_INFO_TEST_ID = "gene-info-button-cell-info";
 const MUI_CHIP_ROOT = ".MuiChip-root";
 
 const CELL_TYPE_SANITY_CHECK_NUMBER = 100;
-
-const COMPARE_DROPDOWN_ID = "compare-dropdown";
 
 const FILTERS_PANEL = "filters-panel";
 


### PR DESCRIPTION
## Reason for Change

- #5777

## Changes

1. Add a few more design token functions in `frontend/src/common/theme.ts`
2. Add SC Button in `frontend/src/components/common/Button/index.tsx`
3. Update `selectOrganism` reducer to fix bug (same fix as in Seve's PR)
4. Add a new selector `selectHasCustomFiltersOrGenesSelected` to detect when the redux state is dirty and need to pop the confirm modal
5. Add Confirm Dialog (frontend/src/views/WheresMyGeneV2/components/Filters/components/Organism/components/Dialog/index.tsx)
6. Update `Organism/connect.ts` to use a new state `pendingOrganism` as a placeholder, so if the user cancel the confirm dialog, it won't dispatch an action to update the organism in the store
7. BONUS: Extract more test constants `frontend/tests/common/constants.ts`
8. Add 10 e2e tests for this feature

## Testing steps

The confirm modal should show up when the user makes any changes to filters on the left panel, cellTypes, and genes

1. Navigate to rdev: https://pr-6075-frontend.rdev.single-cell.czi.technology/gene-expression
9. Change "color scale" to "Unscaled"
10. Change organism to mouse
11. You should see the new confirm dialog
12. Click cancel
13. Click on organism dropdown again, and human should still be selected
14. Select mouse again and click confirm
15. The filters should be reset and mouse tissues are rendered

You can repeat this test with any filters, cellTypes, genes, and the confirm modal should pop up in all cases!

<img width="1468" alt="Screenshot 2023-10-25 at 10 23 34 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/d5b2ccc6-5602-4da6-a610-ac955c4ac93c">

https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/7e9168e7-a1cc-41c9-ae2d-b27012f3c7e0



## Notes for Reviewer
