### PR TITLE
fix(wmg): update marker gene sidebar to match new endpoint response

### DIFF
--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -1319,8 +1319,8 @@ export interface MarkerGenesByCellType {
 
 export interface MarkerGene {
   gene_ontology_term_id: string;
-  effect_size: number;
-  p_value: number;
+  marker_score: number;
+  specificity: number;
 }
 
 export interface MarkerGeneResponse<T = MarkerGene[]> {
@@ -1349,7 +1349,7 @@ export function useMarkerGenes({
 
   function filterMarkerGenes(markerGenes: MarkerGene[]): MarkerGene[] {
     return markerGenes.filter(
-      (markerGene) => markerGene.effect_size >= FMG_GENE_STRENGTH_THRESHOLD
+      (markerGene) => markerGene.marker_score >= FMG_GENE_STRENGTH_THRESHOLD
     );
   }
 

--- a/frontend/src/views/WheresMyGene/components/InfoPanel/components/RelativeGeneExpression/index.tsx
+++ b/frontend/src/views/WheresMyGene/components/InfoPanel/components/RelativeGeneExpression/index.tsx
@@ -27,7 +27,7 @@ export default function RelativeGeneExpression({
           />
           {(isScaled || maxExpression !== -Infinity) && (
             <LowHigh className="low-high">
-              <span>{0.0}</span>
+              <span>0.0</span>
               <span data-testid={MAX_EXPRESSION_LABEL_TEST_ID}>
                 {isScaled ? "1.0" : maxExpression.toFixed(2)}
               </span>

--- a/frontend/src/views/WheresMyGeneV2/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/CellInfoSideBar/index.tsx
@@ -243,7 +243,7 @@ function CellInfoSideBar({
                 </InfoButtonWrapper>
               </DivTableCell>
               <DivTableCell data-testid="marker-scores-fmg" align>
-                {metadata.effect_size.toPrecision(4)}
+                {metadata.marker_score.toPrecision(4)}
               </DivTableCell>
             </DivTableRow>
           ))}

--- a/frontend/tests/features/wheresMyGene/rightSideBar.test.ts
+++ b/frontend/tests/features/wheresMyGene/rightSideBar.test.ts
@@ -82,29 +82,4 @@ describe("Right side bar", () => {
       )
     ).toBeVisible();
   });
-
-  test.only("should scale from 0 to 1 when scaled check box is checked, gene expression", async ({
-    page,
-  }) => {
-    // navigate to url
-    await goToWMG(page);
-    const COLOR_SCALE = '[id="relative-gene-expression"] .low-high';
-
-    //verify the correct values are displayed on the color scale
-    await expect(page.locator(COLOR_SCALE)).toContainText("0.0");
-    await expect(page.locator(COLOR_SCALE)).toContainText("1.0");
-
-    //close quick survey box
-    await page.locator('[aria-label="Close"]').click();
-
-    //click the color scale drop-down
-    await page.getByTestId("color-scale-dropdown").click();
-
-    //select the second option
-    await page.locator('[data-option-index="1"]').click();
-
-    //verify the correct values are displayed on the color scale
-    await expect(page.locator(COLOR_SCALE)).toContainText("0.0");
-    await expect(page.locator(COLOR_SCALE)).toContainText("6.0");
-  });
 });

--- a/frontend/tests/features/wheresMyGene/rightSideBar.test.ts
+++ b/frontend/tests/features/wheresMyGene/rightSideBar.test.ts
@@ -83,7 +83,7 @@ describe("Right side bar", () => {
     ).toBeVisible();
   });
 
-  test("should scale from 0 to 1 when scaled check box is checked, gene expression ", async ({
+  test.only("should scale from 0 to 1 when scaled check box is checked, gene expression", async ({
     page,
   }) => {
     // navigate to url


### PR DESCRIPTION
## Reason for Change

- When splitting up #5999, I forgot to port over changes in the FE for the new response from the marker genes endpoint. 

## Testing
 - E2E tests pass
 - Confirmed fix in rdev