### PR TITLE
fix: reconfigure s3 upload key prefix to work for rdev

### DIFF
--- a/backend/curation/api/v1/curation/collections/collection_id/s3_upload_credentials.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/s3_upload_credentials.py
@@ -26,13 +26,11 @@ def get(collection_id: str, token_info: dict):
     is_owner_or_allowed_else_forbidden(collection_version, user_info)
     if collection_version.published_at:
         raise ForbiddenHTTPException()
-    if user_info.is_super_curator():
-        upload_key_prefix = f"super/{collection_id}/"
+    user = "super" if user_info.is_super_curator() else user_info.user_id
+    if rdev_prefix := os.environ.get("REMOTE_DEV_PREFIX", "").strip("/"):
+        upload_key_prefix = f"{rdev_prefix}/{user}/{collection_id}/"
     else:
-        upload_key_prefix = f"{user_info.user_id}/{collection_id}/"
-    rdev_prefix = os.environ.get("REMOTE_DEV_PREFIX", "").strip("/")
-    if rdev_prefix:
-        upload_key_prefix = f"{rdev_prefix}/{upload_key_prefix}"
+        upload_key_prefix = f"{user}/{collection_id}/"
     parameters = dict(
         RoleArn=config.curator_role_arn,
         RoleSessionName=user_info.user_id.replace("|", "-"),


### PR DESCRIPTION
The UploadKeyPrefix that is returned in response to GET /s3-upload-credentials needed to be reconfigured specifically for the rdev use-case, because in order to satisfy IAM permissions, the user must come before the stack name:
- old prefix format: {rdev_prefix}/{user}/{collection_id}
- new prefix format: {user}/{rdev_prefix}/{collection_id}

## Reason for Change

- #6010 

## Changes

- modify `UploadKeyPrefix` attribute in response for s3 upload credentials request

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Notes for Reviewer
