### PR TITLE
feat: Add support for schema-4 format for "self_reported_ethnicity_ontology_term_id"

### DIFF
--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List
 
@@ -31,6 +32,8 @@ from backend.wmg.data.utils import depluralize, find_all_dim_option_values, find
 # TODO: add cache directives: no-cache (i.e. revalidate); impl etag
 #  https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data
 #  -portal/2132
+
+logger = logging.getLogger("wmg-api")
 
 
 @tracer.wrap()
@@ -358,6 +361,19 @@ def build_ontology_term_id_label_mapping(*, ontology_term_ids: Iterable[str], di
     term_label_getter_func = ontology_term_label
 
     if dim_name == "self_reported_ethnicity_ontology_term_id":
+        logger.info(
+            f"PRATHAP! build_ontology_term_id_label_mapping() func - ontology_term_ids for ethnicity: {ontology_term_ids}"
+        )
+        logger.info(
+            "PRATHAP! build_ontology_term_id_label_mapping() func - about to apply 'ontology_term_label()' func for debugging ethnicity..."
+        )
+        debugging_ethnicity_labels = [
+            {ontology_term_id: ontology_term_label(ontology_term_id)} for ontology_term_id in ontology_term_ids
+        ]
+        logger.info(
+            f"PRATHAP! build_ontology_term_id_label_mapping() func - debugging_ethnicity_labels: {debugging_ethnicity_labels}"
+        )
+
         term_label_getter_func = ethnicity_term_label
 
     return [{ontology_term_id: term_label_getter_func(ontology_term_id)} for ontology_term_id in ontology_term_ids]

--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -1,4 +1,3 @@
-import logging
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List
 
@@ -32,8 +31,6 @@ from backend.wmg.data.utils import depluralize, find_all_dim_option_values, find
 # TODO: add cache directives: no-cache (i.e. revalidate); impl etag
 #  https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data
 #  -portal/2132
-
-logger = logging.getLogger("wmg-api")
 
 
 @tracer.wrap()
@@ -361,19 +358,6 @@ def build_ontology_term_id_label_mapping(*, ontology_term_ids: Iterable[str], di
     term_label_getter_func = ontology_term_label
 
     if dim_name == "self_reported_ethnicity_ontology_term_id":
-        logger.info(
-            f"PRATHAP! build_ontology_term_id_label_mapping() func - ontology_term_ids for ethnicity: {ontology_term_ids}"
-        )
-        logger.info(
-            "PRATHAP! build_ontology_term_id_label_mapping() func - about to apply 'ontology_term_label()' func for debugging ethnicity..."
-        )
-        debugging_ethnicity_labels = [
-            {ontology_term_id: ontology_term_label(ontology_term_id)} for ontology_term_id in ontology_term_ids
-        ]
-        logger.info(
-            f"PRATHAP! build_ontology_term_id_label_mapping() func - debugging_ethnicity_labels: {debugging_ethnicity_labels}"
-        )
-
         term_label_getter_func = ethnicity_term_label
 
     return [{ontology_term_id: term_label_getter_func(ontology_term_id)} for ontology_term_id in ontology_term_ids]

--- a/backend/wmg/data/ontology_labels.py
+++ b/backend/wmg/data/ontology_labels.py
@@ -22,10 +22,10 @@ SUFFIXES_TO_STRIP = ["organoid", "cell culture"]
 
 def ontology_term_label(ontology_term_id: str) -> Optional[str]:
     """
-    Returns the label for an ontology term, given its id. This excludes gene ontology term, which are handled
-    separately by gene_gene_term_label(). Return None if ontology term id is invalid.
+    Returns the label for an ontology term, given its id. This excludes gene ontology term
+    and self reported ethnicity term, which are handled separately by gene_gene_term_label()
+    and ethnicity_term_label() respectively. Return None if ontology term id is invalid.
     """
-    global ontology_term_id_labels
 
     # this catches the organoid tissue edge case (e.g. UBERON:0000995 (organoid)) or the cell culture edge case
     # (e.g. CL:0000082 (cell culture))
@@ -44,18 +44,48 @@ def ontology_term_label(ontology_term_id: str) -> Optional[str]:
     return ontology_term_id_label
 
 
+def ethnicity_term_label(self_reported_ethnicity_ontology_term_id: str) -> str:
+    """
+    Return the label for self reported ethnicity ontology term id.
+
+    This function is compatible with schema-4 and schema-3 format of
+    `self_reported_ethnicity_ontology_term_id`.
+
+    NOTE: It is assumed that self_reported_ethnicity_ontology_term_id has been validated against
+    a schema (ex: schema-3 or schema-4) before this function is called. Therefore,
+    no error error checking on the format of the input is done.
+
+    Parameters
+    ----------
+    self_reported_ethnicity_ontology_term_id: An ontology_term_id string that can
+                                              encode multiple ethnicities with comma delimiter
+                                              in Schema-4.
+                                              NOTE: Schema-3 does not support comma delimited
+                                              ontology term IDs to encode multiple ethnicities
+                                              in a single string.
+
+    Returns
+    -------
+    ethnicity_term_label: A comma delimited ethnicity label corresponding to the input ethnicity_term_id
+    """
+    # In schema-4, self_reported_ethnicity_ontology_term_id can be a comma
+    # separated string to denote multiple ethnicities.
+    individual_term_ids = self_reported_ethnicity_ontology_term_id.split(",")
+    term_labels = [ontology_term_id_labels.get(term_id) for term_id in individual_term_ids]
+    ethnicity_term_label = ",".join(term_labels)
+    return ethnicity_term_label
+
+
 def gene_term_label(gene_ontology_term_id: str) -> Optional[str]:
     """
     Returns the label for a gene ontology term, given its id. Return None if ontology term id is invalid.
     """
-    global gene_term_id_labels
     return gene_term_id_labels.get(gene_ontology_term_id)
 
 
 def __load_ontologies() -> None:
     global ontology_term_id_labels
 
-    ontology_term_id_labels = {}
     all_ontologies = json.loads(__open_ontology_resource(all_ontologies_json_file).read().decode("utf-8"))
     for _, ontology_dict in all_ontologies.items():
         for term_id, term in ontology_dict.items():
@@ -65,7 +95,6 @@ def __load_ontologies() -> None:
 def __load_genes() -> None:
     global gene_term_id_labels
 
-    gene_term_id_labels = {}
     for genes_file in genes_files:
         for row in csv.DictReader(
             __open_ontology_resource(genes_file).read().decode("utf-8").split("\n"),
@@ -80,6 +109,9 @@ def __open_ontology_resource(file) -> IO:
     file_path = root_path.joinpath("common", "ontology_files", file)
     return gzip.open(file_path)
 
+
+ontology_term_id_labels = {}
+gene_term_id_labels = {}
 
 __load_ontologies()
 __load_genes()

--- a/backend/wmg/data/ontology_labels.py
+++ b/backend/wmg/data/ontology_labels.py
@@ -47,7 +47,7 @@ def ontology_term_label(ontology_term_id: str) -> Optional[str]:
     return ontology_term_id_label
 
 
-def ethnicity_term_label(self_reported_ethnicity_ontology_term_id: str) -> str:
+def ethnicity_term_label(self_reported_ethnicity_ontology_term_id: str) -> Optional[str]:
     """
     Return the label for self reported ethnicity ontology term id.
 
@@ -70,6 +70,8 @@ def ethnicity_term_label(self_reported_ethnicity_ontology_term_id: str) -> str:
     Returns
     -------
     ethnicity_term_label: A comma delimited ethnicity label corresponding to the input ethnicity_term_id
+                          or None if the ethnicity term id "unknown", "na", "multiethnic" or some
+                          value that is not recognized.
     """
     # In schema-4, self_reported_ethnicity_ontology_term_id can be a comma
     # separated string to denote multiple ethnicities.
@@ -80,7 +82,7 @@ def ethnicity_term_label(self_reported_ethnicity_ontology_term_id: str) -> str:
     logger.info(f"PRATHAP! ethnicity_term_label() func - individual_term_ids: {individual_term_ids}")
     term_labels = [ontology_term_id_labels.get(term_id) for term_id in individual_term_ids]
     logger.info(f"PRATHAP! ethnicity_term_label() func - term_labels: {term_labels}")
-    ethnicity_term_label = ",".join(term_labels)
+    ethnicity_term_label = ",".join(term_labels) if all([isinstance(t, str) for t in term_labels]) else None
     return ethnicity_term_label
 
 

--- a/backend/wmg/data/ontology_labels.py
+++ b/backend/wmg/data/ontology_labels.py
@@ -20,7 +20,7 @@ genes_files = [
 
 SUFFIXES_TO_STRIP = ["organoid", "cell culture"]
 
-logger = logging.getLogger("wmg")
+logger = logging.getLogger("wmg-ontology-labels")
 
 
 def ontology_term_label(ontology_term_id: str) -> Optional[str]:
@@ -74,10 +74,12 @@ def ethnicity_term_label(self_reported_ethnicity_ontology_term_id: str) -> str:
     # In schema-4, self_reported_ethnicity_ontology_term_id can be a comma
     # separated string to denote multiple ethnicities.
     individual_term_ids = self_reported_ethnicity_ontology_term_id.split(",")
-    logger.info(f"PRATHAP! self_reported_ethnicity_ontology_term_id: {self_reported_ethnicity_ontology_term_id}")
-    logger.info(f"PRATHAP! individual_term_ids: {individual_term_ids}")
+    logger.info(
+        f"PRATHAP! ethnicity_term_label() func - self_reported_ethnicity_ontology_term_id: {self_reported_ethnicity_ontology_term_id}"
+    )
+    logger.info(f"PRATHAP! ethnicity_term_label() func - individual_term_ids: {individual_term_ids}")
     term_labels = [ontology_term_id_labels.get(term_id) for term_id in individual_term_ids]
-    logger.info(f"PRATHAP! term_labels: {term_labels}")
+    logger.info(f"PRATHAP! ethnicity_term_label() func - term_labels: {term_labels}")
     ethnicity_term_label = ",".join(term_labels)
     return ethnicity_term_label
 

--- a/backend/wmg/data/ontology_labels.py
+++ b/backend/wmg/data/ontology_labels.py
@@ -1,7 +1,6 @@
 import csv
 import gzip
 import json
-import logging
 import pathlib
 from typing import IO, Optional
 
@@ -19,8 +18,6 @@ genes_files = [
 ]
 
 SUFFIXES_TO_STRIP = ["organoid", "cell culture"]
-
-logger = logging.getLogger("wmg-ontology-labels")
 
 
 def ontology_term_label(ontology_term_id: str) -> Optional[str]:
@@ -76,12 +73,7 @@ def ethnicity_term_label(self_reported_ethnicity_ontology_term_id: str) -> Optio
     # In schema-4, self_reported_ethnicity_ontology_term_id can be a comma
     # separated string to denote multiple ethnicities.
     individual_term_ids = self_reported_ethnicity_ontology_term_id.split(",")
-    logger.info(
-        f"PRATHAP! ethnicity_term_label() func - self_reported_ethnicity_ontology_term_id: {self_reported_ethnicity_ontology_term_id}"
-    )
-    logger.info(f"PRATHAP! ethnicity_term_label() func - individual_term_ids: {individual_term_ids}")
     term_labels = [ontology_term_id_labels.get(term_id) for term_id in individual_term_ids]
-    logger.info(f"PRATHAP! ethnicity_term_label() func - term_labels: {term_labels}")
     ethnicity_term_label = ",".join(term_labels) if all([isinstance(t, str) for t in term_labels]) else None
     return ethnicity_term_label
 

--- a/backend/wmg/data/ontology_labels.py
+++ b/backend/wmg/data/ontology_labels.py
@@ -1,6 +1,7 @@
 import csv
 import gzip
 import json
+import logging
 import pathlib
 from typing import IO, Optional
 
@@ -18,6 +19,8 @@ genes_files = [
 ]
 
 SUFFIXES_TO_STRIP = ["organoid", "cell culture"]
+
+logger = logging.getLogger("wmg")
 
 
 def ontology_term_label(ontology_term_id: str) -> Optional[str]:
@@ -71,7 +74,10 @@ def ethnicity_term_label(self_reported_ethnicity_ontology_term_id: str) -> str:
     # In schema-4, self_reported_ethnicity_ontology_term_id can be a comma
     # separated string to denote multiple ethnicities.
     individual_term_ids = self_reported_ethnicity_ontology_term_id.split(",")
+    logger.info(f"PRATHAP! self_reported_ethnicity_ontology_term_id: {self_reported_ethnicity_ontology_term_id}")
+    logger.info(f"PRATHAP! individual_term_ids: {individual_term_ids}")
     term_labels = [ontology_term_id_labels.get(term_id) for term_id in individual_term_ids]
+    logger.info(f"PRATHAP! term_labels: {term_labels}")
     ethnicity_term_label = ",".join(term_labels)
     return ethnicity_term_label
 

--- a/backend/wmg/data/ontology_labels.py
+++ b/backend/wmg/data/ontology_labels.py
@@ -23,7 +23,7 @@ SUFFIXES_TO_STRIP = ["organoid", "cell culture"]
 def ontology_term_label(ontology_term_id: str) -> Optional[str]:
     """
     Returns the label for an ontology term, given its id. This excludes gene ontology term
-    and self reported ethnicity term, which are handled separately by gene_gene_term_label()
+    and self reported ethnicity term, which are handled separately by gene_term_label()
     and ethnicity_term_label() respectively. Return None if ontology term id is invalid.
     """
 
@@ -53,7 +53,7 @@ def ethnicity_term_label(self_reported_ethnicity_ontology_term_id: str) -> str:
 
     NOTE: It is assumed that self_reported_ethnicity_ontology_term_id has been validated against
     a schema (ex: schema-3 or schema-4) before this function is called. Therefore,
-    no error error checking on the format of the input is done.
+    no error checking on the format of the input is done.
 
     Parameters
     ----------

--- a/tests/unit/backend/wmg/api/common/test_wmg_api_helpers.py
+++ b/tests/unit/backend/wmg/api/common/test_wmg_api_helpers.py
@@ -1,0 +1,66 @@
+"""This module tests the helper functions used in `backend.wmg.api.v2.py`.
+"""
+
+import unittest
+
+from parameterized import parameterized
+
+from backend.wmg.api.v2 import build_ontology_term_id_label_mapping
+
+
+class ExpressionDotPlotTest(unittest.TestCase):
+    def _ontology_term_id_to_label_map_test_cases():
+        test_cases = [
+            (
+                "disease_ontology_term_id",
+                ["MONDO:0100096", "MONDO:0000001"],
+                [{"MONDO:0100096": "COVID-19"}, {"MONDO:0000001": "disease"}],
+            ),
+            (
+                "tissue_ontology_term_id",
+                ["UBERON:0002539", "UBERON:0000995 (organoid)"],
+                [{"UBERON:0002539": "pharyngeal arch"}, {"UBERON:0000995 (organoid)": "uterus (organoid)"}],
+            ),
+            (
+                "sex_ontology_term_id",
+                ["PATO:0000384", "PATO:0000383", "unknown"],
+                [{"PATO:0000384": "male"}, {"PATO:0000383": "female"}, {"unknown": None}],
+            ),
+            (
+                "self_reported_ethnicity_ontology_term_id",
+                [
+                    # Schema-4 ontology term ids
+                    "HANCESTRO:0005,HANCESTRO:0014",
+                    # Schema-3 ontology term ids
+                    "HANCESTRO:0003",
+                    "unknown",
+                    "multiethnic",
+                    "na",
+                ],
+                [
+                    # Schema-4 values
+                    {"HANCESTRO:0005,HANCESTRO:0014": "European,Hispanic or Latin American"},
+                    # Schema-3 values
+                    {"HANCESTRO:0003": "country"},
+                    {"unknown": None},
+                    {"multiethnic": None},
+                    {"na": None},
+                ],
+            ),
+            ("development_stage_ontology_term_id", ["HsapDv:0000000"], [{"HsapDv:0000000": "human life cycle stage"}]),
+            (
+                "cell_type_ontology_term_id",
+                ["CL:0000000", "CL:0000082 (cell culture)"],
+                [{"CL:0000000": "cell"}, {"CL:0000082 (cell culture)": "epithelial cell of lung (cell culture)"}],
+            ),
+        ]
+
+        return test_cases
+
+    @parameterized.expand(_ontology_term_id_to_label_map_test_cases)
+    def test__build_ontology_term_id_label_mapping(self, dimension, input_ontology_term_id_list, expected_output_list):
+        actual_term_id_to_label = build_ontology_term_id_label_mapping(
+            ontology_term_ids=input_ontology_term_id_list, dim_name=dimension
+        )
+
+        self.assertEqual(actual_term_id_to_label, expected_output_list)

--- a/tests/unit/wmg_processing/test_ontology_labels.py
+++ b/tests/unit/wmg_processing/test_ontology_labels.py
@@ -1,6 +1,6 @@
 import unittest
 
-from backend.wmg.data.ontology_labels import gene_term_label, ontology_term_label
+from backend.wmg.data.ontology_labels import ethnicity_term_label, gene_term_label, ontology_term_label
 
 
 class OntologyLabelTests(unittest.TestCase):
@@ -10,7 +10,6 @@ class OntologyLabelTests(unittest.TestCase):
         # should happen infrequently
         test_cases = {
             "EFO:0000001": "experimental factor",
-            "HANCESTRO:0003": "country",
             "CL:0000000": "cell",
             "HsapDv:0000000": "human life cycle stage",
             "PATO:0000001": "quality",
@@ -24,6 +23,18 @@ class OntologyLabelTests(unittest.TestCase):
         for ontology_term_id, expected_ontology_term_label in test_cases.items():
             with self.subTest(ontology_term_id):
                 self.assertEqual(ontology_term_label(ontology_term_id), expected_ontology_term_label)
+
+    def test__ethnicity_term_label(self):
+        # A conservative, high-level check that all ontologies have been loaded, without checking explicit counts
+        # This test is fragile, in that changes to our ontologies may break these these tests in the future, but that
+        # should happen infrequently
+        test_cases = {
+            "HANCESTRO:0003": "country",
+            "HANCESTRO:0005,HANCESTRO:0014": "European,Hispanic or Latin American",
+        }
+        for ontology_term_id, expected_ontology_term_label in test_cases.items():
+            with self.subTest(ontology_term_id):
+                self.assertEqual(ethnicity_term_label(ontology_term_id), expected_ontology_term_label)
 
     def test__gene_label(self):
         # A conservative, high-level check that all ontologies have been loaded, without checking explicit counts

--- a/tests/unit/wmg_processing/test_ontology_labels.py
+++ b/tests/unit/wmg_processing/test_ontology_labels.py
@@ -29,7 +29,12 @@ class OntologyLabelTests(unittest.TestCase):
         # This test is fragile, in that changes to our ontologies may break these these tests in the future, but that
         # should happen infrequently
         test_cases = {
+            # Schema-3 test cases
             "HANCESTRO:0003": "country",
+            "unknown": None,
+            "multiethnic": None,
+            "na": None,
+            # Schema-4 test cases
             "HANCESTRO:0005,HANCESTRO:0014": "European,Hispanic or Latin American",
         }
         for ontology_term_id, expected_ontology_term_label in test_cases.items():


### PR DESCRIPTION
## Reason for Change

- The specific ticket being addressed is here: https://github.com/chanzuckerberg/single-cell/issues/528
- For the full story see the containing epic here: https://github.com/chanzuckerberg/single-cell/issues/460

## Changes

- add support for comma separated `self_reported_ethnicity_ontology_term_id`

## Testing steps

- Unit tests

## Notes for Reviewer
