### PR TITLE
fix: always print summary for PR rdev

### DIFF
--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -159,8 +159,6 @@ jobs:
 
   summarize:
     runs-on: ubuntu-22.04
-    needs:
-      - deploy-rdev
     if: github.event.action == 'opened'
     steps:
       - name: Summerize deployment


### PR DESCRIPTION
## Reason for Change

- We always want the summary to print out when a PR is created even if deployment fails

## Changes

- remove depending con deploy-rdev for summary.


## Testing steps


## Notes for Reviewer
