### PR TITLE
feat: if preprint DOI in collection has since been published, link to published DOI [in-progress]

### DIFF
--- a/backend/common/providers/crossref_provider.py
+++ b/backend/common/providers/crossref_provider.py
@@ -66,23 +66,7 @@ class CrossrefProvider:
             else:
                 raise CrossrefFetchException("Cannot fetch metadata from Crossref") from e
 
-        # if doi is-preprint-of another, fetch the published doi
-        message = res.json()["message"]
-        if "relation" in message and "is-preprint-of" in message["relation"]:
-            published_ids = message["relation"]["is-preprint-of"]
-            for pub_id in published_ids:
-                if pub_id["id-type"] == "doi":
-                    try:
-                        published_doi_res = requests.get(
-                            f"{self.base_crossref_uri}/{published_ids[pub_id]['id']}",
-                            headers={"Crossref-Plus-API-Token": f"Bearer {self.crossref_api_key}"},
-                        )
-                        published_doi_res.raise_for_status()
-                        return published_doi_res
-                    except requests.RequestException:
-                        # return pre-print if fetching original doi fails
-                        return res
-        return res
+        return self.fetch_preprint_published_doi(res)
 
     def fetch_metadata(self, doi: str) -> dict:
         """
@@ -153,16 +137,29 @@ class CrossrefProvider:
         except Exception as e:
             raise CrossrefParseException("Cannot parse metadata from Crossref") from e
 
-    def fetch_preprint_published_doi(self, doi):
-
-        res = self._fetch_crossref_payload(doi)
+    def fetch_preprint_published_doi(self, res):
+        """
+        If CrossRef API Response is of a preprint with a known published DOI, fetch the metadata for the published DOI
+        instead. Otherwise, return the input Response.
+        """
         message = res.json()["message"]
         is_preprint = message.get("subtype") == "preprint"
+        has_published_doi = ("relation" in message) and ("is-preprint-of" in message["relation"])
 
-        if is_preprint:
-            try:
-                published_doi = message["relation"]["is-preprint-of"]
-                if published_doi[0]["id-type"] == "doi":
-                    return published_doi[0]["id"]
-            except Exception:
-                pass
+        if is_preprint and has_published_doi:
+            published_ids = message["relation"]["is-preprint-of"]
+            for pub_id in published_ids:
+                if pub_id["id-type"] == "doi":
+                    published_doi = published_ids[pub_id]["id"].replace("\\", "")
+                    try:
+                        published_doi_res = requests.get(
+                            f"{self.base_crossref_uri}/{published_doi}",
+                            headers={"Crossref-Plus-API-Token": f"Bearer {self.crossref_api_key}"},
+                        )
+                        published_doi_res.raise_for_status()
+                        return published_doi_res
+                    except requests.RequestException:
+                        pass
+
+        # return pre-print if fetching original doi fails
+        return res


### PR DESCRIPTION
## Reason for Change

- https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell/575

## Changes

- if response from Crossref API contains an 'is-preprint-of' relation for a DOI, fetch the nested published DOI. return the preprint DOI metadata if published DOI fetch fails 

## Testing steps

- TODO: add unit tests, test setting a preprint and non-preprint in rdev

## Notes for Reviewer
