### PR TITLE
feat: Add lightweight FeatureFlagService

### DIFF
--- a/backend/common/feature_flag.py
+++ b/backend/common/feature_flag.py
@@ -1,0 +1,38 @@
+from typing import Literal
+
+from backend.common.corpora_config import CorporaConfig
+
+"""
+This is a lightweight wrapper around feature flags built with CorporaConfig. The intention is
+to provide a generic interface for feature flags, so that if we ever want to swap out the
+underlying implementation, we can do so without updating all client calls.
+
+To add a new feature flag, add it to the FeatureFlag and FeatureFlagValues string literal above.
+
+To use a feature flag:
+```
+if FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4):
+  <logic that only applies if schema 4 is enabled>
+```
+
+To mock a feature flag in a test:
+```
+def mock_config_fn(name):
+    if name == FeatureFlagValues.SCHEMA_4:
+        return "True"
+
+self.mock_config = patch.object(FeatureFlagService, "is_enabled", side_effect=mock_config_fn)
+```
+"""
+
+FeatureFlag = Literal["schema_4_feature_flag"]
+
+
+class FeatureFlagValues:
+    SCHEMA_4 = "schema_4_feature_flag"
+
+
+class FeatureFlagService:
+    def is_enabled(feature_flag: FeatureFlag) -> bool:
+        flag_value = getattr(CorporaConfig(), feature_flag, "").lower()
+        return flag_value == "true"

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 from backend.common.corpora_config import CorporaConfig
+from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
 from backend.common.utils.http_exceptions import ForbiddenHTTPException, GoneHTTPException, NotFoundHTTPException
 from backend.layers.auth.user_info import UserInfo
 from backend.layers.business.business import BusinessLogic
@@ -227,7 +228,7 @@ def reshape_dataset_for_curation_api(
             if col is not None:
                 ds[column] = col
 
-    if ds.get("tissue") is not None and CorporaConfig().schema_4_feature_flag.lower() == "false":
+    if ds.get("tissue") is not None and not FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4):
         for tissue in ds["tissue"]:
             del tissue["tissue_type"]
 

--- a/backend/layers/processing/process_download_validate.py
+++ b/backend/layers/processing/process_download_validate.py
@@ -4,6 +4,7 @@ import numpy
 import scanpy
 
 from backend.common.corpora_config import CorporaConfig
+from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
 from backend.common.utils.corpora_constants import CorporaConstants
 from backend.layers.business.business_interface import BusinessLogicInterface
 from backend.layers.common.entities import (
@@ -86,7 +87,7 @@ class ProcessDownloadValidate(ProcessingLogic):
         if not is_valid:
             raise ValidationFailed(errors)
         else:
-            if CorporaConfig().schema_4_feature_flag.lower() == "true":
+            if FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4):
                 self.populate_dataset_citation(collection_id, dataset_id, output_filename)
 
             # TODO: optionally, these could be batched into one
@@ -184,7 +185,7 @@ class ProcessDownloadValidate(ProcessingLogic):
             name=adata.uns["title"],
             organism=_get_term_pairs("organism"),
             tissue=_get_tissue_terms()
-            if CorporaConfig().schema_4_feature_flag.lower() == "true"
+            if FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4)
             else _get_term_pairs("tissue"),
             assay=_get_term_pairs("assay"),
             disease=_get_term_pairs("disease"),

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from flask import Response, jsonify, make_response
 
-from backend.common.corpora_config import CorporaConfig
+from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
 from backend.common.utils.http_exceptions import (
     ConflictException,
     ForbiddenHTTPException,
@@ -175,7 +175,7 @@ def _dataset_to_response(
         if is_in_revision and revision_created_at and dataset.created_at > revision_created_at:
             published = False
     tissue = None if dataset.metadata is None else _ontology_term_ids_to_response(dataset.metadata.tissue)
-    if tissue is not None and CorporaConfig().schema_4_feature_flag.lower() == "false":
+    if tissue is not None and not FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4):
         for t in tissue:
             del t["tissue_type"]
     return remove_none(

--- a/tests/functional/backend/common.py
+++ b/tests/functional/backend/common.py
@@ -9,7 +9,8 @@ import requests
 from requests.adapters import HTTPAdapter, Response
 from requests.packages.urllib3.util import Retry
 
-from backend.common.corpora_config import CorporaAuthConfig, CorporaConfig
+from backend.common.corpora_config import CorporaAuthConfig
+from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
 
 API_URL = {
     "prod": "https://api.cellxgene.cziscience.com",
@@ -38,7 +39,7 @@ class BaseFunctionalTestCase(unittest.TestCase):
         super().setUpClass()
         cls.deployment_stage = os.environ["DEPLOYMENT_STAGE"]
         cls.config = CorporaAuthConfig()
-        cls.is_using_schema_4 = CorporaConfig().schema_4_feature_flag.lower() == "true"
+        cls.is_using_schema_4 = FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4)
         cls.test_dataset_uri = (
             (
                 "https://www.dropbox.com/scl/fi/d99hpw3p2cxtmi7v4kyv5/"

--- a/tests/unit/backend/common/test_feature_flag.py
+++ b/tests/unit/backend/common/test_feature_flag.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import patch
+
+from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
+
+
+class TestFeatureFlag(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        def mock_config_fn(name):
+            if name == FeatureFlagValues.SCHEMA_4:
+                return "True"
+
+        self.mock_config = patch("backend.common.corpora_config.CorporaConfig.__getattr__", side_effect=mock_config_fn)
+        self.mock_config.start()
+
+    def tearDown(self):
+        self.mock_config.stop()
+
+    def test_feature_flag(self):
+        self.assertTrue(FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4))

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -4,6 +4,7 @@ import anndata
 import numpy as np
 import pandas
 
+from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
 from backend.layers.common.entities import OntologyTermId, TissueOntologyTermId
 from backend.layers.processing.process_download_validate import ProcessDownloadValidate
 from tests.unit.processing.base_processing_test import BaseProcessingTest
@@ -17,10 +18,10 @@ class TestProcessingDownloadValidate(BaseProcessingTest):
         )
 
         def mock_config_fn(name):
-            if name == "schema_4_feature_flag":
+            if name == FeatureFlagValues.SCHEMA_4:
                 return "True"
 
-        self.mock_config = patch("backend.common.corpora_config.CorporaConfig.__getattr__", side_effect=mock_config_fn)
+        self.mock_config = patch.object(FeatureFlagService, "is_enabled", side_effect=mock_config_fn)
         self.mock_config.start()
 
     def tearDown(self):

--- a/tests/unit/processing/test_h5ad_data_file.py
+++ b/tests/unit/processing/test_h5ad_data_file.py
@@ -2,6 +2,7 @@ import json
 import unittest
 from os import path, remove
 from shutil import rmtree
+from unittest.mock import patch
 from uuid import uuid4
 
 import anndata
@@ -9,6 +10,7 @@ import numpy as np
 import tiledb
 from pandas import Categorical, DataFrame, Series
 
+from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
 from backend.common.utils.corpora_constants import CorporaConstants
 from backend.layers.processing.h5ad_data_file import H5ADDataFile
 from tests.unit.backend.fixtures.environment_setup import fixture_file_path
@@ -22,12 +24,10 @@ class TestH5ADDataFile(unittest.TestCase):
         self.sample_output_directory = path.splitext(self.sample_h5ad_filename)[0] + ".cxg"
 
         def mock_config_fn(name):
-            if name == "schema_4_feature_flag":
+            if name == FeatureFlagValues.SCHEMA_4:
                 return "True"
 
-        self.mock_config = unittest.mock.patch(
-            "backend.common.corpora_config.CorporaConfig.__getattr__", side_effect=mock_config_fn
-        )
+        self.mock_config = patch.object(FeatureFlagService, "is_enabled", side_effect=mock_config_fn)
         self.mock_config.start()
 
     def tearDown(self):


### PR DESCRIPTION
## Reason for Change

The goal of this is to provide a lightweight layer for us to access feature flags set up in `CorporaConfig`. This will allow us to, if we ever desire to, swap out the underlying implementation of feature flags. I provided some basic documentation within `feature_flag.py` for how to use this.

Feature flags use a design pattern called string literals. String literals use the `Literal` provided in Python typing to ensure type strictness similar to enums. Since `FeatureFlagService.is_enabled` requires passing in a `FeatureFlag` type, we can ensure that only strings that exist within this `Literal` are allowed. Since they're simply strings, they can be easily passed into functions like `getattr(CorporaConfig(), feature_flag)` without needing to convert between strings and enums.

## Changes

- Adds the FeatureFlagService, and declares `schema_4_feature_flag` as the only valid feature flag
- Updates all instances of `CorporaConfig().schema_4_feature_flag.lower() == "true"` to use `FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4`

## Testing steps

- Adds a test, `TestFeatureFlag` that mocks `CorporaConfig.__getattr__` to verify that the service is working as expected

## Notes for Reviewer
n/a