### PR TITLE
feat: remove non-tissues from WMG

### DIFF
--- a/backend/wmg/pipeline/expression_summary_and_cell_counts.py
+++ b/backend/wmg/pipeline/expression_summary_and_cell_counts.py
@@ -30,7 +30,10 @@ class CensusParameters:
         value_filter = organism_mapping[organism]
         if FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4):
             # Filter out non-tissue tissues and system-level tissues
-            value_filter += " and tissue_type == 'tissue' and tissue_ontology_term_id not in ['UBERON_0001017', 'UBERON:0001007', 'UBERON:0002405', 'UBERON:0000990', 'UBERON:0001004', 'UBERON:0001434']"
+            # TODO: Once cellxgene-census is updated to support tiledbsoma 1.5.0, we can update the tissue filter to use `not in`:
+            # tissue_ontology_term_id not in ['UBERON_0001017', 'UBERON:0001007', 'UBERON:0002405', 'UBERON:0000990', 'UBERON:0001004', 'UBERON:0001434']
+            # This will require updating the pinned versions of cellxgene-census and tiledbsoma in `requirements-wmg-pipeline.txt`
+            value_filter += " and tissue_type == 'tissue' and tissue_general_ontology_term_id != 'UBERON:0001017' and tissue_general_ontology_term_id != 'UBERON:0001007' and tissue_general_ontology_term_id != 'UBERON:0002405' and tissue_general_ontology_term_id != 'UBERON:0000990' and tissue_general_ontology_term_id != 'UBERON:0001004' and tissue_general_ontology_term_id != 'UBERON:0001434'"
         return value_filter
 
 

--- a/backend/wmg/pipeline/expression_summary_and_cell_counts.py
+++ b/backend/wmg/pipeline/expression_summary_and_cell_counts.py
@@ -44,7 +44,7 @@ def create_expression_summary_and_cell_counts_cubes(corpus_path: str):
             organism = organismInfo["label"]
             organismId = organismInfo["id"]
 
-            value_filter = CensusParameters.value_filter[organism]
+            value_filter = CensusParameters.value_filter(organism)
             organism = census["census_data"][organism]
             with organism.axis_query(
                 "RNA",

--- a/backend/wmg/pipeline/expression_summary_and_cell_counts.py
+++ b/backend/wmg/pipeline/expression_summary_and_cell_counts.py
@@ -20,10 +20,16 @@ ORGANISM_INFO = [
 
 class CensusParameters:
     census_version = "latest"
-    value_filter = {
-        "homo_sapiens": f"is_primary_data == True and nnz >= {GENE_EXPRESSION_COUNT_MIN_THRESHOLD}",
-        "mus_musculus": f"is_primary_data == True and nnz >= {GENE_EXPRESSION_COUNT_MIN_THRESHOLD}",
-    }
+
+    def value_filter(organism: str) -> str:
+        value_filter_mapping = {
+            "homo_sapiens": f"is_primary_data == True and nnz >= {GENE_EXPRESSION_COUNT_MIN_THRESHOLD}",
+            "mus_musculus": f"is_primary_data == True and nnz >= {GENE_EXPRESSION_COUNT_MIN_THRESHOLD}",
+        }
+        value_filter = value_filter_mapping[organism]
+        # if schema_4:
+        #     value_filter += " and tissue_type == 'tissue'"
+        return value_filter
 
 
 def create_expression_summary_and_cell_counts_cubes(corpus_path: str):

--- a/tests/test_utils/mocks.py
+++ b/tests/test_utils/mocks.py
@@ -52,6 +52,13 @@ class MockCensusParameters:
         "mus_musculus": "dataset_id in ['ef47280b-3e68-4188-a49a-7b8374c8a6f2']",
     }
 
+    def value_filter(organism: str) -> str:
+        organism_mapping = {
+            "homo_sapiens": "dataset_id in ['0041b9c3-6a49-4bf7-8514-9bc7190067a7']",
+            "mus_musculus": "dataset_id in ['ef47280b-3e68-4188-a49a-7b8374c8a6f2']",
+        }
+        return organism_mapping[organism]
+
 
 def mock_return_dataset_dict_w_publications():
     return {}

--- a/tests/test_utils/mocks.py
+++ b/tests/test_utils/mocks.py
@@ -47,10 +47,6 @@ def mock_bootstrap_rows_percentiles(
 
 class MockCensusParameters:
     census_version = "latest"
-    value_filter = {
-        "homo_sapiens": "dataset_id in ['0041b9c3-6a49-4bf7-8514-9bc7190067a7']",
-        "mus_musculus": "dataset_id in ['ef47280b-3e68-4188-a49a-7b8374c8a6f2']",
-    }
 
     def value_filter(organism: str) -> str:
         organism_mapping = {


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell/526

## Changes

updates the census parameters to filter on `tissue_type == tissue`, and also filters out the system-level UBERON terms

## Testing steps

We can't test the `tissue_type` filter until schema 4 is in census, so the best we can do is hide the logic behind a feature flag and test in staging once we start the schema 4 migration there. I was able to verify that the tissue portion of the filter worked by running this script locally:

```
import cellxgene_census
import tiledbsoma as soma

def main():
    with cellxgene_census.open_soma() as census:
        human = census["census_data"]["homo_sapiens"]
        with human.axis_query(
            measurement_name="RNA",
            obs_query=soma.AxisQuery(
                value_filter="is_primary_data == True"
            )
        ) as query:
            obs_df = query.obs(column_names=["tissue_general_ontology_term_id", "tissue_general", "soma_joinid"]).concat().to_pandas().set_index("soma_joinid")
            
            print("System level tissue counts before filtering them out...")

            central_nervous_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001017']
            print(len(central_nervous_system_rows))

            digestive_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001007']
            print(len(digestive_system_rows))

            immune_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0002405']
            print(len(immune_system_rows))

            reproductive_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0000990']
            print(len(reproductive_system_rows))

            respiratory_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001004']
            print(len(respiratory_system_rows))

            skeletal_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001434']
            print(len(skeletal_system_rows))

    with cellxgene_census.open_soma() as census:
        human = census["census_data"]["homo_sapiens"]
        value_filter = "tissue_general_ontology_term_id != 'UBERON:0001017' and tissue_general_ontology_term_id != 'UBERON:0001007' and tissue_general_ontology_term_id != 'UBERON:0002405' and tissue_general_ontology_term_id != 'UBERON:0000990' and tissue_general_ontology_term_id != 'UBERON:0001004' and tissue_general_ontology_term_id != 'UBERON:0001434'"
        with human.axis_query(
            measurement_name="RNA",
            obs_query=soma.AxisQuery(
                value_filter=f"is_primary_data == True and {value_filter}"
            )
        ) as query:
            obs_df = query.obs(column_names=["tissue_general_ontology_term_id", "tissue_general"]).concat().to_pandas()
            
            print("System level tissue counts after filtering them out...")

            central_nervous_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001017']
            print(len(central_nervous_system_rows))

            digestive_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001007']
            print(len(digestive_system_rows))

            immune_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0002405']
            print(len(immune_system_rows))

            reproductive_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0000990']
            print(len(reproductive_system_rows))

            respiratory_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001004']
            print(len(respiratory_system_rows))

            skeletal_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001434']
            print(len(skeletal_system_rows))

if __name__ == "__main__":
    main()
```
which generated this output:
```
System level tissue counts before filtering them out...
15963
2710
49874
364425
368850
12329
System level tissue counts after filtering them out...
0
0
0
0
0
0
```

## Notes for Reviewer
n/a