### PR TITLE
feat(schema4): Filter out comma-delimited ethnicity term IDs from input datastructures

### DIFF
--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -47,6 +47,8 @@ def primary_filter_dimensions():
 @tracer.wrap()
 def query():
     request = connexion.request.json
+    sanitize_api_query_dict(request["filter"])
+
     is_rollup = request.get("is_rollup", True)
     compare = request.get("compare", None)
 
@@ -81,6 +83,13 @@ def query():
 
         cell_counts = q.cell_counts(criteria, compare_dimension=compare)
 
+        # For schema-4 we filter out comma-delimited values for `self_reported_ethnicity_ontology_term_id`
+        # from being included in the grouping and rollup logic per functional requirements:
+        # See: https://github.com/chanzuckerberg/single-cell/issues/596
+        if (compare is not None) and compare == "self_reported_ethnicity_ontology_term_id":
+            expression_summary = df_not_containing_comma_delimited_ethnicity_values(expression_summary)
+            cell_counts = df_not_containing_comma_delimited_ethnicity_values(cell_counts)
+
     with ServerTiming.time("build response"):
         if expression_summary.shape[0] > 0 or cell_counts.shape[0] > 0:
             group_by_terms = ["tissue_ontology_term_id", "cell_type_ontology_term_id", compare] if compare else None
@@ -113,6 +122,8 @@ def query():
 @tracer.wrap()
 def filters():
     request = connexion.request.json
+    sanitize_api_query_dict(request["filter"])
+
     criteria = WmgFiltersQueryCriteria(**request["filter"])
 
     with ServerTiming.time("load snapshot"):
@@ -165,6 +176,55 @@ def markers():
             marker_genes=marker_genes,
         )
     )
+
+
+def df_not_containing_comma_delimited_ethnicity_values(input_df: DataFrame) -> DataFrame:
+    """
+    Return a new dataframe with only the rows that DO NOT contain comma-delimited
+    values in the `self_reported_ethnicity_ontology_term_id` column.
+
+    Parameters
+    ----------
+    input_df: Dataframe
+        A dataframe that contains `self_reported_ethnicity_ontology_term_id` column
+
+    Returns
+    -------
+    A dataframe containing only the rows that do not have a comma-delimited value
+    for the `self_reported_ethnicity_ontology_term_id` column
+    """
+    return input_df[~input_df.self_reported_ethnicity_ontology_term_id.str.contains(",")]
+
+
+def sanitize_api_query_dict(query_dict: Any):
+    """
+    Remove invalid values in the query dictionary encoding the query API
+    request body.
+
+    The assumption is that this function is called at the beginning of the
+    API function. This usage also helps mitigate query injection attacks.
+
+    NOTE: This is a destructive operation in that it mutates `query_dict`.
+
+    Parameters
+    ----------
+    query_dict : json object
+        The query dictionary to sanitize.
+
+    Returns
+    -------
+    None because this function mutates the function argument
+    """
+
+    # Sanitize `self_reported_ethnicity_ontology_term_ids` by removing
+    # comma-delimited values because WMG does not support filtering and grouping
+    # by ethnicity terms that encode mixed ethnicities encoded as a single comma-delimited string
+    # value
+    if "self_reported_ethnicity_ontology_term_ids" in query_dict:
+        ethnicity_term_ids = query_dict["self_reported_ethnicity_ontology_term_ids"]
+
+        ethnicity_term_ids_to_keep = [x for x in ethnicity_term_ids if "," not in x]
+        query_dict["self_reported_ethnicity_ontology_term_ids"] = ethnicity_term_ids_to_keep
 
 
 def fetch_datasets_metadata(snapshot: WmgSnapshot, dataset_ids: Iterable[str]) -> List[Dict]:

--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -278,6 +278,12 @@ def build_filter_dims_values(criteria: WmgFiltersQueryCriteria, snapshot: WmgSna
             else find_dim_option_values(criteria, snapshot, dim)
         )
 
+    # For schema-4 we filter out comma-delimited values for `self_reported_ethnicity_ontology_term_id`
+    # from the options list per functional requirements:
+    # See: https://github.com/chanzuckerberg/single-cell/issues/596
+    ethnicity_term_ids = dims["self_reported_ethnicity_ontology_term_id"]
+    dims["self_reported_ethnicity_ontology_term_id"] = [term_id for term_id in ethnicity_term_ids if "," not in term_id]
+
     response_filter_dims_values = dict(
         datasets=fetch_datasets_metadata(snapshot, dims["dataset_id"]),
         disease_terms=build_ontology_term_id_label_mapping(dims["disease_ontology_term_id"]),

--- a/backend/wmg/data/utils.py
+++ b/backend/wmg/data/utils.py
@@ -16,13 +16,6 @@ def find_all_dim_option_values(snapshot, organism: str, dimension: str) -> list:
     all_filter_options = set()
     organism_key = "organism_ontology_term_id__" + organism
     all_filter_options = snapshot.filter_relationships[organism_key].get(dimension, [])
-
-    # For schema-4 we filter out comma-delimited values for `self_reported_ethnicity_ontology_term_id`
-    # from the options list per functional requirements:
-    # See: https://github.com/chanzuckerberg/single-cell/issues/596
-    if dimension == "self_reported_ethnicity_ontology_term_id":
-        all_filter_options = [x for x in all_filter_options if "," not in x.split("__")[1]]
-
     return [option.split("__")[1] for option in all_filter_options]
 
 

--- a/backend/wmg/data/utils.py
+++ b/backend/wmg/data/utils.py
@@ -16,6 +16,13 @@ def find_all_dim_option_values(snapshot, organism: str, dimension: str) -> list:
     all_filter_options = set()
     organism_key = "organism_ontology_term_id__" + organism
     all_filter_options = snapshot.filter_relationships[organism_key].get(dimension, [])
+
+    # For schema-4 we filter out comma-delimited values for `self_reported_ethnicity_ontology_term_id`
+    # from the options list per functional requirements:
+    # See: https://github.com/chanzuckerberg/single-cell/issues/596
+    if dimension == "self_reported_ethnicity_ontology_term_id":
+        all_filter_options = [x for x in all_filter_options if "," not in x.split("__")[1]]
+
     return [option.split("__")[1] for option in all_filter_options]
 
 

--- a/tests/unit/backend/wmg/api/common/test_wmg_api_helpers.py
+++ b/tests/unit/backend/wmg/api/common/test_wmg_api_helpers.py
@@ -1,0 +1,50 @@
+"""This module tests the helper functions used in `backend.wmg.api.v2.py`.
+"""
+
+import pytest
+
+from backend.wmg.api.v2 import sanitize_api_query_dict
+
+
+@pytest.mark.parametrize(
+    "input_query,expected_sanitized_query",
+    [
+        (
+            {
+                "organism_ontology_term_id": "NCBITaxon:9606",
+                "self_reported_ethnicity_ontology_term_ids": ["HANCESTRO:0008"],
+            },
+            {
+                "organism_ontology_term_id": "NCBITaxon:9606",
+                "self_reported_ethnicity_ontology_term_ids": ["HANCESTRO:0008"],
+            },
+        ),
+        (
+            {
+                "organism_ontology_term_id": "NCBITaxon:9606",
+                "self_reported_ethnicity_ontology_term_ids": ["HANCESTRO:0008", "HANCESTRO:0008,HANCESTOR:0021"],
+            },
+            {
+                "organism_ontology_term_id": "NCBITaxon:9606",
+                "self_reported_ethnicity_ontology_term_ids": ["HANCESTRO:0008"],
+            },
+        ),
+        (
+            {
+                "organism_ontology_term_id": "NCBITaxon:9606",
+                "self_reported_ethnicity_ontology_term_ids": ["HANCESTRO:0008,HANCESTOR:0021"],
+            },
+            {"organism_ontology_term_id": "NCBITaxon:9606", "self_reported_ethnicity_ontology_term_ids": []},
+        ),
+        (
+            {"organism_ontology_term_id": "NCBITaxon:9606", "self_reported_ethnicity_ontology_term_ids": []},
+            {"organism_ontology_term_id": "NCBITaxon:9606", "self_reported_ethnicity_ontology_term_ids": []},
+        ),
+        ({"organism_ontology_term_id": "NCBITaxon:9606"}, {"organism_ontology_term_id": "NCBITaxon:9606"}),
+    ],
+)
+def test_sanitize_api_query_dict(input_query, expected_sanitized_query):
+    # NOTE: `sanitize_api_query_dict()` mutates the function argument
+    sanitize_api_query_dict(input_query)
+
+    assert input_query == expected_sanitized_query

--- a/tests/unit/backend/wmg/api/test_v2.py
+++ b/tests/unit/backend/wmg/api/test_v2.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from typing import Dict, List
 from unittest.mock import patch
 
 from pytest import approx
@@ -299,15 +300,22 @@ def generate_test_inputs_and_expected_outputs(
     )
 
 
-def sort_filter_api_response_filter_dims_dict(filter_dims_dict):
+def sort_filter_options(filter_options: Dict[str, List[Dict[str, str]]]):
     """
-    This utility function sorts the dictionary of ontology term IDs
-    in the "filter" API response object by ontology term IDs to
-    enable equality checks in test assertions.
+    This utility function sorts the datastructure of ontology term IDs
+    to enable equality checks in test assertions.
 
-    NOTE: This function mutates `filter_dims_dict` by sorting it in-place
+    NOTE: This function mutates `filter_options` by sorting it in-place
+
+    Parameters
+    ----------
+    filter_options : An object that contains values for each dimension
+
+    Returns
+    -------
+    None because this function mutates the function argument
     """
-    for key, value_list in filter_dims_dict.items():
+    for key, value_list in filter_options.items():
         if key != "datasets":
             # The value_list for keys != "datasets", contains
             # a list of dictionaries where each dictionary is
@@ -815,12 +823,12 @@ class WmgApiV2Tests(unittest.TestCase):
             filter_request = dict(filter=filter_dict)
 
             response = self.app.post("/wmg/v2/filters", json=filter_request)
-            actual_response_filter_dims = json.loads(response.data)["filter_dims"]
+            actual_filter_options = json.loads(response.data)["filter_dims"]
 
-            # sorts 'actual_response_filter_dims' in-place
-            sort_filter_api_response_filter_dims_dict(actual_response_filter_dims)
+            # sorts 'actual_filter_options' in-place
+            sort_filter_options(actual_filter_options)
 
-            expected_filters = {
+            expected_filter_options = {
                 "cell_type_terms": [
                     {"cell_type_ontology_term_id_0": "cell_type_ontology_term_id_0_label"},
                     {"cell_type_ontology_term_id_1": "cell_type_ontology_term_id_1_label"},
@@ -865,7 +873,7 @@ class WmgApiV2Tests(unittest.TestCase):
                 ],
             }
 
-            self.assertEqual(actual_response_filter_dims, expected_filters)
+            self.assertEqual(actual_filter_options, expected_filter_options)
 
     @patch("backend.wmg.api.v2.fetch_datasets_metadata")
     @patch("backend.wmg.api.v2.gene_term_label")


### PR DESCRIPTION
## Reason for Change

- https://github.com/chanzuckerberg/single-cell/issues/596

A consequence of including comma-delimited ontology term ID values for `self_reported_ethnicity_ontology_term_id` to encode mixed ethnicities is that _data including such ethnicity values must be excluded when filtering or grouping by `self_reported_ethnicity_ontology_term_id`_. This is the functional requirement indicated in the ticket above.

## Changes

- Add functions to filter input datastructures that might be associated with `self_reported_ethnicity_ontology_term_id` values that contain comma-delimited values

## Testing steps

- Unit tests

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review

- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see

- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
