### PR TITLE
fix: Make it easier to limit a migration by passing as parameter

### DIFF
--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -180,7 +180,8 @@ resource aws_sfn_state_machine sfn_schema_migration {
         "Next": "ApplyDefaults",
         "ResultPath": "$.inputDefaults",
         "Parameters": {
-          "auto_publish": "False"
+          "auto_publish": "False",
+          "limit_migration": "0"
         }
     },
     "ApplyDefaults": {
@@ -223,6 +224,10 @@ resource aws_sfn_state_machine sfn_schema_migration {
             {
               "Name": "AUTO_PUBLISH",
               "Value.$": "$.auto_publish"
+            },
+            {
+              "Name": "LIMIT_MIGRATION",
+              "Value.$": "$.limit_migration"
             }
           ]
         }

--- a/backend/layers/processing/schema_migration.py
+++ b/backend/layers/processing/schema_migration.py
@@ -34,19 +34,19 @@ class SchemaMigrate(ProcessingLogic):
         self.execution_id = os.environ.get("EXECUTION_ID", "test-execution-arn")
         self.logger = logging.getLogger("processing")
         self.local_path: str = "."  # Used for testing
-        self.limit_migration = os.environ.get("LIMIT_MIGRATION", False)  # Run a small migration for testing
-        self.limit_select = 2  # Number of collections to migrate
+        self.limit_migration = os.environ.get("LIMIT_MIGRATION", 0)  # Run a small migration for testing
         self.schema_version = schema_validator.get_current_schema_version()
 
     def limit_collections(self) -> Iterable[CollectionVersion]:
         published_collections = [*self.business_logic.get_collections(CollectionQueryFilter(is_published=True))]
         unpublished_collections = [*self.business_logic.get_collections(CollectionQueryFilter(is_published=False))]
-        if self.limit_migration:
-            select = self.limit_select // 2
+        limit = int(self.limit_migration) if isinstance(self.limit_migration, str) else self.limit_migration
+        if limit > 0:
+            select = limit // 2
             if len(unpublished_collections) >= select:
-                unpublished_collections = random.sample(unpublished_collections, self.limit_select // 2)
+                unpublished_collections = random.sample(unpublished_collections, limit // 2)
             if len(published_collections) >= select:
-                published_collections = random.sample(published_collections, self.limit_select // 2)
+                published_collections = random.sample(published_collections, limit // 2)
         return itertools.chain(unpublished_collections, published_collections)
 
     def gather_collections(self, auto_publish: bool) -> List[Dict[str, str]]:


### PR DESCRIPTION
## Reason for Change

- Make it easier to limit a migration by passing it in as a parameter to the step function

## Changes

- using one variable LIMIT_MIGRATION to indicate how many collection to process in a migration
- accept limit_migration as a parameter to the step function to limit how many collections are migrated.

## Testing steps

- tested by running a schema_migration SFN with
 ```
{
  "limit_migration": "10"
}
```
## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review

- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see

- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
