### PR TITLE
feat: proxy plausible script [WIP]

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -117,6 +117,18 @@ module.exports = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        source: "/js/plausible-script.js",
+        destination: "https://plausible.io/js/script.js",
+      },
+      {
+        source: "/api/event",
+        destination: "https://plausible.io/api/event",
+      },
+    ];
+  },
   sassOptions: {
     functions: {
       /**

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -120,7 +120,7 @@ module.exports = {
   async rewrites() {
     return [
       {
-        source: "/js/plausible-script.js",
+        source: "/js/script.js",
         destination: "https://plausible.io/js/script.js",
       },
       {

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -127,10 +127,7 @@ function App({ Component, pageProps }: AppPropsWithLayout): JSX.Element {
           </EmotionThemeProvider>
         </StyledEngineProvider>
       </QueryClientProvider>
-      <Script
-        data-domain={configs.PLAUSIBLE_DATA_DOMAIN}
-        src="https://plausible.io/js/script.js"
-      />
+      <Script data-domain={configs.API_URL} src="/js/script.js" />
     </>
   );
 }


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/6167

## Changes

follows the instructions [here](https://plausible.io/docs/proxy/guides/nextjs) to proxy the plausible script. this is done by setting the script src to be `/js/script.js` and routing `/js/script.js` to the plausible script

## Testing steps

i don't believe it's possible to verify this works until it's deployed to stage, but i'm admittedly not that familiar with next.js. the instructions describe a way to verify it's working as expected _after_ it's deployed:

> Deploy these changes to your Next.js site. You can verify the proxy is working by opening your network tab. You should see a request to https://yourdomain.com/js/script.js with status 200 and another one to https://yourdomain.com/api/event with status 202.

i'm thinking it could make sense to just deploy this to staging and then check staging. if staging looks good, then don't do anything and wait for this to go through to prod. if it doesn't look good, we can revert the change

EDIT: it might actually work with rdev stacks? TBD

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review

- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see

- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer

i don't think we should merge this until we go through trust review: https://czi.atlassian.net/servicedesk/customer/portal/155/TR-2819