### PR TITLE
feat: Update dataset download modal height to prevent jiggle (#6175)

### DIFF
--- a/frontend/src/components/Datasets/components/DownloadDataset/style.ts
+++ b/frontend/src/components/Datasets/components/DownloadDataset/style.ts
@@ -35,7 +35,7 @@ export const Dialog = styled(SDSDialog)`
     border: 1px solid ${grey100};
     box-shadow: ${shadowL};
     gap: ${spacesXl}px;
-    min-height: unset;
+    min-height: 570px; /* min-height ensures dialog height consistency in any download state. */
     padding: 32px;
   }
 


### PR DESCRIPTION
## Reason for Change

- #6175

## Changes

- Added a minimum height to the download dataset modal to prevent jiggle between download state (i.e. toggle between selection of format type).

## Testing steps

- Use feature flag `dux=true`.
