### PR TITLE
fix(spotlight): fix tiers on directory

### DIFF
--- a/frontend/src/views/CensusDirectory/index.tsx
+++ b/frontend/src/views/CensusDirectory/index.tsx
@@ -21,10 +21,10 @@ function CensusDirectory() {
   );
 
   const communityProjects = Object.values(staticProjects).filter(
-    (project) => project.tier === 1
+    (project) => project.tier === 3
   );
   const maintainedProjects = Object.values(staticProjects).filter(
-    (project) => project.tier === 3
+    (project) => project.tier === 1
   );
 
   return (


### PR DESCRIPTION
The spotlight page had the tier filter inverted for maintained + community projects