### PR TITLE
feat: proxy plausible script

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -131,6 +131,7 @@ function App({ Component, pageProps }: AppPropsWithLayout): JSX.Element {
         data-domain={configs.PLAUSIBLE_DATA_DOMAIN}
         src="https://plausible.io/js/script.js"
       />
+      <Script data-domain={configs.API_URL} src="/js/script.js" />
     </>
   );
 }

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -131,7 +131,7 @@ function App({ Component, pageProps }: AppPropsWithLayout): JSX.Element {
         data-domain={configs.PLAUSIBLE_DATA_DOMAIN}
         src="https://plausible.io/js/script.js"
       />
-      <Script data-domain={configs.API_URL} src="/js/script.js" />
+      <Script data-domain={configs.PLAUSIBLE_DATA_DOMAIN} src="/js/script.js" />
     </>
   );
 }


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/6167

## Changes

follows the instructions [here](https://plausible.io/docs/proxy/guides/cloudfront) to proxy the plausible script. this is done by setting the script src to be `/js/script.js` and routing `/js/script.js` within cloudfront to plausible. cloudfront distribution is set up:
- in dev https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-west-2#/distributions/E2AI5EG7QRYE6E/behaviors
- in staging https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-west-2#/distributions/E1KICGZMYV4YWQ/behaviors

## Testing steps

hitting https://pr-6197-frontend.rdev.single-cell.czi.technology/js/script.js will 404, but not sure if the cloudfront things apply to rdevs? it's possible we can't test this until it's deployed in staging