### PR TITLE
fix: use gzip compression after writing citation to h5ad

### DIFF
--- a/backend/layers/processing/process_validate.py
+++ b/backend/layers/processing/process_validate.py
@@ -117,7 +117,7 @@ class ProcessValidate(ProcessingLogic):
         )
         adata = scanpy.read_h5ad(adata_path)
         adata.uns["citation"] = citation
-        adata.write(adata_path)
+        adata.write(adata_path, compression="gzip")
 
     @logit
     def extract_metadata(self, filename) -> DatasetMetadata:


### PR DESCRIPTION
## Reason for Change

- https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell/579
- Missing compression arg here resulted in h5ad exploding in size after adding citation; we want to save our h5ads with gzip compression

## Changes

- add compression='gzip' to adata.write call after adding citation post-validation add-labels.

## Testing steps
- N/A 