### PR TITLE
fix: slack dataset failure notification reports collection version ID

### DIFF
--- a/backend/layers/processing/upload_failures/app.py
+++ b/backend/layers/processing/upload_failures/app.py
@@ -34,7 +34,7 @@ def handle_failure(event: dict, context, delete_artifacts=True) -> None:
 
 def parse_event(event: dict):
     dataset_version_id = event.get("dataset_version_id")
-    collection_version_id = event.get("collection_id")
+    collection_version_id = event.get("collection_version_id")
     error_cause = event.get("error", {}).get("Cause", "")
     execution_arn = event.get("execution_id")
     try:

--- a/tests/unit/processing/test_handle_error.py
+++ b/tests/unit/processing/test_handle_error.py
@@ -88,7 +88,7 @@ def test_parse_event_with_error_cause():
     event = {
         "execution_id": "arn",
         "dataset_version_id": "123",
-        "collection_id": "456",
+        "collection_version_id": "456",
         "error": {"Cause": expected_error_cause},
     }
     (
@@ -111,7 +111,7 @@ def test_parse_event_with_error_cause():
 
 
 def test_parse_event_without_error_cause():
-    event = {"dataset_version_id": "123", "collection_id": "456", "error": {}}
+    event = {"dataset_version_id": "123", "collection_version_id": "456", "error": {}}
 
     (
         dataset_version_id,
@@ -133,7 +133,7 @@ def test_parse_event_without_error_cause():
 
 
 def test_parse_event_with_invalid_error_cause():
-    event = {"dataset_version_id": "123", "collection_id": "456", "error": {"Cause": "invalid JSON"}}
+    event = {"dataset_version_id": "123", "collection_version_id": "456", "error": {"Cause": "invalid JSON"}}
 
     (
         dataset_version_id,


### PR DESCRIPTION
## Reason for Change

- We recently changed the SFN to use collection version ID instead of collection ID. We missed swapping the env var name in the slack failure notification module, therefore failures were being reported with collection version ID as None. 