### PR TITLE
fix: pass cxg errors to be handled in HandleSuccess

### DIFF
--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -230,8 +230,21 @@ resource "aws_sfn_state_machine" "state_machine" {
                     ]
                   }
                 },
+                "Catch": [
+                  {
+                    "ErrorEquals": [
+                      "States.ALL"
+                    ],
+                    "Next": "CatchCxgFailure",
+                    "ResultPath": "$.error"
+                  }
+                ],
                 "ResultPath": null,
                 "TimeoutSeconds": 360000
+              },
+              "CatchCxgFailure": {
+                "Type": "Pass",
+                "End": true
               }
             }
           },

--- a/backend/layers/processing/process_cxg.py
+++ b/backend/layers/processing/process_cxg.py
@@ -5,7 +5,6 @@ from backend.layers.common.entities import (
     DatasetStatusKey,
     DatasetVersionId,
 )
-from backend.layers.processing.h5ad_data_file import H5ADDataFile
 from backend.layers.processing.logger import logit
 from backend.layers.processing.process_logic import ProcessingLogic
 from backend.layers.thirdparty.s3_provider import S3ProviderInterface
@@ -73,14 +72,15 @@ class ProcessCxg(ProcessingLogic):
         """
 
         cxg_output_container = local_filename.replace(".h5ad", ".cxg")
-        try:
-            h5ad_data_file = H5ADDataFile(local_filename, var_index_column_name="feature_name")
-            h5ad_data_file.to_cxg(cxg_output_container, sparse_threshold=25.0)
-        except Exception as ex:
-            # TODO use a specialized exception
-            msg = "CXG conversion failed."
-            self.logger.exception(msg)
-            raise RuntimeError(msg) from ex
+        raise RuntimeError("DJH Test fail")
+        # try:
+        #     h5ad_data_file = H5ADDataFile(local_filename, var_index_column_name="feature_name")
+        #     h5ad_data_file.to_cxg(cxg_output_container, sparse_threshold=25.0)
+        # except Exception as ex:
+        #     # TODO use a specialized exception
+        #     msg = "CXG conversion failed."
+        #     self.logger.exception(msg)
+        #     raise RuntimeError(msg) from ex
 
         return cxg_output_container
 

--- a/backend/layers/processing/process_cxg.py
+++ b/backend/layers/processing/process_cxg.py
@@ -5,6 +5,7 @@ from backend.layers.common.entities import (
     DatasetStatusKey,
     DatasetVersionId,
 )
+from backend.layers.processing.h5ad_data_file import H5ADDataFile
 from backend.layers.processing.logger import logit
 from backend.layers.processing.process_logic import ProcessingLogic
 from backend.layers.thirdparty.s3_provider import S3ProviderInterface
@@ -72,15 +73,14 @@ class ProcessCxg(ProcessingLogic):
         """
 
         cxg_output_container = local_filename.replace(".h5ad", ".cxg")
-        raise RuntimeError("DJH Test fail")
-        # try:
-        #     h5ad_data_file = H5ADDataFile(local_filename, var_index_column_name="feature_name")
-        #     h5ad_data_file.to_cxg(cxg_output_container, sparse_threshold=25.0)
-        # except Exception as ex:
-        #     # TODO use a specialized exception
-        #     msg = "CXG conversion failed."
-        #     self.logger.exception(msg)
-        #     raise RuntimeError(msg) from ex
+        try:
+            h5ad_data_file = H5ADDataFile(local_filename, var_index_column_name="feature_name")
+            h5ad_data_file.to_cxg(cxg_output_container, sparse_threshold=25.0)
+        except Exception as ex:
+            # TODO use a specialized exception
+            msg = "CXG conversion failed."
+            self.logger.exception(msg)
+            raise RuntimeError(msg) from ex
 
         return cxg_output_container
 


### PR DESCRIPTION
## Reason for Change

- #6215 
- Recent changes to handling errors in the parallel step caused error handling to only be configured for Seurat failures but not for cxg failures

## Changes

- add
- remove
- modify

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review

- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see

- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
