### PR TITLE
feat: quickly modify ingest memory configuration without redeploying,

### DIFF
--- a/backend/common/corpora_config.py
+++ b/backend/common/corpora_config.py
@@ -31,6 +31,12 @@ class CorporaConfig(SecretConfig):
             "submission_bucket": os.getenv("DATASET_SUBMISSIONS_BUCKET", "cellxgene-dataset-submissions-test"),
             "collections_base_url": collections_base_url,
             "dataset_assets_base_url": dataset_assets_base_url,
+            "ingest_memory_modifier": 3,  # adds (x*100)% memory overhead
+            "ingest_min_vcpu": 2,
+            # The largest machine we are allocating is r5a.24xlarge. This machine has 768GB of memory and 96 vCPUs.
+            "ingest_max_vcpu": 96,  # assume 8GB per vCPU
+            "ingest_swap_modifier": 0,  # 0 b/c no swap machines are used.
+            "ingest_max_swap_memory_mb": 300000,
         }
         upload_snf_arn = os.getenv("UPLOAD_SFN_ARN")
         if upload_snf_arn:

--- a/backend/layers/processing/process_download.py
+++ b/backend/layers/processing/process_download.py
@@ -97,7 +97,7 @@ class ProcessDownload(ProcessingLogic):
         :param memory_modifier: A multiplier to increase/decrease the memory requirements by
         :param min_vcpu: The minimum number of vCPUs to allocate.
         :param max_vcpu: The maximum number of vCPUs to allocate.
-        :param memory_per_vcpu: The amount of memory to allocate per vCPU.
+        :param memory_per_vcpu: The amount of memory to allocate per vCPU. 8000 MB is what AWS uses as the ratio
         :param swap_modifier: The multiplier to increase/decrease the swap memory requirements by
         :param max_swap_memory_MB: The maximum amount of swap memory to allocate.
         :return: A dictionary containing the resource requirements

--- a/backend/layers/processing/process_download.py
+++ b/backend/layers/processing/process_download.py
@@ -1,7 +1,7 @@
 import json
 import os
 from math import ceil
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import scanpy
 
@@ -24,8 +24,6 @@ from backend.layers.thirdparty.s3_provider_interface import S3ProviderInterface
 from backend.layers.thirdparty.step_function_provider import StepFunctionProvider
 from backend.layers.thirdparty.uri_provider import UriProviderInterface
 
-config = CorporaConfig()
-
 
 class ProcessDownload(ProcessingLogic):
     """
@@ -42,11 +40,13 @@ class ProcessDownload(ProcessingLogic):
         business_logic: BusinessLogicInterface,
         uri_provider: UriProviderInterface,
         s3_provider: S3ProviderInterface,
+        config: Optional[CorporaConfig] = None,
     ) -> None:
         super().__init__()
         self.business_logic = business_logic
         self.uri_provider = uri_provider
         self.s3_provider = s3_provider
+        self.config = config or CorporaConfig()
 
     @logit
     def download_from_source_uri(self, source_uri: str, local_path: str) -> str:
@@ -80,14 +80,14 @@ class ProcessDownload(ProcessingLogic):
         job_definition_name = f"dp-{prefix}-ingest-process-{dataset_version_id}"
         return job_definition_name
 
-    @staticmethod
     def estimate_resource_requirements(
+        self,
         adata: scanpy.AnnData,
-        memory_modifier: float = config.ingest_memory_modifier,
-        min_vcpu: int = config.ingest_min_vcpu,
-        max_vcpu: int = config.ingest_max_vcpu,
-        max_swap_memory_MB: int = config.ingest_max_swap_memory_mb,
-        swap_modifier: int = config.ingest_swap_modifier,
+        memory_modifier: Optional[float] = None,
+        min_vcpu: Optional[int] = None,
+        max_vcpu: Optional[int] = None,
+        max_swap_memory_MB: Optional[int] = None,
+        swap_modifier: Optional[int] = None,
         memory_per_vcpu: int = 8000,
     ) -> Dict[str, int]:
         """
@@ -102,6 +102,12 @@ class ProcessDownload(ProcessingLogic):
         :param max_swap_memory_MB: The maximum amount of swap memory to allocate.
         :return: A dictionary containing the resource requirements
         """
+        memory_modifier = memory_modifier or self.config.ingest_memory_modifier
+        min_vcpu = min_vcpu or self.config.ingest_min_vcpu
+        max_vcpu = max_vcpu or self.config.ingest_max_vcpu
+        max_swap_memory_MB = max_swap_memory_MB or self.config.ingest_max_swap_memory_mb
+        swap_modifier = swap_modifier or self.config.ingest_swap_modifier
+
         # Note: this is a rough estimate of the uncompressed size of the dataset. This method avoid loading the entire
         # dataset into memory.
         min_memory_MB = min_vcpu * memory_per_vcpu

--- a/tests/unit/processing/test_process_download.py
+++ b/tests/unit/processing/test_process_download.py
@@ -3,12 +3,12 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import scanpy
-from unit.backend.fixtures.environment_setup import fixture_file_path
 
 from backend.common.corpora_config import CorporaConfig
 from backend.common.utils.math_utils import GB
 from backend.layers.common.entities import DatasetArtifactType, DatasetUploadStatus
 from backend.layers.processing.process_download import ProcessDownload
+from tests.unit.backend.fixtures.environment_setup import fixture_file_path
 from tests.unit.processing.base_processing_test import BaseProcessingTest
 
 test_environment = {"REMOTE_DEV_PREFIX": "fake-stack", "DEPLOYMENT_STAGE": "test"}

--- a/tests/unit/processing/test_process_download.py
+++ b/tests/unit/processing/test_process_download.py
@@ -134,8 +134,7 @@ def mock_read_h5ad():
 def memory_settings(
     memory_modifier=1,
     memory_per_vcpu=4000,
-    min_memory_mb=4000,
-    max_memory_mb=64000,
+    min_vcpu=1,
     max_vcpu=16,
     max_swap_memory_mb=300000,
     swap_modifier=5,
@@ -143,8 +142,7 @@ def memory_settings(
     return dict(
         memory_modifier=memory_modifier,
         memory_per_vcpu=memory_per_vcpu,
-        min_memory_MB=min_memory_mb,
-        max_memory_MB=max_memory_mb,
+        min_vcpu=min_vcpu,
         max_vcpu=max_vcpu,
         max_swap_memory_MB=max_swap_memory_mb,
         swap_modifier=swap_modifier,

--- a/tests/unit/processing/test_process_download.py
+++ b/tests/unit/processing/test_process_download.py
@@ -3,13 +3,16 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import scanpy
+from unit.backend.fixtures.environment_setup import fixture_file_path
 
+from backend.common.corpora_config import CorporaConfig
 from backend.common.utils.math_utils import GB
 from backend.layers.common.entities import DatasetArtifactType, DatasetUploadStatus
 from backend.layers.processing.process_download import ProcessDownload
 from tests.unit.processing.base_processing_test import BaseProcessingTest
 
 test_environment = {"REMOTE_DEV_PREFIX": "fake-stack", "DEPLOYMENT_STAGE": "test"}
+test_config = CorporaConfig(source=fixture_file_path("bogo_config.json"))
 
 
 class TestProcessDownload(BaseProcessingTest):
@@ -25,6 +28,7 @@ class TestProcessDownload(BaseProcessingTest):
         2. Set upload status to UPLOADED
         3. upload the original file to S3
         """
+        self.mock_config.stop()
         dropbox_uri = "https://www.dropbox.com/s/fake_location/test.h5ad?dl=0"
         bucket_name = "fake_bucket_name"
         stack_name = test_environment["REMOTE_DEV_PREFIX"]
@@ -44,7 +48,7 @@ class TestProcessDownload(BaseProcessingTest):
         mock_sfn_provider.return_value = mock_sfn
 
         # This is where we're at when we start the SFN
-        pdv = ProcessDownload(self.business_logic, self.uri_provider, self.s3_provider)
+        pdv = ProcessDownload(self.business_logic, self.uri_provider, self.s3_provider, test_config)
         pdv.process(dataset_version_id, dropbox_uri, bucket_name, "fake_sfn_task_token")
 
         status = self.business_logic.get_dataset_status(dataset_version_id)


### PR DESCRIPTION
## Reason for Change

- The memory settings for the ingest process are dynamic and can sometimes be off. This results in fail upload. To make it easier to fine tune and adjust the memory setting for ingest, the values have been move into the CorporaConfig. This allow us to quickly change the memory setting for ingest using the corpora config secret. This saves us the need to redeploy prod.

## Changes

- move ingest memory configuration secret to corpora config
- set default values for the ingest memory configuration
- make all memory calculation based on the number of VCPUs allocated.

## Testing steps

- updated tests
