### PR TITLE
fix: Use built in set and reset in SecretConfig for testing

### DIFF
--- a/backend/common/feature_flag.py
+++ b/backend/common/feature_flag.py
@@ -17,11 +17,8 @@ if FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4):
 
 To mock a feature flag in a test:
 ```
-def mock_config_fn(name):
-    if name == FeatureFlagValues.SCHEMA_4:
-        return "True"
-
-self.mock_config = patch.object(FeatureFlagService, "is_enabled", side_effect=mock_config_fn)
+self.mock_config = CorporaConfig()
+self.mock_config.set(dict(schema_4_feature_flag="True"))
 ```
 """
 

--- a/tests/unit/backend/common/test_feature_flag.py
+++ b/tests/unit/backend/common/test_feature_flag.py
@@ -1,22 +1,17 @@
 import unittest
-from unittest.mock import patch
 
+from backend.common.corpora_config import CorporaConfig
 from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
 
 
 class TestFeatureFlag(unittest.TestCase):
     def setUp(self):
         super().setUp()
-
-        def mock_config_fn(name):
-            if name == FeatureFlagValues.SCHEMA_4:
-                return "True"
-
-        self.mock_config = patch("backend.common.corpora_config.CorporaConfig.__getattr__", side_effect=mock_config_fn)
-        self.mock_config.start()
+        self.mock_config = CorporaConfig()
+        self.mock_config.set({"schema_4_feature_flag": "True"})
 
     def tearDown(self):
-        self.mock_config.stop()
+        self.mock_config.reset()
 
     def test_feature_flag(self):
         self.assertTrue(FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4))

--- a/tests/unit/backend/layers/api/test_gene_info.py
+++ b/tests/unit/backend/layers/api/test_gene_info.py
@@ -8,6 +8,7 @@ import requests
 from backend.api_server.app import app
 from backend.common.utils.http_exceptions import NotFoundHTTPException
 from backend.gene_info.api import ensembl_ids, ncbi_provider
+from backend.gene_info.config import GeneInfoConfig
 from tests.unit.backend.fixtures.environment_setup import EnvironmentSetup
 
 
@@ -25,15 +26,15 @@ class GeneInfoAPIv1Tests(unittest.TestCase):
             "show_warning_banner": False,
         }
 
-        self.mock_config = patch("backend.gene_info.config.GeneInfoConfig.__getattr__", return_value="mock_key")
-        self.mock_config.start()
+        self.mock_config = GeneInfoConfig()
+        self.mock_config.set({"key": "mock_key"})
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.maxDiff = None
 
     def tearDown(self):
-        self.mock_config.stop()
+        self.mock_config.reset()
 
     @patch("backend.gene_info.api.ncbi_provider.urllib.request.urlopen")
     @patch("backend.gene_info.api.v1.NCBIProvider._search_gene_uid")

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -4,9 +4,10 @@ import uuid
 from copy import deepcopy
 from datetime import datetime
 from typing import List, Tuple
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 from uuid import uuid4
 
+from backend.common.corpora_config import CorporaConfig
 from backend.layers.business.business import (
     BusinessLogic,
     CollectionMetadataUpdate,
@@ -87,12 +88,8 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
 
         # Mock CorporaConfig
         # TODO: deduplicate with base_api
-        def mock_config_fn(name):
-            if name == "upload_max_file_size_gb":
-                return 30
-
-        self.mock_config = patch("backend.common.corpora_config.CorporaConfig.__getattr__", side_effect=mock_config_fn)
-        self.mock_config.start()
+        self.mock_config = CorporaConfig()
+        self.mock_config.set({"upload_max_file_size_gb": 30})
 
         # TODO: also deduplicate with base test
         from backend.layers.common import validation
@@ -173,7 +170,7 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
         self.s3_provider.mock_s3_fs = set()
 
     def tearDown(self):
-        self.mock_config.stop()
+        self.mock_config.reset()
         if self.run_as_integration:
             self.database_provider._drop_schema()
 

--- a/tests/unit/backend/layers/common/base_api_test.py
+++ b/tests/unit/backend/layers/common/base_api_test.py
@@ -4,6 +4,7 @@ import time
 import unittest
 from unittest.mock import patch
 
+from backend.common.corpora_config import CorporaAuthConfig, CorporaConfig
 from backend.layers.thirdparty.cdn_provider_interface import CDNProviderInterface
 from tests.unit.backend.layers.api.config import TOKEN_EXPIRES
 from tests.unit.backend.layers.common.base_test import BaseTest
@@ -79,14 +80,17 @@ class BaseAPIPortalTest(BaseAuthAPITest, BaseTest):
             "schema_4_feature_flag": "True",
         }
 
-        def mock_config_fn(name):
-            return mock_config_attr[name]
+        self.mock_auth_config = CorporaAuthConfig()
+        self.mock_auth_config.set(
+            dict(
+                api_base_url="mock_api_base_url",
+                auth0_domain="mock_auth0_domain",
+                curation_audience="mock_curation_audience",
+            )
+        )
 
-        self.mock = patch("backend.common.corpora_config.CorporaAuthConfig.__getattr__", return_value="mock_audience")
-        self.mock.start()
-
-        self.mock_config = patch("backend.common.corpora_config.CorporaConfig.__getattr__", side_effect=mock_config_fn)
-        self.mock_config.start()
+        self.mock_config = CorporaConfig()
+        self.mock_config.set(mock_config_attr)
 
         self.cloudfront_provider = CDNProviderInterface()
 
@@ -108,7 +112,8 @@ class BaseAPIPortalTest(BaseAuthAPITest, BaseTest):
         # Disable mocking of business logic and cloudfront provider
         self.mock_business_logic.stop()
         self.mock_cloudfront_provider.stop()
-        self.mock_config.stop()
+        self.mock_config.reset()
+        self.mock_auth_config.reset()
 
     def get_cxguser_token(self, user="owner"):
         """

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -4,8 +4,9 @@ import typing
 import unittest
 from dataclasses import dataclass
 from typing import List, Optional
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
+from backend.common.corpora_config import CorporaConfig
 from backend.layers.business.business import BusinessLogic
 from backend.layers.common.entities import (
     CollectionId,
@@ -77,15 +78,17 @@ class BaseTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
         os.environ.setdefault("APP_NAME", "corpora-api")
-
+        config = {
+            "upload_max_file_size_gb": 30,
+            "collections_base_url": "http://collections",
+            "dataset_assets_base_url": "http://domain",
+            "schema_4_feature_flag": "True",
+        }
         # Mock CorporaConfig
         # TODO: deduplicate with base_api
-        def mock_config_fn(name):
-            if name == "upload_max_file_size_gb":
-                return 30
 
-        self.mock_config = patch("backend.common.corpora_config.CorporaConfig.__getattr__", side_effect=mock_config_fn)
-        self.mock_config.start()
+        self.mock_config = CorporaConfig()
+        self.mock_config.set(config)
 
         from backend.layers.common import validation
 
@@ -164,7 +167,7 @@ class BaseTest(unittest.TestCase):
 
     def tearDown(self):
         super().tearDown()
-        self.mock_config.stop()
+        self.mock_config.reset()
         if self.run_as_integration:
             self.database_provider._drop_schema()
 

--- a/tests/unit/processing/base_processing_test.py
+++ b/tests/unit/processing/base_processing_test.py
@@ -5,17 +5,6 @@ from backend.layers.thirdparty.schema_validator_provider import SchemaValidatorP
 from backend.layers.thirdparty.uri_provider import FileInfo, UriProvider
 from tests.unit.backend.layers.common.base_test import BaseTest
 
-mock_config_attr = {
-    "collections_base_url": "http://collections",
-    "dataset_assets_base_url": "http://domain",
-    "upload_max_file_size_gb": 1,
-    "schema_4_feature_flag": "True",
-}
-
-
-def mock_config_fn(name):
-    return mock_config_attr[name]
-
 
 class BaseProcessingTest(BaseTest):
     def setUp(self):

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -4,7 +4,6 @@ import anndata
 import numpy as np
 import pandas
 
-from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
 from backend.layers.common.entities import OntologyTermId, TissueOntologyTermId
 from backend.layers.processing.process_validate import ProcessValidate
 from tests.unit.processing.base_processing_test import BaseProcessingTest
@@ -14,16 +13,6 @@ class TestProcessingValidate(BaseProcessingTest):
     def setUp(self):
         super().setUp()
         self.pdv = ProcessValidate(self.business_logic, self.uri_provider, self.s3_provider, self.schema_validator)
-
-        def mock_config_fn(name):
-            if name == FeatureFlagValues.SCHEMA_4:
-                return "True"
-
-        self.mock_config = patch.object(FeatureFlagService, "is_enabled", side_effect=mock_config_fn)
-        self.mock_config.start()
-
-    def tearDown(self):
-        self.mock_config.stop()
 
     @patch("scanpy.read_h5ad")
     def test_extract_metadata(self, mock_read_h5ad):

--- a/tests/unit/processing/test_h5ad_data_file.py
+++ b/tests/unit/processing/test_h5ad_data_file.py
@@ -2,7 +2,6 @@ import json
 import unittest
 from os import path, remove
 from shutil import rmtree
-from unittest.mock import patch
 from uuid import uuid4
 
 import anndata
@@ -10,7 +9,7 @@ import numpy as np
 import tiledb
 from pandas import Categorical, DataFrame, Series
 
-from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
+from backend.common.corpora_config import CorporaConfig
 from backend.common.utils.corpora_constants import CorporaConstants
 from backend.layers.processing.h5ad_data_file import H5ADDataFile
 from tests.unit.backend.fixtures.environment_setup import fixture_file_path
@@ -23,12 +22,8 @@ class TestH5ADDataFile(unittest.TestCase):
 
         self.sample_output_directory = path.splitext(self.sample_h5ad_filename)[0] + ".cxg"
 
-        def mock_config_fn(name):
-            if name == FeatureFlagValues.SCHEMA_4:
-                return "True"
-
-        self.mock_config = patch.object(FeatureFlagService, "is_enabled", side_effect=mock_config_fn)
-        self.mock_config.start()
+        self.mock_config = CorporaConfig()
+        self.mock_config.set({"schema_4_feature_flag": "True"})
 
     def tearDown(self):
         if self.sample_h5ad_filename:
@@ -37,7 +32,7 @@ class TestH5ADDataFile(unittest.TestCase):
         if path.isdir(self.sample_output_directory):
             rmtree(self.sample_output_directory)
 
-        self.mock_config.stop()
+        self.mock_config.reset()
 
     def test__create_h5ad_data_file__non_h5ad_raises_exception(self):
         non_h5ad_filename = "my_fancy_dataset.csv"

--- a/tests/unit/processing/test_process_download.py
+++ b/tests/unit/processing/test_process_download.py
@@ -4,15 +4,12 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import scanpy
 
-from backend.common.corpora_config import CorporaConfig
 from backend.common.utils.math_utils import GB
 from backend.layers.common.entities import DatasetArtifactType, DatasetUploadStatus
 from backend.layers.processing.process_download import ProcessDownload
-from tests.unit.backend.fixtures.environment_setup import fixture_file_path
 from tests.unit.processing.base_processing_test import BaseProcessingTest
 
 test_environment = {"REMOTE_DEV_PREFIX": "fake-stack", "DEPLOYMENT_STAGE": "test"}
-test_config = CorporaConfig(source=fixture_file_path("bogo_config.json"))
 
 
 class TestProcessDownload(BaseProcessingTest):
@@ -28,7 +25,6 @@ class TestProcessDownload(BaseProcessingTest):
         2. Set upload status to UPLOADED
         3. upload the original file to S3
         """
-        self.mock_config.stop()
         dropbox_uri = "https://www.dropbox.com/s/fake_location/test.h5ad?dl=0"
         bucket_name = "fake_bucket_name"
         stack_name = test_environment["REMOTE_DEV_PREFIX"]
@@ -48,7 +44,7 @@ class TestProcessDownload(BaseProcessingTest):
         mock_sfn_provider.return_value = mock_sfn
 
         # This is where we're at when we start the SFN
-        pdv = ProcessDownload(self.business_logic, self.uri_provider, self.s3_provider, test_config)
+        pdv = ProcessDownload(self.business_logic, self.uri_provider, self.s3_provider)
         pdv.process(dataset_version_id, dropbox_uri, bucket_name, "fake_sfn_task_token")
 
         status = self.business_logic.get_dataset_status(dataset_version_id)

--- a/tests/unit/processing/test_process_validate.py
+++ b/tests/unit/processing/test_process_validate.py
@@ -11,13 +11,12 @@ from backend.layers.common.entities import (
 )
 from backend.layers.processing.process import ProcessMain
 from backend.layers.processing.process_validate import ProcessValidate
-from tests.unit.processing.base_processing_test import BaseProcessingTest, mock_config_fn
+from tests.unit.processing.base_processing_test import BaseProcessingTest
 
 
 class ProcessingTest(BaseProcessingTest):
     @patch("scanpy.read_h5ad")
-    @patch("backend.common.corpora_config.CorporaConfig.__getattr__", side_effect=mock_config_fn)
-    def test_process_download_validate_success(self, mock_config, mock_read_h5ad):
+    def test_process_download_validate_success(self, mock_read_h5ad):
         """
         ProcessDownloadValidate should:
         1. Download the h5ad artifact
@@ -71,8 +70,7 @@ class ProcessingTest(BaseProcessingTest):
             artifact.uri = f"s3://fake_bucket_name/{dataset_version_id.id}/local.h5ad"
 
     @patch("scanpy.read_h5ad")
-    @patch("backend.common.corpora_config.CorporaConfig.__getattr__", side_effect=mock_config_fn)
-    def test_populate_dataset_citation__no_publication_doi(self, mock_config, mock_read_h5ad):
+    def test_populate_dataset_citation__no_publication_doi(self, mock_read_h5ad):
         mock_read_h5ad.return_value = MagicMock(uns=dict())
         collection = self.generate_unpublished_collection()
 

--- a/tests/unit/processing/test_processing.py
+++ b/tests/unit/processing/test_processing.py
@@ -9,7 +9,7 @@ from backend.layers.common.entities import (
 from backend.layers.processing.process import ProcessMain
 from backend.layers.processing.process_cxg import ProcessCxg
 from backend.layers.processing.process_seurat import ProcessSeurat
-from tests.unit.processing.base_processing_test import BaseProcessingTest, mock_config_fn
+from tests.unit.processing.base_processing_test import BaseProcessingTest
 
 
 class ProcessingTest(BaseProcessingTest):
@@ -90,11 +90,10 @@ class ProcessingTest(BaseProcessingTest):
 
     @patch("backend.layers.processing.process_download.StepFunctionProvider")
     @patch("scanpy.read_h5ad")
-    @patch("backend.common.corpora_config.CorporaConfig.__getattr__", side_effect=mock_config_fn)
     @patch("backend.layers.processing.process_validate.ProcessValidate.extract_metadata")
     @patch("backend.layers.processing.process_seurat.ProcessSeurat.make_seurat")
     @patch("backend.layers.processing.process_cxg.ProcessCxg.make_cxg")
-    def test_process_all(self, mock_cxg, mock_seurat, mock_h5ad, mock_config, mock_read_h5ad, mock_sfn_provider):
+    def test_process_all(self, mock_cxg, mock_seurat, mock_h5ad, mock_read_h5ad, mock_sfn_provider):
         mock_seurat.return_value = "local.rds"
         mock_cxg.return_value = "local.cxg"
 


### PR DESCRIPTION

## Reason for Change

- Fixes tests that are failing because of how CorporaConfig is mocked
- This simplifies how configuration setting are mocked.

## Changes

- modify how SecretConfig classes are mocked

