### PR TITLE
fix(ingest): Don't retry cxg, seurat, and validate

### DIFF
--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -191,7 +191,7 @@ resource "aws_sfn_state_machine" "state_machine" {
                   "JobDefinition.$": "$.batch.JobDefinitionName",
                   "JobName": "cxg",
                   "JobQueue.$": "$.job_queue",
-                   "ContainerOverrides": {
+                  "ContainerOverrides": {
                     "Environment": [
                       {
                         "Name": "DATASET_VERSION_ID",

--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -147,19 +147,6 @@ resource "aws_sfn_state_machine" "state_machine" {
           "JobDefinition.$": "$.batch.JobDefinitionName",
           "JobName": "validate",
           "JobQueue.$": "$.job_queue",
-          "RetryStrategy": {
-            "Attempts": ${var.max_attempts},
-            "EvaluateOnExit": [
-              {
-                "Action": "EXIT",
-                "OnExitCode": "1"
-              },
-              {
-                "Action": "RETRY",
-                "OnExitCode": "*"
-              }
-            ]
-          },
           "ContainerOverrides": {
             "Environment": [
               {
@@ -204,20 +191,7 @@ resource "aws_sfn_state_machine" "state_machine" {
                   "JobDefinition.$": "$.batch.JobDefinitionName",
                   "JobName": "cxg",
                   "JobQueue.$": "$.job_queue",
-                  "RetryStrategy": {
-                    "Attempts": ${var.max_attempts},
-                    "EvaluateOnExit": [
-                      {
-                        "Action": "EXIT",
-                        "OnExitCode": "1"
-                      },
-                      {
-                        "Action": "RETRY",
-                        "OnExitCode": "*"
-                      }
-                    ]
-                  },
-                  "ContainerOverrides": {
+                   "ContainerOverrides": {
                     "Environment": [
                       {
                         "Name": "DATASET_VERSION_ID",
@@ -259,19 +233,6 @@ resource "aws_sfn_state_machine" "state_machine" {
                   "JobDefinition.$": "$.batch.JobDefinitionName",
                   "JobName": "seurat",
                   "JobQueue.$": "$.job_queue",
-                  "RetryStrategy": {
-                    "Attempts": ${var.max_attempts},
-                    "EvaluateOnExit": [
-                      {
-                        "Action": "EXIT",
-                        "OnExitCode": "1"
-                      },
-                      {
-                        "Action": "RETRY",
-                        "OnExitCode": "*"
-                      }
-                    ]
-                  },
                   "ContainerOverrides": {
                     "Environment": [
                       {

--- a/backend/layers/processing/process_download.py
+++ b/backend/layers/processing/process_download.py
@@ -117,6 +117,22 @@ class ProcessDownload(ProcessingLogic):
         vcpus = max_vcpu if estimated_memory_MB > max_memory_MB else int(ceil(estimated_memory_MB / memory_per_vcpu))
         memory = memory_per_vcpu * vcpus  # round up to nearest memory_per_vcpu
         max_swap = min([max_swap_memory_MB, memory * swap_modifier])
+        self.logger.info(
+            {
+                "message": "Estimated resource requirements",
+                "memory_modifier": memory_modifier,
+                "swap_modifier": swap_modifier,
+                "min_vcpu": min_vcpu,
+                "max_vcpu": max_vcpu,
+                "max_swap_memory_MB": max_swap_memory_MB,
+                "memory_per_vcpu": memory_per_vcpu,
+                "uncompressed_size_MB": uncompressed_size_MB,
+                "max_swap": max_swap,
+                "memory": memory,
+                "vcpus": vcpus,
+            }
+        )
+
         return {"Vcpus": vcpus, "Memory": memory, "MaxSwap": max_swap}
 
     def create_batch_job_definition_parameters(self, local_filename: str, dataset_version_id: str) -> Dict[str, Any]:


### PR DESCRIPTION


## Reason for Change

- Retrying seurat, cxg, and validate have never resulted in a passing job. Removing to reveal error sooner.
- Keeping the retry bon download because sometimes the download source is flakey.


## Changes
- remove try from seurat, cxg, and validate
- Add logging of memory settings. This will help in the future with looking down memory usuage
