### PR TITLE
fix: Track mismatches in compare_dict

### DIFF
--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -26,9 +26,9 @@ class CompareDictsAddin:
         @contextmanager
         def path(key):
             try:
-                yield path.append(key)
+                yield _path.append(key)
             finally:
-                path.pop()
+                _path.pop()
 
         def _compare_dict(_dict1, _dict2):
             if len(_dict1) != len(_dict2):

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -1,59 +1,82 @@
-class CompareDictsAddin:
-    _maxDiff = 10
+import contextlib
+from contextlib import contextmanager
 
-    def assert_dicts_equal(self, dict1, dict2):
+
+class CompareDictsAddin:
+    def assert_dicts_equal(self, dict1, dict2, fail_fast=True, max_diff=None):
         """
         This function recursive compares two dictionaries handling cases where the values
         are unordered arrays with elements that could be dictionaries.
+        :param dict1: first dictionary
+        :param dict2: second dictionary
+        :param fail_fast: if True, raise an exception on the first mismatch
+        :param max_diff: maximum number of differences to report
         """
-        mismatch = []
-        path = ["$"]
+        _mismatch = []
+        _path = ["$"]
+
+        class Stop(Exception):
+            pass
+
+        def update_mismatch(message):
+            _mismatch.append(message)
+            if fail_fast:
+                raise Stop()
+
+        @contextmanager
+        def path(key):
+            try:
+                yield path.append(key)
+            finally:
+                path.pop()
 
         def _compare_dict(_dict1, _dict2):
             if len(_dict1) != len(_dict2):
-                mismatch.append("{}: Lengths differ: {} vs {}".format(".".join(path), len(_dict1), len(_dict2)))
+                update_mismatch("{}: Lengths differ: {} vs {}".format(".".join(path), len(_dict1), len(_dict2)))
 
             for key in dict1:
                 if key not in _dict2:
-                    mismatch.append("{}: Key {} not in dict2".format(".".join(path), key))
+                    update_mismatch("{}: Key {} not in dict2".format(".".join(path), key))
                     continue
-                path.append(key)
                 value1 = _dict1[key]
                 value2 = _dict2[key]
 
-                if isinstance(value1, dict) and isinstance(value2, dict):
-                    _compare_dict(value1, value2)
-                elif isinstance(value1, list) and isinstance(value2, list):
-                    if len(value1) != len(value2):
-                        mismatch.append("{}: Lengths differ: {} vs {}".format(".".join(path), len(value1), len(value2)))
-                    # check if the lists contain dictionaries as elements
-                    elif len(value1) > 0 and isinstance(value1[0], dict) and isinstance(value2[0], dict):
-                        for i in range(len(value1)):
-                            path.append(f"[{i}]")
-                            _compare_dict(value1[i], value2[i])
-                            path.pop()
-                    elif sorted(value1) != sorted(value2):
-                        # compare as sets and print the differences
-                        value1_set = set(value1)
-                        value2_set = set(value2)
-                        mismatch.append(
-                            "{}: Values differ: {} vs {}".format(
-                                ".".join(path), value1_set - value2_set, value2_set - value1_set
+                with path(key):
+                    if isinstance(value1, dict) and isinstance(value2, dict):
+                        _compare_dict(value1, value2)
+                    elif isinstance(value1, list) and isinstance(value2, list):
+                        if len(value1) != len(value2):
+                            update_mismatch(
+                                "{}: Lengths differ: {} vs {}".format(".".join(path), len(value1), len(value2))
                             )
-                        )
-                else:
-                    if value1 != value2:
-                        mismatch.append("{}: Values differ: {} vs {}".format(".".join(path), value1, value2))
-                path.pop()
+                        # check if the lists contain dictionaries as elements
+                        elif len(value1) > 0 and isinstance(value1[0], dict) and isinstance(value2[0], dict):
+                            for i in range(len(value1)):
+                                with path(f"[{i}]"):
+                                    _compare_dict(value1[i], value2[i])
+                        elif sorted(value1) != sorted(value2):
+                            # compare as sets and print the differences
+                            value1_set = set(value1)
+                            value2_set = set(value2)
+                            update_mismatch(
+                                "{}: Values differ: {} vs {}".format(
+                                    ".".join(path), value1_set - value2_set, value2_set - value1_set
+                                )
+                            )
+                    else:
+                        if value1 != value2:
+                            update_mismatch("{}: Values differ: {} vs {}".format(".".join(path), value1, value2))
 
-        _compare_dict(dict1, dict2)
-        if mismatch:
-            if len(mismatch) > self._maxDiff:
+        with contextlib.suppress(Stop):
+            _compare_dict(dict1, dict2)
+
+        if _mismatch:
+            if len(_mismatch) > max_diff:
                 raise self.failureException(
-                    f"Mismatched keys: {len[mismatch]}" + "\n\t".join(mismatch[: self._maxDiff]) + "\n\t..."
+                    f"Mismatched keys: {len[_mismatch]}" + "\n\t".join(_mismatch[:max_diff]) + "\n\t..."
                 )
             else:
-                raise self.failureException(f"Mismatched keys: {len[mismatch]}" + "\n\t".join(mismatch))
+                raise self.failureException(f"Mismatched keys: {len[_mismatch]}" + "\n\t".join(_mismatch))
 
 
 def sort_dataframe(df):

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -1,36 +1,59 @@
-def compare_dicts(dict1, dict2):
-    """
-    This function recursive compares two dictionaries handling cases where the values
-    are unordered arrays with elements that could be dictionaries.
-    """
-    if len(dict1) != len(dict2):
-        return False
+class CompareDictsAddin:
+    _maxDiff = 10
 
-    for key in dict1:
-        if key not in dict2:
-            return False
+    def assert_dicts_equal(self, dict1, dict2):
+        """
+        This function recursive compares two dictionaries handling cases where the values
+        are unordered arrays with elements that could be dictionaries.
+        """
+        mismatch = []
+        path = ["$"]
 
-        value1 = dict1[key]
-        value2 = dict2[key]
+        def _compare_dict(_dict1, _dict2):
+            if len(_dict1) != len(_dict2):
+                mismatch.append("{}: Lengths differ: {} vs {}".format(".".join(path), len(_dict1), len(_dict2)))
 
-        if isinstance(value1, dict) and isinstance(value2, dict):
-            if not compare_dicts(value1, value2):
-                return False
-        elif isinstance(value1, list) and isinstance(value2, list):
-            if len(value1) != len(value2):
-                return False
-            # check if the lists contain dictionaries as elements
-            if len(value1) > 0 and isinstance(value1[0], dict) and isinstance(value2[0], dict):
-                for i in range(len(value1)):
-                    if not compare_dicts(value1[i], value2[i]):
-                        return False
-            elif sorted(value1) != sorted(value2):
-                return False
-        else:
-            if value1 != value2:
-                return False
+            for key in dict1:
+                if key not in _dict2:
+                    mismatch.append("{}: Key {} not in dict2".format(".".join(path), key))
+                    continue
+                path.append(key)
+                value1 = _dict1[key]
+                value2 = _dict2[key]
 
-    return True
+                if isinstance(value1, dict) and isinstance(value2, dict):
+                    _compare_dict(value1, value2)
+                elif isinstance(value1, list) and isinstance(value2, list):
+                    if len(value1) != len(value2):
+                        mismatch.append("{}: Lengths differ: {} vs {}".format(".".join(path), len(value1), len(value2)))
+                    # check if the lists contain dictionaries as elements
+                    elif len(value1) > 0 and isinstance(value1[0], dict) and isinstance(value2[0], dict):
+                        for i in range(len(value1)):
+                            path.append(f"[{i}]")
+                            _compare_dict(value1[i], value2[i])
+                            path.pop()
+                    elif sorted(value1) != sorted(value2):
+                        # compare as sets and print the differences
+                        value1_set = set(value1)
+                        value2_set = set(value2)
+                        mismatch.append(
+                            "{}: Values differ: {} vs {}".format(
+                                ".".join(path), value1_set - value2_set, value2_set - value1_set
+                            )
+                        )
+                else:
+                    if value1 != value2:
+                        mismatch.append("{}: Values differ: {} vs {}".format(".".join(path), value1, value2))
+                path.pop()
+
+        _compare_dict(dict1, dict2)
+        if mismatch:
+            if len(mismatch) > self._maxDiff:
+                raise self.failureException(
+                    f"Mismatched keys: {len[mismatch]}" + "\n\t".join(mismatch[: self._maxDiff]) + "\n\t..."
+                )
+            else:
+                raise self.failureException(f"Mismatched keys: {len[mismatch]}" + "\n\t".join(mismatch))
 
 
 def sort_dataframe(df):

--- a/tests/unit/backend/wmg/api/test_v2.py
+++ b/tests/unit/backend/wmg/api/test_v2.py
@@ -8,7 +8,7 @@ from pytest import approx
 from backend.api_server.app import app
 from backend.wmg.api.v2 import find_dimension_id_from_compare
 from backend.wmg.data.query import MarkerGeneQueryCriteria
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.unit.backend.fixtures.environment_setup import EnvironmentSetup
 from tests.unit.backend.wmg.fixtures.test_cube_schema import expression_summary_non_indexed_dims
 from tests.unit.backend.wmg.fixtures.test_primary_filters import (
@@ -430,7 +430,7 @@ def sort_filter_options(filter_options: Dict[str, List[Dict[str, str]]]):
 # backend.wmg.api.v2.rollup() so that we can test backend.wmg.api.v2.query() with
 # rollup operations.
 # see: https://github.com/chanzuckerberg/single-cell-data-portal/issues/4997
-class WmgApiV2Tests(unittest.TestCase):
+class WmgApiV2Tests(unittest.TestCase, CompareDictsAddin):
     """
     Tests WMG API endpoints. Tests the flask app only, and not other stack dependencies, such as S3. Builds and uses a
     temporary WMG cube on local filesystem to avoid dependency on localstack S3.
@@ -793,7 +793,7 @@ class WmgApiV2Tests(unittest.TestCase):
             self.assertEqual(200, response.status_code)
 
             expected = expected_term_id_labels["cell_types"]
-            self.assertTrue(compare_dicts(expected, json.loads(response.data)["term_id_labels"]["cell_types"]))
+            self.assert_dicts_equal(expected, json.loads(response.data)["term_id_labels"]["cell_types"])
 
     @patch("backend.wmg.api.v2.gene_term_label")
     @patch("backend.wmg.api.v2.ontology_term_label")

--- a/tests/unit/cellguide_pipeline/test_canonical_marker_genes.py
+++ b/tests/unit/cellguide_pipeline/test_canonical_marker_genes.py
@@ -10,7 +10,7 @@ from backend.cellguide.pipeline.canonical_marker_genes.utils import (
     get_title_and_citation_from_doi,
 )
 from backend.cellguide.pipeline.utils import convert_dataclass_to_dict_and_strip_nones
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.test_utils.mocks import mock_get_asctb_master_sheet, mock_get_title_and_citation_from_doi
 from tests.unit.backend.wmg.fixtures.test_snapshot import (
     load_realistic_test_snapshot,
@@ -23,7 +23,7 @@ from tests.unit.cellguide_pipeline.constants import (
 TEST_SNAPSHOT = "realistic-test-snapshot"
 
 
-class CanonicalMarkerGeneCompilerTests(unittest.TestCase):
+class CanonicalMarkerGeneCompilerTests(unittest.TestCase, CompareDictsAddin):
     def test__canonical_marker_genes(self):
         with open(f"{CELLGUIDE_PIPELINE_FIXTURES_BASEPATH}/{CANONICAL_MARKER_GENES_FIXTURE_FILENAME}", "r") as f:
             expected__canonical_marker_genes = json.load(f)
@@ -49,7 +49,7 @@ class CanonicalMarkerGeneCompilerTests(unittest.TestCase):
                 canonical_marker_genes = convert_dataclass_to_dict_and_strip_nones(
                     marker_gene_compiler.get_processed_asctb_table_entries()
                 )
-            self.assertTrue(compare_dicts(canonical_marker_genes, expected__canonical_marker_genes))
+            self.assert_dicts_equal(canonical_marker_genes, expected__canonical_marker_genes)
 
 
 class CanonicalMarkerGeneCompilerUtilsTests(unittest.TestCase):

--- a/tests/unit/cellguide_pipeline/test_computational_marker_genes.py
+++ b/tests/unit/cellguide_pipeline/test_computational_marker_genes.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from backend.cellguide.pipeline.computational_marker_genes import get_computational_marker_genes
 from backend.cellguide.pipeline.ontology_tree.tree_builder import OntologyTreeBuilder
 from backend.cellguide.pipeline.utils import convert_dataclass_to_dict_and_strip_nones
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.test_utils.mocks import mock_bootstrap_rows_percentiles
 from tests.unit.backend.wmg.fixtures.test_snapshot import (
     load_realistic_test_snapshot,
@@ -19,7 +19,7 @@ from tests.unit.cellguide_pipeline.constants import (
 TEST_SNAPSHOT = "realistic-test-snapshot"
 
 
-class MarkerGeneCalculatorTests(unittest.TestCase):
+class MarkerGeneCalculatorTests(unittest.TestCase, CompareDictsAddin):
     def test__marker_gene_calculation(self):
         with open(f"{CELLGUIDE_PIPELINE_FIXTURES_BASEPATH}/{COMPUTATIONAL_MARKER_GENES_FIXTURE_FILENAME}", "r") as f:
             expected__computational_marker_genes = json.load(f)
@@ -39,5 +39,5 @@ class MarkerGeneCalculatorTests(unittest.TestCase):
             )
             computational_marker_genes = convert_dataclass_to_dict_and_strip_nones(computational_marker_genes)
             reformatted_marker_genes = convert_dataclass_to_dict_and_strip_nones(reformatted_marker_genes)
-            self.assertTrue(compare_dicts(computational_marker_genes, expected__computational_marker_genes))
-            self.assertTrue(compare_dicts(reformatted_marker_genes, expected__reformatted_marker_genes))
+            self.assert_dicts_equal(computational_marker_genes, expected__computational_marker_genes)
+            self.assert_dicts_equal(reformatted_marker_genes, expected__reformatted_marker_genes)

--- a/tests/unit/cellguide_pipeline/test_gpt_descriptions.py
+++ b/tests/unit/cellguide_pipeline/test_gpt_descriptions.py
@@ -12,7 +12,7 @@ from backend.cellguide.pipeline.gpt_descriptions.gpt_description_generator impor
     generate_new_seo_gpt_descriptions,
 )
 from backend.cellguide.pipeline.ontology_tree.tree_builder import OntologyTreeBuilder
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.unit.backend.wmg.fixtures.test_snapshot import (
     load_realistic_test_snapshot,
 )
@@ -42,7 +42,7 @@ class MockCellGuideConfig:
         self.bucket = "cellguide-data-public-test"
 
 
-class TestGptDescriptionGenerator(unittest.TestCase):
+class TestGptDescriptionGenerator(unittest.TestCase, CompareDictsAddin):
     def test__gpt_description_generator(self):
         expected_outputs = {}
         for obj in WHICH_OBJECTS_DO_NOT_EXIST:
@@ -64,7 +64,7 @@ class TestGptDescriptionGenerator(unittest.TestCase):
             for obj in WHICH_OBJECTS_DO_NOT_EXIST:
                 tree_builder.all_cell_type_ids_to_labels_in_corpus[obj["id"]] = obj["name"]
             new_gpt_descriptions = generate_new_gpt_descriptions(tree_builder.all_cell_type_ids_to_labels_in_corpus)
-            self.assertTrue(compare_dicts(new_gpt_descriptions, expected_outputs))
+            self.assert_dicts_equal(new_gpt_descriptions, expected_outputs)
 
     def test__gpt_seo_description_generator(self):
         expected_outputs = {}
@@ -84,4 +84,4 @@ class TestGptDescriptionGenerator(unittest.TestCase):
         ):
             fake_new_gpt_descriptions = {i["id"]: i["fake_gpt_description"] for i in WHICH_OBJECTS_DO_NOT_EXIST}
             new_gpt_seo_descriptions = generate_new_seo_gpt_descriptions(fake_new_gpt_descriptions)
-            self.assertTrue(compare_dicts(new_gpt_seo_descriptions, expected_outputs))
+            self.assert_dict_equal(new_gpt_seo_descriptions, expected_outputs)

--- a/tests/unit/cellguide_pipeline/test_metadata_generator.py
+++ b/tests/unit/cellguide_pipeline/test_metadata_generator.py
@@ -7,7 +7,7 @@ from backend.cellguide.pipeline.metadata.metadata_generator import (
 )
 from backend.cellguide.pipeline.ontology_tree.tree_builder import OntologyTreeBuilder
 from backend.cellguide.pipeline.utils import convert_dataclass_to_dict_and_strip_nones
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.unit.backend.wmg.fixtures.test_snapshot import (
     load_realistic_test_snapshot,
 )
@@ -20,7 +20,7 @@ from tests.unit.cellguide_pipeline.constants import (
 TEST_SNAPSHOT = "realistic-test-snapshot"
 
 
-class TestMetadataGenerator(unittest.TestCase):
+class TestMetadataGenerator(unittest.TestCase, CompareDictsAddin):
     def test__cell_metadata_generator(self):
         with open(f"{CELLGUIDE_PIPELINE_FIXTURES_BASEPATH}/{CELLTYPE_METADATA_FIXTURE_FILENAME}", "r") as f:
             expected__cell_metadata = json.load(f)
@@ -32,9 +32,7 @@ class TestMetadataGenerator(unittest.TestCase):
                 all_cell_type_ids_in_corpus=tree_builder.all_cell_type_ids_in_corpus
             )
 
-            self.assertTrue(
-                compare_dicts(convert_dataclass_to_dict_and_strip_nones(cell_metadata), expected__cell_metadata)
-            )
+            self.assert_dicts_equal(convert_dataclass_to_dict_and_strip_nones(cell_metadata), expected__cell_metadata)
 
     def test__tissue_metadata_generator(self):
         with open(f"{CELLGUIDE_PIPELINE_FIXTURES_BASEPATH}/{TISSUE_METADATA_FIXTURE_FILENAME}", "r") as f:
@@ -46,6 +44,6 @@ class TestMetadataGenerator(unittest.TestCase):
             tissue_metadata = generate_cellguide_tissue_card_metadata(
                 all_tissue_ids_in_corpus=tree_builder.all_tissue_ids_in_corpus
             )
-            self.assertTrue(
-                compare_dicts(convert_dataclass_to_dict_and_strip_nones(tissue_metadata), expected__tissue_metadata)
+            self.assert_dicts_equal(
+                convert_dataclass_to_dict_and_strip_nones(tissue_metadata), expected__tissue_metadata
             )

--- a/tests/unit/cellguide_pipeline/test_ontology_tree.py
+++ b/tests/unit/cellguide_pipeline/test_ontology_tree.py
@@ -3,7 +3,7 @@ import unittest
 
 from backend.cellguide.pipeline.ontology_tree.tree_builder import OntologyTreeBuilder
 from backend.cellguide.pipeline.utils import convert_dataclass_to_dict_and_strip_nones
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.unit.backend.wmg.fixtures.test_snapshot import (
     load_realistic_test_snapshot,
 )
@@ -17,7 +17,7 @@ from tests.unit.cellguide_pipeline.constants import (
 TEST_SNAPSHOT = "realistic-test-snapshot"
 
 
-class OntologyTreeBuilderTests(unittest.TestCase):
+class OntologyTreeBuilderTests(unittest.TestCase, CompareDictsAddin):
     def test__ontology_tree_builder(self):
         with open(f"{CELLGUIDE_PIPELINE_FIXTURES_BASEPATH}/{ONTOLOGY_GRAPH_FIXTURE_FILENAME}", "r") as f:
             expected__ontology_graph = json.load(f)
@@ -30,14 +30,14 @@ class OntologyTreeBuilderTests(unittest.TestCase):
             tree_builder = OntologyTreeBuilder(cell_counts_df)
 
             ontology_graph = convert_dataclass_to_dict_and_strip_nones(tree_builder.get_ontology_tree())
-            self.assertTrue(compare_dicts(ontology_graph, expected__ontology_graph))
+            self.assert_dicts_equal(ontology_graph, expected__ontology_graph)
 
             all_states_per_cell_type = convert_dataclass_to_dict_and_strip_nones(
                 tree_builder.get_ontology_tree_state_per_celltype()
             )
-            self.assertTrue(compare_dicts(all_states_per_cell_type, expected__all_states_per_cell_type))
+            self.assert_dicts_equal(all_states_per_cell_type, expected__all_states_per_cell_type)
 
             all_states_per_tissue = convert_dataclass_to_dict_and_strip_nones(
                 tree_builder.get_ontology_tree_state_per_tissue()
             )
-            self.assertTrue(compare_dicts(all_states_per_tissue, expected__all_states_per_tissue))
+            self.assert_dicts_equal(all_states_per_tissue, expected__all_states_per_tissue)

--- a/tests/unit/cellguide_pipeline/test_source_collections_generator.py
+++ b/tests/unit/cellguide_pipeline/test_source_collections_generator.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from backend.cellguide.pipeline.ontology_tree.tree_builder import OntologyTreeBuilder
 from backend.cellguide.pipeline.source_collections.source_collections_generator import generate_source_collections_data
 from backend.cellguide.pipeline.utils import convert_dataclass_to_dict_and_strip_nones
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.test_utils.mocks import (
     mock_get_collections_from_curation_endpoint,
     mock_get_datasets_from_curation_endpoint,
@@ -21,7 +21,7 @@ from tests.unit.cellguide_pipeline.constants import (
 TEST_SNAPSHOT = "realistic-test-snapshot"
 
 
-class TestSourceCollectionsGenerator(unittest.TestCase):
+class TestSourceCollectionsGenerator(unittest.TestCase, CompareDictsAddin):
     def test__source_collections_generator(self):
         with open(f"{CELLGUIDE_PIPELINE_FIXTURES_BASEPATH}/{SOURCE_COLLECTIONS_FIXTURE_FILENAME}", "r") as f:
             expected__source_collections = json.load(f)
@@ -39,8 +39,6 @@ class TestSourceCollectionsGenerator(unittest.TestCase):
                     all_cell_type_ids_in_corpus=tree_builder.all_cell_type_ids_in_corpus
                 )
 
-            self.assertTrue(
-                compare_dicts(
-                    convert_dataclass_to_dict_and_strip_nones(source_collections), expected__source_collections
-                )
+            self.assert_dicts_equal(
+                convert_dataclass_to_dict_and_strip_nones(source_collections), expected__source_collections
             )

--- a/tests/unit/wmg_processing/test_cell_type_ordering.py
+++ b/tests/unit/wmg_processing/test_cell_type_ordering.py
@@ -8,11 +8,11 @@ from backend.wmg.pipeline.constants import (
     EXPRESSION_SUMMARY_AND_CELL_COUNTS_CUBE_CREATED_FLAG,
 )
 from backend.wmg.pipeline.utils import load_pipeline_state, write_pipeline_state
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.unit.backend.wmg.fixtures.test_snapshot import load_realistic_test_snapshot_tmpdir
 
 
-class CellTypeOrderingTests(unittest.TestCase):
+class CellTypeOrderingTests(unittest.TestCase, CompareDictsAddin):
     @classmethod
     def setUpClass(cls):
         cls.temp_cube_dir = load_realistic_test_snapshot_tmpdir("realistic-test-snapshot")
@@ -39,4 +39,4 @@ class CellTypeOrderingTests(unittest.TestCase):
             cell_type_orderings = json.load(f)
         pipeline_state = load_pipeline_state(self.temp_cube_dir.name)
         self.assertTrue(pipeline_state.get(CELL_TYPE_ORDERING_CREATED_FLAG))
-        self.assertTrue(compare_dicts(cell_type_orderings, self.expected_cell_type_orderings))
+        self.assert_dicts_equal(cell_type_orderings, self.expected_cell_type_orderings)

--- a/tests/unit/wmg_processing/test_dataset_metadata.py
+++ b/tests/unit/wmg_processing/test_dataset_metadata.py
@@ -8,12 +8,12 @@ from backend.wmg.pipeline.constants import (
 )
 from backend.wmg.pipeline.dataset_metadata import create_dataset_metadata
 from backend.wmg.pipeline.utils import load_pipeline_state, write_pipeline_state
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.test_utils.mocks import mock_get_datasets_from_curation_endpoint
 from tests.unit.backend.wmg.fixtures.test_snapshot import load_realistic_test_snapshot_tmpdir
 
 
-class DatasetMetadataTests(unittest.TestCase):
+class DatasetMetadataTests(unittest.TestCase, CompareDictsAddin):
     @classmethod
     def setUpClass(cls):
         cls.temp_cube_dir = load_realistic_test_snapshot_tmpdir("realistic-test-snapshot")
@@ -39,4 +39,4 @@ class DatasetMetadataTests(unittest.TestCase):
             dataset_metadata = json.load(f)
         pipeline_state = load_pipeline_state(self.temp_cube_dir.name)
         self.assertTrue(pipeline_state.get(DATASET_METADATA_CREATED_FLAG))
-        self.assertTrue(compare_dicts(dataset_metadata, self.expected_dataset_metadata))
+        self.assert_dicts_equal(dataset_metadata, self.expected_dataset_metadata)

--- a/tests/unit/wmg_processing/test_filter_relationships.py
+++ b/tests/unit/wmg_processing/test_filter_relationships.py
@@ -8,11 +8,11 @@ from backend.wmg.pipeline.constants import (
 )
 from backend.wmg.pipeline.filter_relationships import create_filter_relationships_graph
 from backend.wmg.pipeline.utils import load_pipeline_state, write_pipeline_state
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.unit.backend.wmg.fixtures.test_snapshot import load_realistic_test_snapshot_tmpdir
 
 
-class FilterRelationshipsTests(unittest.TestCase):
+class FilterRelationshipsTests(unittest.TestCase, CompareDictsAddin):
     @classmethod
     def setUpClass(cls):
         cls.temp_cube_dir = load_realistic_test_snapshot_tmpdir("realistic-test-snapshot")
@@ -39,4 +39,4 @@ class FilterRelationshipsTests(unittest.TestCase):
             filter_relationships = json.load(f)
         pipeline_state = load_pipeline_state(self.temp_cube_dir.name)
         self.assertTrue(pipeline_state.get(FILTER_RELATIONSHIPS_CREATED_FLAG))
-        self.assertTrue(compare_dicts(filter_relationships, self.expected_filter_relationships))
+        self.assert_dicts_equal(filter_relationships, self.expected_filter_relationships)

--- a/tests/unit/wmg_processing/test_primary_filter_dimensions.py
+++ b/tests/unit/wmg_processing/test_primary_filter_dimensions.py
@@ -9,13 +9,13 @@ from backend.wmg.pipeline.constants import (
 )
 from backend.wmg.pipeline.primary_filter_dimensions import create_primary_filter_dimensions
 from backend.wmg.pipeline.utils import load_pipeline_state, write_pipeline_state
-from tests.test_utils import compare_dicts
+from tests.test_utils import CompareDictsAddin
 from tests.unit.backend.wmg.fixtures.test_snapshot import load_realistic_test_snapshot_tmpdir
 
 TEST_SNAPSHOT_NAME = "realistic-test-snapshot"
 
 
-class PrimaryFilterDimensionsTests(unittest.TestCase):
+class PrimaryFilterDimensionsTests(unittest.TestCase, CompareDictsAddin):
     @classmethod
     def setUpClass(cls):
         cls.temp_cube_dir = load_realistic_test_snapshot_tmpdir(TEST_SNAPSHOT_NAME)
@@ -44,4 +44,4 @@ class PrimaryFilterDimensionsTests(unittest.TestCase):
             primary_filter_dimensions["snapshot_id"] = TEST_SNAPSHOT_NAME
         pipeline_state = load_pipeline_state(self.temp_cube_dir.name)
         self.assertTrue(pipeline_state.get(PRIMARY_FILTER_DIMENSIONS_CREATED_FLAG))
-        self.assertTrue(compare_dicts(primary_filter_dimensions, self.expected_primary_filter_dimensions))
+        self.assert_dicts_equal(primary_filter_dimensions, self.expected_primary_filter_dimensions)


### PR DESCRIPTION
## Reason for Change

- Some times test fails on this check and there is no information to help debug. This track the mismatches between two dicts and prints them out if the any are found. This also use `unittest` syntax to keep error reporting consistent.
## Changes

- make compare_dicts errors visible to unittest 
- rename compare_dicts to assert_dicts_equal
