### PR TITLE
fix: The name of the sfn created uses the new dataset version id

### DIFF
--- a/backend/layers/processing/schema_migration.py
+++ b/backend/layers/processing/schema_migration.py
@@ -123,7 +123,7 @@ class SchemaMigrate(ProcessingLogic):
             existing_dataset_version_id=DatasetVersionId(dataset_version_id),
             start_step_function=False,  # The schema_migration sfn will start the ingest sfn
         )
-        sfn_name = sfn_name_generator(dataset_version_id, prefix="migrate")
+        sfn_name = sfn_name_generator(new_dataset_version_id, prefix="migrate")
         return {
             "collection_version_id": collection_version_id,
             "dataset_version_id": new_dataset_version_id.id,

--- a/tests/unit/processing/schema_migration/test_dataset_migrate.py
+++ b/tests/unit/processing/schema_migration/test_dataset_migrate.py
@@ -49,7 +49,7 @@ class TestDatasetMigrate:
         assert dataset_version_id != new_dataset_version_id.id
         assert response["uri"] == f"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad"
         assert response["sfn_name"].startswith("migrate_")
-        assert dataset_version_id in response["sfn_name"]
+        assert new_dataset_version_id in response["sfn_name"]
         schema_migrate.schema_validator.migrate.assert_called_once_with(
             "previous_schema.h5ad", "migrated.h5ad", published.collection_id.id, published.datasets[0].dataset_id.id
         )
@@ -75,7 +75,7 @@ class TestDatasetMigrate:
         assert dataset_version_id != new_dataset_version_id.id
         assert response["uri"] == f"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad"
         assert response["sfn_name"].startswith("migrate_")
-        assert dataset_version_id in response["sfn_name"]
+        assert new_dataset_version_id in response["sfn_name"]
         schema_migrate.schema_validator.migrate.assert_called_once_with(
             "previous_schema.h5ad", "migrated.h5ad", revision.collection_id.id, revision.datasets[0].dataset_id.id
         )

--- a/tests/unit/processing/schema_migration/test_dataset_migrate.py
+++ b/tests/unit/processing/schema_migration/test_dataset_migrate.py
@@ -49,7 +49,7 @@ class TestDatasetMigrate:
         assert dataset_version_id != new_dataset_version_id.id
         assert response["uri"] == f"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad"
         assert response["sfn_name"].startswith("migrate_")
-        assert new_dataset_version_id in response["sfn_name"]
+        assert new_dataset_version_id.id in response["sfn_name"]
         schema_migrate.schema_validator.migrate.assert_called_once_with(
             "previous_schema.h5ad", "migrated.h5ad", published.collection_id.id, published.datasets[0].dataset_id.id
         )
@@ -75,7 +75,7 @@ class TestDatasetMigrate:
         assert dataset_version_id != new_dataset_version_id.id
         assert response["uri"] == f"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad"
         assert response["sfn_name"].startswith("migrate_")
-        assert new_dataset_version_id in response["sfn_name"]
+        assert new_dataset_version_id.id in response["sfn_name"]
         schema_migrate.schema_validator.migrate.assert_called_once_with(
             "previous_schema.h5ad", "migrated.h5ad", revision.collection_id.id, revision.datasets[0].dataset_id.id
         )

--- a/tests/unit/processing/schema_migration/test_dataset_migrate.py
+++ b/tests/unit/processing/schema_migration/test_dataset_migrate.py
@@ -23,7 +23,7 @@ class TestDatasetMigrate:
         assert dataset_version_id != new_dataset_version_id.id
         assert response["uri"] == f"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad"
         assert response["sfn_name"].startswith("migrate_")
-        assert dataset_version_id in response["sfn_name"]
+        assert new_dataset_version_id.id in response["sfn_name"]
         schema_migrate.schema_validator.migrate.assert_called_once_with(
             "previous_schema.h5ad", "migrated.h5ad", private.collection_id.id, private.datasets[0].dataset_id.id
         )


### PR DESCRIPTION
## Reason for Change

- This will make it easier to find datasets that failed during migration.

## Changes

- modify the sfn name to use the new dataset_version_id

## Testing steps

- updated tests
