### PR TITLE
chore: pin no publication to the bottom of publication filter

### DIFF
--- a/frontend/src/views/WheresMyGeneV2/components/Filters/connect.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/connect.ts
@@ -260,6 +260,18 @@ export const useConnect = ({
     sdsStyle: "minimal",
   } as Partial<InputDropdownProps>;
 
+  const sortedPublicationCitations = useMemo(() => {
+    const sortedCitations = [...publication_citations];
+    sortedCitations.sort((a, b) =>
+      a.name === "No Publication"
+        ? 1
+        : b.name === "No Publication"
+        ? -1
+        : a.name.localeCompare(b.name)
+    );
+    return sortedCitations;
+  }, [publication_citations]);
+
   return {
     handle: {
       tissuesChange: handleTissuesChange,
@@ -280,7 +292,7 @@ export const useConnect = ({
     terms: {
       tissue: tissue_terms,
       sex: sex_terms,
-      publication: publication_citations,
+      publication: sortedPublicationCitations,
       self_reported_ethnicity: self_reported_ethnicity_terms,
       disease: disease_terms,
     },

--- a/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
+++ b/frontend/tests/features/wheresMyGene/tissueAutoExpand.test.ts
@@ -293,6 +293,33 @@ describe("WMG tissue auto-expand", () => {
     await checkTissues(page, EXPECTED_FILTERED_TISSUES_WITH_DISEASE_FILTER);
   });
 
+  test("Publication Filter - Verify that No Publication is pinned to the bottom of the list", async ({
+    page,
+  }) => {
+    await tryUntil(
+      async () => {
+        await goToWMG(page);
+        await clickIntoFilter(
+          page,
+          PUBLICATION_FILTER_TEST_ID,
+          PUBLICATION_FILTER_LABEL
+        );
+        const count = await page
+          .getByRole("listbox")
+          .getByRole("option")
+          .count();
+        await expect(
+          page
+            .getByRole("tooltip")
+            .locator(`[data-option-index="${count - 1}"]`)
+            .locator("span")
+            .getByText("No Publication")
+        ).toBeVisible();
+      },
+      { page }
+    );
+  });
+
   test("Share link with genes and cellTypes", async ({ page }) => {
     await Promise.all([
       /**


### PR DESCRIPTION
## Reason for Change

- #5352
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- this code is creating a sorted version of publication_citations where any object with a name of "No Publication" is moved to the end, and the rest are sorted alphabetically by name. The sorted array is memoized, so it will only be recomputed when publication_citations changes.
<img width="462" alt="Screenshot 2023-11-21 at 9 38 36 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/7976579/912498e7-6adb-47d0-881d-ed8cafc78a72">

