### PR TITLE
chore: ge style updates

### DIFF
--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Compare/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Compare/index.tsx
@@ -1,5 +1,5 @@
 import { Wrapper, Label, StyledDropdown } from "../common/style";
-import { LabelWrapper } from "./style";
+import { CompareWrapper, LabelWrapper } from "./style";
 import {
   COMPARE_OPTIONS,
   GROUP_BY_TOOLTIP_TEXT,
@@ -21,7 +21,7 @@ export default function Compare({ areFiltersDisabled }: Props): JSX.Element {
   });
 
   return (
-    <div>
+    <CompareWrapper>
       <LabelWrapper>
         <Label>
           Group By
@@ -52,7 +52,6 @@ export default function Compare({ areFiltersDisabled }: Props): JSX.Element {
             </TooltipButton>
           </Tooltip>
         </Label>
-        {/* <NewChip label="NEW" /> */}
       </LabelWrapper>
       <Wrapper>
         <StyledDropdown
@@ -64,6 +63,6 @@ export default function Compare({ areFiltersDisabled }: Props): JSX.Element {
           value={optionLabel}
         />
       </Wrapper>
-    </div>
+    </CompareWrapper>
   );
 }

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Compare/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Compare/index.tsx
@@ -1,5 +1,5 @@
 import { Wrapper, Label, StyledDropdown } from "../common/style";
-import { LabelWrapper, NewChip } from "./style";
+import { LabelWrapper } from "./style";
 import {
   COMPARE_OPTIONS,
   GROUP_BY_TOOLTIP_TEXT,
@@ -52,7 +52,7 @@ export default function Compare({ areFiltersDisabled }: Props): JSX.Element {
             </TooltipButton>
           </Tooltip>
         </Label>
-        <NewChip label="NEW" />
+        {/* <NewChip label="NEW" /> */}
       </LabelWrapper>
       <Wrapper>
         <StyledDropdown

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Compare/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Compare/style.ts
@@ -1,17 +1,17 @@
 import styled from "@emotion/styled";
-import { Chip } from "@czi-sds/components";
-import { PINK, spacesXs, spacesXxs } from "src/common/theme";
+// import { Chip } from "@czi-sds/components";
+import { spacesXs } from "src/common/theme";
 
-export const NewChip = styled(Chip)`
-  background-color: ${PINK};
-  color: white;
-  height: 20px !important;
+// export const NewChip = styled(Chip)`
+//   background-color: ${PINK};
+//   color: white;
+//   height: 20px !important;
 
-  .MuiChip-label {
-    padding: ${spacesXxs}px ${spacesXs}px;
-    font-weight: 500;
-  }
-`;
+//   .MuiChip-label {
+//     padding: ${spacesXxs}px ${spacesXs}px;
+//     font-weight: 500;
+//   }
+// `;
 
 export const LabelWrapper = styled("div")`
   display: flex;

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Compare/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Compare/style.ts
@@ -1,17 +1,5 @@
 import styled from "@emotion/styled";
-// import { Chip } from "@czi-sds/components";
 import { spacesXs } from "src/common/theme";
-
-// export const NewChip = styled(Chip)`
-//   background-color: ${PINK};
-//   color: white;
-//   height: 20px !important;
-
-//   .MuiChip-label {
-//     padding: ${spacesXxs}px ${spacesXs}px;
-//     font-weight: 500;
-//   }
-// `;
 
 export const LabelWrapper = styled("div")`
   display: flex;

--- a/frontend/src/views/WheresMyGeneV2/components/Filters/components/Compare/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/Filters/components/Compare/style.ts
@@ -1,6 +1,10 @@
 import styled from "@emotion/styled";
 import { spacesXs } from "src/common/theme";
 
+export const CompareWrapper = styled("div")`
+  margin: 0;
+`;
+
 export const LabelWrapper = styled("div")`
   display: flex;
   gap: ${spacesXs}px;

--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SourceDataButton/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SourceDataButton/style.ts
@@ -61,8 +61,8 @@ export const StyledLabel = styled.div`
 export const StyledButtonIcon = styled(ButtonIcon)<ButtonProps>`
   width: 30px;
   height: 30px;
-  position: relative;
+  position: absolute;
   cursor: pointer;
-  padding-bottom: 24px;
+  padding-top: 34px;
   z-index: 1;
 `;

--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SourceDataButton/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SourceDataButton/style.ts
@@ -61,8 +61,8 @@ export const StyledLabel = styled.div`
 export const StyledButtonIcon = styled(ButtonIcon)<ButtonProps>`
   width: 30px;
   height: 30px;
-  position: absolute;
+  position: relative;
   cursor: pointer;
-  top: 99px;
+  padding-bottom: 24px;
   z-index: 1;
 `;

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/components/YAxisChart/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/components/YAxisChart/index.tsx
@@ -180,6 +180,7 @@ const TissueHeaderButton = ({
           sdsSize="s"
           color="gray"
           sdsType="static"
+          shade={300}
         />
         <TissueHeaderLabelStyle expanded={expanded}>
           <TissueLabel

--- a/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/ExpressedInCells/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/ExpressedInCells/index.tsx
@@ -1,5 +1,6 @@
 import { convertPercentageToDiameter } from "../../../HeatMap/components/Chart/utils";
-import { Content, Label, LowHigh } from "../../common/style";
+import { Content, LowHigh } from "../../common/style";
+import { Label } from "../RelativeGeneExpression/style";
 import { Dot, Dots, Wrapper } from "./style";
 
 const PERCENTAGES = [0, 0.25, 0.5, 0.75, 1];
@@ -8,7 +9,6 @@ export default function ExpressedInCells(): JSX.Element {
   return (
     <Wrapper id="expressed-in-cells">
       <Label id="expressed-in-cells-label">Expressed in Cells (%)</Label>
-
       <Content>
         <Dots id="expressed-in-cells-dots">
           {PERCENTAGES.map((percentage) => (

--- a/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/ExpressedInCells/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/ExpressedInCells/style.ts
@@ -26,7 +26,7 @@ export const Dot = styled.span`
 
 export const Dots = styled.div`
   display: flex;
-  margin-bottom: 3px;
+  margin: 4px 0px 4px 0px;
   justify-content: space-between;
   align-items: center;
 `;

--- a/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/Legend/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/Legend/style.ts
@@ -11,6 +11,7 @@ export const LegendWrapper = styled.div`
 
 export const ActionsWrapper = styled.div`
   display: flex;
+  padding-top: 2px;
 `;
 
 export const ColorLegendWrapper = styled.div`

--- a/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/RelativeGeneExpression/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/RelativeGeneExpression/index.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
 import { Tooltip } from "@czi-sds/components";
-import { Content, Label, LowHigh } from "../../common/style";
+import { Content, LowHigh } from "../../common/style";
 import plasmaImage from "./plasma.png";
-import { ContentWrapper, Wrapper, TooltipLink } from "./style";
+import { ContentWrapper, Wrapper, TooltipLink, Label } from "./style";
 import { MAX_EXPRESSION_LABEL_TEST_ID } from "./constants";
 import {
   StyledIconImage,

--- a/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/RelativeGeneExpression/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/RelativeGeneExpression/style.ts
@@ -1,5 +1,7 @@
+import { fontBodyXxs } from "@czi-sds/components";
 import styled from "@emotion/styled";
 import { FormControlLabel } from "@mui/material";
+import { gray500 } from "src/common/theme";
 
 export const Wrapper = styled.div`
   padding: 0 10px;
@@ -26,6 +28,7 @@ export const Dots = styled.div`
 export const ContentWrapper = styled.div`
   display: flex;
   position: relative;
+  margin: 2px 0px 4px 0px;
 `;
 
 export const StyledFormControlLabel = styled(FormControlLabel)`
@@ -48,4 +51,11 @@ export const FlexDiv = styled.div`
 export const TooltipLink = styled.a`
   text-decoration: underline;
   cursor: pointer;
+`;
+
+export const Label = styled.label`
+  ${fontBodyXxs}
+  font-weight: 400;
+  white-space: nowrap;
+  color: ${gray500};
 `;


### PR DESCRIPTION
## Reason for Change

- #5838

## Changes

 - Change chevron color from rgb(153, 153, 153) to colors.gray[300]
 - Remove “New” tag from “Group By” (P2 since performance is so bad, maybe users will be more understanding)
 - Labels for color scale and dot size legends should be aligned with the labels for download, share, and source data.

## Testing steps

- check changes in UI

## Checklist 🛎️

- [x] Add product, design, and eng as reviewers for rdev review
- [x] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
<img width="33" alt="Screenshot 2023-11-21 at 2 27 36 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/7976579/7cceb847-cbc9-41a8-8b2f-967d538f3ed8">
<img width="221" alt="Screenshot 2023-11-21 at 2 27 31 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/7976579/70c86cff-9555-40ce-9314-7e32bcd737d0">
<img width="640" alt="Screenshot 2023-11-21 at 2 27 25 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/7976579/a2505b1a-f049-4965-8b74-5b55329ed4e5">
