### PR TITLE
feat: filter out system level tissues w/o using tissue type

### DIFF
--- a/backend/wmg/pipeline/expression_summary_and_cell_counts.py
+++ b/backend/wmg/pipeline/expression_summary_and_cell_counts.py
@@ -1,7 +1,6 @@
 import cellxgene_census
 import tiledbsoma as soma
 
-from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
 from backend.wmg.pipeline.cell_counts import create_cell_counts_cube
 from backend.wmg.pipeline.constants import (
     EXPRESSION_SUMMARY_AND_CELL_COUNTS_CUBE_CREATED_FLAG,
@@ -28,12 +27,8 @@ class CensusParameters:
             "mus_musculus": f"is_primary_data == True and nnz >= {GENE_EXPRESSION_COUNT_MIN_THRESHOLD}",
         }
         value_filter = organism_mapping[organism]
-        if FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4):
-            # Filter out non-tissue tissues and system-level tissues
-            # TODO: Once cellxgene-census is updated to support tiledbsoma 1.5.0, we can update the tissue filter to use `not in`:
-            # tissue_ontology_term_id not in ['UBERON_0001017', 'UBERON:0001007', 'UBERON:0002405', 'UBERON:0000990', 'UBERON:0001004', 'UBERON:0001434']
-            # This will require updating the pinned versions of cellxgene-census and tiledbsoma in `requirements-wmg-pipeline.txt`
-            value_filter += " and tissue_type == 'tissue' and tissue_general_ontology_term_id != 'UBERON:0001017' and tissue_general_ontology_term_id != 'UBERON:0001007' and tissue_general_ontology_term_id != 'UBERON:0002405' and tissue_general_ontology_term_id != 'UBERON:0000990' and tissue_general_ontology_term_id != 'UBERON:0001004' and tissue_general_ontology_term_id != 'UBERON:0001434'"
+        # Filter out system-level tissues. Census filters out organoids + cell cultures
+        value_filter += " and tissue_general_ontology_term_id not in ['UBERON:0001017', 'UBERON:0001007', 'UBERON:0002405', 'UBERON:0000990', 'UBERON:0001004', 'UBERON:0001434']"
         return value_filter
 
 

--- a/requirements-wmg-pipeline.txt
+++ b/requirements-wmg-pipeline.txt
@@ -5,7 +5,7 @@ black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.y
 boto3==1.28.7
 botocore>=1.31.7, <1.32.0
 click==8.1.3
-cellxgene-census==1.6.0
+cellxgene-census==1.8.0
 coverage==7.2.7
 dataclasses-json==0.5.7
 ddtrace==2.1.4
@@ -35,5 +35,5 @@ scipy==1.10.1
 SQLAlchemy==1.4.49
 SQLAlchemy-Utils==0.41.1
 tenacity==8.2.2
-tiledbsoma==1.4.4
+tiledbsoma==1.5.1
 dask==2023.8.1


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/6293

## Changes

now that census has filtered out organoids and cell cultures, we actually don't need to filter these out in WMG--through `tissue_type` or explicit UBERON terms. so this PR just removes the `tissue_type` portion of the query so that we don't run into an issue with census not having that field.

additionally, it upgrades the census package so that we can build a query using `not in` which is a bit cleaner than what we had before.

## Testing steps

i ran this script locally to verify that the `not in` query portion works, and still filters out system level tissues:
```
import cellxgene_census
import tiledbsoma as soma

def main():
    with cellxgene_census.open_soma() as census:
        human = census["census_data"]["homo_sapiens"]
        with human.axis_query(
            measurement_name="RNA",
            obs_query=soma.AxisQuery(
                value_filter="is_primary_data == True"
            )
        ) as query:
            obs_df = query.obs(column_names=["tissue_general_ontology_term_id", "tissue_general", "soma_joinid"]).concat().to_pandas().set_index("soma_joinid")
            
            print("System level tissue counts before filtering them out...")

            central_nervous_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001017']
            print(len(central_nervous_system_rows))

            digestive_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001007']
            print(len(digestive_system_rows))

            immune_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0002405']
            print(len(immune_system_rows))

            reproductive_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0000990']
            print(len(reproductive_system_rows))

            respiratory_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001004']
            print(len(respiratory_system_rows))

            skeletal_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001434']
            print(len(skeletal_system_rows))

    with cellxgene_census.open_soma() as census:
        human = census["census_data"]["homo_sapiens"]
        # value_filter = "tissue_general_ontology_term_id != 'UBERON:0001017' and tissue_general_ontology_term_id != 'UBERON:0001007' and tissue_general_ontology_term_id != 'UBERON:0002405' and tissue_general_ontology_term_id != 'UBERON:0000990' and tissue_general_ontology_term_id != 'UBERON:0001004' and tissue_general_ontology_term_id != 'UBERON:0001434'"
        value_filter = "tissue_general_ontology_term_id not in ['UBERON:0001017', 'UBERON:0001007', 'UBERON:0002405', 'UBERON:0000990', 'UBERON:0001004', 'UBERON:0001434']"
        with human.axis_query(
            measurement_name="RNA",
            obs_query=soma.AxisQuery(
                value_filter=f"is_primary_data == True and {value_filter}"
            )
        ) as query:
            obs_df = query.obs(column_names=["tissue_general_ontology_term_id", "tissue_general"]).concat().to_pandas()
            
            print("System level tissue counts after filtering them out...")

            central_nervous_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001017']
            print(len(central_nervous_system_rows))

            digestive_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001007']
            print(len(digestive_system_rows))

            immune_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0002405']
            print(len(immune_system_rows))

            reproductive_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0000990']
            print(len(reproductive_system_rows))

            respiratory_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001004']
            print(len(respiratory_system_rows))

            skeletal_system_rows = obs_df[obs_df['tissue_general_ontology_term_id'] == 'UBERON:0001434']
            print(len(skeletal_system_rows))

if __name__ == "__main__":
    main()
```

next step for testing would be to deploy this change to dev/staging, build the WMG pipeline, and verify that system-level tissues are filtered out of GE/census

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
