### PR TITLE
chore: lower min tissue count

### DIFF
--- a/backend/wmg/pipeline/validation/validation.py
+++ b/backend/wmg/pipeline/validation/validation.py
@@ -22,7 +22,7 @@ class Validation:
         self.env = os.getenv("DEPLOYMENT_STAGE")
         self.validation_dataset_id = "3de0ad6d-4378-4f62-b37b-ec0b75a50d94"
         self.MIN_CUBE_SIZE_GB = 2
-        self.MIN_TISSUE_COUNT = 53
+        self.MIN_TISSUE_COUNT = 49
         self.MIN_SPECIES_COUNT = 2
         self.MIN_DATASET_COUNT = 254
         self.MIN_MALAT1_GENE_EXPRESSION_CELL_COUNT_PERCENT = 80


### PR DESCRIPTION
## Reason for Change

as a result of the changes to exclude system-level tissues from WMG, our expected number of tissues in the corpus should now be 49. therefore, we need to reduce the min tissue count validation from 53 to 49 so that we won't fail to publish a new cube because of this validation error

<img width="977" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/5653616/cd824687-54f2-453b-8cb5-d8b65a72a2e7">

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/6307

## Changes

lowers min tissue count to 49

## Testing steps

after merging this, i'll deploy to dev and re-run WMG

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
