### PR TITLE
fix(wmg): Remove links to outdated data downloads

### DIFF
--- a/frontend/doc-site/04__Analyze Public Data/4_2__Gene Expression Documentation/4_2_6__Gene Expression Source Data.mdx
+++ b/frontend/doc-site/04__Analyze Public Data/4_2__Gene Expression Documentation/4_2_6__Gene Expression Source Data.mdx
@@ -1,8 +1,3 @@
 # Gene Expression Source Data
 
-Two versions of Gene Expression data can be downloaded.
-
-1. **Full dataset**: The <NextLink href="https://ge-data.cellxgene.cziscience.com/expression-summary-full-07-23-23.csv.gz">full dataset</NextLink> contains the summed expression, number of cells with nonzero expression, and total number of cells for all possible combinations of metadata displayed in Gene Expression (organism, tissue, gene, cell type, dataset, disease, self-reported ethnicity, publication, and sex).
-1. **Condensed dataset**: The <NextLink href="https://ge-data.cellxgene.cziscience.com/expression-summary-condensed-07-23-23.csv.gz">condensed dataset</NextLink> reports the same measurements for all possible combinations of organism, tissue, cell type, and gene.
-
-These datasets were generated on and reflect the state of CZ CELLxGENE Discover on July 23, 2023.
+12/5/2023: We are currently in the process of updating these datasets to reflect the recent change to ln(CPTT+1) normalization. Check back here soon!


### PR DESCRIPTION
## Reason for Change

We got an email from a user flagging a data integrity issue. I've filed a separate bug to update these and populate the correct links asap. For now, this PR just removes the download links to the incorrect data.