### PR TITLE
chore: add bespoke feature flag for DOI update triggering artifact citation updates

### DIFF
--- a/backend/common/feature_flag.py
+++ b/backend/common/feature_flag.py
@@ -22,11 +22,12 @@ self.mock_config.set(dict(schema_4_feature_flag="True"))
 ```
 """
 
-FeatureFlag = Literal["schema_4_feature_flag"]
+FeatureFlag = Literal["schema_4_feature_flag", "citation_update_feature_flag"]
 
 
 class FeatureFlagValues:
     SCHEMA_4 = "schema_4_feature_flag"
+    CITATION_UPDATE = "citation_update_feature_flag"
 
 
 class FeatureFlagService:

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -412,7 +412,9 @@ class BusinessLogic(BusinessLogicInterface):
             self.database_provider.save_collection_publisher_metadata(version_id, publisher_metadata_to_set)
         self.database_provider.save_collection_metadata(version_id, new_metadata)
 
-        if all([apply_doi_update, new_doi != current_doi, FeatureFlagService.is_enabled(FeatureFlagValues.SCHEMA_4)]):
+        if all(
+            [apply_doi_update, new_doi != current_doi, FeatureFlagService.is_enabled(FeatureFlagValues.CITATION_UPDATE)]
+        ):
             for dataset in current_collection_version.datasets:
                 if dataset.status.processing_status != DatasetProcessingStatus.SUCCESS:
                     self.logger.info(

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -94,6 +94,7 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
             {
                 "upload_max_file_size_gb": 30,
                 "schema_4_feature_flag": "True",
+                "citation_update_feature_flag": "True",
                 "dataset_assets_base_url": "https://dataset_assets_domain",
                 "collections_base_url": "https://collections_domain",
             }


### PR DESCRIPTION
## Changes

- instead of using schema 4 feature flag for citation updates, add and use its own feature flag to decouple from schema 4 migration changes while feature is in QA by Product