### PR TITLE
chore: adhoc metadata reprocess -- DO NOT MERGE

### DIFF
--- a/backend/curation/api/v1/curation/collections/collection_id/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/actions.py
@@ -2,7 +2,11 @@ from dataclasses import asdict
 
 from flask import Response, jsonify, make_response
 
-from backend.common.utils.http_exceptions import InvalidParametersHTTPException, MethodNotAllowedException
+from backend.common.utils.http_exceptions import (
+    ForbiddenHTTPException,
+    InvalidParametersHTTPException,
+    MethodNotAllowedException,
+)
 from backend.curation.api.v1.curation.collections.common import (
     extract_doi_from_links,
     get_inferred_collection_version,
@@ -39,7 +43,10 @@ def get(collection_id: str, token_info: dict) -> Response:
 
 
 def patch(collection_id: str, body: dict, token_info: dict) -> Response:
+
     user_info = UserInfo(token_info)
+    if not user_info.is_cxg_admin():
+        raise ForbiddenHTTPException("Unauthorized") from None
 
     if "links" in body and not body["links"]:
         raise InvalidParametersHTTPException(detail="If provided, the 'links' array may not be empty")

--- a/backend/layers/processing/process_logic.py
+++ b/backend/layers/processing/process_logic.py
@@ -80,25 +80,24 @@ class ProcessingLogic:  # TODO: ProcessingLogicBase
         file_name: str,
         artifact_type: str,
         key_prefix: str,
-        dataset_version_id: DatasetVersionId,
         artifact_bucket: str,
         processing_status_key: DatasetStatusKey,
         datasets_bucket: Optional[str] = None,  # If provided, dataset will be uploaded to this bucket for public access
     ):
-        self.update_processing_status(dataset_version_id, processing_status_key, DatasetConversionStatus.UPLOADING)
+        # self.update_processing_status(dataset_version_id, processing_status_key, DatasetConversionStatus.UPLOADING)
         try:
-            s3_uri = self.upload_artifact(file_name, key_prefix, artifact_bucket)
-            self.logger.info(f"Uploaded [{dataset_version_id}/{file_name}] to {s3_uri}")
-            self.business_logic.add_dataset_artifact(dataset_version_id, artifact_type, s3_uri)
-            self.logger.info(f"Updated database with {artifact_type}.")
-            if datasets_bucket:
-                key = ".".join((key_prefix, artifact_type))
-                self.s3_provider.upload_file(
-                    file_name, datasets_bucket, key, extra_args={"ACL": "bucket-owner-full-control"}
-                )
-                datasets_s3_uri = self.make_s3_uri(datasets_bucket, key_prefix, key)
-                self.logger.info(f"Uploaded {dataset_version_id}.{artifact_type} to {datasets_s3_uri}")
-            self.update_processing_status(dataset_version_id, processing_status_key, DatasetConversionStatus.UPLOADED)
+            self.upload_artifact(file_name, key_prefix, artifact_bucket)
+            # self.logger.info(f"Uploaded [{dataset_version_id}/{file_name}] to {s3_uri}")
+            # self.business_logic.add_dataset_artifact(dataset_version_id, artifact_type, s3_uri)
+            # self.logger.info(f"Updated database with {artifact_type}.")
+            # if datasets_bucket:
+            #     key = ".".join((key_prefix, artifact_type))
+            #     self.s3_provider.upload_file(
+            #         file_name, datasets_bucket, key, extra_args={"ACL": "bucket-owner-full-control"}
+            #     )
+            #     datasets_s3_uri = self.make_s3_uri(datasets_bucket, key_prefix, key)
+            #     self.logger.info(f"Uploaded {dataset_version_id}.{artifact_type} to {datasets_s3_uri}")
+            # self.update_processing_status(dataset_version_id, processing_status_key, DatasetConversionStatus.UPLOADED)
         except Exception:
             raise ConversionFailed(processing_status_key) from None
 

--- a/backend/layers/thirdparty/batch_job_provider.py
+++ b/backend/layers/thirdparty/batch_job_provider.py
@@ -15,7 +15,6 @@ class BatchJobProviderInterface:
     def start_metadata_update_batch_job(
         self,
         current_dataset_version_id: DatasetVersionId,
-        new_dataset_version_id: DatasetVersionId,
         metadata_update: DatasetArtifactMetadataUpdate,
     ) -> None:
         pass
@@ -28,7 +27,6 @@ class BatchJobProvider(BatchJobProviderInterface):
     def start_metadata_update_batch_job(
         self,
         current_dataset_version_id: DatasetVersionId,
-        new_dataset_version_id: DatasetVersionId,
         metadata_update: DatasetArtifactMetadataUpdate,
     ) -> Dict[str, str]:
         """
@@ -39,7 +37,7 @@ class BatchJobProvider(BatchJobProviderInterface):
         if os.environ.get("REMOTE_DEV_PREFIX"):
             stack_name = os.environ.get("REMOTE_DEV_PREFIX").replace("/", "")
         return self.client.submit_job(
-            jobName=f"metadata_update_{new_dataset_version_id}_{int(time())}",
+            jobName=f"metadata_update_{current_dataset_version_id}_{int(time())}",
             jobQueue=f"dp-{deployment_stage}",
             jobDefinition=f"dp-{deployment_stage}-{stack_name}-dataset-metadata-update",
             containerOverrides={
@@ -47,10 +45,6 @@ class BatchJobProvider(BatchJobProviderInterface):
                     {
                         "name": "CURRENT_DATASET_VERSION_ID",
                         "value": current_dataset_version_id.id,
-                    },
-                    {
-                        "name": "NEW_DATASET_VERSION_ID",
-                        "value": new_dataset_version_id.id,
                     },
                     {
                         "name": "METADATA_UPDATE_JSON",


### PR DESCRIPTION
## Reason for Change

- Temporary deployment to allow adhoc metadata reprocessing
- Goal: create updated artifacts with `_updated.(h5ad|rds|cxg)` suffix.

## Changes

    - do not create new db entities -- ONLY create new artifacts
    - start process by PATCH /curation/v1/collections/{collection_id}
    - works for published and private alike
    - no interaction with db rows -- no status updates
    - write files to prefix ending with "_updated"
    - no writes to public datasets bucket -- these will fail due to write constraints for key name -- can copy from artifacts bucket to public datasets bucket later.

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
