### PR TITLE
feat: reprocess dataset citations in-place

### DIFF
--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -106,6 +106,55 @@ resource aws_batch_job_definition dataset_metadata_update {
 })
 }
 
+resource aws_batch_job_definition dataset_metadata_update {
+  type = "container"
+  name = "dp-${var.deployment_stage}-${var.custom_stack_name}-reprocess-dataset-metadata"
+  container_properties = jsonencode({
+  "command": ["python3", "-m", "backend.layers.processing.reprocess_dataset_metadata"],
+  "jobRoleArn": "${var.batch_role_arn}",
+  "image": "${var.image}",
+  "memory": var.batch_container_memory_limit,
+  "environment": [
+    {
+      "name": "ARTIFACT_BUCKET",
+      "value": "${var.artifact_bucket}"
+    },
+    {
+      "name": "CELLXGENE_BUCKET",
+      "value": "${var.cellxgene_bucket}"
+    },
+    {
+      "name": "DATASETS_BUCKET",
+      "value": "${var.datasets_bucket}"
+    },
+    {
+      "name": "DEPLOYMENT_STAGE",
+      "value": "${var.deployment_stage}"
+    },
+    {
+      "name": "AWS_DEFAULT_REGION",
+      "value": "${data.aws_region.current.name}"
+    },
+    {
+      "name": "REMOTE_DEV_PREFIX",
+      "value": "${var.remote_dev_prefix}"
+    }
+  ],
+  "vcpus": 8,
+  "linuxParameters": {
+     "maxSwap": 800000,
+     "swappiness": 60
+  },
+  "logConfiguration": {
+    "logDriver": "awslogs",
+    "options": {
+      "awslogs-group": "${aws_cloudwatch_log_group.cloud_watch_logs_group.id}",
+      "awslogs-region": "${data.aws_region.current.name}"
+    }
+  }
+})
+}
+
 resource aws_cloudwatch_log_group cloud_watch_logs_group {
   retention_in_days = 365
   name              = "/dp/${var.deployment_stage}/${var.custom_stack_name}/upload"

--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -106,7 +106,7 @@ resource aws_batch_job_definition dataset_metadata_update {
 })
 }
 
-resource aws_batch_job_definition dataset_metadata_update {
+resource aws_batch_job_definition reprocess_dataset_metadata {
   type = "container"
   name = "dp-${var.deployment_stage}-${var.custom_stack_name}-reprocess-dataset-metadata"
   container_properties = jsonencode({

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -213,9 +213,13 @@ class BusinessLogic(BusinessLogicInterface):
         """
         return self.database_provider.get_collection_mapped_version(collection_id)
 
-    def get_collection_map_to_latest_published_version_by_schema(
+    def get_latest_published_collection_versions_by_schema(
         self, schema_version: str
-    ) -> Dict[CollectionId, CollectionVersion]:
+    ) -> List[CollectionVersionWithPublishedDatasets]:
+        """
+        Returns a list with the latest published collection version that matches the given schema_version, for each
+        canonical collection
+        """
         has_wildcards = "_" in schema_version
         collection_versions = self.database_provider.get_collection_versions_by_schema(schema_version, has_wildcards)
 
@@ -230,16 +234,7 @@ class BusinessLogic(BusinessLogicInterface):
             else:
                 if collection_version.published_at > collections[canonical_collection_id].published_at:
                     collections[canonical_collection_id] = collection_version
-        return collections
 
-    def get_latest_published_collection_versions_by_schema(
-        self, schema_version: str
-    ) -> List[CollectionVersionWithPublishedDatasets]:
-        """
-        Returns a list with the latest published collection version that matches the given schema_version, for each
-        canonical collection
-        """
-        collections = self.get_collection_map_to_latest_published_version_by_schema(schema_version)
         # for each mapped collection version, populate its dataset versions' details
         latest_collection_versions = list(collections.values())
         dataset_version_ids = [

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -213,13 +213,9 @@ class BusinessLogic(BusinessLogicInterface):
         """
         return self.database_provider.get_collection_mapped_version(collection_id)
 
-    def get_latest_published_collection_versions_by_schema(
+    def get_collection_map_to_latest_published_version_by_schema(
         self, schema_version: str
-    ) -> List[CollectionVersionWithPublishedDatasets]:
-        """
-        Returns a list with the latest published collection version that matches the given schema_version, for each
-        canonical collection
-        """
+    ) -> Dict[CollectionId, CollectionVersion]:
         has_wildcards = "_" in schema_version
         collection_versions = self.database_provider.get_collection_versions_by_schema(schema_version, has_wildcards)
 
@@ -234,7 +230,16 @@ class BusinessLogic(BusinessLogicInterface):
             else:
                 if collection_version.published_at > collections[canonical_collection_id].published_at:
                     collections[canonical_collection_id] = collection_version
+        return collections
 
+    def get_latest_published_collection_versions_by_schema(
+        self, schema_version: str
+    ) -> List[CollectionVersionWithPublishedDatasets]:
+        """
+        Returns a list with the latest published collection version that matches the given schema_version, for each
+        canonical collection
+        """
+        collections = self.get_collection_map_to_latest_published_version_by_schema(schema_version)
         # for each mapped collection version, populate its dataset versions' details
         latest_collection_versions = list(collections.values())
         dataset_version_ids = [

--- a/backend/layers/processing/reprocess_dataset_metadata.py
+++ b/backend/layers/processing/reprocess_dataset_metadata.py
@@ -208,7 +208,7 @@ class DatasetMetadataReprocess(ProcessDownload):
 
         artifact_uris = {artifact.type: artifact.uri for artifact in current_dataset_version.artifacts}
 
-        new_artifact_key_prefix = self.get_key_prefix(current_dataset_version_id) + "_updated"
+        new_artifact_key_prefix = self.get_key_prefix(current_dataset_version_id.id) + "_updated"
 
         artifact_jobs = []
 

--- a/backend/layers/processing/reprocess_dataset_metadata.py
+++ b/backend/layers/processing/reprocess_dataset_metadata.py
@@ -1,0 +1,308 @@
+"""
+Updates citations in-place across dataset artifacts for a Collection
+"""
+import json
+import logging
+import os
+from multiprocessing import Process
+
+import scanpy
+import tiledb
+from rpy2.robjects import StrVector
+from rpy2.robjects.packages import importr
+
+from backend.common.utils.corpora_constants import CorporaConstants
+from backend.layers.business.business import BusinessLogic
+from backend.layers.common.entities import (
+    CollectionVersionId,
+    DatasetArtifactMetadataUpdate,
+    DatasetArtifactType,
+    DatasetConversionStatus,
+    DatasetProcessingStatus,
+    DatasetVersion,
+    DatasetVersionId,
+)
+from backend.layers.persistence.persistence import DatabaseProvider
+from backend.layers.processing.exceptions import ProcessingFailed
+from backend.layers.processing.h5ad_data_file import H5ADDataFile
+from backend.layers.processing.logger import configure_logging
+from backend.layers.processing.process_download import ProcessDownload
+from backend.layers.thirdparty.s3_provider import S3Provider
+from backend.layers.thirdparty.uri_provider import UriProvider
+
+base = importr("base")
+seurat = importr("SeuratObject")
+
+configure_logging(level=logging.INFO)
+
+
+class DatasetMetadataReprocessWorker(ProcessDownload):
+    def __init__(self, artifact_bucket: str, datasets_bucket: str) -> None:
+        # init each worker with business logic backed by non-shared DB connection
+        self.business_logic = BusinessLogic(
+            DatabaseProvider(),
+            None,
+            None,
+            None,
+            S3Provider(),
+            UriProvider(),
+        )
+        super().__init__(self.business_logic, self.business_logic.uri_provider, self.business_logic.s3_provider)
+        self.artifact_bucket = artifact_bucket
+        self.datasets_bucket = datasets_bucket
+
+    def create_updated_artifacts(
+        self,
+        file_name: str,
+        artifact_type: str,
+        key_prefix: str,
+        dataset_version_id: DatasetVersionId,
+    ):
+        try:
+            s3_uri = self.upload_artifact(file_name, key_prefix, self.artifact_bucket)
+            self.logger.info(f"Uploaded [{dataset_version_id}/{file_name}] to {s3_uri}")
+
+            # TODO: include datasets_bucket uploads or not?
+            # key = ".".join((key_prefix, DatasetArtifactType.H5AD))
+            # self.s3_provider.upload_file(
+            #     file_name, self.datasets_bucket, key, extra_args={"ACL": "bucket-owner-full-control"}
+            # )
+            # datasets_s3_uri = self.make_s3_uri(self.datasets_bucket, key_prefix, key)
+            # self.logger.info(f"Uploaded [{dataset_version_id}/{file_name}] to {datasets_s3_uri}")
+        except Exception:
+            self.logger.error(f"Uploading Artifact {artifact_type} from dataset {dataset_version_id} failed.")
+            raise ProcessingFailed from None
+
+    def update_h5ad(
+        self,
+        h5ad_uri: str,
+        current_dataset_version: DatasetVersion,
+        new_key_prefix: str,
+        metadata_update: DatasetArtifactMetadataUpdate,
+    ):
+        h5ad_filename = self.download_from_source_uri(
+            source_uri=h5ad_uri,
+            local_path=CorporaConstants.LABELED_H5AD_ARTIFACT_FILENAME,
+        )
+
+        adata = scanpy.read_h5ad(h5ad_filename)
+        metadata = current_dataset_version.metadata
+        # maps artifact name for metadata field to DB field name, if different
+        for key, val in metadata_update.as_dict_without_none_values().items():
+            adata.uns[key] = val
+            setattr(metadata, key, val)
+
+        adata.write(h5ad_filename, compression="gzip")
+        current_dataset_version_id = current_dataset_version.version_id
+        self.business_logic.set_dataset_metadata(current_dataset_version_id, metadata)
+        self.create_updated_artifacts(
+            h5ad_filename, DatasetArtifactType.H5AD, new_key_prefix, current_dataset_version_id
+        )
+        os.remove(h5ad_filename)
+
+    def update_rds(
+        self,
+        rds_uri: str,
+        new_key_prefix: str,
+        current_dataset_version_id: DatasetVersionId,
+        metadata_update: DatasetArtifactMetadataUpdate,
+    ):
+        seurat_filename = self.download_from_source_uri(
+            source_uri=rds_uri,
+            local_path=CorporaConstants.LABELED_RDS_ARTIFACT_FILENAME,
+        )
+
+        rds_object = base.readRDS(seurat_filename)
+
+        for key, val in metadata_update.as_dict_without_none_values().items():
+            seurat_metadata = seurat.Misc(object=rds_object)
+            if seurat_metadata.rx2[key]:
+                val = val if isinstance(val, list) else [val]
+                seurat_metadata[seurat_metadata.names.index(key)] = StrVector(val)
+
+        base.saveRDS(rds_object, file=seurat_filename)
+
+        self.create_updated_artifacts(
+            seurat_filename, DatasetArtifactType.RDS, new_key_prefix, current_dataset_version_id
+        )
+        os.remove(seurat_filename)
+
+    def update_cxg(
+        self,
+        cxg_uri: str,
+        new_cxg_dir: str,
+        metadata_update: DatasetArtifactMetadataUpdate,
+    ):
+        self.s3_provider.upload_directory(cxg_uri, new_cxg_dir)
+        ctx = tiledb.Ctx(H5ADDataFile.tile_db_ctx_config)
+        array_name = f"{new_cxg_dir}/cxg_group_metadata"
+        with tiledb.open(array_name, mode="r", ctx=ctx) as metadata_array:
+            cxg_metadata_dict = json.loads(metadata_array.meta["corpora"])
+            cxg_metadata_dict.update(metadata_update.as_dict_without_none_values())
+
+        with tiledb.open(array_name, mode="w", ctx=ctx) as metadata_array:
+            metadata_array.meta["corpora"] = json.dumps(cxg_metadata_dict)
+
+
+class DatasetMetadataReprocess(ProcessDownload):
+    def __init__(
+        self, business_logic: BusinessLogic, artifact_bucket: str, cellxgene_bucket: str, datasets_bucket: str
+    ) -> None:
+        super().__init__(business_logic, business_logic.uri_provider, business_logic.s3_provider)
+        self.artifact_bucket = artifact_bucket
+        self.cellxgene_bucket = cellxgene_bucket
+        self.datasets_bucket = datasets_bucket
+
+    @staticmethod
+    def update_h5ad(
+        artifact_bucket: str,
+        datasets_bucket: str,
+        h5ad_uri: str,
+        current_dataset_version: DatasetVersion,
+        new_key_prefix: str,
+        metadata_update: DatasetArtifactMetadataUpdate,
+    ):
+        DatasetMetadataReprocessWorker(artifact_bucket, datasets_bucket).update_h5ad(
+            h5ad_uri,
+            current_dataset_version,
+            new_key_prefix,
+            metadata_update,
+        )
+
+    @staticmethod
+    def update_rds(
+        artifact_bucket: str,
+        datasets_bucket: str,
+        rds_uri: str,
+        new_key_prefix: str,
+        current_dataset_version_id: DatasetVersionId,
+        metadata_update: DatasetArtifactMetadataUpdate,
+    ):
+        DatasetMetadataReprocessWorker(artifact_bucket, datasets_bucket).update_rds(
+            rds_uri, new_key_prefix, current_dataset_version_id, metadata_update
+        )
+
+    @staticmethod
+    def update_cxg(
+        artifact_bucket: str,
+        datasets_bucket: str,
+        cxg_uri: str,
+        new_cxg_dir: str,
+        metadata_update: DatasetArtifactMetadataUpdate,
+    ):
+        DatasetMetadataReprocessWorker(artifact_bucket, datasets_bucket).update_cxg(
+            cxg_uri, new_cxg_dir, metadata_update
+        )
+
+    def update_dataset_metadata(
+        self,
+        current_dataset_version_id: DatasetVersionId,
+        metadata_update: DatasetArtifactMetadataUpdate,
+    ):
+        current_dataset_version = self.business_logic.get_dataset_version(current_dataset_version_id)
+        if current_dataset_version.status.processing_status != DatasetProcessingStatus.SUCCESS:
+            self.logger.info(
+                f"Dataset {current_dataset_version_id} is not successfully processed. Skipping metadata update."
+            )
+            return
+
+        artifact_uris = {artifact.type: artifact.uri for artifact in current_dataset_version.artifacts}
+
+        new_artifact_key_prefix = self.get_key_prefix(current_dataset_version_id) + "_updated"
+
+        artifact_jobs = []
+
+        if DatasetArtifactType.H5AD in artifact_uris:
+            self.logger.info("Main: Starting thread for h5ad update")
+            h5ad_job = Process(
+                target=DatasetMetadataReprocess.update_h5ad,
+                args=(
+                    self.artifact_bucket,
+                    self.datasets_bucket,
+                    artifact_uris[DatasetArtifactType.H5AD],
+                    current_dataset_version,
+                    new_artifact_key_prefix,
+                    metadata_update,
+                ),
+            )
+            artifact_jobs.append(h5ad_job)
+            h5ad_job.start()
+        else:
+            self.logger.error(f"Cannot find labeled H5AD artifact uri for {current_dataset_version_id}.")
+            raise ProcessingFailed from None
+
+        if DatasetArtifactType.RDS in artifact_uris:
+            self.logger.info("Main: Starting thread for rds update")
+            rds_job = Process(
+                target=DatasetMetadataReprocess.update_rds,
+                args=(
+                    self.artifact_bucket,
+                    self.datasets_bucket,
+                    artifact_uris[DatasetArtifactType.RDS],
+                    new_artifact_key_prefix,
+                    current_dataset_version_id,
+                    metadata_update,
+                ),
+            )
+            artifact_jobs.append(rds_job)
+            rds_job.start()
+        elif current_dataset_version.status.rds_status == DatasetConversionStatus.SKIPPED:
+            pass
+        else:
+            self.logger.error(
+                f"Cannot find RDS artifact uri for {current_dataset_version_id}, and Conversion Status is not SKIPPED."
+            )
+            raise ProcessingFailed from None
+
+        if DatasetArtifactType.CXG in artifact_uris:
+            self.logger.info("Main: Starting thread for cxg update")
+            cxg_job = Process(
+                target=DatasetMetadataReprocess.update_cxg,
+                args=(
+                    self.artifact_bucket,
+                    self.datasets_bucket,
+                    artifact_uris[DatasetArtifactType.CXG],
+                    f"s3://{self.cellxgene_bucket}/{new_artifact_key_prefix}.cxg",
+                    metadata_update,
+                ),
+            )
+            artifact_jobs.append(cxg_job)
+            cxg_job.start()
+        else:
+            self.logger.error(f"Cannot find cxg artifact uri for {current_dataset_version_id}.")
+            raise ProcessingFailed from None
+
+        # blocking call on async functions before checking for valid artifact statuses
+        [j.join() for j in artifact_jobs]
+
+    def update_dataset_citations_in_collection(
+        self,
+        collection_version_id: CollectionVersionId,
+    ):
+        collection_version = self.business_logic.get_collection_version(collection_version_id)
+        doi = next((link.uri for link in collection_version.metadata.links if link.type == "DOI"), None)
+        for dataset in collection_version.datasets:
+            new_citation = self.business_logic.generate_dataset_citation(
+                collection_version.collection_id, dataset.version_id, doi
+            )
+            metadata_update = DatasetArtifactMetadataUpdate(citation=new_citation)
+            self.update_dataset_metadata(dataset.version_id, metadata_update)
+
+
+if __name__ == "__main__":
+    business_logic = BusinessLogic(
+        DatabaseProvider(),
+        None,
+        None,
+        None,
+        S3Provider(),
+        UriProvider(),
+    )
+
+    artifact_bucket = os.environ.get("ARTIFACT_BUCKET", "test-bucket")
+    cellxgene_bucket = os.environ.get("CELLXGENE_BUCKET", "test-cellxgene-bucket")
+    datasets_bucket = os.environ.get("DATASETS_BUCKET", "test-datasets-bucket")
+    collection_version_id = CollectionVersionId(os.environ["COLLECTION_VERSION_ID"])
+    DatasetMetadataReprocess(
+        business_logic, artifact_bucket, cellxgene_bucket, datasets_bucket
+    ).update_dataset_citations_in_collection(collection_version_id)

--- a/backend/layers/processing/reprocess_dataset_metadata.py
+++ b/backend/layers/processing/reprocess_dataset_metadata.py
@@ -275,18 +275,19 @@ class DatasetMetadataReprocess(ProcessDownload):
         # blocking call on async functions before checking for valid artifact statuses
         [j.join() for j in artifact_jobs]
 
-    def update_dataset_citations_in_collection(
+    def update_dataset_citation(
         self,
         collection_version_id: CollectionVersionId,
+        dataset_version_id: DatasetVersionId,
     ):
+
         collection_version = self.business_logic.get_collection_version(collection_version_id)
         doi = next((link.uri for link in collection_version.metadata.links if link.type == "DOI"), None)
-        for dataset in collection_version.datasets:
-            new_citation = self.business_logic.generate_dataset_citation(
-                collection_version.collection_id, dataset.version_id, doi
-            )
-            metadata_update = DatasetArtifactMetadataUpdate(citation=new_citation)
-            self.update_dataset_metadata(dataset.version_id, metadata_update)
+        new_citation = self.business_logic.generate_dataset_citation(
+            collection_version.collection_id, dataset_version_id, doi
+        )
+        metadata_update = DatasetArtifactMetadataUpdate(citation=new_citation)
+        self.update_dataset_metadata(dataset_version_id, metadata_update)
 
 
 if __name__ == "__main__":
@@ -303,6 +304,7 @@ if __name__ == "__main__":
     cellxgene_bucket = os.environ.get("CELLXGENE_BUCKET", "test-cellxgene-bucket")
     datasets_bucket = os.environ.get("DATASETS_BUCKET", "test-datasets-bucket")
     collection_version_id = CollectionVersionId(os.environ["COLLECTION_VERSION_ID"])
+    dataset_version_id = DatasetVersionId(os.environ["DATASET_VERSION_ID"])
     DatasetMetadataReprocess(
         business_logic, artifact_bucket, cellxgene_bucket, datasets_bucket
-    ).update_dataset_citations_in_collection(collection_version_id)
+    ).update_dataset_citation(collection_version_id, dataset_version_id)


### PR DESCRIPTION
## Reason for Change

- #6345
- Proposed solution, built off of proposed approach in https://github.com/chanzuckerberg/single-cell-data-portal/pull/6350/files#diff-df36ae23a2a7f265486f5569606db86dbd40811ca8b99fda3aafb293d1b1d379

## Changes
- new batch job for reprocessing dataset citations modeled after dataset_metadata_update (i.e. 'light' reprocessing by doing point updates of our artifacts' metadata where necessary, rather than re-validating, re-converting our datasets)
- 1 batch job per dataset
- old files are not overwritten as part of job, new artifacts will be created in a new file in the same directory as existing datasets in corpora-data-prod. Then validated and then copied to replace old artifacts with a bulk cp job [This approach is To Be Finalized]
- Does not create new dataset versions, to retain existing dataset version IDs.
- Updates dataset metadata in DB for current dataset version IDs to include new citation

## Testing steps

- rdev
- Test [Run](https://us-west-2.console.aws.amazon.com/batch/home?region=us-west-2#jobs/ec2/detail/0a7bebb7-3286-4d50-80ca-f60ab67ce60b) + S3 [Output](https://s3.console.aws.amazon.com/s3/buckets/env-rdev-artifacts?region=us-west-2&prefix=pr-6351/45fd8020-45e5-40a0-8562-e4fc405f0a9a_updated/&showversions=false)
- requires refinement of vCPU + swap allotted for batch job, need to test with collection with multiple large datasets

## Checklist 🛎️

## Notes for Reviewer
