### PR TITLE
feat: rollback Collection Versions

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -215,7 +215,7 @@ class BusinessLogic(BusinessLogicInterface):
 
     def get_collection_map_to_latest_published_version_by_schema(
         self, schema_version: str
-    ) -> Dict[CollectionId, CollectionVersion]:
+    ) -> Dict[str, CollectionVersion]:
         has_wildcards = "_" in schema_version
         collection_versions = self.database_provider.get_collection_versions_by_schema(schema_version, has_wildcards)
 
@@ -1100,4 +1100,12 @@ class BusinessLogic(BusinessLogicInterface):
         )
         self.database_provider.replace_dataset_in_collection_version(
             collection_version_id, current_version.version_id, previous_version_id
+        )
+
+    def set_collection_versions_as_canonical(self, collection_map: Dict[str, CollectionVersion]):
+        self.database_provider.set_collection_versions_as_canonical(
+            {
+                collection_id: collection_version.version_id
+                for collection_id, collection_version in collection_map.items()
+            }
         )

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -213,13 +213,9 @@ class BusinessLogic(BusinessLogicInterface):
         """
         return self.database_provider.get_collection_mapped_version(collection_id)
 
-    def get_latest_published_collection_versions_by_schema(
+    def get_collection_map_to_latest_published_version_by_schema(
         self, schema_version: str
-    ) -> List[CollectionVersionWithPublishedDatasets]:
-        """
-        Returns a list with the latest published collection version that matches the given schema_version, for each
-        canonical collection
-        """
+    ) -> Dict[CollectionId, CollectionVersion]:
         has_wildcards = "_" in schema_version
         collection_versions = self.database_provider.get_collection_versions_by_schema(schema_version, has_wildcards)
 
@@ -234,7 +230,16 @@ class BusinessLogic(BusinessLogicInterface):
             else:
                 if collection_version.published_at > collections[canonical_collection_id].published_at:
                     collections[canonical_collection_id] = collection_version
+        return collections
 
+    def get_latest_published_collection_versions_by_schema(
+        self, schema_version: str
+    ) -> List[CollectionVersionWithPublishedDatasets]:
+        """
+        Returns a list with the latest published collection version that matches the given schema_version, for each
+        canonical collection
+        """
+        collections = self.get_collection_map_to_latest_published_version_by_schema(schema_version)
         # for each mapped collection version, populate its dataset versions' details
         latest_collection_versions = list(collections.values())
         dataset_version_ids = [

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from sqlalchemy import create_engine, delete
 from sqlalchemy.exc import ProgrammingError, SQLAlchemyError
@@ -651,6 +651,16 @@ class DatabaseProvider(DatabaseProviderInterface):
                     dataset.published_at = published_at
 
             return dataset_version_ids_to_delete_from_s3
+
+    def set_collection_versions_as_canonical(self, collection_map: Dict[str, CollectionVersionId]) -> None:
+        """
+        Sets Collection Version as canonical collection for each mapped pair of IDs
+        """
+        with self._manage_session() as session:
+            # update canonical collection -> collection version mapping
+            collections = session.query(CollectionTable).filter(CollectionTable.id.in_(collection_map.keys())).all()
+            for collection in collections:
+                collection.version_id = collection_map[collection.id].id
 
     def get_dataset_version(self, dataset_version_id: DatasetVersionId, get_tombstoned: bool = False) -> DatasetVersion:
         """

--- a/scripts/cxg_admin_scripts/schema_migration.py
+++ b/scripts/cxg_admin_scripts/schema_migration.py
@@ -14,3 +14,8 @@ def rollback_dataset(ctx, report_path: Path):
             ctx.obj["business_logic"].restore_previous_dataset_version(
                 CollectionVersionId(collection_version_id), DatasetId(dataset_id)
             )
+
+
+def rollback_collections_to_schema_version(ctx, schema_version: str):
+    collection_map = ctx.obj["business_logic"].get_collection_map_to_latest_published_version_by_schema(schema_version)
+    ctx.obj["business_logic"].set_collection_versions_as_canonical(collection_map)


### PR DESCRIPTION
## Reason for Change

- #6345
- Proposed approach to rollback published schema versions to most recently published Collection Version containing datasets of the previous schema version. Generalized approach for rolling back any Collections published with issues after a schema migration. 

## Changes

- add business logic function, persistence function, and cxg admin CLI function to support rollback of corpus to a particular schema_version
- leverages existing logic used to fetch a particular set of Collection Versions of a particular schema for Discover API endpoints 
- fetches most recently published Collection Version containing datasets of the previous schema version, and maps to their canonical collection version 
- use map of canonical collections IDs to collection version IDs to remap the given version IDs as the new canonical versions in the DB

## Testing steps

- rdev

## Notes for Reviewer
