### PR TITLE
chore: remove parameterize from requirements-processing.txt

### DIFF
--- a/requirements-processing.txt
+++ b/requirements-processing.txt
@@ -17,7 +17,6 @@ numba==0.56.2
 numpy==1.23.2
 owlready2==0.40.0
 pandas==1.4.4
-parameterized
 psutil>=5.9.0
 psycopg2-binary>=2.8.5
 pyarrow>=1.0

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock, patch
 import pytest
 import scanpy
 import tiledb
-from parameterized import parameterized
 from rpy2.robjects.packages import importr
 
 from backend.common.utils.corpora_constants import CorporaConstants
@@ -500,7 +499,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
             self.business_logic, "artifact_bucket", "cellxgene_bucket", "datasets_bucket"
         )
 
-    @parameterized.expand([DatasetConversionStatus.CONVERTED, DatasetConversionStatus.SKIPPED])
+    @pytest.mark.parametrize("rds_status", [DatasetConversionStatus.CONVERTED, DatasetConversionStatus.SKIPPED])
     def test_has_valid_artifact_statuses(self, rds_status):
         dataset_version = self.generate_dataset(
             statuses=[
@@ -514,7 +513,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
         dataset_version_id = DatasetVersionId(dataset_version.dataset_version_id)
         assert self.updater.has_valid_artifact_statuses(dataset_version_id) is True
 
-    @parameterized.expand([DatasetConversionStatus.CONVERTING, DatasetConversionStatus.FAILED])
+    @pytest.mark.parametrize("rde_status", [DatasetConversionStatus.CONVERTING, DatasetConversionStatus.FAILED])
     def test_has_valid_artifact_statuses__invalid_rds_status(self, rds_status):
         dataset_version = self.generate_dataset(
             statuses=[
@@ -528,7 +527,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
         dataset_version_id = DatasetVersionId(dataset_version.dataset_version_id)
         assert self.updater.has_valid_artifact_statuses(dataset_version_id) is False
 
-    @parameterized.expand([DatasetConversionStatus.CONVERTING, DatasetConversionStatus.FAILED])
+    @pytest.mark.parametrize("h5ad_status", [DatasetConversionStatus.CONVERTING, DatasetConversionStatus.FAILED])
     def test_has_valid_artifact_statuses__invalid_h5ad_status(self, h5ad_status):
         dataset_version = self.generate_dataset(
             statuses=[
@@ -542,7 +541,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
         dataset_version_id = DatasetVersionId(dataset_version.dataset_version_id)
         assert self.updater.has_valid_artifact_statuses(dataset_version_id) is False
 
-    @parameterized.expand([DatasetConversionStatus.CONVERTING, DatasetConversionStatus.FAILED])
+    @pytest.mark.parametrize("cxg_status", [DatasetConversionStatus.CONVERTING, DatasetConversionStatus.FAILED])
     def test_has_valid_artifact_statuses__invalid_cxg_status(self, cxg_status):
         dataset_version = self.generate_dataset(
             statuses=[


### PR DESCRIPTION
## Reason for Change

- remove parameterize a superfluous requirement from requirements-processing.txt

## Changes

- remove parameterize a superfluous requirement from requirements-processing.txt

