### PR TITLE
fix: wrong CellGuide data link in dev

### DIFF
--- a/frontend/runtime_configs/dev.env
+++ b/frontend/runtime_configs/dev.env
@@ -1,5 +1,5 @@
 RUNTIME_VAR_API_URL=https://api.cellxgene.dev.single-cell.czi.technology
-RUNTIME_VAR_CELLGUIDE_DATA_URL=https://cellxgene-contrib-public.s3.us-west-2.amazonaws.com
+RUNTIME_VAR_CELLGUIDE_DATA_URL=https://cellguide.cellxgene.dev.single-cell.czi.technology
 RUNTIME_VAR_CENSUS_MODELS_DATA_URL=https://contrib.cellxgene.cziscience.com
 RUNTIME_VAR_PLAUSIBLE_DATA_DOMAIN=cellxgene.staging.single-cell.czi.technology
 RUNTIME_VAR_SENTRY_DEPLOYMENT_ENVIRONMENT=staging


### PR DESCRIPTION
Solves a config bug that only exists in dev and prevents CellGuide from working.