### PR TITLE
fix: unescape CrossRef journal

### DIFF
--- a/backend/common/providers/crossref_provider.py
+++ b/backend/common/providers/crossref_provider.py
@@ -1,3 +1,4 @@
+import html
 import logging
 from datetime import datetime
 from urllib.parse import urlparse
@@ -101,13 +102,15 @@ class CrossrefProvider:
             # Journal
             try:
                 if "short-container-title" in message and message["short-container-title"]:
-                    journal = message["short-container-title"][0]
+                    raw_journal = message["short-container-title"][0]
                 elif "container-title" in message and message["container-title"]:
-                    journal = message["container-title"][0]
+                    raw_journal = message["container-title"][0]
                 elif "institution" in message:
-                    journal = message["institution"][0]["name"]
+                    raw_journal = message["institution"][0]["name"]
             except Exception:
                 raise CrossrefParseException("Journal node missing") from None
+
+            journal = html.unescape(raw_journal)
 
             # Authors
             # Note: make sure that the order is preserved, as it is a relevant information
@@ -138,7 +141,6 @@ class CrossrefProvider:
             raise CrossrefParseException("Cannot parse metadata from Crossref") from e
 
     def fetch_preprint_published_doi(self, doi):
-
         res = self._fetch_crossref_payload(doi)
         message = res.json()["message"]
         is_preprint = message.get("subtype") == "preprint"

--- a/backend/layers/thirdparty/crossref_provider.py
+++ b/backend/layers/thirdparty/crossref_provider.py
@@ -1,3 +1,4 @@
+import html
 import logging
 from datetime import datetime
 from urllib.parse import urlparse
@@ -107,13 +108,15 @@ class CrossrefProvider(CrossrefProviderInterface):
             # Journal
             try:
                 if "short-container-title" in message and message["short-container-title"]:
-                    journal = message["short-container-title"][0]
+                    raw_journal = message["short-container-title"][0]
                 elif "container-title" in message and message["container-title"]:
-                    journal = message["container-title"][0]
+                    raw_journal = message["container-title"][0]
                 elif "institution" in message:
-                    journal = message["institution"][0]["name"]
+                    raw_journal = message["institution"][0]["name"]
             except Exception:
                 raise CrossrefParseException("Journal node missing") from None
+
+            journal = html.unescape(raw_journal)
 
             # Authors
             # Note: make sure that the order is preserved, as it is a relevant information

--- a/tests/unit/backend/layers/thirdparty/test_crossref_provider.py
+++ b/tests/unit/backend/layers/thirdparty/test_crossref_provider.py
@@ -25,7 +25,6 @@ class TestCrossrefProvider(unittest.TestCase):
     @patch("backend.common.providers.crossref_provider.requests.get")
     @patch("backend.common.providers.crossref_provider.CorporaConfig")
     def test__provider_calls_crossref_if_api_key_defined(self, mock_config, mock_get):
-
         # Defining a mocked CorporaConfig will allow the provider to consider the `crossref_api_key`
         # not None, so it will go ahead and do the mocked call.
 
@@ -75,7 +74,6 @@ class TestCrossrefProvider(unittest.TestCase):
     @patch("backend.common.providers.crossref_provider.requests.get")
     @patch("backend.common.providers.crossref_provider.CorporaConfig")
     def test__provider_parses_authors_and_dates_correctly(self, mock_config, mock_get):
-
         response = Response()
         response.status_code = 200
         response._content = str.encode(
@@ -133,6 +131,45 @@ class TestCrossrefProvider(unittest.TestCase):
             "published_day": 1,
             "published_at": 1635724800.0,
             "journal": "Nature",
+            "is_preprint": False,
+        }
+
+        self.assertDictEqual(expected_response, res)
+
+    @patch("backend.common.providers.crossref_provider.requests.get")
+    @patch("backend.common.providers.crossref_provider.CorporaConfig")
+    def test__provider_unescapes_journal_correctly(self, mock_config, mock_get):
+        response = Response()
+        response.status_code = 200
+        response._content = str.encode(
+            json.dumps(
+                {
+                    "status": "ok",
+                    "message": {
+                        "author": [
+                            {"name": "A consortium"},
+                        ],
+                        "published-online": {"date-parts": [[2021, 11]]},
+                        "container-title": ["Clinical &amp; Translational Med"],
+                    },
+                }
+            )
+        )
+
+        mock_get.return_value = response
+        provider = CrossrefProvider()
+        res = provider.fetch_metadata("test_doi")
+        mock_get.assert_called_once()
+
+        expected_response = {
+            "authors": [
+                {"name": "A consortium"},
+            ],
+            "published_year": 2021,
+            "published_month": 11,
+            "published_day": 1,
+            "published_at": 1635724800.0,
+            "journal": "Clinical & Translational Med",
             "is_preprint": False,
         }
 


### PR DESCRIPTION
## Reason for Change

- #6268

## Changes

- Added unescape to journal value returned from CrossRef.
- 
## Testing steps

- Tested in rdev ([collection list](https://mim-unescape-journal-frontend.rdev.single-cell.czi.technology/collections), [collection detail page](https://mim-unescape-journal-frontend.rdev.single-cell.czi.technology/collections/14f0683e-bcd0-42af-8ff2-5579850c0c0d)).
- Added unit test.

## Checklist 🛎️

- [x] Add product, design, and eng as reviewers for rdev review (see [Slack](https://clevercanary.slack.com/archives/C02CF7MQPGV/p1703012526210559)).
