### PR TITLE
chore: Explicitly set eslint tsconfigRootDir

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: {
     project: "./tsconfig.json",
+    tsconfigRootDir: __dirname,
     ecmaFeatures: {
       jsx: true,
     },


### PR DESCRIPTION
## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

1. Somehow some machines don't use `__dirname` as root when finding `tsconfig.json` file, so we need to explicitly set this!

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
