### PR TITLE
fix: source data badge overlapping download modal

### DIFF
--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SaveExport/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SaveExport/style.ts
@@ -33,6 +33,8 @@ export const StyledModal = styled(Modal)`
     font-size: 24px !important;
     margin: 0px !important;
   }
+  z-index: 10;
+  position: relative;
 `;
 
 export const StyledTitle = styled.div`

--- a/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SourceDataButton/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/GeneSearchBar/components/SourceDataButton/style.ts
@@ -23,7 +23,7 @@ export const BadgeCounter = styled(Badge)<StyledBadgeProps>`
   height: 16px;
   text-align: center;
   position: relative;
-  z-index: 22;
+  z-index: 5;
   top: 4px;
   left: 14px;
 


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/6379

## Changes

fixes the z-index of the download modal and the source data badge to make sure the source data badge does not overlap the download modal

## Testing steps

![image](https://github.com/chanzuckerberg/single-cell-data-portal/assets/5653616/c7a96bb4-100c-4baa-84d8-5617ef9495d0)

## Checklist 🛎️

- [x] Add product, design, and eng as reviewers for rdev review
- [x] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
  - not necessary for this imo

## Notes for Reviewer
