### PR TITLE
fix: update dependencies to be able to read latest census version

### DIFF
--- a/requirements-wmg-pipeline.txt
+++ b/requirements-wmg-pipeline.txt
@@ -5,7 +5,7 @@ black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.y
 boto3==1.28.7
 botocore>=1.31.7, <1.32.0
 click==8.1.3
-cellxgene-census==1.6.0
+cellxgene-census==1.9.1
 coverage==7.2.7
 dataclasses-json==0.5.7
 ddtrace==2.1.4
@@ -35,5 +35,5 @@ scipy==1.10.1
 SQLAlchemy==1.4.49
 SQLAlchemy-Utils==0.41.1
 tenacity==8.2.2
-tiledbsoma==1.4.4
+tiledbsoma==1.6.1
 dask==2023.8.1


### PR DESCRIPTION
## Reason for Change

 - Latest census builds require updates to the census dependencies to be read.

## Changes

- updated census and tiledbsoma dependencies

## Testing steps

- Unit tested only
