### PR TITLE
test: Fix CellGuide tree view e2e test

### DIFF
--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/constants.ts
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/constants.ts
@@ -10,6 +10,9 @@ export const CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_FULLSCREEN_BUTTON =
 export const CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_HOVER_CONTAINER =
   "cell-guide-card-ontology-dag-view-hover-container";
 
+export const CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_CONTENT =
+  "cell-guide-card-ontology-dag-view-content";
+
 export const CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_DEACTIVATE_MARKER_GENE_MODE =
   "cell-guide-card-ontology-dag-view-deactivate-marker-gene-mode";
 export const MINIMUM_NUMBER_OF_HIDDEN_CHILDREN_FOR_DUMMY_NODE = 3;

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -58,6 +58,7 @@ import {
   CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_DEACTIVATE_MARKER_GENE_MODE,
   MINIMUM_NUMBER_OF_HIDDEN_CHILDREN_FOR_DUMMY_NODE,
   ANIMAL_CELL_ID,
+  CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_CONTENT,
 } from "src/views/CellGuide/components/common/OntologyDagView/constants";
 import {
   ALL_TISSUES,
@@ -518,6 +519,7 @@ export default function OntologyDagView({
                 height={height}
                 ref={zoom.containerRef}
                 isDragging={zoom.isDragging}
+                data-testid={CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_CONTENT}
               >
                 <RectClipPath id="zoom-clip" width={width} height={height} />
                 <rect

--- a/frontend/tests/features/cellGuide/cellGuide.test.ts
+++ b/frontend/tests/features/cellGuide/cellGuide.test.ts
@@ -17,6 +17,7 @@ import {
   CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_FULLSCREEN_BUTTON,
   CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_TOOLTIP,
   CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_DEACTIVATE_MARKER_GENE_MODE,
+  CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_CONTENT,
 } from "src/views/CellGuide/components/common/OntologyDagView/constants";
 import { CELL_GUIDE_ONTOLOGY_VIEW_LEGEND_TEST_ID } from "src/views/CellGuide/components/common/OntologyDagView/components/Legend/constants";
 import { CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_CLICKABLE_TEXT_LABEL } from "src/views/CellGuide/components/common/OntologyDagView/components/Node/constants";
@@ -904,17 +905,37 @@ describe("Cell Guide", () => {
           CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_DEACTIVATE_MARKER_GENE_MODE
         );
 
-        /**
-         * Hover over the `neural cell` node, since it will still be in the tree
-         * view window when on a small viewport size.
-         * Otherwise, choosing a different node will risk it being hidden and
-         * not be hoverable
-         */
-        const node = page.getByTestId(
-          `${CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}-CL:0002319__0-has-children-isTargetNode=false`
+        const neuralNodeId = `${CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}-CL:0002319__0-has-children-isTargetNode=false`;
+
+        await isElementVisible(page, neuralNodeId);
+
+        const dagContent = page.getByTestId(
+          CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_CONTENT
         );
-        await node.hover();
-        await isElementVisible(page, CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_TOOLTIP);
+
+        await dagContent.hover();
+
+        await tryUntil(
+          async () => {
+            /**
+             * (thuang): Zoom out the tree view a little, in case the node is half hidden
+             * and not hoverable
+             */
+            await page.mouse.wheel(0, 1);
+            /**
+             * Hover over the `neural cell` node, since it will still be in the tree
+             * view window when on a small viewport size.
+             * Otherwise, choosing a different node will risk it being hidden and
+             * not be hoverable
+             */
+            await page.getByTestId(neuralNodeId).hover();
+            await isElementVisible(
+              page,
+              CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_TOOLTIP
+            );
+          },
+          { page }
+        );
 
         // assert that the tooltip text contains the marker gene information
         const tooltipText = await page


### PR DESCRIPTION
## Reason for Change

The test is failing right now because the node is half hidden and not hoverable

<img width="935" alt="Screenshot 2024-01-03 at 9 25 40 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/6309723/6c7cf658-56c2-46e4-be87-fc3da958e39f">

## Changes

1. Update test to zoom out of the tree view, so more nodes are in the view

## Testing steps

All tests should pass now!

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
