### PR TITLE
feat: notify @sc-pm and @sc-eng with each deploy

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -90,7 +90,8 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: repo,commit,author,eventName,workflow,job,mention
-          mention: "here"
+          mention: "subteam^S02KZL4SQM6"
+          if_mention: "always"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: failure() && github.ref == 'refs/heads/main'
@@ -412,7 +413,8 @@ jobs:
         with:
           status: ${{ steps.check.outputs.status }}
           fields: repo,commit,author,eventName,workflow,job,mention
-          mention: "here"
+          mention: "subteam^S02KZL4SQM6,subteam^S03MNFMGD0F"
+          if_mention: "always"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-        if: steps.check.outputs.status == 'failure' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod'

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -417,4 +417,13 @@ jobs:
           if_mention: "always"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod'
+        if: github.ref == 'refs/heads/prod'
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ steps.check.outputs.status }}
+          fields: repo,commit,author,eventName,workflow,job,mention
+          mention: "subteam^S02KZL4SQM6"
+          if_mention: "always"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: steps.check.outputs.status == 'failure' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/6100

## Changes

three things this changes:
1. notifies @sc-eng if there are issues with any happy deploy
2. notifies @sc-eng and @sc-pm for all prod deploys, regardless of status
3. notifies @sc-eng for all other deploys that fail

the [documentation](https://action-slack.netlify.app/usage/with/) isn't 100% clear, but i believe we need to specify `if_mention` if we want any of the things specified in `mention` to work. i'm pretty sure this is why our existing slack alerts are not notifying @here. regardless, i think @sc-eng is better than @here 

note that (2) notifies #cell-science-ops, which is where we currently do the manual notification, so that seems right to me.

## Testing steps

not sure how to test this.. is it possible? it may make sense to split out the 3 changes into separate PR's so we can look at them individually