### PR TITLE
feat: remove notifying @sc-eng for failed non-prod deploys

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -421,9 +421,7 @@ jobs:
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ steps.check.outputs.status }}
-          fields: repo,commit,author,eventName,workflow,job,mention
-          mention: "subteam^S02KZL4SQM6"
-          if_mention: "always"
+          fields: repo,commit,author,eventName,workflow,job
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: steps.check.outputs.status == 'failure' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')


### PR DESCRIPTION
## Reason for Change

previously, we intended to use `@here` for failed deploys, but i changed it to use `@sc-eng` because that seemed better than notifying everyone in that channel. based on feedback, it doesn't seem necessary to @-message anyone, so i'm just removing the @-mention for this job entirely.

## Changes

removes notifying `@sc-eng` when a non-prod deploy fails. note that we will still notify `@sc-eng` and `@sc-pm` for all prod deploys (success and failure), to automate a process that we do manually now.

## Testing steps

testing after merge seems fine to me

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
