### PR TITLE
feat: notify oncall engineer for failed non-prod deploys

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: repo,commit,author,eventName,workflow,job,mention
-          mention: "subteam^S02KZL4SQM6"
+          mention: "subteam^S02K38PMTTQ"
           if_mention: "always"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
@@ -421,7 +421,9 @@ jobs:
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ steps.check.outputs.status }}
-          fields: repo,commit,author,eventName,workflow,job
+          fields: repo,commit,author,eventName,workflow,job,mention
+          mention: "subteam^S02K38PMTTQ"
+          if_mention: "always"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: steps.check.outputs.status == 'failure' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')


### PR DESCRIPTION
## Reason for Change

i discovered we had a group for single cell oncall, `@sc-oncall-eng`.

## Changes

now instead of:
1. notifying nobody when a non-prod deploy fails
2. notifying `@sc-eng` when there are errors with the build

for both of these failures, we'll notify `@sc-oncall-eng`

## Testing steps

merge and test : )

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
