### PR TITLE
fix: db/remote_migration_init

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -5,7 +5,7 @@ db/migrate:
 .PHONY: db/remote_migration_init
 db/remote_migration_init:
 	# Run utility installation before invoking these commands.
-	pip install awscli -r ../requirements-backend.txt
+	pip install awscli -r ../requirements.txt
 	apt-get update && apt-get install -y postgresql-client jq
 
 .PHONY: db/init_remote_dev


### PR DESCRIPTION
## Reason for Change

- fixing the make recipe db/remote_migration_init
- the break was caused by https://github.com/chanzuckerberg/single-cell-data-portal/pull/6425
