### PR TITLE
chore: Adjust concurrency of rdev create to cancel if it's safe. 2 of 3

### DIFF
--- a/.github/workflows/rdev-delete-for-pr.yml
+++ b/.github/workflows/rdev-delete-for-pr.yml
@@ -8,10 +8,6 @@ on:
       - closed
 
 env:
-  # Force using BuildKit instead of normal Docker, required so that metadata
-  # is written/read to allow us to use layers of previous builds as cache.
-  DOCKER_BUILDKIT: 1
-  COMPOSE_DOCKER_CLI_BUILD: 1
   DOCKER_REPO: ${{ secrets.ECR_REPO }}/
   STACK_NAME: pr-${{ github.event.number }}
 
@@ -21,7 +17,7 @@ permissions:
 
 # prevent the rdev from being updated in concurrent GHA
 concurrency:
-  group: pr-${{ github.event.number }}
+  group: pr-${{ github.event.number }}-happy
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -1,0 +1,256 @@
+name: rdev tests
+
+on:
+  workflow_call:
+
+env:
+  DOCKER_REPO: ${{ secrets.ECR_REPO }}/
+  STACK_NAME: pr-${{ github.event.number }}
+
+permissions:
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  functional-test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    needs:
+      - seed-wmg-cellguide-rdev
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 2700
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      # TODO: Wait until the deployment is complete and return 200 responses from the version endpoint.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Run functional test
+        run: |
+          pip3 install -r tests/functional/requirements.txt
+          DEPLOYMENT_STAGE=rdev STACK_NAME=${{ env.STACK_NAME }} make functional-test
+
+  seed-wmg-cellguide-rdev:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Grant Execute Permission to Bash Script
+        run: |
+          chmod +x ./scripts/populate_rdev_with_cellguide_data.sh ./scripts/populate_rdev_with_wmg_data.sh
+
+      - name: Seed cell guide data
+        run: |
+          ./scripts/populate_rdev_with_cellguide_data.sh ${{ env.STACK_NAME }}
+      - name: Seed WMG data
+        run: |
+          ./scripts/populate_rdev_with_wmg_data.sh ${{ env.STACK_NAME }}
+
+  seed-database-e2e-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Seed database for e2e tests
+        run: |
+          pip3 install -r scripts/smoke_tests/requirements.txt
+          STACK_NAME=${{ env.STACK_NAME }} DEPLOYMENT_STAGE=rdev python3 -m scripts.smoke_tests.setup
+
+  run-e2e-tests:
+    needs:
+      - seed-wmg-cellguide-rdev
+      - seed-database-e2e-tests
+    timeout-minutes: 30
+    name: e2e-tests ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only run Chrome for now, since GHA only has 250 workers and will cancel jobs if it runs out
+        project: [chromium]
+        shardCurrent: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shardTotal: [10]
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20.10.0"
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Login to ECR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.ECR_REPO }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Install dependencies
+        ### config.js set-up required due to transient test dependencies on API_URL
+        run: |
+          npm ci
+          npx playwright install --with-deps
+          cp src/configs/local.js src/configs/configs.js
+
+      # Run e2e tests
+      - name: Run e2e tests
+        env:
+          CI: true
+          PROJECT: ${{ matrix.project }}
+          SHARD: ${{ matrix.shardCurrent }}/${{ matrix.shardTotal }}
+        run: DEBUG=pw:api RDEV_LINK=https://${{ env.STACK_NAME }}-frontend.rdev.single-cell.czi.technology npm run e2e-rdev-ci
+
+      - name: Upload FE test results as an artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: playwright-report ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
+          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
+          retention-days: 14
+
+      - name: Upload blob report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: all-blob-reports
+          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/blob-report
+          retention-days: 1
+
+      # Upload Allure results as an artifact
+      - uses: actions/upload-artifact@v3
+        with:
+          name: allure-results
+          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/allure-results
+          retention-days: 20
+
+      - name: Install happy
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+        with:
+          happy_version: "0.110.1"
+
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,eventName,workflow,job,mention
+          mention: "here"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure() && github.ref == 'refs/heads/main'
+
+  merge-playwright-reports:
+    # Merge reports after playwright-tests, even if some shards have failed
+    if: always()
+    needs: run-e2e-tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: all-blob-reports
+          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/blob-reports
+
+      - name: Merge into HTML Report
+        run: npx playwright merge-reports --reporter html ./blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-report--attempt-${{ github.run_attempt }}
+          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
+          retention-days: 30
+
+  # https://github.com/myieye/web-languageforge/blob/develop/.github/workflows/e2e-tests.yml
+  e2e-test:
+    if: always()
+    name: e2e-test
+    runs-on: ubuntu-latest
+    needs:
+      - run-e2e-tests
+    steps:
+      - name: Check result
+        run: |
+          passed="${{ needs.run-e2e-tests.result }}"
+          if [[ $passed == "success" ]]; then
+            echo "Shards passed"
+            exit 0
+          else
+            echo "Shards failed"
+            exit 1
+          fi
+
+  e2e-logged-in-test:
+    timeout-minutes: 30
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: frontend
+    needs:
+      - seed-wmg-cellguide-rdev
+      - seed-database-e2e-tests
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "20.10.0"
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 2700
+      - name: Install dependencies
+        ### config.js set-up required due to transient test dependencies on API_URL
+        run: |
+          npm ci
+          npx playwright install --with-deps
+          cp src/configs/local.js src/configs/configs.js
+      - name: Run e2e Logged In tests
+        run: |
+          DEBUG=pw:api RDEV_LINK=https://${{ env.STACK_NAME }}-frontend.rdev.single-cell.czi.technology npm run e2e-rdev-logged-in-ci
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: logged-in-test-results
+          path: frontend/playwright-report/
+          retention-days: 30

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -9,11 +9,6 @@ on:
       - synchronize
       - reopened
 
-# prevent the rdev from being updated in concurrent GHA
-concurrency:
-  group: pr-${{ github.event.number }}
-  cancel-in-progress: false
-
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.
@@ -61,9 +56,15 @@ jobs:
   build_images:
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
+    concurrency:
+      group: pr-${{ github.event.number }}-build
+      cancel-in-progress: true
 
   deploy-rdev:
     runs-on: ubuntu-22.04
+    concurrency:
+      group: pr-${{ github.event.number }}-happy
+      cancel-in-progress: false
     needs:
       - build_images
       - get_previous_image_digests
@@ -140,249 +141,10 @@ jobs:
               body: "${{ steps.summary.outputs.summary}}"
             })
 
-  functional-test:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    needs:
-      - deploy-rdev
-      - seed-wmg-cellguide-rdev
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 2700
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      # TODO: Wait until the deployment is complete and return 200 responses from the version endpoint.
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Run functional test
-        run: |
-          pip3 install -r tests/functional/requirements.txt
-          DEPLOYMENT_STAGE=rdev STACK_NAME=${{ env.STACK_NAME }} make functional-test
-
-  seed-wmg-cellguide-rdev:
-    runs-on: ubuntu-22.04
-    needs:
-      - deploy-rdev
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1800
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-
-      - name: Grant Execute Permission to Bash Script
-        run: |
-          chmod +x ./scripts/populate_rdev_with_cellguide_data.sh ./scripts/populate_rdev_with_wmg_data.sh
-
-      - name: Seed cell guide data
-        run: |
-          ./scripts/populate_rdev_with_cellguide_data.sh ${{ env.STACK_NAME }}
-      - name: Seed WMG data
-        run: |
-          ./scripts/populate_rdev_with_wmg_data.sh ${{ env.STACK_NAME }}
-
-  seed-database-e2e-tests:
-    runs-on: ubuntu-22.04
-    needs:
-      - deploy-rdev
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1800
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - name: Seed database for e2e tests
-        run: |
-          pip3 install -r scripts/smoke_tests/requirements.txt
-          STACK_NAME=${{ env.STACK_NAME }} DEPLOYMENT_STAGE=rdev python3 -m scripts.smoke_tests.setup
-
-  run-e2e-tests:
-    needs:
-      - seed-wmg-cellguide-rdev
-      - seed-database-e2e-tests
-    timeout-minutes: 30
-    name: e2e-tests ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        # Only run Chrome for now, since GHA only has 250 workers and will cancel jobs if it runs out
-        project: [chromium]
-        shardCurrent: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        shardTotal: [10]
-    defaults:
-      run:
-        working-directory: frontend
-    steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "20.10.0"
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1800
-      - name: Login to ECR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.ECR_REPO }}
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Install dependencies
-        ### config.js set-up required due to transient test dependencies on API_URL
-        run: |
-          npm ci
-          npx playwright install --with-deps
-          cp src/configs/local.js src/configs/configs.js
-
-      # Run e2e tests
-      - name: Run e2e tests
-        env:
-          CI: true
-          PROJECT: ${{ matrix.project }}
-          SHARD: ${{ matrix.shardCurrent }}/${{ matrix.shardTotal }}
-        run: DEBUG=pw:api RDEV_LINK=https://${{ env.STACK_NAME }}-frontend.rdev.single-cell.czi.technology npm run e2e-rdev-ci
-
-      - name: Upload FE test results as an artifact
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: playwright-report ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
-          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
-          retention-days: 14
-
-      - name: Upload blob report to GitHub Actions Artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: all-blob-reports
-          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/blob-report
-          retention-days: 1
-
-      # Upload Allure results as an artifact
-      - uses: actions/upload-artifact@v3
-        with:
-          name: allure-results
-          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/allure-results
-          retention-days: 20
-
-      - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
-        with:
-          happy_version: "0.110.1"
-
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,commit,author,eventName,workflow,job,mention
-          mention: "here"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-        if: failure() && github.ref == 'refs/heads/main'
-
-  merge-playwright-reports:
-    # Merge reports after playwright-tests, even if some shards have failed
-    if: always()
-    needs: run-e2e-tests
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: all-blob-reports
-          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/blob-reports
-
-      - name: Merge into HTML Report
-        run: npx playwright merge-reports --reporter html ./blob-reports
-
-      - name: Upload HTML report
-        uses: actions/upload-artifact@v3
-        with:
-          name: html-report--attempt-${{ github.run_attempt }}
-          path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
-          retention-days: 30
-
-  # https://github.com/myieye/web-languageforge/blob/develop/.github/workflows/e2e-tests.yml
-  e2e-test:
-    if: always()
-    name: e2e-test
-    runs-on: ubuntu-latest
-    needs:
-      - run-e2e-tests
-    steps:
-      - name: Check result
-        run: |
-          passed="${{ needs.run-e2e-tests.result }}"
-          if [[ $passed == "success" ]]; then
-            echo "Shards passed"
-            exit 0
-          else
-            echo "Shards failed"
-            exit 1
-          fi
-
-  e2e-logged-in-test:
-    timeout-minutes: 30
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: frontend
-    needs:
-      - seed-wmg-cellguide-rdev
-      - seed-database-e2e-tests
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "20.10.0"
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 2700
-      - name: Install dependencies
-        ### config.js set-up required due to transient test dependencies on API_URL
-        run: |
-          npm ci
-          npx playwright install --with-deps
-          cp src/configs/local.js src/configs/configs.js
-      - name: Run e2e Logged In tests
-        run: |
-          DEBUG=pw:api RDEV_LINK=https://${{ env.STACK_NAME }}-frontend.rdev.single-cell.czi.technology npm run e2e-rdev-logged-in-ci
-      - uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: logged-in-test-results
-          path: frontend/playwright-report/
-          retention-days: 30
+  rdev-tests:
+    uses: ./.github/workflows/rdev-tests.yml
+    secrets: inherit
+    concurrency:
+      group: pr-${{ github.event.number }}-test
+      cancel-in-progress: true
+    needs: deploy-rdev


### PR DESCRIPTION
## Reason for Change

- https://github.com/chanzuckerberg/single-cell-data-portal/issues/5895
- related to https://github.com/chanzuckerberg/single-cell-data-portal/issues/6169
- This will improve the rdev testing development cycle by stopping GHA jobs from running when newer commits come in.

## Changes

- add specific concurrency group to .github/workflows/rdev-update-for-pr.yml. 
- Cancel build-images if a new one is in progress. This will interrupt upload docker build and upload which is not a problem
- cancel e2e and functional tests if a new commit comes in.
- rdev deployments are not interrupted if they are started.

## Testing steps

- running the github action and interrupting with new commits.
- updates workflow
<img width="1709" alt="Screenshot 2024-01-11 at 3 08 16 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/1429913/c7fdfcdd-ee89-44ea-bf19-d8e0283242f4">


