### PR TITLE
chore: Reuse build images to simplify GHAs, 1 of 3

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -22,51 +22,9 @@ permissions:
 
 jobs:
   build_images:
-    strategy:
-      matrix:
-        image:
-          - frontend # pushed both the frontend and backend images
-          - upload_failures
-          - upload_success
-          - dataset_submissions
-          - processing
-          - wmg_processing
-          - cellguide_pipeline
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1800
-      - name: Login to ECR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.ECR_REPO }}
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ env.GITHUB_BRANCH }}
-          fetch-depth: 1
-      - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
-        with:
-          happy_version: "0.110.1"
-      - name: Push images
-        run: |
-          echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
-          echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
-          happy push devstack --env dev --slice ${{ matrix.image }} \
-          --docker-compose-env-file envfile --aws-profile "" \
-          --tags sha-${GITHUB_SHA:0:8},branch-$(echo ${GITHUB_REF#refs/heads/} | sed 's/[\+\/]/-/g')
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,commit,author,eventName,workflow,job,mention
-          mention: "here"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-        if: failure() && (env.GITHUB_BRANCH == 'refs/heads/main' || env.GITHUB_BRANCH == 'refs/heads/staging' || env.GITHUB_BRANCH == 'refs/heads/prod')
+    uses: ./.github/workflows/build-images.yml
+    secrets: inherit
+    needs: get_previous_image_digests
 
   create_deployment:
     needs:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -3,9 +3,9 @@ name: rdev build-images
 on:
   workflow_call:
     outputs:
-      iamge_tag:
+      image_tag:
         description: "the image tag to be pushed"
-        value: ${{ jobs.create-image-tag.outputs.image_tag }}
+        value: ${{ jobs.build_images.outputs.image_tag }}
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.
@@ -18,18 +18,6 @@ permissions:
   id-token: write
 
 jobs:
-  create-image-tag:
-    runs-on: ubuntu-22.04
-    outputs:
-      image_tag: ${{ steps.create-image-tag.outputs.image_tag }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - name: Create image tag
-        id: create-image-tag
-        run: echo "image_tag=sha-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
-
   build_images:
     strategy:
       matrix:
@@ -42,7 +30,8 @@ jobs:
           - wmg_processing
           - cellguide_pipeline
     runs-on: ubuntu-22.04
-    needs: create-image-tag
+    outputs:
+      image_tag: ${{ steps.push_images.outputs.image_tag }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -63,12 +52,12 @@ jobs:
           happy_version: "0.110.1"
       - name: Push images
         id: push_images
-        env:
-          IMAGE_TAG: ${{ needs.create-image-tag.outputs.image_tag }}
         run: |
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
           echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
+          export IMAGE_TAG=sha-${GITHUB_SHA:0:7}
           export BRANCH_TAG=branch-$(echo ${GITHUB_REF_NAME} | sed 's/[\+\/]/-/g')
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           happy push devstack --env dev --slice ${{ matrix.image }} \
           --docker-compose-env-file envfile --aws-profile "" \
           --tags ${STACK_NAME},${IMAGE_TAG},${BRANCH_TAG}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -57,6 +57,7 @@ jobs:
           echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
           export IMAGE_TAG=sha-${GITHUB_SHA:0:7}
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "IMAGE_TAG=${IMAGE_TAG}"
           export BRANCH_TAG=branch-$(echo ${GITHUB_REF_NAME} | sed 's/[\+\/]/-/g')
           happy push devstack --env dev --slice ${{ matrix.image }} \
           --docker-compose-env-file envfile --aws-profile "" \

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -56,8 +56,8 @@ jobs:
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
           echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
           export IMAGE_TAG=sha-${GITHUB_SHA:0:7}
-          export BRANCH_TAG=branch-$(echo ${GITHUB_REF_NAME} | sed 's/[\+\/]/-/g')
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          export BRANCH_TAG=branch-$(echo ${GITHUB_REF_NAME} | sed 's/[\+\/]/-/g')
           happy push devstack --env dev --slice ${{ matrix.image }} \
           --docker-compose-env-file envfile --aws-profile "" \
           --tags ${STACK_NAME},${IMAGE_TAG},${BRANCH_TAG}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,7 +5,7 @@ on:
     outputs:
       iamge_tag:
         description: "the image tag to be pushed"
-        value: ${{ jobs.build_images.outputs.image_tag }}
+        value: ${{ jobs.create-image-tag.outputs.image_tag }}
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.
@@ -18,6 +18,18 @@ permissions:
   id-token: write
 
 jobs:
+  create-image-tag:
+    runs-on: ubuntu-22.04
+    outputs:
+      image_tag: ${{ steps.create-image-tag.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Create image tag
+        id: create-image-tag
+        run: echo "image_tag=sha-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+
   build_images:
     strategy:
       matrix:
@@ -55,13 +67,10 @@ jobs:
         run: |
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
           echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
-          export IMAGE_TAG=sha-${GITHUB_SHA:0:7}
-          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-          echo "image_tag=${IMAGE_TAG}"
           export BRANCH_TAG=branch-$(echo ${GITHUB_REF_NAME} | sed 's/[\+\/]/-/g')
           happy push devstack --env dev --slice ${{ matrix.image }} \
           --docker-compose-env-file envfile --aws-profile "" \
-          --tags ${STACK_NAME},${IMAGE_TAG},${BRANCH_TAG}
+          --tags ${STACK_NAME},${needs.create-image-tag.output.image_tag},${BRANCH_TAG}
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -42,8 +42,7 @@ jobs:
           - wmg_processing
           - cellguide_pipeline
     runs-on: ubuntu-22.04
-    outputs:
-      image_tag: ${{ steps.push_images.outputs.image_tag }}
+    needs: create-image-tag
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -64,13 +63,15 @@ jobs:
           happy_version: "0.110.1"
       - name: Push images
         id: push_images
+        env:
+          IMAGE_TAG: ${{ needs.create-image-tag.outputs.image_tag }}
         run: |
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
           echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
           export BRANCH_TAG=branch-$(echo ${GITHUB_REF_NAME} | sed 's/[\+\/]/-/g')
           happy push devstack --env dev --slice ${{ matrix.image }} \
           --docker-compose-env-file envfile --aws-profile "" \
-          --tags ${STACK_NAME},${needs.create-image-tag.output.image_tag},${BRANCH_TAG}
+          --tags ${STACK_NAME},${IMAGE_TAG},${BRANCH_TAG}
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -56,8 +56,8 @@ jobs:
           echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
           echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
           export IMAGE_TAG=sha-${GITHUB_SHA:0:7}
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-          echo "IMAGE_TAG=${IMAGE_TAG}"
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "image_tag=${IMAGE_TAG}"
           export BRANCH_TAG=branch-$(echo ${GITHUB_REF_NAME} | sed 's/[\+\/]/-/g')
           happy push devstack --env dev --slice ${{ matrix.image }} \
           --docker-compose-env-file envfile --aws-profile "" \

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,71 @@
+name: rdev build-images
+
+on:
+  workflow_call:
+    outputs:
+      iamge_tag:
+        description: "the image tag to be pushed"
+        value: ${{ jobs.build_images.outputs.image_tag }}
+env:
+  # Force using BuildKit instead of normal Docker, required so that metadata
+  # is written/read to allow us to use layers of previous builds as cache.
+  DOCKER_BUILDKIT: 1
+  COMPOSE_DOCKER_CLI_BUILD: 1
+  DOCKER_REPO: ${{ secrets.ECR_REPO }}/
+  STACK_NAME: pr-${{ github.event.number }}
+
+permissions:
+  id-token: write
+
+jobs:
+  build_images:
+    strategy:
+      matrix:
+        image:
+          - frontend # pushed both the frontend and backend images
+          - upload_failures
+          - upload_success
+          - dataset_submissions
+          - processing
+          - wmg_processing
+          - cellguide_pipeline
+    runs-on: ubuntu-22.04
+    outputs:
+      image_tag: ${{ steps.push_images.outputs.image_tag }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Login to ECR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.ECR_REPO }}
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Install happy
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
+        with:
+          happy_version: "0.110.1"
+      - name: Push images
+        id: push_images
+        run: |
+          echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
+          echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
+          export IMAGE_TAG=sha-${GITHUB_SHA:0:7}
+          export BRANCH_TAG=branch-$(echo ${GITHUB_REF_NAME} | sed 's/[\+\/]/-/g')
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          happy push devstack --env dev --slice ${{ matrix.image }} \
+          --docker-compose-env-file envfile --aws-profile "" \
+          --tags ${STACK_NAME},${IMAGE_TAG},${BRANCH_TAG}
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,eventName,workflow,job,mention
+          mention: "here"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure() && (env.GITHUB_BRANCH == 'refs/heads/main' || env.GITHUB_BRANCH == 'refs/heads/staging' || env.GITHUB_BRANCH == 'refs/heads/prod')

--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -23,49 +23,10 @@ permissions:
   contents: read
 
 jobs:
-  build_push_images:
-    strategy:
-      matrix:
-        image:
-          - frontend # pushed both the frontend and backend images
-          - upload_failures
-          - upload_success
-          - dataset_submissions
-          - processing
-          - wmg_processing
-          - cellguide_pipeline
-    runs-on: ubuntu-22.04
-    outputs:
-      image_tag: ${{ steps.push_images.outputs.image_tag }}
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1800
-      - name: Login to ECR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.ECR_REPO }}
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
-        with:
-          happy_version: "0.92.0"
-      - name: Push images
-        id: push_images
-        run: |
-          echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
-          echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
-          export IMAGE_TAG=sha-${GITHUB_SHA:0:7}
-          export BRANCH_TAG=branch-$(echo ${GITHUB_REF_NAME} | sed 's/[\+\/]/-/g')
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-          happy push devstack --env dev --slice ${{ matrix.image }} \
-          --docker-compose-env-file envfile --aws-profile "" \
-          --tags ${STACK_NAME},${IMAGE_TAG},${BRANCH_TAG}
+  build_images:
+    uses: ./.github/workflows/build-images.yml
+    secrets: inherit
+    needs: get_previous_image_digests
 
   summarize:
     runs-on: ubuntu-22.04

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -61,12 +61,12 @@ jobs:
   build_images:
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
-    needs: get_previous_image_digests
 
   deploy-rdev:
     runs-on: ubuntu-22.04
     needs:
       - build_images
+      - get_previous_image_digests
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -59,50 +59,9 @@ jobs:
           echo "IMAGE_DIGESTS=${IMAGE_DIGESTS[@]}" >> $GITHUB_OUTPUT
 
   build_images:
-    strategy:
-      matrix:
-        image:
-          - frontend # pushed both the frontend and backend images
-          - upload_failures
-          - upload_success
-          - dataset_submissions
-          - processing
-          - wmg_processing
-          - cellguide_pipeline
-    runs-on: ubuntu-22.04
-    needs:
-      - get_previous_image_digests
-    outputs:
-      image_tag: ${{ steps.push_images.outputs.image_tag }}
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1800
-      - name: Login to ECR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.ECR_REPO }}
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
-        with:
-          happy_version: "0.110.1"
-      - name: Push images
-        id: push_images
-        run: |
-          echo "HAPPY_COMMIT=$(git rev-parse --verify HEAD)" >> envfile
-          echo "HAPPY_BRANCH=$(git branch --show-current)" >> envfile
-          export IMAGE_TAG=sha-${GITHUB_SHA:0:7}
-          export BRANCH_TAG=branch-$(echo ${GITHUB_REF_NAME} | sed 's/[\+\/]/-/g')
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-          happy push devstack --env dev --slice ${{ matrix.image }} \
-          --docker-compose-env-file envfile --aws-profile "" \
-          --tags ${STACK_NAME},${IMAGE_TAG},${BRANCH_TAG}
+    uses: ./.github/workflows/build-images.yml
+    secrets: inherit
+    needs: get_previous_image_digests
 
   deploy-rdev:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Reason for Change

Make building docker images DRY for easier to maintain.

## Changes

- add build-images.yml to build docker images
- call build-images.yml in areas where building docker images is required

## Testing steps

- testing in rdev

