### PR TITLE
feat: add cellguide descriptions to fmg sidebar panel

### DIFF
--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -198,7 +198,6 @@ jobs:
       run:
         working-directory: frontend
     needs:
-      - seed-wmg-cellguide-rdev
       - seed-database-e2e-tests
     steps:
       - uses: actions/setup-node@v2

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -16,8 +16,6 @@ jobs:
   functional-test:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    needs:
-      - seed-wmg-cellguide-rdev
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -36,29 +34,6 @@ jobs:
         run: |
           pip3 install -r tests/functional/requirements.txt
           DEPLOYMENT_STAGE=rdev STACK_NAME=${{ env.STACK_NAME }} make functional-test
-
-  seed-wmg-cellguide-rdev:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1800
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-
-      - name: Grant Execute Permission to Bash Script
-        run: |
-          chmod +x ./scripts/populate_rdev_with_cellguide_data.sh ./scripts/populate_rdev_with_wmg_data.sh
-
-      - name: Seed cell guide data
-        run: |
-          ./scripts/populate_rdev_with_cellguide_data.sh ${{ env.STACK_NAME }}
-      - name: Seed WMG data
-        run: |
-          ./scripts/populate_rdev_with_wmg_data.sh ${{ env.STACK_NAME }}
 
   seed-database-e2e-tests:
     runs-on: ubuntu-22.04
@@ -80,7 +55,6 @@ jobs:
 
   run-e2e-tests:
     needs:
-      - seed-wmg-cellguide-rdev
       - seed-database-e2e-tests
     timeout-minutes: 30
     name: e2e-tests ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -60,6 +60,29 @@ jobs:
       group: pr-${{ github.event.number }}-build
       cancel-in-progress: true
 
+  seed-wmg-cellguide-rdev:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Grant Execute Permission to Bash Script
+        run: |
+          chmod +x ./scripts/populate_rdev_with_cellguide_data.sh ./scripts/populate_rdev_with_wmg_data.sh
+
+      - name: Seed cell guide data
+        run: |
+          ./scripts/populate_rdev_with_cellguide_data.sh ${{ env.STACK_NAME }}
+      - name: Seed WMG data
+        run: |
+          ./scripts/populate_rdev_with_wmg_data.sh ${{ env.STACK_NAME }}
+
   deploy-rdev:
     runs-on: ubuntu-22.04
     concurrency:
@@ -68,6 +91,7 @@ jobs:
     needs:
       - build_images
       - get_previous_image_digests
+      - seed-wmg-cellguide-rdev
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/Description/index.tsx
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/Description/index.tsx
@@ -58,7 +58,7 @@ interface DescriptionProps {
   cellTypeName: string;
   cellTypeId: string;
   skinnyMode: boolean;
-  setTooltipContent: Dispatch<
+  setTooltipContent?: Dispatch<
     SetStateAction<{
       title: string;
       element: JSX.Element;
@@ -209,6 +209,7 @@ export default function Description({
           }}
           onClick={() => {
             skinnyMode &&
+              setTooltipContent &&
               setTooltipContent({
                 title: "ChatGPT Descriptions",
                 element: tooltipContent,
@@ -216,10 +217,11 @@ export default function Description({
           }}
           // only setting mobile Tooltip View on touch and not click
           onTouchEnd={() => {
-            setTooltipContent({
-              title: "ChatGPT Descriptions",
-              element: tooltipContent,
-            });
+            setTooltipContent &&
+              setTooltipContent({
+                title: "ChatGPT Descriptions",
+                element: tooltipContent,
+              });
           }}
         >
           <StyledIconImage src={questionMarkIcon} />

--- a/frontend/src/views/WheresMyGeneV2/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/CellInfoSideBar/index.tsx
@@ -59,6 +59,7 @@ import {
   DivTableHead,
   DivTableRow,
 } from "../../common/styles";
+import Description from "src/views/CellGuide/components/CellGuideCard/components/Description";
 
 function CellInfoSideBar({
   cellInfoCellType,
@@ -103,6 +104,12 @@ function CellInfoSideBar({
       >
         {MARKER_SCORE_CELLGUIDE_LINK_TEXT}
       </Link>
+      <Description
+        cellTypeId={cellInfoCellType.cellType.id}
+        cellTypeName={cellInfoCellType.cellType.name}
+        skinnyMode={true}
+        inSideBar
+      />
       <ButtonContainer>
         <ButtonWrapper>
           <StyledMarkerGeneHeader>{MARKER_GENE_LABEL}</StyledMarkerGeneHeader>

--- a/frontend/src/views/WheresMyGeneV2/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/CellInfoSideBar/index.tsx
@@ -92,6 +92,12 @@ function CellInfoSideBar({
   return (
     <>
       <TissueName>{tissueInfo.name}</TissueName>
+      <Description
+        cellTypeId={cellInfoCellType.cellType.id}
+        cellTypeName={cellInfoCellType.cellType.name}
+        skinnyMode={true}
+        inSideBar
+      />
       <Link
         href={`${ROUTES.CELL_GUIDE}/${cellInfoCellType.cellType.id}`}
         onClick={() =>
@@ -104,12 +110,7 @@ function CellInfoSideBar({
       >
         {MARKER_SCORE_CELLGUIDE_LINK_TEXT}
       </Link>
-      <Description
-        cellTypeId={cellInfoCellType.cellType.id}
-        cellTypeName={cellInfoCellType.cellType.name}
-        skinnyMode={true}
-        inSideBar
-      />
+
       <ButtonContainer>
         <ButtonWrapper>
           <StyledMarkerGeneHeader>{MARKER_GENE_LABEL}</StyledMarkerGeneHeader>

--- a/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
@@ -53,6 +53,7 @@ import {
   SPECIFICITY_TOOLTIP_CONTENT_SECOND_HALF,
   SPECIFICITY_TOOLTIP_TEST_ID,
 } from "src/common/constants/markerGenes";
+import { CELL_GUIDE_CARD_GPT_DESCRIPTION } from "src/views/CellGuide/components/CellGuideCard/components/Description/constants";
 
 const HOMO_SAPIENS_TERM_ID = "NCBITaxon:9606";
 
@@ -333,6 +334,18 @@ describe("Where's My Gene", () => {
       const geneLabels = await getGeneNames(page);
       const numGenes = geneLabels.length;
       expect(numGenes).toBeGreaterThan(0);
+    });
+
+    test("Marker gene panel displays cell type description", async ({
+      page,
+    }) => {
+      await goToWMG(page);
+
+      await expandTissue(page, "lung");
+
+      await getCellTypeFmgButtonAndClick(page, "memory B cell");
+
+      await waitForElement(page, CELL_GUIDE_CARD_GPT_DESCRIPTION);
     });
 
     // need to find a tissue, cell type with no marker genes


### PR DESCRIPTION
## Reason for Change

- #6133

## Changes

- added cellguide descriptions to marker gene panel. this component mirrors what is shown in the cellguide sidebar that pops up when you click on a cell type in the ontology tree.
- updated gha workflow to seed data before rdev deployment

<img width="838" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/16548075/bafd96e2-51ae-4bd0-a37a-d19e0ebbe595">

## Testing steps

- E2E test added
- tested locally
- tested in rdev
