### PR TITLE
chore: Remove suffix logic for tissue term Ids that don't exist in schema-4

### DIFF
--- a/backend/wmg/data/ontology_labels.py
+++ b/backend/wmg/data/ontology_labels.py
@@ -17,8 +17,6 @@ genes_files = [
     "genes_mus_musculus.csv.gz",
 ]
 
-SUFFIXES_TO_STRIP = ["organoid", "cell culture"]
-
 
 def ontology_term_label(ontology_term_id: str) -> Optional[str]:
     """
@@ -27,21 +25,7 @@ def ontology_term_label(ontology_term_id: str) -> Optional[str]:
     """
     global ontology_term_id_labels
 
-    # this catches the organoid tissue edge case (e.g. UBERON:0000995 (organoid)) or the cell culture edge case
-    # (e.g. CL:0000082 (cell culture))
-    suffix_to_strip = None
-    for suffix in SUFFIXES_TO_STRIP:
-        if suffix in ontology_term_id:
-            suffix_to_strip = suffix
-            break
-
-    if suffix_to_strip:
-        ontology_term_id = ontology_term_id.split(f"({suffix_to_strip})")[0].strip()
-    ontology_term_id_label = ontology_term_id_labels.get(ontology_term_id)
-    if suffix_to_strip:
-        ontology_term_id_label = ontology_term_id_label + f" ({suffix_to_strip})"
-
-    return ontology_term_id_label
+    return ontology_term_id_labels.get(ontology_term_id)
 
 
 def gene_term_label(gene_ontology_term_id: str) -> Optional[str]:

--- a/tests/unit/wmg_processing/test_ontology_labels.py
+++ b/tests/unit/wmg_processing/test_ontology_labels.py
@@ -18,8 +18,6 @@ class OntologyLabelTests(unittest.TestCase):
             "MmusDv:0000000": "mouse life cycle stage",
             "MONDO:0000001": "disease",
             "UBERON:0002539": "pharyngeal arch",
-            "UBERON:0000995 (organoid)": "uterus (organoid)",
-            "CL:0000082 (cell culture)": "epithelial cell of lung (cell culture)",
         }
         for ontology_term_id, expected_ontology_term_label in test_cases.items():
             with self.subTest(ontology_term_id):


### PR DESCRIPTION
## Reason for Change

For schema-4 tissue term IDs with suffixes like `(orgonoid)` are invalid. Therefore, this PR removes the handling of such term IDs when determining the term label associated with a given tissue term ID.

https://github.com/chanzuckerberg/single-cell/issues/525

## Changes

- modify `ontology_term_label()` by removing the suffix logic and updating unit tests.

## Testing steps

- Passing unit tests

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
