### PR TITLE
fix: re-add repository dispatch when triggering deployment

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - prod
+  repository_dispatch:
+    types: [build-images-for-staging, build-images-for-prod]
   workflow_call:
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata

--- a/.github/workflows/promote-staging-to-prod.yml
+++ b/.github/workflows/promote-staging-to-prod.yml
@@ -16,6 +16,13 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           ./scripts/promote_staging_to_prod.sh ${{ secrets.GITHUB_TOKEN }}
+      - name: Trigger repository_dispatch to build images for staging
+        if: success()
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: build-images-for-prod
+          client-payload: '{"ref": "refs/heads/prod"}'
       - name: Send slack notification with @sc-on-call tag if staging not merged into prod
         if: failure()
         uses: 8398a7/action-slack@v3
@@ -26,8 +33,3 @@ jobs:
           if_mention: "always"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-
-  build_images_and_create_deployment:
-    needs: merge_staging_to_prod
-    uses: chanzuckerberg/single-cell-data-portal/.github/workflows/build-images-and-create-deployment.yml@prod
-    secrets: inherit

--- a/.github/workflows/trigger-release-candidate-build-and-deploy.yml
+++ b/.github/workflows/trigger-release-candidate-build-and-deploy.yml
@@ -40,7 +40,13 @@ jobs:
           git merge --verbose main -m "Merging main branch into staging branch"
 
           git push origin staging
-
+      - name: Trigger repository_dispatch to build images for staging
+        if: success()
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: build-images-for-staging
+          client-payload: '{"ref": "refs/heads/staging"}'
       - name: Send slack notification if main not merged into staging
         if: failure()
         uses: 8398a7/action-slack@v3
@@ -50,8 +56,3 @@ jobs:
           mention: "here"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-
-  build_images_and_create_deployment:
-    needs: deploy_to_stage_env_on_test_pass_on_main
-    uses: chanzuckerberg/single-cell-data-portal/.github/workflows/build-images-and-create-deployment.yml@staging
-    secrets: inherit


### PR DESCRIPTION
## Reason for Change

- #5482
- Reusable workflow implementation not working with staging / prod deploys, reverting to repository dispatch implementation since there is only a relatively small advantage of reusable workflow approach (keeps gha logs for triggering a deployment in two actions rather than split across three)

## Changes

- Use repository dispatch rather than reusable workflow to deploy to staging / prod