### PR TITLE
chore: remove Datadog tracing from frontend

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -20,8 +20,6 @@ const HUBSPOT_FORMS_URL = "https://forms.hsforms.com";
 
 const CROSS_REF_URL = "https://api.crossref.org";
 
-const DATADOG_URL = "browser-intake-datadoghq.com";
-
 const GOOGLE_FONTS_URL = "https://fonts.gstatic.com";
 
 const SCRIPT_SRC = [
@@ -47,7 +45,6 @@ const defaultSecureHeaders = {
         configs.CELLGUIDE_DATA_URL,
         configs.CENSUS_MODELS_DATA_URL,
         CROSS_REF_URL,
-        DATADOG_URL,
         GOOGLE_FONTS_URL,
       ],
       defaultSrc: ["'self'", HUBSPOT_FORMS_URL],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,6 @@
         "@blueprintjs/select": "^4.9.24",
         "@czi-sds/components": "^18.1.2",
         "@czi-sds/data-viz": "^0.3.0",
-        "@datadog/browser-rum": "^5.1.0",
         "@emotion/css": "^11.11.2",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
@@ -1530,36 +1529,6 @@
         "lodash": "^4.17.21",
         "react": ">=17.0.1",
         "react-dom": ">=17.0.1"
-      }
-    },
-    "node_modules/@datadog/browser-core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-5.1.0.tgz",
-      "integrity": "sha512-KZMLXcJqA59TiXF4nFEaUEE23LhflxvLhv4LfGyhH9DIX7Be3bCJqrEyXajZHXYQiXUoZSsImC20w1d6kSf+KA=="
-    },
-    "node_modules/@datadog/browser-rum": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-5.1.0.tgz",
-      "integrity": "sha512-bmHg6ObcusctOqi3e0VVroxz6h6SKK627gAfijB3dcVZ+T2dEmRJaht19DUekf1T0iPWh3K43pBWn4eEWLUGew==",
-      "dependencies": {
-        "@datadog/browser-core": "5.1.0",
-        "@datadog/browser-rum-core": "5.1.0"
-      },
-      "peerDependencies": {
-        "@datadog/browser-logs": "5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@datadog/browser-logs": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@datadog/browser-rum-core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-5.1.0.tgz",
-      "integrity": "sha512-2i3rx1iJlL52sQgYKQLX5IIQpQy69nk1vk4VTQzaJ/ubUip3nV3sc6oj/UfOMYEVokQGd2AvNAqd3mA1x3JUvw==",
-      "dependencies": {
-        "@datadog/browser-core": "5.1.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -17296,28 +17265,6 @@
       "requires": {
         "echarts": "^5.4.2",
         "lodash": "^4.17.21"
-      }
-    },
-    "@datadog/browser-core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-5.1.0.tgz",
-      "integrity": "sha512-KZMLXcJqA59TiXF4nFEaUEE23LhflxvLhv4LfGyhH9DIX7Be3bCJqrEyXajZHXYQiXUoZSsImC20w1d6kSf+KA=="
-    },
-    "@datadog/browser-rum": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-5.1.0.tgz",
-      "integrity": "sha512-bmHg6ObcusctOqi3e0VVroxz6h6SKK627gAfijB3dcVZ+T2dEmRJaht19DUekf1T0iPWh3K43pBWn4eEWLUGew==",
-      "requires": {
-        "@datadog/browser-core": "5.1.0",
-        "@datadog/browser-rum-core": "5.1.0"
-      }
-    },
-    "@datadog/browser-rum-core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-5.1.0.tgz",
-      "integrity": "sha512-2i3rx1iJlL52sQgYKQLX5IIQpQy69nk1vk4VTQzaJ/ubUip3nV3sc6oj/UfOMYEVokQGd2AvNAqd3mA1x3JUvw==",
-      "requires": {
-        "@datadog/browser-core": "5.1.0"
       }
     },
     "@emotion/babel-plugin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
     "@blueprintjs/select": "^4.9.24",
     "@czi-sds/components": "^18.1.2",
     "@czi-sds/data-viz": "^0.3.0",
-    "@datadog/browser-rum": "^5.1.0",
     "@emotion/css": "^11.11.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,6 +1,5 @@
 import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
-import { datadogRum } from "@datadog/browser-rum";
 import { NextPage } from "next";
 import { AppProps } from "next/app";
 import Head from "next/head";
@@ -41,20 +40,6 @@ type NextPageWithLayout = NextPage & {
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
 };
-
-datadogRum.init({
-  applicationId: "44f77ca2-1482-404a-ad38-23499bb925e5",
-  clientToken: "pub55d4baaac2091f9656a83da732732a89",
-  site: "datadoghq.com",
-  service: "single-cell-data-portal",
-  env: process.env.NODE_ENV,
-  sessionSampleRate: 100,
-  sessionReplaySampleRate: 20,
-  trackUserInteractions: true,
-  trackResources: true,
-  trackLongTasks: true,
-  defaultPrivacyLevel: "mask-user-input",
-});
 
 function App({ Component, pageProps }: AppPropsWithLayout): JSX.Element {
   const Layout = Component.Layout || DefaultLayout;


### PR DESCRIPTION
## Reason for Change

- #6555 

## Changes

For posterity:

- this reverses the changes made on the frontend for Datadog in this [PR](https://github.com/chanzuckerberg/single-cell-data-portal/pull/6140)
- this [PR](https://github.com/chanzuckerberg/single-cell-data-portal/pull/6217) (that was never merged) shows the steps it takes to combine RUM (frontend user monitoring) with Traces (backend tracing)

