### PR TITLE
feat: remove redundant code for dealing with root CL terms

### DIFF
--- a/backend/wmg/pipeline/cell_type_ordering.py
+++ b/backend/wmg/pipeline/cell_type_ordering.py
@@ -121,11 +121,7 @@ def _cell_type_ordering_compute(cells: Set[str], root: str) -> pd.DataFrame:
         if node in cells:
             cells.remove(node)
             yield cell_entity(node, depth)
-
-            # Make the root and other high level cell types stay at 0 level. Avoids creating
-            # a situation where only the root is at lowest level
-            if node not in ["CL:0000003", "CL:0000255", "CL:0000548"]:
-                depth += 1
+            depth += 1
 
         children = [
             (c, positions[c.id]) for c in onto[node].subclasses(with_self=False, distance=1) if c.id in ancestor_ids

--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -511,14 +511,6 @@ export interface CellTypeByTissueName {
   [tissueName: string]: CellTypeRow[];
 }
 
-// Cell types that we want to exclude from each tissue
-
-const FILTERED_CELL_TYPE_ONTOLOGY_IDS = [
-  "CL:0000003", // Native cell
-  "CL:0000255", // Eukaryotic cell
-  "CL:0000548", // Animal cell
-];
-
 export function useCellTypesByTissueName(version: 1 | 2 = 2): {
   isLoading: boolean;
   data: CellTypeByTissueName;
@@ -559,9 +551,6 @@ export function useCellTypesByTissueName(version: 1 | 2 = 2): {
         // (thuang): Reverse the order, so the first cell type is at the top of
         // the heat map
         .reverse()
-        .filter(([_, cellTypeRow]) => {
-          return !FILTERED_CELL_TYPE_ONTOLOGY_IDS.includes(cellTypeRow.id);
-        })
         .map(([_, cellTypeName]) => {
           return cellTypeName;
         });


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell/527

## Changes

removes the named frontend + backend code that explicitly filters out root CL terms

## Testing steps

no-op on list of tissues on gene expression and tissue filter dropdown

![Screenshot 2024-01-22 at 2 10 37 PM](https://github.com/chanzuckerberg/single-cell-data-portal/assets/5653616/09a24a71-9380-4769-b26c-8133fc56ef9d)
![Screenshot 2024-01-22 at 2 10 47 PM](https://github.com/chanzuckerberg/single-cell-data-portal/assets/5653616/a8636e2b-cb74-451f-8f4e-1f1478316657)

## Checklist 🛎️

- [n/a] Add product, design, and eng as reviewers for rdev review
- [x] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [n/a] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
