### PR TITLE
feat: Update copy for scale constraints

### DIFF
--- a/frontend/doc-site/032__Contribute and Publish Data.mdx
+++ b/frontend/doc-site/032__Contribute and Publish Data.mdx
@@ -25,7 +25,7 @@ CELLxGENE is focused on supporting the global community attempting to create ref
 
 ### Scale Constraints
 
-CELLxGENE Discover sets the maximum dataset size for uploads to 50GB. This is enforced in the UX by a property in the [Dropbox Chooser](https://github.com/chanzuckerberg/single-cell-data-portal/blob/75c648e8b277d23c4ff0fe198754e660dfd981d9/frontend/src/components/DropboxChooser/index.tsx#L29). There is pending discovery to support larger dataset sizes. Additionally, CELLxGENE Explorer sets the maximum number of cells to 4.6 million for exploration of datasets. See [Disable exploration of datasets larger than 2 million cells](https://github.com/chanzuckerberg/single-cell-data-portal/issues/1538).
+CELLxGENE Discover sets the maximum dataset size for submissions to 50GB. Additionally, CELLxGENE Explorer sets the maximum number of cells to 4.6 million for exploration of datasets.
 
 ### Formatting Requirements
 

--- a/frontend/doc-site/032__Contribute and Publish Data.mdx
+++ b/frontend/doc-site/032__Contribute and Publish Data.mdx
@@ -23,6 +23,11 @@ CELLxGENE is focused on supporting the global community attempting to create ref
 - cell lines
 - organisms other than mouse or human
 
+### Scale Requirements
+
+- CELLxGENE Discover sets the maximum dataset size for uploads to 30GB. This is enforced in the UX by a property in the [Dropbox Chooser](https://github.com/chanzuckerberg/single-cell-data-portal/blob/75c648e8b277d23c4ff0fe198754e660dfd981d9/frontend/src/components/DropboxChooser/index.tsx#L29). There is pending discovery to support larger dataset sizes.
+- CELLxGENE Explorer sets the maximum number of cells to 4.6 million for exploration of datasets. See [Disable exploration of datasets larger than 2 million cells](https://github.com/chanzuckerberg/single-cell-data-portal/issues/1538).
+
 ### Formatting Requirements
 
 We need the following collection metadata (i.e. details associated with your publication or study)

--- a/frontend/doc-site/032__Contribute and Publish Data.mdx
+++ b/frontend/doc-site/032__Contribute and Publish Data.mdx
@@ -23,10 +23,9 @@ CELLxGENE is focused on supporting the global community attempting to create ref
 - cell lines
 - organisms other than mouse or human
 
-### Scale Requirements
+### Scale Constraints
 
-- CELLxGENE Discover sets the maximum dataset size for uploads to 30GB. This is enforced in the UX by a property in the [Dropbox Chooser](https://github.com/chanzuckerberg/single-cell-data-portal/blob/75c648e8b277d23c4ff0fe198754e660dfd981d9/frontend/src/components/DropboxChooser/index.tsx#L29). There is pending discovery to support larger dataset sizes.
-- CELLxGENE Explorer sets the maximum number of cells to 4.6 million for exploration of datasets. See [Disable exploration of datasets larger than 2 million cells](https://github.com/chanzuckerberg/single-cell-data-portal/issues/1538).
+CELLxGENE Discover sets the maximum dataset size for uploads to 30GB. This is enforced in the UX by a property in the [Dropbox Chooser](https://github.com/chanzuckerberg/single-cell-data-portal/blob/75c648e8b277d23c4ff0fe198754e660dfd981d9/frontend/src/components/DropboxChooser/index.tsx#L29). There is pending discovery to support larger dataset sizes. Additionally, CELLxGENE Explorer sets the maximum number of cells to 4.6 million for exploration of datasets. See [Disable exploration of datasets larger than 2 million cells](https://github.com/chanzuckerberg/single-cell-data-portal/issues/1538).
 
 ### Formatting Requirements
 

--- a/frontend/doc-site/032__Contribute and Publish Data.mdx
+++ b/frontend/doc-site/032__Contribute and Publish Data.mdx
@@ -25,7 +25,7 @@ CELLxGENE is focused on supporting the global community attempting to create ref
 
 ### Scale Constraints
 
-CELLxGENE Discover sets the maximum dataset size for uploads to 30GB. This is enforced in the UX by a property in the [Dropbox Chooser](https://github.com/chanzuckerberg/single-cell-data-portal/blob/75c648e8b277d23c4ff0fe198754e660dfd981d9/frontend/src/components/DropboxChooser/index.tsx#L29). There is pending discovery to support larger dataset sizes. Additionally, CELLxGENE Explorer sets the maximum number of cells to 4.6 million for exploration of datasets. See [Disable exploration of datasets larger than 2 million cells](https://github.com/chanzuckerberg/single-cell-data-portal/issues/1538).
+CELLxGENE Discover sets the maximum dataset size for uploads to 50GB. This is enforced in the UX by a property in the [Dropbox Chooser](https://github.com/chanzuckerberg/single-cell-data-portal/blob/75c648e8b277d23c4ff0fe198754e660dfd981d9/frontend/src/components/DropboxChooser/index.tsx#L29). There is pending discovery to support larger dataset sizes. Additionally, CELLxGENE Explorer sets the maximum number of cells to 4.6 million for exploration of datasets. See [Disable exploration of datasets larger than 2 million cells](https://github.com/chanzuckerberg/single-cell-data-portal/issues/1538).
 
 ### Formatting Requirements
 


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/3685

## Changes

Adds the proposed copy changes, with a few minor tweaks:
- Sets the maximum dataset size to 30GB instead of 50GB, since that is what the [code](https://github.com/chanzuckerberg/single-cell-data-portal/blob/75c648e8b277d23c4ff0fe198754e660dfd981d9/frontend/src/components/DropboxChooser/index.tsx#L29) appears to say
- Removes "in 2023" since we're doing this after 2023

## Testing steps

<img width="677" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/5653616/55121e47-fb9e-483c-b694-7d79b6040e5d">

## Checklist 🛎️

- [x] Add product, design, and eng as reviewers for rdev review
- [x] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [n/a] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
