### PR TITLE
fix: await gpt description generation

### DIFF
--- a/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
@@ -452,7 +452,7 @@ describe("Where's My Gene", () => {
       );
     });
 
-    test(`Should verify effect size and specificity column`, async ({
+    test.only(`Should verify effect size and specificity column`, async ({
       page,
     }) => {
       await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);

--- a/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
@@ -465,6 +465,10 @@ describe("Where's My Gene", () => {
         .getByTestId("cell-type-info-button-adipose tissue-contractile cell")
         .click();
 
+      // GPT description can take longer to generate, so we want to wait for this to load
+      // before doing anything else in the marker genes table
+      await isElementVisible(page, CELL_GUIDE_CARD_GPT_DESCRIPTION);
+
       // Verify effect size header and tooltip
       const effectSizeHeader = (await page
         .getByTestId(EFFECT_SIZE_HEADER_ID)

--- a/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
+++ b/frontend/tests/features/wheresMyGene/wheresMyGene.test.ts
@@ -452,7 +452,7 @@ describe("Where's My Gene", () => {
       );
     });
 
-    test.only(`Should verify effect size and specificity column`, async ({
+    test(`Should verify effect size and specificity column`, async ({
       page,
     }) => {
       await goToPage(`${TEST_URL}${ROUTES.WHERE_IS_MY_GENE}`, page);


### PR DESCRIPTION
## Reason for Change

this e2e test for verifying the copy of the effect size + specificity tooltip started to fail after merging a seemingly unrelated PR: https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/7630357037/job/20787018226

looking at the playwright trace, i believe the failure is due to a race condition of:
- we hover onto the tooltip
- gpt description loads, pushing the tooltip further down the page
- we aren't able to find the tooltip

## Changes

updates this e2e test to wait for the GPT description element to load before doing anything else with the marker genes table in the test

## Testing steps

i ran this locally with `npm run e2e -- -- tests/features/wheresMyGene/wheresMyGene.test.ts` and it passed, but since the test passed locally but not in the staging deploy, hard to know for sure until we merge it.

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions

## Notes for Reviewer
