### PR TITLE
feat: order-datasets DP API endpoint

### DIFF
--- a/backend/database/versions/05_67c4015bce73_add_custom_dataset_order.py
+++ b/backend/database/versions/05_67c4015bce73_add_custom_dataset_order.py
@@ -5,6 +5,7 @@ Revises: 04_2f30f3bcc9aa
 Create Date: 2024-01-25 11:42:46.126701
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -18,7 +19,7 @@ depends_on = None
 def upgrade():
     op.add_column(
         "CollectionVersion",
-        sa.Column("custom_dataset_order", sa.BOOLEAN(), nullable=False, server_default=sa.sql.expression.false()),
+        sa.Column("custom_dataset_order", sa.BOOLEAN(), nullable=True, server_default=sa.sql.expression.false()),
         schema="persistence_schema",
     )
 

--- a/backend/database/versions/05_67c4015bce73_add_custom_dataset_order.py
+++ b/backend/database/versions/05_67c4015bce73_add_custom_dataset_order.py
@@ -1,4 +1,4 @@
-"""add datasets custom ordered to collection version
+"""add custom dataset order
 
 Revision ID: 05_67c4015bce73
 Revises: 04_2f30f3bcc9aa
@@ -18,10 +18,10 @@ depends_on = None
 def upgrade():
     op.add_column(
         "CollectionVersion",
-        sa.Column("datasets_custom_ordered", sa.Boolean(), nullable=False, server_default=sa.sql.expression.false()),
+        sa.Column("custom_dataset_order", sa.BOOLEAN(), nullable=False, server_default=sa.sql.expression.false()),
         schema="persistence_schema",
     )
 
 
 def downgrade():
-    op.drop_column("CollectionVersion", "datasets_custom_ordered", schema="persistence_schema")
+    op.drop_column("CollectionVersion", "custom_dataset_order", schema="persistence_schema")

--- a/backend/database/versions/05_67c4015bce73_add_custom_dataset_order.py
+++ b/backend/database/versions/05_67c4015bce73_add_custom_dataset_order.py
@@ -19,7 +19,7 @@ depends_on = None
 def upgrade():
     op.add_column(
         "CollectionVersion",
-        sa.Column("custom_dataset_order", sa.BOOLEAN(), nullable=True, server_default=sa.sql.expression.false()),
+        sa.Column("custom_dataset_order", sa.BOOLEAN(), nullable=True),
         schema="persistence_schema",
     )
 

--- a/backend/database/versions/05_67c4015bce73_add_custom_dataset_order.py
+++ b/backend/database/versions/05_67c4015bce73_add_custom_dataset_order.py
@@ -19,10 +19,10 @@ depends_on = None
 def upgrade():
     op.add_column(
         "CollectionVersion",
-        sa.Column("custom_dataset_order", sa.BOOLEAN(), nullable=True),
+        sa.Column("has_custom_dataset_order", sa.BOOLEAN(), nullable=True),
         schema="persistence_schema",
     )
 
 
 def downgrade():
-    op.drop_column("CollectionVersion", "custom_dataset_order", schema="persistence_schema")
+    op.drop_column("CollectionVersion", "has_custom_dataset_order", schema="persistence_schema")

--- a/backend/database/versions/05_67c4015bce73_add_datasets_custom_ordered_to_.py
+++ b/backend/database/versions/05_67c4015bce73_add_datasets_custom_ordered_to_.py
@@ -1,0 +1,27 @@
+"""add datasets custom ordered to collection version
+
+Revision ID: 05_67c4015bce73
+Revises: 04_2f30f3bcc9aa
+Create Date: 2024-01-25 11:42:46.126701
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "05_67c4015bce73"
+down_revision = "04_2f30f3bcc9aa"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "CollectionVersion",
+        sa.Column("datasets_custom_ordered", sa.Boolean(), nullable=False, server_default=sa.sql.expression.false()),
+        schema="persistence_schema",
+    )
+
+
+def downgrade():
+    op.drop_column("CollectionVersion", "datasets_custom_ordered", schema="persistence_schema")

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -604,6 +604,15 @@ class BusinessLogic(BusinessLogicInterface):
             raise DatasetIsPrivateException from None
         self.database_provider.delete_dataset_from_collection_version(collection_version_id, dataset_version_id)
 
+    def set_collection_version_datasets_order(
+        self, collection_version_id: CollectionVersionId, dataset_version_ids: List[DatasetVersionId]
+    ) -> None:
+        """
+        Sets the order of datasets in a collection version.
+        """
+        self._assert_collection_version_unpublished(collection_version_id)
+        self.database_provider.set_collection_version_datasets_order(collection_version_id, dataset_version_ids)
+
     def set_dataset_metadata(self, dataset_version_id: DatasetVersionId, metadata: DatasetMetadata) -> None:
         """
         Sets the metadata for a dataset version

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -277,7 +277,7 @@ class CollectionVersionBase:
     created_at: datetime
     schema_version: str
     canonical_collection: CanonicalCollection
-    datasets_custom_ordered: bool
+    custom_dataset_order: bool
 
     def is_published(self) -> bool:
         """

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -277,7 +277,7 @@ class CollectionVersionBase:
     created_at: datetime
     schema_version: str
     canonical_collection: CanonicalCollection
-    custom_dataset_order: bool
+    has_custom_dataset_order: bool
 
     def is_published(self) -> bool:
         """

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -277,6 +277,7 @@ class CollectionVersionBase:
     created_at: datetime
     schema_version: str
     canonical_collection: CanonicalCollection
+    datasets_custom_ordered: bool
 
     def is_published(self) -> bool:
         """

--- a/backend/layers/common/helpers.py
+++ b/backend/layers/common/helpers.py
@@ -76,3 +76,10 @@ def get_dataset_versions_with_published_at_and_collection_version_id(
             )
         )
     return published_datasets_for_collection
+
+
+def sort_datasets_by_cell_count(datasets: List[DatasetVersion]):
+    """
+    Applies the default sort order (cell count, descending) to the given list of datasets.
+    """
+    return sorted(datasets, key=lambda d: 0 if d.metadata is None else d.metadata.cell_count, reverse=True)

--- a/backend/layers/persistence/orm.py
+++ b/backend/layers/persistence/orm.py
@@ -12,7 +12,6 @@ mapper_registry = registry(metadata=metadata)
 
 @mapper_registry.mapped
 class CollectionTable:
-
     __tablename__ = "Collection"
 
     id = Column(UUID(as_uuid=True), primary_key=True)
@@ -24,7 +23,6 @@ class CollectionTable:
 
 @mapper_registry.mapped
 class CollectionVersionTable:
-
     __tablename__ = "CollectionVersion"
 
     id = Column(UUID(as_uuid=True), primary_key=True)
@@ -37,11 +35,11 @@ class CollectionVersionTable:
     created_at = Column(DateTime)
     schema_version = Column(String)
     datasets = Column(ARRAY(UUID(as_uuid=True)))
+    datasets_custom_ordered = Column(BOOLEAN)
 
 
 @mapper_registry.mapped
 class DatasetTable:
-
     __tablename__ = "Dataset"
 
     id = Column(UUID(as_uuid=True), primary_key=True)
@@ -52,7 +50,6 @@ class DatasetTable:
 
 @mapper_registry.mapped
 class DatasetVersionTable:
-
     __tablename__ = "DatasetVersion"
 
     id = Column(UUID(as_uuid=True), primary_key=True)
@@ -66,7 +63,6 @@ class DatasetVersionTable:
 
 @mapper_registry.mapped
 class DatasetArtifactTable:
-
     __tablename__ = "DatasetArtifact"
 
     id = Column(UUID(as_uuid=True), primary_key=True)

--- a/backend/layers/persistence/orm.py
+++ b/backend/layers/persistence/orm.py
@@ -35,7 +35,7 @@ class CollectionVersionTable:
     created_at = Column(DateTime)
     schema_version = Column(String)
     datasets = Column(ARRAY(UUID(as_uuid=True)))
-    datasets_custom_ordered = Column(BOOLEAN)
+    custom_dataset_order = Column(BOOLEAN)
 
 
 @mapper_registry.mapped

--- a/backend/layers/persistence/orm.py
+++ b/backend/layers/persistence/orm.py
@@ -35,7 +35,7 @@ class CollectionVersionTable:
     created_at = Column(DateTime)
     schema_version = Column(String)
     datasets = Column(ARRAY(UUID(as_uuid=True)))
-    custom_dataset_order = Column(BOOLEAN)
+    has_custom_dataset_order = Column(BOOLEAN)
 
 
 @mapper_registry.mapped

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -120,7 +120,7 @@ class DatabaseProvider(DatabaseProviderInterface):
     def _row_to_collection_version_with_datasets(
         self, row: Any, canonical_collection: CanonicalCollection, datasets: List[DatasetVersion]
     ) -> CollectionVersionWithDatasets:
-        with_datasets = self._sort_datasets(row, datasets)
+        sorted_datasets = self._sort_datasets(row, datasets)
         return CollectionVersionWithDatasets(
             collection_id=CollectionId(str(row.collection_id)),
             version_id=CollectionVersionId(str(row.id)),
@@ -128,7 +128,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             curator_name=row.curator_name,
             metadata=CollectionMetadata.from_json(row.collection_metadata),
             publisher_metadata=None if row.publisher_metadata is None else json.loads(row.publisher_metadata),
-            datasets=with_datasets,
+            datasets=sorted_datasets,
             published_at=row.published_at,
             created_at=row.created_at,
             schema_version=row.schema_version,
@@ -974,12 +974,12 @@ class DatabaseProvider(DatabaseProviderInterface):
         dataset_version_ids: List[DatasetVersionId],
     ) -> None:
         """
-        Update the datasets in a collection version to match the given order.
+        Updates the datasets in a collection version to match the given order.
         """
         with self._manage_session() as session:
             collection_version = session.query(CollectionVersionTable).filter_by(id=collection_version_id.id).one()
 
-            # Confirm collection version datasets length matches given dataset version IDs length
+            # Confirm collection version datasets length matches given dataset version IDs length.
             if len(collection_version.datasets) != len(dataset_version_ids):
                 raise ValueError(
                     f"Dataset version IDs length does not match collection version {collection_version_id} datasets length"

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -179,7 +179,9 @@ class DatabaseProvider(DatabaseProviderInterface):
         if row.datasets_custom_ordered:
             datasets_order = [DatasetVersionId(str(id)) for id in row.datasets]
             return sorted(datasets, key=lambda d: datasets_order.index(d.version_id))
-        return sorted(datasets, key=lambda d: d.metadata.cell_count, reverse=True)
+        return sorted(
+            datasets, key=lambda d: 0 if d is None or d.metadata is None else d.metadata.cell_count, reverse=True
+        )
 
     def _hydrate_dataset_version(self, dataset_version: DatasetVersionTable) -> DatasetVersion:
         """

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -114,7 +114,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             created_at=row.created_at,
             schema_version=row.schema_version,
             canonical_collection=canonical_collection,
-            custom_dataset_order=row.custom_dataset_order,
+            has_custom_dataset_order=row.has_custom_dataset_order,
         )
 
     def _row_to_collection_version_with_datasets(
@@ -133,7 +133,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             created_at=row.created_at,
             schema_version=row.schema_version,
             canonical_collection=canonical_collection,
-            custom_dataset_order=row.custom_dataset_order,
+            has_custom_dataset_order=row.has_custom_dataset_order,
         )
 
     def _row_to_canonical_dataset(self, row: Any):
@@ -176,7 +176,7 @@ class DatabaseProvider(DatabaseProviderInterface):
         Sorts datasets by the order they appear in the collection version's datasets array if custom
         order is enabled, otherwise sorts datasets by cell count.
         """
-        if row.custom_dataset_order:
+        if row.has_custom_dataset_order:
             datasets_order = [DatasetVersionId(str(id)) for id in row.datasets]
             return sorted(datasets, key=lambda d: datasets_order.index(d.version_id))
         return sort_datasets_by_cell_count(datasets)
@@ -239,7 +239,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             created_at=now,
             schema_version=None,
             datasets=list(),
-            custom_dataset_order=False,
+            has_custom_dataset_order=False,
         )
 
         with self._manage_session() as session:
@@ -533,7 +533,7 @@ class DatabaseProvider(DatabaseProviderInterface):
                 created_at=datetime.utcnow(),
                 schema_version=None,
                 datasets=current_version.datasets,
-                custom_dataset_order=current_version.custom_dataset_order,
+                has_custom_dataset_order=current_version.has_custom_dataset_order,
             )
             session.add(new_version)
             return CollectionVersionId(new_version_id)
@@ -990,7 +990,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             # Replace collection version datasets with given, ordered dataset version IDs and update custom ordered flag.
             updated_datasets = [uuid.UUID(dv_id.id) for dv_id in dataset_version_ids]
             collection_version.datasets = updated_datasets
-            collection_version.custom_dataset_order = True
+            collection_version.has_custom_dataset_order = True
 
     def get_dataset_mapped_version(
         self, dataset_id: DatasetId, get_tombstoned: bool = False

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -136,7 +136,7 @@ class DatabaseProviderInterface:
         self, version_id: CollectionVersionId, datasets: List[DatasetVersionId]
     ) -> None:
         """
-        Sets the datasets order for a collection version.
+        Sets the datasets order of a collection version.
         """
 
     def finalize_collection_version(

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -132,6 +132,13 @@ class DatabaseProviderInterface:
         Deletes DatasetVersionTable rows.
         """
 
+    def set_collection_version_datasets_order(
+        self, version_id: CollectionVersionId, datasets: List[DatasetVersionId]
+    ) -> None:
+        """
+        Sets the datasets order for a collection version.
+        """
+
     def finalize_collection_version(
         self,
         collection_id: CollectionId,

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -105,9 +105,10 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             # Replace 'datasets' array of Dataset version ids with 'datasets' array of actual Dataset versions
             copied_version.datasets = datasets_to_include
             # Order by cell count if not custom ordered.
-            copied_version.datasets.sort(
-                key=lambda d: 0 if d is None or d.metadata is None else d.metadata.cell_count, reverse=True
-            )
+            if not copied_version.datasets_custom_ordered:
+                copied_version.datasets.sort(
+                    key=lambda d: 0 if d is None or d.metadata is None else d.metadata.cell_count, reverse=True
+                )
             # Hack for business logic that uses isinstance
             copied_version.__class__ = CollectionVersionWithDatasets
         cc = self.collections.get(version.collection_id.id)

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -78,7 +78,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             schema_version=None,
             canonical_collection=canonical,
             datasets=[],
-            custom_dataset_order=False,
+            has_custom_dataset_order=False,
         )
         self.collections_versions[version_id.id] = version
         # Don't set mappings here - those will be set when publishing the collection!
@@ -106,7 +106,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             # Replace 'datasets' array of Dataset version ids with 'datasets' array of actual Dataset versions
             copied_version.datasets = datasets_to_include
             # Order by cell count if not custom ordered.
-            if not copied_version.custom_dataset_order:
+            if not copied_version.has_custom_dataset_order:
                 copied_version.datasets = sort_datasets_by_cell_count(copied_version.datasets)
             # Hack for business logic that uses isinstance
             copied_version.__class__ = CollectionVersionWithDatasets
@@ -207,7 +207,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             created_at=datetime.utcnow(),
             schema_version=None,
             canonical_collection=cc,
-            custom_dataset_order=current_version.custom_dataset_order,
+            has_custom_dataset_order=current_version.has_custom_dataset_order,
         )
         self.collections_versions[new_version_id.id] = collection_version
         return new_version_id
@@ -571,7 +571,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
 
         # Replace collection version datasets with given, ordered dataset version IDs and update custom ordered flag.
         collection_version.datasets = dataset_version_ids
-        collection_version.custom_dataset_order = True
+        collection_version.has_custom_dataset_order = True
 
     def get_dataset_version_status(self, version_id: DatasetVersionId) -> DatasetStatus:
         return copy.deepcopy(self.datasets_versions[version_id.id].status)

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -104,14 +104,10 @@ class DatabaseProviderMock(DatabaseProviderInterface):
                     datasets_to_include.append(dataset_version)
             # Replace 'datasets' array of Dataset version ids with 'datasets' array of actual Dataset versions
             copied_version.datasets = datasets_to_include
-            # Order by cell count if not custom ordered. Protect against None dataset values and None dataset metadata values
-            # here as they are possible values in the test data.
-            if (
-                not copied_version.datasets_custom_ordered
-                and None not in copied_version.datasets
-                and all(d.metadata for d in copied_version.datasets)
-            ):
-                copied_version.datasets.sort(key=lambda d: d.metadata.cell_count, reverse=True)
+            # Order by cell count if not custom ordered.
+            copied_version.datasets.sort(
+                key=lambda d: 0 if d is None or d.metadata is None else d.metadata.cell_count, reverse=True
+            )
             # Hack for business logic that uses isinstance
             copied_version.__class__ = CollectionVersionWithDatasets
         cc = self.collections.get(version.collection_id.id)

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -382,6 +382,42 @@ paths:
         "404":
           $ref: "#/components/responses/404"
 
+  /v1/collections/{collection_id}/order-datasets:
+    put:
+      tags:
+        - collections
+      summary: Reorder datasets in a collection version
+      security:
+        - cxguserCookie: []
+      description: >-
+        Updates the order of datasets in a collection version and permanently converts the
+        collection version to have a custom datasets sort order instead of the default.
+      operationId: backend.portal.api.portal_api.set_collection_version_datasets_order
+      parameters:
+        - $ref: "#/components/parameters/path_collection_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - datasets
+              properties:
+                datasets:
+                  type: array
+                  description: The ordered list of dataset IDs.
+                  items:
+                    $ref: "#/components/schemas/dataset_id"
+      responses:
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+
   /v1/collections/index:
     get:
       tags:

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -618,6 +618,31 @@ def upload_from_link(collection_id: str, token_info: dict, url: str, dataset_id:
         ) from None
 
 
+def set_collection_version_datasets_order(collection_id: str, body: dict, token_info: dict):
+    """
+    Sets the order of datasets in a collection and updates collection datasets cutom ordered
+    flag to true.
+    """
+    version = lookup_collection(collection_id)
+    if version is None or not UserInfo(token_info).is_user_owner_or_allowed(version.owner):
+        raise ForbiddenHTTPException()
+
+    datasets = body.get("datasets")
+    if datasets is None or len(datasets) == 0:
+        raise InvalidParametersHTTPException(detail="Missing datasets field")
+
+    try:
+        get_business_logic().set_collection_version_datasets_order(
+            version.version_id, [DatasetVersionId(dv_id) for dv_id in datasets]
+        )
+    except CollectionNotFoundException:
+        raise ForbiddenHTTPException() from None
+    except CollectionIsPublishedException:
+        raise ForbiddenHTTPException() from None
+
+    return make_response("", 200)
+
+
 # TODO: those two methods should probably be collapsed into one
 # TODO: not quite sure what's the difference between url and link - investigate
 def upload_link(collection_id: str, body: dict, token_info: dict):

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1606,7 +1606,6 @@ class TestUpdateCollection(BaseAPIPortalTest):
         # Forbidden - collection is published.
         self.assertEqual(403, response.status_code)
 
-
     def test__set_collection_version_datasets_order_invalid_collection__403(self):
         collection = self.generate_published_collection()
 
@@ -1617,12 +1616,10 @@ class TestUpdateCollection(BaseAPIPortalTest):
             }
         )
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
-        response = self.app.put(
-            "/dp/v1/collections/fake_id/order-datasets", data=data, headers=headers
-        )
+        response = self.app.put("/dp/v1/collections/fake_id/order-datasets", data=data, headers=headers)
 
         # Forbidden - collection not found.
-        self.assertEqual(403, response.status_code)        
+        self.assertEqual(403, response.status_code)
 
     def test__set_collection_version_datasets_order_unauthenticated__401(self):
         collection = self.generate_unpublished_collection()

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1506,12 +1506,9 @@ class TestUpdateCollection(BaseAPIPortalTest):
     def test__set_collection_version_datasets_order__OK(self):
         collection = self.generate_unpublished_collection(add_datasets=2)
 
-        # Convert collections.datasets from a list of objects to a list of IDs
-        # and then reverse the order. Use version_id here (this is masked in
-        # the FE as dataset.version_id is mapped to dataset.id in _dataset_to_response).
+        # Reverse dataset order and save.
         dataset_ids = [d.version_id.id for d in collection.datasets]
         dataset_ids.reverse()
-
         data = json.dumps(
             {
                 "datasets": dataset_ids,

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -1,10 +1,10 @@
 import dataclasses
 import itertools
 import json
+import uuid
 from datetime import datetime
 from unittest import mock
 from unittest.mock import Mock, patch
-import uuid
 
 from furl import furl
 

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 from unittest import mock
 from unittest.mock import Mock, patch
+import uuid
 
 from furl import furl
 
@@ -1613,7 +1614,7 @@ class TestUpdateCollection(BaseAPIPortalTest):
             }
         )
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
-        response = self.app.put("/dp/v1/collections/fake_id/order-datasets", data=data, headers=headers)
+        response = self.app.put(f"/dp/v1/collections/{str(uuid.uuid4())}/order-datasets", data=data, headers=headers)
 
         # Forbidden - collection not found.
         self.assertEqual(403, response.status_code)

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1007,7 +1007,7 @@ class TestSetCollectionVersionDatasetsOrder(BaseBusinessLogicTestCase):
         self.assertListEqual([dv.version_id for dv in read_version.datasets], dv_ids)
 
         # Confirm the collection version datasets are marked as custom ordered.
-        self.assertTrue(read_version.datasets_custom_ordered)
+        self.assertTrue(read_version.custom_dataset_order)
 
     def test_set_collection_version_datasets_order_length_fail(self):
         """
@@ -1023,7 +1023,7 @@ class TestSetCollectionVersionDatasetsOrder(BaseBusinessLogicTestCase):
             self.business_logic.set_collection_version_datasets_order(version.version_id, dv_ids)
         self.assertEqual(
             str(ex.exception),
-            f"Dataset version IDs length does not match collection version {version.version_id.id} datasets length",
+            f"Dataset Version IDs length does not match Collection Version {version.version_id.id} Datasets length",
         )
 
     def test_set_collection_version_datasets_order_invalid_dataset_fail(self):
@@ -1039,7 +1039,7 @@ class TestSetCollectionVersionDatasetsOrder(BaseBusinessLogicTestCase):
 
         with self.assertRaises(ValueError) as ex:
             self.business_logic.set_collection_version_datasets_order(version.version_id, dv_ids)
-        self.assertEqual(str(ex.exception), "Dataset version IDs do not match saved collection version dataset IDs")
+        self.assertEqual(str(ex.exception), "Dataset Version IDs do not match saved Collection Version Dataset IDs")
 
     def test_set_collection_version_datasets_order_no_custom_order_ok(self):
         """

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1007,7 +1007,7 @@ class TestSetCollectionVersionDatasetsOrder(BaseBusinessLogicTestCase):
         self.assertListEqual([dv.version_id for dv in read_version.datasets], dv_ids)
 
         # Confirm the collection version datasets are marked as custom ordered.
-        self.assertTrue(read_version.custom_dataset_order)
+        self.assertTrue(read_version.has_custom_dataset_order)
 
     def test_set_collection_version_datasets_order_length_fail(self):
         """
@@ -1088,7 +1088,7 @@ class TestSetCollectionVersionDatasetsOrder(BaseBusinessLogicTestCase):
         self.assertListEqual([dv.version_id for dv in read_version.datasets], updated_dv_ids)
 
         # Confirm the collection version datasets are marked as custom ordered.
-        self.assertTrue(read_version.custom_dataset_order)
+        self.assertTrue(read_version.has_custom_dataset_order)
 
 
 class TestDeleteDataset(BaseBusinessLogicTestCase):

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -987,7 +987,15 @@ class TestSetCollectionVersionDatasetsOrder(BaseBusinessLogicTestCase):
         """
         The order of the datasets in a collection version is set using `set_collection_version_datasets_order`.
         """
-        version = self.initialize_unpublished_collection()
+        version = self.initialize_unpublished_collection(num_datasets=3)
+
+        # Update cell counts to confirm custom order is returned and not default order.
+        metadata_11 = deepcopy(self.sample_dataset_metadata)
+        metadata_11.cell_count = 11
+        self.database_provider.set_dataset_metadata(version.datasets[2].version_id, metadata_11)
+        metadata_12 = deepcopy(self.sample_dataset_metadata)
+        metadata_12.cell_count = 12
+        self.database_provider.set_dataset_metadata(version.datasets[1].version_id, metadata_12)
 
         # Reverse and save the order of the dataset version IDs.
         dv_ids = [d.version_id for d in version.datasets]
@@ -1040,12 +1048,12 @@ class TestSetCollectionVersionDatasetsOrder(BaseBusinessLogicTestCase):
         version = self.initialize_unpublished_collection(num_datasets=3)
 
         # Update cell counts to facilitate testing of order.
-        metadata_01 = deepcopy(self.sample_dataset_metadata)
-        metadata_01.cell_count = 11
-        self.database_provider.set_dataset_metadata(version.datasets[1].version_id, metadata_01)
-        metadata_02 = deepcopy(self.sample_dataset_metadata)
-        metadata_02.cell_count = 12
-        self.database_provider.set_dataset_metadata(version.datasets[2].version_id, metadata_02)
+        metadata_11 = deepcopy(self.sample_dataset_metadata)
+        metadata_11.cell_count = 11
+        self.database_provider.set_dataset_metadata(version.datasets[2].version_id, metadata_11)
+        metadata_12 = deepcopy(self.sample_dataset_metadata)
+        metadata_12.cell_count = 12
+        self.database_provider.set_dataset_metadata(version.datasets[1].version_id, metadata_12)
 
         # Confirm datasets on read collection version are ordered by cell count, descending.
         read_version = self.business_logic.get_collection_version(version.version_id)

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1072,7 +1072,7 @@ class TestSetCollectionVersionDatasetsOrder(BaseBusinessLogicTestCase):
         self.business_logic.set_collection_version_datasets_order(version.version_id, dv_ids)
 
         # Replace the first dataset in the collection version.
-        dataset_id_to_replace = dv_ids[0].version_id
+        dataset_id_to_replace = dv_ids[0]
 
         replaced_dataset_version_id, _ = self.business_logic.ingest_dataset(
             version.version_id, "http://fake.url", None, dataset_id_to_replace
@@ -1084,7 +1084,7 @@ class TestSetCollectionVersionDatasetsOrder(BaseBusinessLogicTestCase):
         updated_dv_ids = [replaced_dataset_version_id] + dv_ids[1:]
 
         # Confirm collection version lists datasets in the custom order.
-        read_version = self.database_provider.get_collection_version(version.version_id)
+        read_version = self.business_logic.get_collection_version(version.version_id)
         self.assertListEqual([dv.version_id for dv in read_version.datasets], updated_dv_ids)
 
         # Confirm the collection version datasets are marked as custom ordered.


### PR DESCRIPTION
## Reason for Change

- #6484

## Changes

- Added database migration to add `datasets_custom_ordered` column.
- Added `datasets_custom_ordered` to CollectionVersion
- Added `order-datasets` endpoint.

## Testing steps

- Added tests to [test_portal_api.py](https://github.com/chanzuckerberg/single-cell-data-portal/compare/mim/6484-save-dataset-order?expand=1#diff-09a58764042645262735c766e7d4656104dcab6eda35bc3d82f641fe42efe581) and [test_business.py](https://github.com/chanzuckerberg/single-cell-data-portal/compare/mim/6484-save-dataset-order?expand=1#diff-98efcfe189db84e8fdd45833310cbcf9bcd4debb00f0e1aa2e89581034980fed).
- Tested in rdev
  - **Valid reorder:** `curl -X PUT --cookie _oauth2_proxy=${oauth2_proxy} --cookie cxguser=${cxguser} -H 'Content-Type: application/json' -d '{"datasets":["30362c1c-96e1-44ef-b0dd-6a783ae9a40d", "6a7a0fad-101f-468e-9938-f446b743d113"]}' https://pr-6579-backend.rdev.single-cell.czi.technology/dp/v1/collections/1b3d1248-5c47-45f3-8295-0d98dbf0af8f/order-datasets`
  - **Invalid dataset length:** `curl -X PUT --cookie _oauth2_proxy=${oauth2_proxy} --cookie cxguser=${cxguser} -H 'Content-Type: application/json' -d '{"datasets":["30362c1c-96e1-44ef-b0dd-6a783ae9a40d"]}' https://pr-6579-backend.rdev.single-cell.czi.technology/dp/v1/collections/1b3d1248-5c47-45f3-8295-0d98dbf0af8f/order-datasets`
  - **Invalid dataset ID:** `curl -X PUT --cookie _oauth2_proxy=${oauth2_proxy} --cookie cxguser=${cxguser} -H 'Content-Type: application/json' -d '{"datasets":["30362c1c-96e1-44ef-b0dd-6a783ae9a40d", "invalid_id"]}' https://pr-6579-backend.rdev.single-cell.czi.technology/dp/v1/collections/1b3d1248-5c47-45f3-8295-0d98dbf0af8f/order-datasets`

