### PR TITLE
fix: Skip downloading WMG snapshot for db fargate tasks

### DIFF
--- a/.happy/terraform/modules/deletion/main.tf
+++ b/.happy/terraform/modules/deletion/main.tf
@@ -31,6 +31,10 @@ resource aws_ecs_task_definition task_definition {
       {
         "name": "DEPLOYMENT_STAGE",
         "value": "${var.deployment_stage}"
+      },
+      {
+        "name": "DOWNLOAD_WMG_DATA_TO_DISK",
+        "value": "false"
       }
     ],
     "logConfiguration": {

--- a/.happy/terraform/modules/migration/main.tf
+++ b/.happy/terraform/modules/migration/main.tf
@@ -37,6 +37,10 @@ resource aws_ecs_task_definition task_definition {
       {
         "name": "DEPLOYMENT_STAGE",
         "value": "${var.deployment_stage}"
+      },
+      {
+        "name": "DOWNLOAD_WMG_DATA_TO_DISK",
+        "value": "false"
       }
     ],
     "logConfiguration": {

--- a/.happy/terraform/modules/service/main.tf
+++ b/.happy/terraform/modules/service/main.tf
@@ -205,6 +205,10 @@ resource aws_ecs_task_definition task_definition {
       {
         "name": "AWS_DEFAULT_REGION",
         "value": "${data.aws_region.current.name}"
+      },
+      {
+        "name": "DOWNLOAD_WMG_DATA_TO_DISK",
+        "value": "true"
       }
     ],
     "portMappings": [

--- a/container_init.sh
+++ b/container_init.sh
@@ -9,8 +9,11 @@ echo
 # This is done as optimization because retrieving data from local disk is
 # significantly faster than retrieving data from S3
 WMG_SNAPSHOT_FS_CACHE_ROOT_PATH="/single-cell-data-portal/wmg_snapshot_cache"
+echo "| DOWNLOAD_WMG_DATA_to_DISK: ${DOWNLOAD_WMG_DATA_TO_DISK}"
 
-if [[ "${DEPLOYMENT_STAGE}" == "rdev" && -n "${REMOTE_DEV_PREFIX}" ]]; then
+if [[ "${DOWNLOAD_WMG_DATA_TO_DISK}" == "false"]]; then
+  echo "| Skipping downloading WMG data snapshot because DOWNLOAD_WMG_DATA_TO_DISK is set to false" 
+elif [[ "${DEPLOYMENT_STAGE}" == "rdev" && -n "${REMOTE_DEV_PREFIX}" ]]; then
   echo "| Downloading WMG data snapshot for RDEV stack: ${REMOTE_DEV_PREFIX} from S3 to filesystem path: ${WMG_SNAPSHOT_FS_CACHE_ROOT_PATH}"
   
   strip_slash_remote_dev_prefix="${REMOTE_DEV_PREFIX//\//}" # strips ALL "/"

--- a/container_init.sh
+++ b/container_init.sh
@@ -9,9 +9,9 @@ echo
 # This is done as optimization because retrieving data from local disk is
 # significantly faster than retrieving data from S3
 WMG_SNAPSHOT_FS_CACHE_ROOT_PATH="/single-cell-data-portal/wmg_snapshot_cache"
-echo "| DOWNLOAD_WMG_DATA_to_DISK: ${DOWNLOAD_WMG_DATA_TO_DISK}"
+echo "| ENV VAR DOWNLOAD_WMG_DATA_TO_DISK: ${DOWNLOAD_WMG_DATA_TO_DISK}"
 
-if [[ "${DOWNLOAD_WMG_DATA_TO_DISK}" == "false"]]; then
+if [[ "${DOWNLOAD_WMG_DATA_TO_DISK}" == "false" ]]; then
   echo "| Skipping downloading WMG data snapshot because DOWNLOAD_WMG_DATA_TO_DISK is set to false" 
 elif [[ "${DEPLOYMENT_STAGE}" == "rdev" && -n "${REMOTE_DEV_PREFIX}" ]]; then
   echo "| Downloading WMG data snapshot for RDEV stack: ${REMOTE_DEV_PREFIX} from S3 to filesystem path: ${WMG_SNAPSHOT_FS_CACHE_ROOT_PATH}"


### PR DESCRIPTION
## Reason for Change

Ensure that db migration ECS tasks do not download WMG data snapshot to Fargate instance disk. This is done so that deployments aren't slowed by an unnecessary 27 GB data download of WMG cube

## Changes

- add
- remove
- modify

## Testing steps

- Manual testing on rdev and staging

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
