### PR TITLE
fix: remove static code checks from python deployment dependencies.

### DIFF
--- a/python_dependencies/backend/requirements.txt
+++ b/python_dependencies/backend/requirements.txt
@@ -36,7 +36,6 @@ python-jose[cryptography]>=3.1.0
 python-json-logger
 requests>=2.22.0
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
-ruff==0.0.239 # Must be kept in sync with ruff version in .pre-commit-config.yaml
 s3fs==0.4.2
 scanpy==1.9.3
 setproctitle==1.3.2 # for gunicorn integration with datadog

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,7 +1,6 @@
 alembic>=1.9, <2
 anndata==0.8.0
 allure-pytest<3
-black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
 boto3>=1.11.17
 botocore>=1.14.17
 cellxgene-schema
@@ -29,7 +28,6 @@ python-json-logger
 requests>=2.22.0
 rpy2==3.5.14
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
-ruff==0.0.239 # Must be kept in sync with ruff version in .pre-commit-config.yaml
 s3fs==0.4.2
 scanpy==1.9.3
 SQLAlchemy>=1.4.0,<1.5

--- a/python_dependencies/wmg/requirements.txt
+++ b/python_dependencies/wmg/requirements.txt
@@ -1,7 +1,6 @@
 alembic==1.11.1
 anndata==0.8.0
 allure-pytest==2.13.2
-black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
 boto3==1.28.7
 botocore>=1.31.7, <1.32.0
 click==8.1.3
@@ -29,7 +28,6 @@ pytest-subtests==0.11.0
 python-json-logger==2.0.7
 requests>=2.22.0
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
-ruff==0.0.239 # Must be kept in sync with ruff version in .pre-commit-config.yaml
 scanpy==1.9.3
 scipy==1.10.1
 SQLAlchemy==1.4.49


### PR DESCRIPTION


## Reason for Change

- #These are not need for running the code and can be removed. This reduce the number of dependencies to manage.

## Changes

- remove ruff and black from requirements.txt files
