### PR TITLE
fix(PR tests): GHA flow randomly fails

### DIFF
--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -65,14 +65,13 @@ jobs:
   build_images:
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
+    needs: push-tests
     concurrency:
       group: pr-${{ github.event.number }}-build
       cancel-in-progress: true
 
   seed-wmg-cellguide-rdev:
     runs-on: ubuntu-22.04
-    needs:
-      - build_images
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Reason for Change

The GHA rdev-update-for-pr.yml randomly fails when a multiple jobs are running in parallel. The error is `Error: The operation was canceled.` This PR reduces the level of parallelism to reduce the change of that error. The suspected it cause is out of memory.

# Changes
- build-image depends on push-test
- remove seed-wmg-cellguide-rdev dependencies

## Testing steps


## Checklist 🛎️

## Notes for Reviewer
new workflow
<img width="1490" alt="Screenshot 2024-02-16 at 3 49 29 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/1429913/0d72d14b-874f-4682-ae20-1ae3db38cdb1">

