### PR TITLE
fix: reduce GHA parallelism to reduce canceled jobs

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   build_images:
     strategy:
+      max-parallel: 4
       matrix:
         image:
           - frontend # pushed both the frontend and backend images

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build_images:
     strategy:
-      max-parallel: 4
+      max-parallel: 4 #TODO: Added to reduce parellelism. Remove when we have more workers.
       matrix:
         image:
           - frontend # pushed both the frontend and backend images

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -56,7 +56,7 @@ jobs:
   run-e2e-tests:
     needs:
       - seed-database-e2e-tests
-      - functional-test # Not actually dependent on functional-test. This is to reduce parallelism. Remove when we have more workers.
+      - functional-test #TODO: Added to reduce parellelism. Remove when we have more workers.
     timeout-minutes: 30
     name: e2e-tests ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -56,6 +56,7 @@ jobs:
   run-e2e-tests:
     needs:
       - seed-database-e2e-tests
+      - functional-test # Not actually dependent on functional-test. This is to reduce parallelism. Remove when we have more workers.
     timeout-minutes: 30
     name: e2e-tests ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Reason for Change

- reducing the chance that the GHA will terminated by reducing parallelism in workflows

## Changes

- run-e2e-tests depends  on seed-database-e2e-tests and functional-test

## Testing steps

- verifying GHA passes