### PR TITLE
fix: Use soma blockwise iterator for WMG Pipeline

### DIFF
--- a/backend/wmg/pipeline/expression_summary.py
+++ b/backend/wmg/pipeline/expression_summary.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 import pandas as pd
 import tiledb
-from cellxgene_census.experimental.util._csr_iter import X_sparse_iter
 from numba import njit
 from scipy import sparse
 from tiledbsoma import ExperimentAxisQuery
@@ -163,12 +162,8 @@ class ExpressionSummaryCubeBuilder:
         logger.info(f"Reducing X with {self.obs_df.shape[0]} total cells")
 
         iteration = 0
-        for (obs_soma_joinids_chunk, _), raw_array in X_sparse_iter(
-            self.query,
-            X_name="raw",
-            stride=row_stride,
-            fmt="csr",
-        ):
+        for raw_array, (obs_soma_joinids_chunk, _) in self.query.X("raw").blockwise(axis=0, size=row_stride).scipy():
+            assert isinstance(raw_array, sparse.csr_matrix)
             logger.info(f"Reducer iteration {iteration} out of {math.ceil(self.obs_df.shape[0] / row_stride)}")
             iteration += 1
 

--- a/python_dependencies/wmg/requirements.txt
+++ b/python_dependencies/wmg/requirements.txt
@@ -12,7 +12,7 @@ ddtrace==2.1.4
 furl==2.1.3
 jsonschema==4.18.4
 moto>=5.0.0
-numba==0.56.4
+numba>=0.56.4
 numpy==1.23.5
 openai==0.27.7
 owlready2==0.40.0

--- a/python_dependencies/wmg/requirements.txt
+++ b/python_dependencies/wmg/requirements.txt
@@ -5,7 +5,7 @@ black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.y
 boto3==1.28.7
 botocore>=1.31.7, <1.32.0
 click==8.1.3
-cellxgene-census>=1.9.1 # WMG pipeline always reads the latest version of Census so we need to use the latest package version
+cellxgene-census>=1.10.0 # WMG pipeline always reads the latest version of Census so we need to use the latest package version
 coverage==7.2.7
 dataclasses-json==0.5.7
 ddtrace==2.1.4
@@ -35,5 +35,5 @@ scipy==1.10.1
 SQLAlchemy==1.4.49
 SQLAlchemy-Utils==0.41.1
 tenacity==8.2.2
-tiledbsoma>=1.6.1 # WMG pipeline always reads the latest version of Census so we need to use the latest package version
+tiledbsoma>=1.7.0 # WMG pipeline always reads the latest version of Census so we need to use the latest package version
 dask==2023.8.1

--- a/python_dependencies/wmg/requirements.txt
+++ b/python_dependencies/wmg/requirements.txt
@@ -12,7 +12,7 @@ ddtrace==2.1.4
 furl==2.1.3
 jsonschema==4.18.4
 moto>=5.0.0
-numba>=0.56.4
+numba>=0.58.0
 numpy==1.23.5
 openai==0.27.7
 owlready2==0.40.0


### PR DESCRIPTION
## Reason for Change

In order for WMG pipeline to properly work with the latest version of `cellxgene-census` and `tiledbsoma`, we have to do 2 things:

1. Unpin `numba` so that the dependency versions are properly resolved such that WMG is using the latest versions of `cellxgene-census` and `tiledbsoma`
2. Fix the failure between WMG pipeline and `cellxgene-census` by having WMG pipeline code use SOMA blockwise iterators instead of`cellxgene_census.experimental.util.X_sparse_iter` [due to this backward incompatible change in cellxgene-census](https://github.com/chanzuckerberg/cellxgene-census/pull/962)

## Changes

## Testing steps

- Passing WMG pipeline unit tests
- Passing run of WMG pipeline in rdev and staging

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
