### PR TITLE
fix: update RDS citation to use .rds instead of .h5ad

### DIFF
--- a/backend/layers/processing/process_seurat.py
+++ b/backend/layers/processing/process_seurat.py
@@ -2,6 +2,8 @@ import logging
 import os
 import subprocess
 
+import anndata
+
 from backend.layers.business.business_interface import BusinessLogicInterface
 from backend.layers.common.entities import (
     DatasetArtifactType,
@@ -61,12 +63,19 @@ class ProcessSeurat(ProcessingLogic):
             self.logger.info("Skipping Seurat conversion")
             return
 
+        # Download h5ad locally
         labeled_h5ad_filename = "local.h5ad"
-
         key_prefix = self.get_key_prefix(dataset_version_id.id)
         object_key = f"{key_prefix}/{labeled_h5ad_filename}"
         self.download_from_s3(artifact_bucket, object_key, labeled_h5ad_filename)
 
+        # Convert the citation from h5ad to RDS
+        adata = anndata.read_h5ad(labeled_h5ad_filename)
+        if "citation" in adata.uns:
+            adata.uns["citation"] = adata.uns["citation"].replace(".h5ad", ".rds")
+        adata.write_h5ad(labeled_h5ad_filename)
+
+        # Use Seurat to convert to RDS
         seurat_filename = self.convert_file(
             self.make_seurat,
             labeled_h5ad_filename,

--- a/backend/layers/processing/process_seurat.py
+++ b/backend/layers/processing/process_seurat.py
@@ -13,6 +13,7 @@ from backend.layers.common.entities import (
 )
 from backend.layers.processing.logger import logit
 from backend.layers.processing.process_logic import ProcessingLogic
+from backend.layers.processing.utils import rds_citation_from_h5ad
 from backend.layers.thirdparty.s3_provider import S3ProviderInterface
 from backend.layers.thirdparty.uri_provider import UriProviderInterface
 
@@ -72,7 +73,7 @@ class ProcessSeurat(ProcessingLogic):
         # Convert the citation from h5ad to RDS
         adata = anndata.read_h5ad(labeled_h5ad_filename)
         if "citation" in adata.uns:
-            adata.uns["citation"] = adata.uns["citation"].replace(".h5ad", ".rds")
+            adata.uns["citation"] = rds_citation_from_h5ad(adata.uns["citation"])
         adata.write_h5ad(labeled_h5ad_filename)
 
         # Use Seurat to convert to RDS

--- a/backend/layers/processing/utils.py
+++ b/backend/layers/processing/utils.py
@@ -1,0 +1,7 @@
+import re
+
+from backend.common.utils.regex import DATASET_ID_REGEX
+
+
+def rds_citation_from_h5ad(citation: str) -> str:
+    return re.sub(f"{DATASET_ID_REGEX}\.h5ad", r"\g<dataset_id>.rds", citation)


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/6671

## Changes

- modifies the anndata of the `local.h5ad` that we pull down from S3 before doing the seurat RDS conversion
- i chose this approach so that i don't have to learn R lol

## Testing steps

#### To test that the citation has been updated in the RDS artifact:

1. i downloaded an RDS dataset from the rdev generated by this PR
2. i sent the `.rds` file to @brianraymor, who has RStudio up and running, and verified the citation field has `.rds` instead of `.h5ad`

![image](https://github.com/chanzuckerberg/single-cell-data-portal/assets/5653616/78ed749f-6cdb-4f07-85a8-241319a2a14c)

#### To test that the regex for replacing the citation works:

i isolated this logic to `utils.rds_citation_from_h5ad` and added some tests in `test_utils.py`

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
