### PR TITLE
chore: Unpin tiledb for backend docker container

### DIFF
--- a/python_dependencies/backend/requirements.txt
+++ b/python_dependencies/backend/requirements.txt
@@ -43,5 +43,5 @@ setproctitle==1.3.2 # for gunicorn integration with datadog
 SQLAlchemy-Utils>=0.36.8
 SQLAlchemy>=1.4.0,<1.5
 tenacity
-tiledb==0.24.0  # Portal's tiledb version should always be the same or older than Explorer's
+tiledb
 Werkzeug==2.2.3


### PR DESCRIPTION
## Reason for Change

Unpinning `tiledb` so that it is compatible with `tiledbsoma` version for WMG pipeline. This is because `tiledbsoma` version is unpinned for WMG pipeline to track the latest version. Therefore, the reader in the backend container must have the latest `tiledb` version to read WMG pipeline data artifact.

## Changes

- add
- remove
- modify

## Testing steps

- This was first **hotfixed in prod** and verified to work: https://github.com/chanzuckerberg/single-cell-data-portal/commit/60b7f9a40468cef5b7bf392a6d50144131ddb786
- Manual Testing: The rdev backend is successfully able to read the latest snapshot as seen in the API response for `\query` when hitting the frontend rdev: https://pr-6704-frontend.rdev.single-cell.czi.technology/gene-expression. It is able to read `snapshot_id: 1708884209` which was built by latest `cellxgene-census` and `tiledbsoma` versions.

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
