### PR TITLE
fix: data submission policy version

### DIFF
--- a/backend/common/constants.py
+++ b/backend/common/constants.py
@@ -3,3 +3,5 @@ DEPLOYMENT_STAGE_TO_API_URL = {
     "staging": "https://api.cellxgene.staging.single-cell.czi.technology",
     "dev": "https://api.cellxgene.dev.single-cell.czi.technology",
 }
+
+DATA_SUBMISSION_POLICY_VERSION = "2.0"

--- a/backend/database/versions/06_8bced1b1470b_add_data_submission_policy_version.py
+++ b/backend/database/versions/06_8bced1b1470b_add_data_submission_policy_version.py
@@ -1,0 +1,29 @@
+"""add data submission policy version
+
+Revision ID: 06_8bced1b1470b
+Revises: 05_67c4015bce73
+Create Date: 2024-02-14 15:42:20.549707
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "06_8bced1b1470b"
+down_revision = "05_67c4015bce73"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "CollectionVersion",
+        sa.Column("data_submission_policy_version", sa.String(), nullable=True),
+        schema="persistence_schema",
+    )
+
+
+def downgrade():
+    op.drop_column("CollectionVersion", "data_submission_policy_version", schema="persistence_schema")

--- a/backend/database/versions/06_8bced1b1470b_add_data_submission_policy_version.py
+++ b/backend/database/versions/06_8bced1b1470b_add_data_submission_policy_version.py
@@ -6,9 +6,8 @@ Create Date: 2024-02-14 15:42:20.549707
 
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "06_8bced1b1470b"

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from functools import reduce
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
+from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
 from backend.common.corpora_config import CorporaConfig
 from backend.common.feature_flag import FeatureFlagService, FeatureFlagValues
 from backend.layers.business.business_interface import BusinessLogicInterface
@@ -877,7 +878,9 @@ class BusinessLogic(BusinessLogicInterface):
         # Reset tombstone values in database
         self.database_provider.resurrect_collection(collection_id, datasets_to_resurrect)
 
-    def publish_collection_version(self, version_id: CollectionVersionId) -> None:
+    def publish_collection_version(
+        self, version_id: CollectionVersionId, data_submission_policy_version: str = DATA_SUBMISSION_POLICY_VERSION
+    ) -> None:
         """
         Publishes a collection version.
         """
@@ -910,7 +913,11 @@ class BusinessLogic(BusinessLogicInterface):
 
         # Finalize Collection publication and delete any tombstoned assets
         dataset_version_ids_to_delete_from_s3 = self.database_provider.finalize_collection_version(
-            version.collection_id, version_id, schema_version, update_revised_at=has_dataset_revisions
+            version.collection_id,
+            version_id,
+            schema_version,
+            data_submission_policy_version,
+            update_revised_at=has_dataset_revisions,
         )
         self.delete_dataset_versions_from_public_bucket(dataset_version_ids_to_delete_from_s3)
 

--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -101,7 +101,7 @@ class BusinessLogicInterface:
     def delete_collection_version(self, collection_version: CollectionVersionWithDatasets) -> None:
         pass
 
-    def publish_collection_version(self, version_id: CollectionVersionId) -> None:
+    def publish_collection_version(self, version_id: CollectionVersionId, data_submission_policy_version: str) -> None:
         pass
 
     def ingest_dataset(

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -278,6 +278,7 @@ class CollectionVersionBase:
     schema_version: str
     canonical_collection: CanonicalCollection
     has_custom_dataset_order: bool
+    data_submission_policy_version: str
 
     def is_published(self) -> bool:
         """

--- a/backend/layers/persistence/orm.py
+++ b/backend/layers/persistence/orm.py
@@ -36,6 +36,7 @@ class CollectionVersionTable:
     schema_version = Column(String)
     datasets = Column(ARRAY(UUID(as_uuid=True)))
     has_custom_dataset_order = Column(BOOLEAN)
+    data_submission_policy_version = Column(String)
 
 
 @mapper_registry.mapped

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -115,6 +115,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             schema_version=row.schema_version,
             canonical_collection=canonical_collection,
             has_custom_dataset_order=row.has_custom_dataset_order,
+            data_submission_policy_version=row.data_submission_policy_version,
         )
 
     def _row_to_collection_version_with_datasets(
@@ -134,6 +135,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             schema_version=row.schema_version,
             canonical_collection=canonical_collection,
             has_custom_dataset_order=row.has_custom_dataset_order,
+            data_submission_policy_version=row.data_submission_policy_version,
         )
 
     def _row_to_canonical_dataset(self, row: Any):
@@ -240,6 +242,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             schema_version=None,
             datasets=list(),
             has_custom_dataset_order=False,
+            data_submission_policy_version=None,
         )
 
         with self._manage_session() as session:
@@ -514,8 +517,8 @@ class DatabaseProvider(DatabaseProviderInterface):
     def add_collection_version(self, collection_id: CollectionId) -> CollectionVersionId:
         """
         Adds a collection version to an existing canonical collection. The new version copies all data from
-        the previous version except version_id, schema_version, and datetime-based fields (i.e. created_at,
-        published_at)
+        the previous version except version_id, schema_version, data_submission_policy_version and datetime-based
+        fields (i.e. created_at, published_at)
         Returns the new version id.
         """
         with self._manage_session() as session:
@@ -534,6 +537,7 @@ class DatabaseProvider(DatabaseProviderInterface):
                 schema_version=None,
                 datasets=current_version.datasets,
                 has_custom_dataset_order=current_version.has_custom_dataset_order,
+                data_submission_policy_version=None,
             )
             session.add(new_version)
             return CollectionVersionId(new_version_id)
@@ -603,6 +607,7 @@ class DatabaseProvider(DatabaseProviderInterface):
         collection_id: CollectionId,
         version_id: CollectionVersionId,
         schema_version: str,
+        data_submission_policy_version: str,
         published_at: Optional[datetime] = None,
         update_revised_at: bool = False,
     ) -> List[str]:
@@ -627,6 +632,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             collection_version = session.query(CollectionVersionTable).filter_by(id=version_id.id).one()
             collection_version.published_at = published_at
             collection_version.schema_version = schema_version
+            collection_version.data_submission_policy_version = data_submission_policy_version
 
             dataset_ids_for_new_collection_version = [
                 d.dataset_id.id for d in self.get_collection_version_with_datasets(version_id).datasets

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -144,6 +144,7 @@ class DatabaseProviderInterface:
         collection_id: CollectionId,
         version_id: CollectionVersionId,
         schema_version: str,
+        data_submission_policy_version: str,
         published_at: Optional[datetime] = None,
         update_revised_at: bool = False,
     ) -> List[str]:

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -79,6 +79,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             canonical_collection=canonical,
             datasets=[],
             has_custom_dataset_order=False,
+            data_submission_policy_version=None,
         )
         self.collections_versions[version_id.id] = version
         # Don't set mappings here - those will be set when publishing the collection!
@@ -208,6 +209,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             schema_version=None,
             canonical_collection=cc,
             has_custom_dataset_order=current_version.has_custom_dataset_order,
+            data_submission_policy_version=None,
         )
         self.collections_versions[new_version_id.id] = collection_version
         return new_version_id
@@ -284,6 +286,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
         collection_id: CollectionId,
         version_id: CollectionVersionId,
         schema_version: str,
+        data_submission_policy_version: str,
         published_at: Optional[datetime] = None,
         update_revised_at: bool = False,
     ) -> List[str]:
@@ -332,6 +335,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             self.collections[collection_id.id] = new_collection
         self.collections_versions[version_id.id].published_at = published_at
         self.collections_versions[version_id.id].schema_version = schema_version
+        self.collections_versions[version_id.id].data_submission_policy_version = data_submission_policy_version
 
         return dataset_version_ids_to_delete_from_s3
 

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -1093,7 +1093,6 @@ components:
         - consortia
         - created_at
         - updated_at
-        - data_submission_policy_version
       properties:
         access_type:
           $ref: "#/components/schemas/access_type"

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -263,7 +263,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
             "contact_name": collection.metadata.contact_name,
             "created_at": collection.created_at,
             "curator_name": collection.curator_name,
-            "data_submission_policy_version": "1.0",  # TODO
+            "data_submission_policy_version": collection.data_submission_policy_version,
             "datasets": [
                 _dataset_to_response(
                     ds,
@@ -575,8 +575,12 @@ def publish_post(collection_id: str, body: object, token_info: dict):
     if version is None or not UserInfo(token_info).is_user_owner_or_allowed(version.owner):
         raise ForbiddenHTTPException()
 
+    data_submission_policy_version = body.get("data_submission_policy_version")
+    if data_submission_policy_version is None or data_submission_policy_version == "":
+        raise InvalidParametersHTTPException(detail="Missing or invalid data_submission_policy_version field")
+
     try:
-        get_business_logic().publish_collection_version(version.version_id)
+        get_business_logic().publish_collection_version(version.version_id, data_submission_policy_version)
     except CollectionPublishException:
         raise ConflictException(detail="The collection must have a least one dataset.") from None
 

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -5,7 +5,6 @@ from typing import Iterable, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from flask import Response, jsonify, make_response
-from packaging import version
 
 from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
 from backend.common.utils.http_exceptions import (
@@ -70,18 +69,18 @@ def get_collections_list(from_date: int = None, to_date: int = None, token_info:
     user_private_collections = get_user_private_collections(token_info)
 
     collections = []
-    for collection_version in itertools.chain(all_published_collections, user_private_collections):
+    for version in itertools.chain(all_published_collections, user_private_collections):
         collection = {
-            "visibility": "PRIVATE" if collection_version.published_at is None else "PUBLIC",
-            "owner": collection_version.owner,
-            "created_at": collection_version.created_at,
+            "visibility": "PRIVATE" if version.published_at is None else "PUBLIC",
+            "owner": version.owner,
+            "created_at": version.created_at,
         }
-        if collection_version.is_unpublished_version():
-            collection["id"] = collection_version.version_id.id
+        if version.is_unpublished_version():
+            collection["id"] = version.version_id.id
         else:
-            collection["id"] = collection_version.collection_id.id
-        if not collection_version.is_published():
-            collection["revision_of"] = collection_version.collection_id.id
+            collection["id"] = version.collection_id.id
+        if not version.is_published():
+            collection["revision_of"] = version.collection_id.id
         collections.append(collection)
 
     result = {"collections": collections}
@@ -143,11 +142,7 @@ def _is_data_submission_policy_version_valid(data_submission_policy_version: str
     """
     if not data_submission_policy_version:
         return False
-
-    try:
-        return version.parse(data_submission_policy_version) == version.parse(DATA_SUBMISSION_POLICY_VERSION)
-    except version.InvalidVersion:
-        return False
+    return data_submission_policy_version == DATA_SUBMISSION_POLICY_VERSION
 
 
 def _ontology_term_ids_to_response(ontology_term_ids: List[OntologyTermId]):

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -5,7 +5,9 @@ from typing import Iterable, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from flask import Response, jsonify, make_response
+from packaging import version
 
+from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
 from backend.common.utils.http_exceptions import (
     ConflictException,
     ForbiddenHTTPException,
@@ -68,18 +70,18 @@ def get_collections_list(from_date: int = None, to_date: int = None, token_info:
     user_private_collections = get_user_private_collections(token_info)
 
     collections = []
-    for version in itertools.chain(all_published_collections, user_private_collections):
+    for collection_version in itertools.chain(all_published_collections, user_private_collections):
         collection = {
-            "visibility": "PRIVATE" if version.published_at is None else "PUBLIC",
-            "owner": version.owner,
-            "created_at": version.created_at,
+            "visibility": "PRIVATE" if collection_version.published_at is None else "PUBLIC",
+            "owner": collection_version.owner,
+            "created_at": collection_version.created_at,
         }
-        if version.is_unpublished_version():
-            collection["id"] = version.version_id.id
+        if collection_version.is_unpublished_version():
+            collection["id"] = collection_version.version_id.id
         else:
-            collection["id"] = version.collection_id.id
-        if not version.is_published():
-            collection["revision_of"] = version.collection_id.id
+            collection["id"] = collection_version.collection_id.id
+        if not collection_version.is_published():
+            collection["revision_of"] = collection_version.collection_id.id
         collections.append(collection)
 
     result = {"collections": collections}
@@ -133,6 +135,19 @@ def _dataset_asset_to_response(dataset_artifact: DatasetArtifact, dataset_id: st
         "updated_at": 0,
         "user_submitted": True,
     }
+
+
+def _is_data_submission_policy_version_valid(data_submission_policy_version: str) -> bool:
+    """
+    Returns True if the given policy version is equal to the latest policy version.
+    """
+    if not data_submission_policy_version:
+        return False
+
+    try:
+        return version.parse(data_submission_policy_version) == version.parse(DATA_SUBMISSION_POLICY_VERSION)
+    except version.InvalidVersion:
+        return False
 
 
 def _ontology_term_ids_to_response(ontology_term_ids: List[OntologyTermId]):
@@ -576,7 +591,7 @@ def publish_post(collection_id: str, body: object, token_info: dict):
         raise ForbiddenHTTPException()
 
     data_submission_policy_version = body.get("data_submission_policy_version")
-    if data_submission_policy_version is None or data_submission_policy_version == "":
+    if not _is_data_submission_policy_version_valid(data_submission_policy_version):
         raise InvalidParametersHTTPException(detail="Missing or invalid data_submission_policy_version field")
 
     try:

--- a/python_dependencies/backend/requirements.txt
+++ b/python_dependencies/backend/requirements.txt
@@ -24,7 +24,6 @@ moto>=5.0.0
 numba==0.56.2 # required for where's my gene
 numpy==1.23.5  # required for where's my gene
 owlready2==0.40.0
-packaging==23.1
 pandas==1.5.3 # required for where's my gene
 psutil>=5.9.5, <6
 psycopg2-binary>=2.8.5

--- a/python_dependencies/backend/requirements.txt
+++ b/python_dependencies/backend/requirements.txt
@@ -24,6 +24,7 @@ moto>=5.0.0
 numba==0.56.2 # required for where's my gene
 numpy==1.23.5  # required for where's my gene
 owlready2==0.40.0
+packaging==23.1
 pandas==1.5.3 # required for where's my gene
 psutil>=5.9.5, <6
 psycopg2-binary>=2.8.5

--- a/scripts/smoke_tests/setup.py
+++ b/scripts/smoke_tests/setup.py
@@ -3,6 +3,7 @@ import json
 import sys
 import threading
 
+from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
 from tests.functional.backend.common import BaseFunctionalTestCase
 
 # Amount to reduce chance of collision where multiple test instances select the same collection to test against
@@ -52,7 +53,7 @@ class SmokeTestsInitializer(BaseFunctionalTestCase):
         return data["collection_id"]
 
     def publish_collection(self, collection_id):
-        body = {"data_submission_policy_version": "1.0"}
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
         res = self.session.post(
             f"{self.api}/dp/v1/collections/{collection_id}/publish", headers=self.headers, data=json.dumps(body)
         )

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -6,6 +6,7 @@ import unittest
 import requests
 from requests import HTTPError
 
+from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
 from tests.functional.backend.common import BaseFunctionalTestCase
 
 
@@ -98,7 +99,7 @@ class TestApi(BaseFunctionalTestCase):
 
         # make collection public
         with self.subTest("Test make collection public"):
-            body = {"data_submission_policy_version": "1.0"}
+            body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
             res = self.session.post(
                 f"{self.api}/dp/v1/collections/{collection_id}/publish", headers=headers, data=json.dumps(body)
             )

--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -6,6 +6,7 @@ from urllib.parse import quote
 import requests
 from tenacity import retry, stop_after_attempt, wait_fixed
 
+from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
 from tests.functional.backend.common import BaseFunctionalTestCase
 
 
@@ -60,7 +61,7 @@ class TestRevisions(BaseFunctionalTestCase):
 
         # make collection public
         with self.subTest("Test make collection public"):
-            body = {"data_submission_policy_version": "1.0"}
+            body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
             res = self.session.post(
                 f"{self.api}/dp/v1/collections/{collection_id}/publish", headers=headers, data=json.dumps(body)
             )
@@ -115,7 +116,7 @@ class TestRevisions(BaseFunctionalTestCase):
 
         with self.subTest("Publishing a revised dataset replaces the original dataset"):
             # Publish the revision
-            body = {"data_submission_policy_version": "1.0"}
+            body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
             res = self.session.post(
                 f"{self.api}/dp/v1/collections/{revision_id}/publish", headers=headers, data=json.dumps(body)
             )
@@ -156,7 +157,7 @@ class TestRevisions(BaseFunctionalTestCase):
             self.assertCountEqual(public_datasets_before, public_datasets_after)
 
         # Publish the revision
-        body = {"data_submission_policy_version": "1.0"}
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
         res = self.session.post(
             f"{self.api}/dp/v1/collections/{revision_id}/publish", headers=headers, data=json.dumps(body)
         )
@@ -210,7 +211,7 @@ class TestRevisions(BaseFunctionalTestCase):
 
         with self.subTest("Publishing a revision that deletes a dataset removes it from the data portal"):
             # Publish the revision
-            body = {"data_submission_policy_version": "1.0"}
+            body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
             res = self.session.post(
                 f"{self.api}/dp/v1/collections/{revision_id}/publish", headers=headers, data=json.dumps(body)
             )

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -2666,20 +2666,6 @@ class TestPublishRevision(BaseAPIPortalTest):
 
         self.assertEqual(400, response.status_code)
 
-    def test__publish_revision_old_data_submission_policy_version__400(self):
-        """
-        Checks for failure on submit of a data submission policy version that is not the latest.
-        """
-
-        unpublished_collection = self.generate_unpublished_collection(add_datasets=1)
-
-        path = f"{self.base_path}/{unpublished_collection.version_id.id}/publish"
-        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
-        body = {"data_submission_policy_version": "1.0.0"}  # 1.0.0 is older than current version.
-        response = self.app.post(path, headers=headers, data=json.dumps(body))
-
-        self.assertEqual(400, response.status_code)
-
     def test__publish_revision_invalid_data_submission_policy_version__400(self):
         """
         Checks for failure on submit of a data submission policy version that is not a valid version.

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -79,7 +79,7 @@ class TestCollection(BaseAPIPortalTest):
             "contact_name": "john doe",
             "created_at": mock.ANY,
             "curator_name": "Jane Smith",
-            "data_submission_policy_version": "2.0",
+            "data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION,
             "datasets": [
                 {
                     "assay": [{"label": "test_assay_label", "ontology_term_id": "test_assay_term_id"}],
@@ -2652,6 +2652,19 @@ class TestPublishRevision(BaseAPIPortalTest):
 
         response_json = json.loads(response.data)
         self.assertEqual(response_json["data_submission_policy_version"], data_submission_policy_version)
+
+    def test__publish_revision_missing_data_submission_policy_version__400(self):
+        """
+        Checks data submission policy is correctly saved on publish of a revision.
+        """
+
+        unpublished_collection = self.generate_unpublished_collection(add_datasets=1)
+
+        path = f"{self.base_path}/{unpublished_collection.version_id.id}/publish"
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
+        response = self.app.post(path, headers=headers)
+
+        self.assertEqual(400, response.status_code)
 
     # ✅
     def test__publish_revision_with_new_dataset__OK(self):

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 
 from furl import furl
 
+from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
 from backend.layers.business.entities import DatasetArtifactDownloadData
 from backend.layers.common.entities import (
     CollectionId,
@@ -78,7 +79,7 @@ class TestCollection(BaseAPIPortalTest):
             "contact_name": "john doe",
             "created_at": mock.ANY,
             "curator_name": "Jane Smith",
-            "data_submission_policy_version": "1.0",
+            "data_submission_policy_version": "2.0",
             "datasets": [
                 {
                     "assay": [{"label": "test_assay_label", "ontology_term_id": "test_assay_term_id"}],
@@ -258,6 +259,11 @@ class TestCollection(BaseAPIPortalTest):
                 if expected_response_code == 200:
                     actual_body = json.loads(response.data)
                     self.assertEqual(expected_access_type, actual_body["access_type"])
+                    # Confirm only published collections have a data_submission_policy_version.
+                    if visi == "public":
+                        self.assertEqual(DATA_SUBMISSION_POLICY_VERSION, actual_body["data_submission_policy_version"])
+                    else:
+                        self.assertNotIn("data_submission_policy_version", actual_body)
 
     def test__get_collection_id_returns_revision_of_published_collection(self):
         version = self.generate_published_collection()
@@ -741,7 +747,6 @@ class TestCollection(BaseAPIPortalTest):
         self.assertEqual(body["name"], data["name"].strip())
         self.assertEqual(body["contact_name"], data["contact_name"].strip())
         self.assertEqual(body["contact_email"], body["contact_email"].strip())
-        self.assertEqual(body["data_submission_policy_version"], body["data_submission_policy_version"].strip())
         self.assertEqual(body["consortia"], ["Consortia 1"])
 
         for link in body["links"]:
@@ -1195,6 +1200,9 @@ class TestUpdateCollection(BaseAPIPortalTest):
         for field in test_fields:
             self.assertEqual(expected_body[field], actual_body[field])
 
+        # data_submission_policy_version should not be returned for unpublished collections.
+        self.assertNotIn("data_submission_policy_version", data)
+
     def test__update_collection_strip_string_fields__OK(self):
         collection = self.generate_unpublished_collection()
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
@@ -1211,7 +1219,6 @@ class TestUpdateCollection(BaseAPIPortalTest):
         }
         data = json.dumps(new_body)
         response = self.app.put(f"/dp/v1/collections/{collection.version_id.id}", data=data, headers=headers)
-
         self.assertEqual(200, response.status_code)
         actual_body = json.loads(response.data)
         self.assertEqual(new_body["name"].strip(), actual_body["name"])
@@ -2465,6 +2472,7 @@ class TestRevision(BaseAPIPortalTest):
         # Ensures that getting the version has:
         # - PRIVATE visibility (since it's unpublished)
         # - WRITE access_type if the header is from the owner
+        # - Data submission policy version is "cleared"
         # - The response matches the one from the POST request
         path = f"/dp/v1/collections/{revision_id}"
         response = self.app.get(path, headers=headers)
@@ -2472,6 +2480,7 @@ class TestRevision(BaseAPIPortalTest):
         response_json = json.loads(response.data)
         self.assertEqual("PRIVATE", response_json["visibility"])
         self.assertEqual("WRITE", response_json["access_type"])
+        self.assertNotIn("data_submission_policy_version", response_json)
         self.assertEqual(response_post_json, response_json)
 
         # If no auth is passed, the collection should be returned with access_type=READ
@@ -2621,6 +2630,29 @@ class TestPublishRevision(BaseAPIPortalTest):
             "Cookie": self.get_cxguser_token(),
         }
 
+    def test__publish_revision_data_submission_policy_version__OK(self):
+        """
+        Checks data submission policy is correctly saved on publish of a revision.
+        """
+
+        unpublished_collection = self.generate_unpublished_collection(add_datasets=1)
+
+        path = f"{self.base_path}/{unpublished_collection.version_id.id}/publish"
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
+        data_submission_policy_version = DATA_SUBMISSION_POLICY_VERSION
+        body = {"data_submission_policy_version": data_submission_policy_version}
+        response = self.app.post(path, headers=headers, data=json.dumps(body))
+
+        self.assertEqual(202, response.status_code)
+
+        # Check GET collection/<collection_id>
+        path = f"{self.base_path}/{unpublished_collection.collection_id.id}"
+        response = self.app.get(path, headers=headers)
+        self.assertEqual(200, response.status_code)
+
+        response_json = json.loads(response.data)
+        self.assertEqual(response_json["data_submission_policy_version"], data_submission_policy_version)
+
     # ✅
     def test__publish_revision_with_new_dataset__OK(self):
         """
@@ -2631,7 +2663,7 @@ class TestPublishRevision(BaseAPIPortalTest):
 
         path = f"{self.base_path}/{unpublished_collection.version_id.id}/publish"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
-        body = {"data_submission_policy_version": "1.0"}  # TODO: still in use?
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
         response = self.app.post(path, headers=headers, data=json.dumps(body))
 
         self.assertEqual(202, response.status_code)
@@ -2670,7 +2702,7 @@ class TestPublishRevision(BaseAPIPortalTest):
         # Publish the revision with the deleted dataset
         path = f"{self.base_path}/{unpublished_collection.version_id.id}/publish"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
-        body = {"data_submission_policy_version": "1.0"}  # TODO: still in use?
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
 
         response = self.app.post(path, headers=headers, data=json.dumps(body))
         self.assertEqual(202, response.status_code)
@@ -2699,7 +2731,7 @@ class TestPublishRevision(BaseAPIPortalTest):
         # Publish the revision with the deleted dataset
         path = f"{self.base_path}/{unpublished_collection.version_id.id}/publish"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
-        body = {"data_submission_policy_version": "1.0"}  # TODO: still in use?
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
         response = self.app.post(path, headers=headers, data=json.dumps(body))
         self.assertEqual(409, response.status_code)
 
@@ -2709,7 +2741,7 @@ class TestPublishRevision(BaseAPIPortalTest):
         """
         collection = self.generate_unpublished_collection(add_datasets=1)
         path = f"{self.base_path}/{collection.version_id.id}/publish"
-        body = {"data_submission_policy_version": "1.0"}
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
         headers = {"host": "localhost", "Content-Type": "application/json"}
         response = self.app.post(path, headers=headers, data=json.dumps(body))
         self.assertEqual(401, response.status_code)
@@ -2721,7 +2753,7 @@ class TestPublishRevision(BaseAPIPortalTest):
         """
         collection = self.generate_unpublished_collection(add_datasets=1, owner="someone_else")
         path = f"{self.base_path}/{collection.version_id.id}/publish"
-        body = {"data_submission_policy_version": "1.0"}
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
         response = self.app.post(path, headers=self.headers, data=json.dumps(body))
         self.assertEqual(403, response.status_code)
 
@@ -2731,7 +2763,7 @@ class TestPublishRevision(BaseAPIPortalTest):
         Publish a collection with a bad uuid (non existant) returns 403
         """
         collection_id = CollectionId()
-        body = {"data_submission_policy_version": "1.0"}
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
         path = f"{self.base_path}/{collection_id}/publish"
         response = self.app.post(path, headers=self.headers, data=json.dumps(body))
         self.assertEqual(403, response.status_code)
@@ -2740,7 +2772,7 @@ class TestPublishRevision(BaseAPIPortalTest):
     def test__can_publish_owned_collection(self):
         collection = self.generate_unpublished_collection(add_datasets=1)
         path = f"{self.base_path}/{collection.version_id.id}/publish"
-        body = {"data_submission_policy_version": "1.0"}
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
         headers = {
             "host": "localhost",
             "Content-Type": "application/json",
@@ -2753,7 +2785,7 @@ class TestPublishRevision(BaseAPIPortalTest):
     def test__can_publish_non_owned_collection_as_super_curator(self):
         collection = self.generate_unpublished_collection(add_datasets=1, owner="someone else")
         path = f"{self.base_path}/{collection.version_id.id}/publish"
-        body = {"data_submission_policy_version": "1.0"}
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
         headers = {
             "host": "localhost",
             "Content-Type": "application/json",
@@ -2766,7 +2798,7 @@ class TestPublishRevision(BaseAPIPortalTest):
         self.cloudfront_provider.create_invalidation_for_index_paths = Mock()
         collection = self.generate_unpublished_collection(add_datasets=1)
         path = f"{self.base_path}/{collection.version_id.id}/publish"
-        body = {"data_submission_policy_version": "1.0"}
+        body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
         headers = {
             "host": "localhost",
             "Content-Type": "application/json",

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -2655,7 +2655,7 @@ class TestPublishRevision(BaseAPIPortalTest):
 
     def test__publish_revision_missing_data_submission_policy_version__400(self):
         """
-        Checks data submission policy is correctly saved on publish of a revision.
+        Checks for failure on missing data submission policy version.
         """
 
         unpublished_collection = self.generate_unpublished_collection(add_datasets=1)
@@ -2663,6 +2663,34 @@ class TestPublishRevision(BaseAPIPortalTest):
         path = f"{self.base_path}/{unpublished_collection.version_id.id}/publish"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
         response = self.app.post(path, headers=headers)
+
+        self.assertEqual(400, response.status_code)
+
+    def test__publish_revision_old_data_submission_policy_version__400(self):
+        """
+        Checks for failure on submit of a data submission policy version that is not the latest.
+        """
+
+        unpublished_collection = self.generate_unpublished_collection(add_datasets=1)
+
+        path = f"{self.base_path}/{unpublished_collection.version_id.id}/publish"
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
+        body = {"data_submission_policy_version": "1.0.0"}  # 1.0.0 is older than current version.
+        response = self.app.post(path, headers=headers, data=json.dumps(body))
+
+        self.assertEqual(400, response.status_code)
+
+    def test__publish_revision_invalid_data_submission_policy_version__400(self):
+        """
+        Checks for failure on submit of a data submission policy version that is not a valid version.
+        """
+
+        unpublished_collection = self.generate_unpublished_collection(add_datasets=1)
+
+        path = f"{self.base_path}/{unpublished_collection.version_id.id}/publish"
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": self.get_cxguser_token()}
+        body = {"data_submission_policy_version": "x"}  # Invalid version
+        response = self.app.post(path, headers=headers, data=json.dumps(body))
 
         self.assertEqual(400, response.status_code)
 

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -7,6 +7,7 @@ from typing import List, Tuple
 from unittest.mock import ANY, Mock, call
 from uuid import uuid4
 
+from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
 from backend.common.corpora_config import CorporaConfig
 from backend.layers.business.business import (
     BusinessLogic,
@@ -245,7 +246,11 @@ class BaseBusinessLogicTestCase(unittest.TestCase):
         else:
             published_at = datetime.utcnow()
         self.database_provider.finalize_collection_version(
-            version.collection_id, version.version_id, "3.0.0", published_at=published_at
+            version.collection_id,
+            version.version_id,
+            "3.0.0",
+            DATA_SUBMISSION_POLICY_VERSION,
+            published_at=published_at,
         )
         return self.database_provider.get_collection_version_with_datasets(version.version_id)
 
@@ -415,6 +420,7 @@ class TestGetCollectionVersion(BaseBusinessLogicTestCase):
         self.assertIsNotNone(fetched_version)
         self.assertIsNotNone(fetched_version.published_at)
         self.assertEqual(fetched_version.metadata, version.metadata)
+        self.assertIsNotNone(fetched_version.data_submission_policy_version)
 
     def test_get_published_collection_version_for_published_collection_is_none(self):
         """
@@ -435,6 +441,7 @@ class TestGetCollectionVersion(BaseBusinessLogicTestCase):
 
         self.assertIsNone(fetched_version.published_at)
         self.assertEqual(fetched_version.metadata, version.metadata)
+        self.assertIsNone(fetched_version.data_submission_policy_version)
 
     def test_get_collection_version_for_published_collection_ok(self):
         """
@@ -1810,6 +1817,7 @@ class TestCollectionOperations(BaseBusinessLogicTestCase):
         )  # TODO: ideally, do a date assertion here (requires mocking)
         self.assertIsNotNone(published_version.canonical_collection.originally_published_at)
         self.assertEqual(published_version.published_at, published_version.canonical_collection.originally_published_at)
+        self.assertEqual(published_version.data_submission_policy_version, DATA_SUBMISSION_POLICY_VERSION)
 
         # The published and unpublished collection have the same collection_id and version_id
         self.assertEqual(published_version.collection_id, unpublished_collection.collection_id)


### PR DESCRIPTION
## Reason for Change

- #6202

## Changes

- Updated publish of collection to save data submission policy version to DB.
- Updated read of collection to return saved data submission policy version. 

## Testing steps

- Updated controller and business-layer tests.
- Tested in rdev.
 
## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review

