### PR TITLE
chore: freeze dev deploys

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -42,6 +42,8 @@ jobs:
             echo "DEPLOYMENT_STAGE=dev" >> $GITHUB_ENV
           fi
       - uses: avakar/create-deployment@v1
+        #  TODO remove if conidition after we're done with testing schema 5.0.0 in dev
+        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod'
         with:
           auto_merge: false
           environment: ${{ env.DEPLOYMENT_STAGE }}


### PR DESCRIPTION
## Reason for Change

to freeze dev deploys while we run the schema 5.0 migration in dev

## Changes

freezes dev deploys with merges to main

## Notes for Reviewer

this will be reverted after dev migration concludes