### PR TITLE
feat: persist distributed mode in schema migration script

### DIFF
--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -247,7 +247,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
       "Type": "Map",
       "ItemProcessor": {
         "ProcessorConfig": {
-          "Mode": "INLINE"
+          "Mode": "DISTRIBUTED"
         },
         "StartAt": "CollectionMigration",
         "States": {
@@ -370,7 +370,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
             "Type": "Map",
             "ItemProcessor": {
               "ProcessorConfig": {
-                "Mode": "INLINE"
+                "Mode": "DISTRIBUTED"
               },
               "StartAt": "DatasetMigration",
               "States": {


### PR DESCRIPTION
## Reason for Change

so that we don't have to change this manually with each run

## Changes

changes to `DISTRIBUTED` mode

## Notes for Reviewer
