### PR TITLE
feat(cellguide): enable search by ontology term ID

### DIFF
--- a/frontend/src/views/CellGuide/components/CellGuideCardSearchBar/index.tsx
+++ b/frontend/src/views/CellGuide/components/CellGuideCardSearchBar/index.tsx
@@ -188,7 +188,7 @@ export default function CellGuideCardSearchBar({
               return (
                 entity.label &&
                 (entity.label.toLowerCase().includes(searchTerm) ||
-                  entity.id.toLowerCase().startsWith(searchTerm) ||
+                  entity.id.toLowerCase().includes(searchTerm) ||
                   synonymStartsWithSearch)
               );
             })

--- a/frontend/src/views/CellGuide/components/CellGuideCardSearchBar/index.tsx
+++ b/frontend/src/views/CellGuide/components/CellGuideCardSearchBar/index.tsx
@@ -34,6 +34,7 @@ export default function CellGuideCardSearchBar({
 }): JSX.Element {
   const router = useRouter();
   const { data: cellTypes } = useCellTypeMetadata();
+  console.log(cellTypes);
   const { data: tissueData } = useTissueMetadata();
 
   const options: Entity[] = useMemo(() => {
@@ -187,6 +188,7 @@ export default function CellGuideCardSearchBar({
               return (
                 entity.label &&
                 (entity.label.toLowerCase().includes(searchTerm) ||
+                  entity.id.toLowerCase().startsWith(searchTerm) ||
                   synonymStartsWithSearch)
               );
             })

--- a/frontend/src/views/CellGuide/components/CellGuideCardSearchBar/index.tsx
+++ b/frontend/src/views/CellGuide/components/CellGuideCardSearchBar/index.tsx
@@ -34,7 +34,6 @@ export default function CellGuideCardSearchBar({
 }): JSX.Element {
   const router = useRouter();
   const { data: cellTypes } = useCellTypeMetadata();
-  console.log(cellTypes);
   const { data: tissueData } = useTissueMetadata();
 
   const options: Entity[] = useMemo(() => {

--- a/frontend/tests/features/cellGuide/cellGuide.test.ts
+++ b/frontend/tests/features/cellGuide/cellGuide.test.ts
@@ -165,6 +165,60 @@ describe("Cell Guide", () => {
       // check that the url has changed to the correct CellGuide card
       await page.waitForURL(`${TEST_URL}${ROUTES.CELL_GUIDE}/CL_0000746`); // cardiac muscle cell
     });
+    test("Cell type search bar filters by CL ID properly and links to a CellGuideCard", async ({
+      page,
+    }) => {
+      await goToPage(`${TEST_URL}${ROUTES.CELL_GUIDE}`, page);
+
+      const element = getSearchBarLocator(page);
+
+      await waitForElementAndClick(element);
+      await waitForOptionsToLoad(page);
+      // get number of elements with role option in dropdown
+      const numOptionsBefore = await countLocator(page.getByRole("option"));
+      // type in search bar
+      await element.type("CL:0000540");
+      // get number of elements with role option in dropdown
+      const numOptionsAfter = await countLocator(page.getByRole("option"));
+      // check that number of elements with role option in dropdown has decreased
+      expect(numOptionsAfter).toBeLessThan(numOptionsBefore);
+      // check that the first element in the dropdown is the one we searched for (neuron)
+      const firstOption = (await page.getByRole("option").all())[0];
+      const firstOptionText = await firstOption?.textContent();
+      expect(firstOptionText).toBe("neuron");
+      // click on first element in dropdown
+      await firstOption?.click();
+      // check that the url has changed to the correct CellGuide card
+      await page.waitForURL(`${TEST_URL}${ROUTES.CELL_GUIDE}/CL_0000540`); // neuron
+    });
+    test("Cell type search bar filters by UBERON ID properly and links to a TissueCard", async ({
+      page,
+    }) => {
+      await goToPage(`${TEST_URL}${ROUTES.CELL_GUIDE}`, page);
+
+      const element = getSearchBarLocator(page);
+
+      await waitForElementAndClick(element);
+      await waitForOptionsToLoad(page);
+      // get number of elements with role option in dropdown
+      const numOptionsBefore = await countLocator(page.getByRole("option"));
+      // type in search bar
+      await element.type("UBERON:0002048");
+      // get number of elements with role option in dropdown
+      const numOptionsAfter = await countLocator(page.getByRole("option"));
+      // check that number of elements with role option in dropdown has decreased
+      expect(numOptionsAfter).toBeLessThan(numOptionsBefore);
+      // check that the first element in the dropdown is the one we searched for (lung)
+      const firstOption = (await page.getByRole("option").all())[0];
+      const firstOptionText = await firstOption?.textContent();
+      expect(firstOptionText).toBe("lung");
+      // click on first element in dropdown
+      await firstOption?.click();
+      // check that the url has changed to the correct CellGuide card
+      await page.waitForURL(
+        `${TEST_URL}${ROUTES.CELL_GUIDE}/tissues/UBERON_0002048`
+      ); // lung
+    });
     test("Cell type search bar keyboard input works properly", async ({
       page,
     }) => {


### PR DESCRIPTION
This PR lets you search by CL or UBERON ontology term ID
<img width="464" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/16548075/37415b7e-984b-4ef6-8e07-904613803701">

Testing steps:
 - Added e2e tests
 - Tested locally