### PR TITLE
test: fix revision deletion

### DIFF
--- a/frontend/tests/features/collection/revision.test.ts
+++ b/frontend/tests/features/collection/revision.test.ts
@@ -477,14 +477,10 @@ async function startRevision(
       try {
         await expect(page.getByTestId(collectionRowTestId)).toBeTruthy();
 
-        await tryUntil(
-          async () => {
-            const collectionRows = await page.getByTestId(collectionRowTestId);
-            expect(await collectionRows.count()).toBeGreaterThan(
-              MIN_USABLE_COLLECTION_COUNT - 1
-            );
-          },
-          { page }
+        const collectionRows = await page.getByTestId(collectionRowTestId);
+
+        expect(await collectionRows.count()).toBeGreaterThan(
+          MIN_USABLE_COLLECTION_COUNT - 1
         );
       } catch {
         const revisionRowTestId = buildCollectionRowLocator(


### PR DESCRIPTION
The fix is simply removing the `tryUntil()` block around the assertion:

```ts
expect(await collectionRows.count()).toBeGreaterThan(
  MIN_USABLE_COLLECTION_COUNT - 1
);
```

so the `catch()` block can delete revision and recheck the assertion!