### PR TITLE
chore(cg): a couple bug fixes and tooltip update

### DIFF
--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/MarkerGeneTables/hooks/common.ts
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/MarkerGeneTables/hooks/common.ts
@@ -36,7 +36,7 @@ export function useOrganAndOrganismFilterListForCellType(
     }
     const tissues = data[cellTypeId];
     const organsMap = new Map<string, string>();
-    for (let i = 0; i < tissues.length; i++) {
+    for (let i = 0; i < tissues?.length; i++) {
       const id = tissues[i];
       const label = tissueMetadata[id].name;
       organsMap.set(label, id);

--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/common/HelpTooltip/style.ts
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/common/HelpTooltip/style.ts
@@ -31,4 +31,5 @@ export const ExtraContentWrapper = styled.span`
   flex-direction: row;
   align-items: center;
   gap: ${spacesXxxs}px;
+  white-space: nowrap;
 `;

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -5,7 +5,6 @@ import React, {
   Dispatch,
   SetStateAction,
 } from "react";
-import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Group } from "@visx/group";
 import { Global } from "@emotion/react";
 import { useTooltip, useTooltipInPortal } from "@visx/tooltip";
@@ -45,6 +44,7 @@ import {
   RightAligned,
   StyledTagFilter,
   WarningTooltipTextWrapper,
+  WarningTooltipIcon,
 } from "./style";
 import { useFullScreen } from "../FullScreenProvider";
 import {
@@ -475,7 +475,7 @@ export default function OntologyDagView({
             buttonDataTestId={
               CELLGUIDE_OPEN_INTEGRATED_EMBEDDING_TOOLTIP_TEST_ID
             }
-            placement="left"
+            placement="top"
             text={
               <>
                 {tooltipTextFirstPart}
@@ -502,9 +502,11 @@ export default function OntologyDagView({
                 <br />
                 <>
                   <WarningTooltipTextWrapper>
-                    <WarningAmberIcon
-                      fontSize="small"
-                      style={{ marginRight: "4px" }}
+                    <WarningTooltipIcon
+                      sdsIcon="exclamationMarkCircle"
+                      color="warning"
+                      sdsSize="l"
+                      sdsType="static"
                     />
                     <span>
                       UMAP embeddings are helpful for exploration, but may be

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/style.ts
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/style.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { IconButton } from "@mui/material";
-import { ButtonIcon, TagFilter } from "@czi-sds/components";
+import { ButtonIcon, Icon, TagFilter } from "@czi-sds/components";
 import { primary400, spacesL } from "src/common/theme";
 import { HEADER_HEIGHT_PX } from "src/components/Header/style";
 
@@ -63,6 +63,10 @@ export const TooltipInPortalStyle = css`
 export const WarningTooltipTextWrapper = styled.div`
   display: flex;
   align-items: center;
+`;
+
+export const WarningTooltipIcon = styled(Icon)`
+  margin-right: 4px;
 `;
 
 interface StyledSVGProps {

--- a/frontend/tests/features/cellGuide/cellGuide.test.ts
+++ b/frontend/tests/features/cellGuide/cellGuide.test.ts
@@ -92,6 +92,7 @@ const GLIOBLAST_CELL_TYPE_ID = "CL_0000030";
 const T_CELL_CELL_TYPE_ID = "CL_0000084";
 const BRAIN_TISSUE_ID = "UBERON_0000955";
 const LUNG_TISSUE_ID = "UBERON_0002048";
+const SALIVARY_ACINAR_GLAND_CELL_TYPE_ID = "CL_0002623";
 const ABNORMAL_CELL_TYPE_ID = "CL_0001061";
 const PROGENITOR_CELL_CELL_TYPE_ID = "CL_0011026";
 const CELL_CELL_TYPE_ID = "CL_0000000";
@@ -968,6 +969,35 @@ describe("Cell Guide", () => {
 
         expect(linkHrefAfterTissueSelection).toContain(
           "tissues/mus_musculus/UBERON_0000955__"
+        );
+      });
+      test("Selecting 'Mus musculus' from organism selector on a cell type with no mouse cells removes ontology", async ({
+        page,
+      }) => {
+        await goToPage(
+          `${TEST_URL}${ROUTES.CELL_GUIDE}/${SALIVARY_ACINAR_GLAND_CELL_TYPE_ID}`,
+          page
+        );
+
+        await isElementVisible(
+          page,
+          CELL_GUIDE_CARD_GLOBAL_ORGANISM_FILTER_DROPDOWN
+        );
+
+        await page
+          .getByTestId(CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW)
+          .waitFor({ timeout: WAIT_FOR_TIMEOUT_MS });
+
+        await page
+          .getByTestId(CELL_GUIDE_CARD_GLOBAL_ORGANISM_FILTER_DROPDOWN)
+          .click();
+        await page.getByRole("option").getByText("Mus musculus").click();
+
+        const dagViewTextContent = await page
+          .getByTestId(CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW)
+          .textContent();
+        expect(dagViewTextContent).toContain(
+          "Cell ontology visualization unavailable"
         );
       });
       test("Selecting 'Mus musculus' from organism selector updates the cell counts in the ontology", async ({


### PR DESCRIPTION
## Reason for Change / Changes

- Changing organisms on a cell type with no cells for the new organism crashed the page.
  - Allowed `tissues` to be undefined.
- Tooltip for open integrated embedding button was using an incorrect warning icon
  - Used design-approved icon
- Tooltip was placed in an orientation that was not compatible with mobile layouts
  - Placed the tooltip on top, instead
- "Open Integrated Embedding" text wrap on mobile layouts looked ugly
  - Turned off text wrap
<img width="520" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/16548075/aec51f23-b01b-46b6-9d10-8f6141c92832">

## Testing steps

- Tested locally
- Added e2e test for the primary bug