### PR TITLE
chore: fix wmg rollup by removing extraneous filtering step

### DIFF
--- a/backend/wmg/api/v2.py
+++ b/backend/wmg/api/v2.py
@@ -123,18 +123,6 @@ def query():
                 )
                 rolled_cell_counts_grouped_df = rollup(cell_counts_grouped_df, snapshot.cell_type_ancestors)
 
-                # filter out rows that do not have a corresponding cell type in the cell counts dataframe
-                # as these will not be displayed in the UI anyway
-
-                with ServerTiming.time("filter out rows"):
-                    rolled_gene_expression_df = rolled_gene_expression_df[
-                        rolled_gene_expression_df["cell_type_ontology_term_id"].isin(
-                            cell_counts_grouped_df.index.levels[
-                                cell_counts_grouped_df.index.names.index("cell_type_ontology_term_id")
-                            ]
-                        )
-                    ]
-
             response = jsonify(
                 dict(
                     snapshot_id=snapshot.snapshot_identifier,


### PR DESCRIPTION
## Reason for Change

[Slack context](https://czi-sci.slack.com/archives/C0247APK621/p1710178286312599)
- `cell` ancestor node in lung is not showing any data, even though it's the root of the tree. The reason for this was because there was an extraneous filtering step where we were filtering out cell type IDs from the gene expression dataframe that wasn't included in the ORIGINAL, UNROLLED cell counts dataframe. This was a mistake as we should have been comparing against the POST-ROLLUP cell counts dataframe.
- Also, after empirical testing, this filtering step rarely (if ever) actually filters out any entries, so we can safely remove it.

## Changes

- remove extraneous filtering step

## Testing steps

- Tested in rdev.