### PR TITLE
fix: pin pytest 8.0.2

### DIFF
--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -23,7 +23,7 @@ psycopg2-binary>=2.8.5
 pyarrow>=1.0
 pydantic>=1.9.0
 PyMySQL==0.9.3
-pytest
+pytest==8.0.2
 pytest-subtests
 python-json-logger
 requests>=2.22.0


### PR DESCRIPTION
## Reason for Change
- [bug in pytest 8.1.0+](https://github.com/pytest-dev/pytest/issues/12069) is causing failures in processing unit tests