### PR TITLE
chore: update cellguide embedding tooltip to indicate LTS support only

### DIFF
--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -478,7 +478,7 @@ export default function OntologyDagView({
             placement="top"
             text={
               <>
-                {tooltipTextFirstPart}
+                <b>{tooltipTextFirstPart}</b>
                 <br />
                 <br />
                 UMAP was run using Scanpy&apos;s default parameters on the{" "}
@@ -498,6 +498,12 @@ export default function OntologyDagView({
                   CELLxGENE Census
                 </a>
                 .
+                <br />
+                <br />
+                The cell counts in the Explorer view may not match the cell
+                counts in the ontology view because the integrated embeddings
+                were generated from the long-term supported (LTS) Census data
+                (12-15-2023).
                 <br />
                 <br />
                 <>


### PR DESCRIPTION
## Reason for Change

- #6779 


## Changes

- updated tooltip

## Testing steps

- Tested locally
<img width="623" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/16548075/4ae91ad7-ad04-46b4-b692-8d0abcde92bb">
