### PR TITLE
chore: persist memory bump to schema migration jobs

### DIFF
--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -11,7 +11,7 @@ resource aws_batch_job_definition batch_job_def {
   container_properties = jsonencode({
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
-  "memory": var.batch_container_memory_limit,
+  "memory": 508000,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",

--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -48,7 +48,7 @@ resource aws_batch_job_definition schema_migrations_swap {
       },
       {
         Type="MEMORY",
-        Value = "256000"
+        Value = "508000"
       }
     ]
     linuxParameters= {


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell/686

## Changes

bumps memory up as we did when running locally

## Testing steps

tested a dev SFN push with these memory numbers
