### PR TITLE
Change models page to support new embeddings mode

### DIFF
--- a/frontend/src/common/queries/censusDirectory.ts
+++ b/frontend/src/common/queries/censusDirectory.ts
@@ -7,7 +7,7 @@ import { API } from "../API";
 
 export interface Project {
   id: string;
-  tier: "hosted";
+  tier: string;
   census_version: string;
   experiment_name: string;
   measurement_name: string;
@@ -83,7 +83,11 @@ async function fetchProjects(): Promise<ProjectResponse | undefined> {
 
           data[id].publication_info = publication_info;
           data[id].publication_link = result.message.URL;
-          data[id].tier = "hosted";
+          if (data[id].id.startsWith("CxG-contrib-")) {
+            data[id].tier = "hosted";
+          } else if (data[id].id.startsWith("CxG-czi-")) {
+            data[id].tier = "maintained";
+          }
         }
       )
     );

--- a/frontend/src/views/CensusDirectory/index.tsx
+++ b/frontend/src/views/CensusDirectory/index.tsx
@@ -24,7 +24,7 @@ function CensusDirectory() {
 
   const hostedProjects = clobberAndDifferentiateProjectMetadata(
     Object.values(projects ?? ({} as ProjectType[])).filter(
-      (project) => !project.revised_by
+      (project) => project.tier === "hosted"
     )
   );
 
@@ -35,7 +35,7 @@ function CensusDirectory() {
   );
 
   const maintainedProjects = clobberAndDifferentiateProjectMetadata(
-    Object.values(staticProjects).filter(
+    Object.values(projects ?? ({} as ProjectType[])).filter(
       (project) => project.tier === "maintained"
     )
   );


### PR DESCRIPTION
Collaboration models will now exist in contributions.json, so this PR retrieves them from there.