### PR TITLE
feat: block dev deployment

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -30,7 +30,7 @@ jobs:
   #    secrets: inherit
 
   create_deployment:
-    needs:
+    #    needs:
     #      - build_images
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -46,10 +46,6 @@ jobs:
         # To stop deployment to a specific DEPLOYMENT_STAGE remove it from condition below.
         # The DEPLOYMENT_STAGE that should be present are dev, stage, prod.
         if: env.DEPLOYMENT_STAGE == 'prod' || env.DEPLOYMENT_STAGE == 'stage'
-        run: |
-          echo "DEPLOYMENT_STAGE: ${{ env.DEPLOYMENT_STAGE }}"
-          echo "payload: ${{ env.payload }}"
-
         with:
           auto_merge: false
           environment: ${{ env.DEPLOYMENT_STAGE }}

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -1,16 +1,13 @@
 name: Build Images and Create Deployment
 
 on:
-  #  push:
-  #    branches:
-  #      - main
-  #      - prod
-  pull_request:
+  push:
     branches:
-      - "*"
-#  repository_dispatch:
-#    types: [build-images-for-staging, build-images-for-prod]
-#  workflow_call:
+      - main
+      - prod
+  repository_dispatch:
+    types: [build-images-for-staging, build-images-for-prod]
+  workflow_call:
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.
@@ -25,13 +22,13 @@ permissions:
   deployments: write
 
 jobs:
-  #  build_images:
-  #    uses: ./.github/workflows/build-images.yml
-  #    secrets: inherit
+  build_images:
+    uses: ./.github/workflows/build-images.yml
+    secrets: inherit
 
   create_deployment:
-    #    needs:
-    #      - build_images
+    needs:
+      - build_images
     runs-on: ubuntu-22.04
     steps:
       - name: Generate payload
@@ -44,9 +41,8 @@ jobs:
           else
             echo "DEPLOYMENT_STAGE=dev" >> $GITHUB_ENV
           fi
-      - name: test
-        #        uses: avakar/create-deployment@v1
-
+      - name: Create deployment
+        uses: avakar/create-deployment@v1
         # To stop deployment to a specific DEPLOYMENT_STAGE remove it from condition below.
         # The DEPLOYMENT_STAGE that should be present are dev, stage, prod.
         if: env.DEPLOYMENT_STAGE == 'prod' || env.DEPLOYMENT_STAGE == 'stage'
@@ -54,17 +50,17 @@ jobs:
           echo "DEPLOYMENT_STAGE: ${{ env.DEPLOYMENT_STAGE }}"
           echo "payload: ${{ env.payload }}"
 
-#        with:
-#          auto_merge: false
-#          environment: ${{ env.DEPLOYMENT_STAGE }}
-#          payload: ${{ env.payload }}
-#          required_contexts: "" # Temporary hack to avoid checking Github Status for the commit
-#          # TODO: Avoid circular dependency on the deploy step; this step hasn't finished yet so
-#          # it's not considered ready for deploy normally by required_contexts, but we need to
-#          # deploy for this to be considered ready.
-#          # Unfortunately there is no blocklist for required_contexts, only an allowlist, so
-#          # we'd have to enumerate every other Github PR status here, which can be constantly changing.
-#          # For now, we just ignore required_contexts to deploy on every success.
-#          # See https://github.community/t/can-i-avoid-creating-a-check-run-from-a-job-needed-for-deployments-api/16426
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}
+        with:
+          auto_merge: false
+          environment: ${{ env.DEPLOYMENT_STAGE }}
+          payload: ${{ env.payload }}
+          required_contexts: "" # Temporary hack to avoid checking Github Status for the commit
+          # TODO: Avoid circular dependency on the deploy step; this step hasn't finished yet so
+          # it's not considered ready for deploy normally by required_contexts, but we need to
+          # deploy for this to be considered ready.
+          # Unfortunately there is no blocklist for required_contexts, only an allowlist, so
+          # we'd have to enumerate every other Github PR status here, which can be constantly changing.
+          # For now, we just ignore required_contexts to deploy on every success.
+          # See https://github.community/t/can-i-avoid-creating-a-check-run-from-a-job-needed-for-deployments-api/16426
+        env:
+          GITHUB_TOKEN: ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -42,8 +42,9 @@ jobs:
             echo "DEPLOYMENT_STAGE=dev" >> $GITHUB_ENV
           fi
       - uses: avakar/create-deployment@v1
-        #  TODO remove if conidition after we're done with testing schema 5.0.0 in dev
-        if: ${{ env.GITHUB_BRANCH }} == 'refs/heads/prod' || ${{ env.GITHUB_BRANCH }} == 'refs/heads/staging'
+        # To stop deployment to a specific DEPLOYMENT_STAGE remove it from condition below.
+        # The DEPLOYMENT_STAGE that should be present are dev, stage, prod.
+        if: ${{ env.DEPLOYMENT_STAGE }} == 'prod' || ${{ env.DEPLOYMENT_STAGE }} == 'stage'
         with:
           auto_merge: false
           environment: ${{ env.DEPLOYMENT_STAGE }}

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -1,16 +1,16 @@
 name: Build Images and Create Deployment
 
 on:
-  push:
-    branches:
-      - main
-      - prod
+  #  push:
+  #    branches:
+  #      - main
+  #      - prod
   pull_request:
     branches:
       - tsmith/block-dev
-  repository_dispatch:
-    types: [build-images-for-staging, build-images-for-prod]
-  workflow_call:
+#  repository_dispatch:
+#    types: [build-images-for-staging, build-images-for-prod]
+#  workflow_call:
 env:
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -49,7 +49,7 @@ jobs:
 
         # To stop deployment to a specific DEPLOYMENT_STAGE remove it from condition below.
         # The DEPLOYMENT_STAGE that should be present are dev, stage, prod.
-        if: ${{ env.DEPLOYMENT_STAGE }} == 'prod' || ${{ env.DEPLOYMENT_STAGE }} == 'stage'
+        if: env.DEPLOYMENT_STAGE == 'prod' || env.DEPLOYMENT_STAGE == 'stage'
         run: |
           echo "DEPLOYMENT_STAGE: ${{ env.DEPLOYMENT_STAGE }}"
           echo "payload: ${{ env.payload }}"

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -45,7 +45,7 @@ jobs:
             echo "DEPLOYMENT_STAGE=dev" >> $GITHUB_ENV
           fi
       - name: test
-        uses: avakar/create-deployment@v1
+        #        uses: avakar/create-deployment@v1
 
         # To stop deployment to a specific DEPLOYMENT_STAGE remove it from condition below.
         # The DEPLOYMENT_STAGE that should be present are dev, stage, prod.

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - prod
+  pull_request:
+    branches:
+      - tsmith/block-dev
   repository_dispatch:
     types: [build-images-for-staging, build-images-for-prod]
   workflow_call:
@@ -22,13 +25,13 @@ permissions:
   deployments: write
 
 jobs:
-  build_images:
-    uses: ./.github/workflows/build-images.yml
-    secrets: inherit
+  #  build_images:
+  #    uses: ./.github/workflows/build-images.yml
+  #    secrets: inherit
 
   create_deployment:
     needs:
-      - build_images
+    #      - build_images
     runs-on: ubuntu-22.04
     steps:
       - name: Generate payload
@@ -41,21 +44,27 @@ jobs:
           else
             echo "DEPLOYMENT_STAGE=dev" >> $GITHUB_ENV
           fi
-      - uses: avakar/create-deployment@v1
+      - name: test
+        uses: avakar/create-deployment@v1
+
         # To stop deployment to a specific DEPLOYMENT_STAGE remove it from condition below.
         # The DEPLOYMENT_STAGE that should be present are dev, stage, prod.
         if: ${{ env.DEPLOYMENT_STAGE }} == 'prod' || ${{ env.DEPLOYMENT_STAGE }} == 'stage'
-        with:
-          auto_merge: false
-          environment: ${{ env.DEPLOYMENT_STAGE }}
-          payload: ${{ env.payload }}
-          required_contexts: "" # Temporary hack to avoid checking Github Status for the commit
-          # TODO: Avoid circular dependency on the deploy step; this step hasn't finished yet so
-          # it's not considered ready for deploy normally by required_contexts, but we need to
-          # deploy for this to be considered ready.
-          # Unfortunately there is no blocklist for required_contexts, only an allowlist, so
-          # we'd have to enumerate every other Github PR status here, which can be constantly changing.
-          # For now, we just ignore required_contexts to deploy on every success.
-          # See https://github.community/t/can-i-avoid-creating-a-check-run-from-a-job-needed-for-deployments-api/16426
-        env:
-          GITHUB_TOKEN: ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}
+        run: |
+          echo "DEPLOYMENT_STAGE: ${{ env.DEPLOYMENT_STAGE }}"
+          echo "payload: ${{ env.payload }}"
+
+#        with:
+#          auto_merge: false
+#          environment: ${{ env.DEPLOYMENT_STAGE }}
+#          payload: ${{ env.payload }}
+#          required_contexts: "" # Temporary hack to avoid checking Github Status for the commit
+#          # TODO: Avoid circular dependency on the deploy step; this step hasn't finished yet so
+#          # it's not considered ready for deploy normally by required_contexts, but we need to
+#          # deploy for this to be considered ready.
+#          # Unfortunately there is no blocklist for required_contexts, only an allowlist, so
+#          # we'd have to enumerate every other Github PR status here, which can be constantly changing.
+#          # For now, we just ignore required_contexts to deploy on every success.
+#          # See https://github.community/t/can-i-avoid-creating-a-check-run-from-a-job-needed-for-deployments-api/16426
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}

--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -7,7 +7,7 @@ on:
   #      - prod
   pull_request:
     branches:
-      - tsmith/block-dev
+      - "*"
 #  repository_dispatch:
 #    types: [build-images-for-staging, build-images-for-prod]
 #  workflow_call:


### PR DESCRIPTION
## Reason for Change
- sometime deployment to dev needs to be pause for testing or migrations

## Changes

- add comments on how to enable and disable deployment of an environment
- remove dev from deployed environments

## Testing
- verified if logic works https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/8270321903/job/22627569180

## Checklist 🛎️


## Notes for Reviewer
`${{ }}` were used incorrectly. According to [GHA docs](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#overview):
> When you use expressions in an if conditional, you can, optionally, omit the ${{ }} expression syntax because GitHub Actions automatically evaluates the if conditional as an expression. However, this exception does not apply everywhere.

So either the whole expression should be in `${{ }}`, or none of it of `if`s.