### PR TITLE
chore: decrease e2e shards

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -209,8 +209,8 @@ jobs:
       matrix:
         # Only run Chrome for now, since GHA only has 250 workers and will cancel jobs if it runs out
         project: [chromium]
-        shardCurrent: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        shardTotal: [10]
+        shardCurrent: [1, 2, 3, 4, 5]
+        shardTotal: [5]
 
     defaults:
       run:

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -65,8 +65,8 @@ jobs:
       matrix:
         # Only run Chrome for now, since GHA only has 250 workers and will cancel jobs if it runs out
         project: [chromium]
-        shardCurrent: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        shardTotal: [10]
+        shardCurrent: [1, 2, 3, 4, 5]
+        shardTotal: [5]
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
Lower e2e shard count from 10 to 5 to hopefully relieve the GHA cancelling jobs issue