### PR TITLE
fix: disable new dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -9,12 +10,14 @@ updates:
       - "seve"
   - package-ecosystem: pip
     directory: "/python_dependencies/backend/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "daily"
     assignees:
       - "Bento007"
   - package-ecosystem: pip
     directory: "/python_dependencies/wmg/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -22,6 +25,7 @@ updates:
       - "prathapsridharan"
   - package-ecosystem: pip
     directory: "/python_dependencies/upload_handler/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -29,6 +33,7 @@ updates:
       - "ebezzi"
   - package-ecosystem: pip
     directory: "/python_dependencies/submissions/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -36,6 +41,7 @@ updates:
       - "nayib-jose-gloria"
   - package-ecosystem: pip
     directory: "/python_dependencies/cellguide_pipeline/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -43,6 +49,7 @@ updates:
       - "atarashansky"
   - package-ecosystem: pip
     directory: "/python_dependencies/processing/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -50,6 +57,7 @@ updates:
       - "danieljhegeman"
   - package-ecosystem: npm
     directory: "/frontend/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
## Reason for Change

- disable dependabot from making new PR. This might help reduce the issue of cancel jobs in GHA.

## Changes

- set open-pull-requests-limit: 0 for all dependency files/

