### PR TITLE
feat: Remove reorder feature flag (#6493)

### DIFF
--- a/frontend/src/common/featureFlags/features.ts
+++ b/frontend/src/common/featureFlags/features.ts
@@ -2,5 +2,4 @@ export enum FEATURES {
   GENE_SETS = "gs",
   CURATOR = "curator",
   FILTER = "filter",
-  REORDER = "reorder",
 }

--- a/frontend/src/views/Collection/components/CollectionActions/components/MoreDropdown/components/Menu/index.tsx
+++ b/frontend/src/views/Collection/components/CollectionActions/components/MoreDropdown/components/Menu/index.tsx
@@ -75,19 +75,17 @@ const Menu = ({
       open={Boolean(menuProps.open)}
     >
       <CreateCollection id={collection.id} Button={EditButton} />
-      {reorder.isReorderUX && (
-        <ReorderMenuItem
-          data-testid="dropdown-reorder-datasets"
-          disabled={reorder.disabled}
-          onClick={() => {
-            menuProps.onClose();
-            reorder.startReorder();
-          }}
-        >
-          <IconSort />
-          Reorder Datasets
-        </ReorderMenuItem>
-      )}
+      <ReorderMenuItem
+        data-testid="dropdown-reorder-datasets"
+        disabled={reorder.disabled}
+        onClick={() => {
+          menuProps.onClose();
+          reorder.startReorder();
+        }}
+      >
+        <IconSort />
+        Reorder Datasets
+      </ReorderMenuItem>
       <DeleteCollection
         Button={DeleteButton}
         handleDeleteCollection={handleDeleteCollection}

--- a/frontend/src/views/Collection/hooks/useReorder/useReorder.ts
+++ b/frontend/src/views/Collection/hooks/useReorder/useReorder.ts
@@ -1,6 +1,4 @@
 import { useCallback, useState } from "react";
-import { useFeatureFlag } from "src/common/hooks/useFeatureFlag";
-import { FEATURES } from "src/common/featureFlags/features";
 import { useOrderDatasets } from "src/common/queries/collections";
 import { Collection } from "src/common/entities";
 
@@ -26,7 +24,6 @@ export enum REORDER_MODE {
 
 export interface UseReorder {
   isReorder: boolean;
-  isReorderUX: boolean;
   orderedIds?: string[];
   reorderAction: ReorderAction;
 }
@@ -39,7 +36,6 @@ export interface UseReorder {
  * @returns reorder mode.
  */
 export function useReorder(collectionId: Collection["id"]): UseReorder {
-  const isReorderUX = useFeatureFlag(FEATURES.REORDER); // Reorder datasets UX feature flag (reordering is currently only available with the feature flag).
   const [mode, setMode] = useState<REORDER_MODE>(REORDER_MODE.INACTIVE);
   const [orderedIds, setOrderedIds] = useState<string[]>();
   const orderDatasetsMutation = useOrderDatasets(collectionId);
@@ -87,7 +83,6 @@ export function useReorder(collectionId: Collection["id"]): UseReorder {
 
   return {
     isReorder: mode === REORDER_MODE.ACTIVE,
-    isReorderUX,
     reorderAction: {
       onCancelReorder,
       onReorder,


### PR DESCRIPTION
## Reason for Change

- #6493.

## Changes

- Removed `reorder` feature flag.

## Testing steps

- Curator may only reorder datasets while collection is private collection, or private revision collection.
- Curator may reorder datasets - without the feature flag `reorder` (now removed).
