### PR TITLE
fix: add appropriate failure tolerances to schema migration sfn

### DIFF
--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -479,7 +479,8 @@ resource aws_sfn_state_machine sfn_schema_migration {
                 "ResultPath": "$.error"
               }
             ],
-            "OutputPath": "$[0]"
+            "OutputPath": "$[0]",
+            "ToleratedFailurePercentage": 100
           },
           "CollectionError": {
             "Type": "Pass",
@@ -498,7 +499,8 @@ resource aws_sfn_state_machine sfn_schema_migration {
           "Next": "report",
           "ResultPath": null
         }
-      ]
+      ],
+      "ToleratedFailurePercentage": 20
     },
     "report": {
       "Type": "Task",


### PR DESCRIPTION
The SFN will fail if a single subtask fails unless we add these values. We'll fail after 20% of Collections fail (20); a Collection fails if any single Dataset fails, but all Datasets will be processed for a given Collection (100).

## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- add
- remove
- modify

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
