### PR TITLE
feat: allow rebuild of processing image GHA to be triggered manually

### DIFF
--- a/.github/workflows/rebuild-processing-image.yml
+++ b/.github/workflows/rebuild-processing-image.yml
@@ -14,6 +14,7 @@ permissions:
   deployments: write
 
 on:
+  workflow_dispatch: {}
   repository_dispatch:
     types: [rebuild-processing]
   workflow_call:


### PR DESCRIPTION
## Reason for Change

- This is to facilitate scenarios (such as the present migration) where it is useful to trigger the processing image rebuild manually in the Github console _without also triggering a schema migration sfn run_

## Changes

- add
- remove
- modify

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
