### PR TITLE
feat: add publishing denylist to mass  revision publish batch job

### DIFF
--- a/backend/layers/processing/publish_revisions.py
+++ b/backend/layers/processing/publish_revisions.py
@@ -4,6 +4,9 @@ After a migration has run, this can be used to publish all open revision for mig
 $ aws batch submit-job --job-name publish-revisions \
   \ --job-queue <your_job_queue_ARN>
   \ --job-definition <your_job_definition_ARN>
+  \ --container-overrides {
+    "environment": [{"name": "DO_NOT_PUBLISH_LIST", "value": "collection_version_id1,collection_version_id2"}]
+  }
 
 """
 import logging
@@ -27,13 +30,14 @@ configure_logging(level=logging.INFO)
 
 
 class PublishRevisions(ProcessingLogic):
-    def __init__(self, business_logic: BusinessLogic) -> None:
+    def __init__(self, business_logic: BusinessLogic, do_not_publish_list: List[str] = None) -> None:
         super().__init__()
         self.business_logic = business_logic
         self.s3_provider = business_logic.s3_provider
         self.schema_validator = SchemaValidatorProvider()
         self.artifact_bucket = os.environ.get("ARTIFACT_BUCKET", "test-bucket")
         self.schema_version = self.schema_validator.get_current_schema_version()
+        self.do_not_publish_list = do_not_publish_list if do_not_publish_list else []
 
     def check_datasets(self, collection_version: CollectionVersionWithDatasets) -> List[Dict]:
         """Check that all datasets have been migrated and are in a success state"""
@@ -63,6 +67,12 @@ class PublishRevisions(ProcessingLogic):
     def run(self):
         for collection_version in self.business_logic.get_collections(CollectionQueryFilter(is_published=False)):
             if collection_version.is_unpublished_version():
+                if collection_version.version_id.id in self.do_not_publish_list:
+                    self.logger.info(
+                        "Skipping collection version, it is in the do not publish list",
+                        extra={"collection_version_id": collection_version.version_id.id},
+                    )
+                    continue
                 _collection_version = self.business_logic.get_collection_version(collection_version.version_id)
                 errors = self.check_datasets(_collection_version)
                 if errors:
@@ -94,5 +104,5 @@ if __name__ == "__main__":
         S3Provider(),
         UriProvider(),
     )
-
-    PublishRevisions(business_logic).run()
+    do_not_publish_list = os.environ.get("DO_NOT_PUBLISH_LIST", None).split(",")
+    PublishRevisions(business_logic, do_not_publish_list).run()

--- a/backend/layers/processing/publish_revisions.py
+++ b/backend/layers/processing/publish_revisions.py
@@ -2,11 +2,11 @@
 After a migration has run, this can be used to publish all open revision for migrated collections.
 
 $ aws batch submit-job --job-name publish-revisions \
-  \ --job-queue <your_job_queue_ARN>
-  \ --job-definition <your_job_definition_ARN>
-  \ --container-overrides {
+  --job-queue <your_job_queue_ARN> \
+  --job-definition <your_job_definition_ARN> \
+  --container-overrides '{
     "environment": [{"name": "DO_NOT_PUBLISH_LIST", "value": "collection_version_id1,collection_version_id2"}]
-  }
+  }'
 
 """
 import logging

--- a/scripts/smoke_tests/setup.py
+++ b/scripts/smoke_tests/setup.py
@@ -67,8 +67,8 @@ if __name__ == "__main__":
     if collection_count >= NUM_TEST_COLLECTIONS:
         sys.exit(0)
     dataset_dropbox_url = (
-        "https://www.dropbox.com/scl/fi/d99hpw3p2cxtmi7v4kyv5/"
-        "4_0_0_test_dataset.h5ad?rlkey=i5ownt8g1mropbu41r7fa0i06&dl=0"
+        "https://www.dropbox.com/scl/fi/y50umqlcrbz21a6jgu99z/"
+        "5_0_0_example_valid.h5ad?rlkey=s7p6ybyx082hswix26hbl11pm&dl=0"
     )
     num_to_create = NUM_TEST_COLLECTIONS - collection_count
     threads = []

--- a/tests/functional/backend/common.py
+++ b/tests/functional/backend/common.py
@@ -39,8 +39,8 @@ class BaseFunctionalTestCase(unittest.TestCase):
         cls.deployment_stage = os.environ["DEPLOYMENT_STAGE"]
         cls.config = CorporaAuthConfig()
         cls.test_dataset_uri = (
-            "https://www.dropbox.com/scl/fi/d99hpw3p2cxtmi7v4kyv5/"
-            "4_0_0_test_dataset.h5ad?rlkey=i5ownt8g1mropbu41r7fa0i06&dl=0"
+            "https://www.dropbox.com/scl/fi/y50umqlcrbz21a6jgu99z/"
+            "5_0_0_example_valid.h5ad?rlkey=s7p6ybyx082hswix26hbl11pm&dl=0"
         )
         cls.session = requests.Session()
         # apply retry config to idempotent http methods we use + POST requests, which are currently all either

--- a/tests/unit/processing/schema_migration/test_publish_revisions.py
+++ b/tests/unit/processing/schema_migration/test_publish_revisions.py
@@ -126,6 +126,7 @@ class TestPublishRevisions:
         _, revision = collections["revision"]
         publish_revisions.business_logic.get_collections.return_value = [collections]
         publish_revisions.do_not_publish_list = [revision.version_id.id]
+        publish_revisions.check_datasets = Mock(return_value=[])
 
         # Call the method
         publish_revisions.run()

--- a/tests/unit/processing/schema_migration/test_publish_revisions.py
+++ b/tests/unit/processing/schema_migration/test_publish_revisions.py
@@ -118,6 +118,23 @@ class TestPublishRevisions:
         assert "Unable to publish collection version." in caplog.messages
         publish_revisions.business_logic.publish_collection_version.assert_not_called()
 
+    def test_run_pos__do_not_publish_list(self, published_revisions_and_collections, caplog):
+        """Run method when revision is skipped via do_not_publish_list."""
+        # Mock necessary objects and methods
+        caplog.set_level(logging.INFO)
+        publish_revisions, collections = published_revisions_and_collections
+        _, revision = collections["revision"]
+        publish_revisions.business_logic.get_collections.return_value = [collections]
+        publish_revisions.do_not_publish_list = [revision.version_id.id]
+
+        # Call the method
+        publish_revisions.run()
+
+        # Assert the calls and behavior
+        publish_revisions.check_datasets.assert_not_called()
+        assert "Skipping collection version, it is in the do not publish list" in caplog.messages
+        publish_revisions.business_logic.publish_collection_version.assert_not_called()
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/unit/processing/schema_migration/test_publish_revisions.py
+++ b/tests/unit/processing/schema_migration/test_publish_revisions.py
@@ -118,11 +118,11 @@ class TestPublishRevisions:
         assert "Unable to publish collection version." in caplog.messages
         publish_revisions.business_logic.publish_collection_version.assert_not_called()
 
-    def test_run_pos__do_not_publish_list(self, published_revisions_and_collections, caplog):
+    def test_run_pos__do_not_publish_list(self, publish_revisions_and_collections, caplog):
         """Run method when revision is skipped via do_not_publish_list."""
         # Mock necessary objects and methods
         caplog.set_level(logging.INFO)
-        publish_revisions, collections = published_revisions_and_collections
+        publish_revisions, collections = publish_revisions_and_collections
         _, revision = collections["revision"]
         publish_revisions.business_logic.get_collections.return_value = [collections]
         publish_revisions.do_not_publish_list = [revision.version_id.id]


### PR DESCRIPTION
## Reason for Change

- For migrations, we support a bulk revision publish job. Currently, it publishes all open revisions where all datasets are 1) in a successful processing state and 2) migrated to the latest schema version release. However, there are some cases where we would like to hold on publish for certain, pinpointed revisions. This adds the ability to pass a 'deny_list' to the bulk publish batch job.

## Changes

- fetch do_not_publish_list from env var, optionally defined in container overrides for a batch job. If set, skips publish of collections with collection_version_id in the input list. 
- do_not_publish_list is set as a comma-delimited string with collection_version_ids with "DO_NOT_PUBLISH_LIST" as the expected env var name.
- use 5.0.0 test dataset for post-deploy tests

## Testing steps

- rdev + unit tests 
