### PR TITLE
fix: GHA concurrency collisions

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -17,6 +17,10 @@ env:
 permissions:
   id-token: write
 
+concurrency:
+  group: ${{ github.event.number || github.event.ref }}-build
+  cancel-in-progress: true
+
 jobs:
   build_images:
     strategy:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -18,7 +18,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.event.number || github.event.ref }}-build
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.event.number || github.event.ref }}-tests
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -12,6 +12,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.event.number || github.event.ref }}-tests
+  cancel-in-progress: true
+
 jobs:
   functional-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/rdev-update-for-pr.yml
+++ b/.github/workflows/rdev-update-for-pr.yml
@@ -54,25 +54,9 @@ jobs:
           echo "ECR_REPOS=${ECR_REPOS[@]}" >> $GITHUB_OUTPUT
           echo "IMAGE_DIGESTS=${IMAGE_DIGESTS[@]}" >> $GITHUB_OUTPUT
 
-  # This is a workaround because concurrency can't use the `env` context to get STACK_NAME
-  stack_name:
-    runs-on: ubuntu-22.04
-    outputs:
-      stack_name: ${{ steps.get_stack_name.outputs.stack_name }}
-    steps:
-      - name: Get stack name
-        id: get_stack_name
-        run: |
-          echo "stack_name=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
-
   build_images:
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
-    needs:
-      - stack_name
-    concurrency:
-      group: ${{ needs.stack_name.outputs.stack_name }}-build
-      cancel-in-progress: true
 
   seed-wmg-cellguide-rdev:
     runs-on: ubuntu-22.04
@@ -100,13 +84,12 @@ jobs:
   deploy-rdev:
     runs-on: ubuntu-22.04
     concurrency:
-      group: ${{ needs.stack_name.outputs.stack_name }}-happy
+      group: pr-${{ github.event.number }}-happy
       cancel-in-progress: false
     needs:
       - build_images
       - get_previous_image_digests
       - seed-wmg-cellguide-rdev
-      - stack_name
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -183,9 +166,5 @@ jobs:
   rdev-tests:
     uses: ./.github/workflows/rdev-tests.yml
     secrets: inherit
-    concurrency:
-      group: ${{ needs.stack_name.outputs.stack_name }}-test
-      cancel-in-progress: true
     needs:
       - deploy-rdev
-      - stack_name


### PR DESCRIPTION
## Reason for Change

When calling a workflow from another workflow with a `concurreny.group` containing dynamic values ( `${{}}` ), the group name is not constructed properly. For example:
Give the job
```
job:
  job-1:
    uses: ./.github/workflows/build-images.yml
    concurrency:
      group: ${{ github.event.number }}-test
```

The group would be `-test`. An example can be seen in [this](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/8382082600?pr=6835) workflow summary
<img width="642" alt="Screenshot 2024-03-22 at 11 35 50 AM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/1429913/b93895b0-bef3-4088-8666-bd6ea33fdd77">

This is causing workflows to be cancelled prematurely and interfere with other workflow.

## Changes

- move concurrency group into the called workflow
- remove concurrency group from the caller workflow
- remove the `stack_name` workflow.

## Testing steps

- running multiple PR with this workflow 
- ran [this](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/8395118173?pr=6841) workflow around the same time and nothing got cancelled 
