### PR TITLE
feat: suppress slack notification in wrangling channel for migration failures

### DIFF
--- a/backend/layers/processing/upload_failures/app.py
+++ b/backend/layers/processing/upload_failures/app.py
@@ -30,7 +30,9 @@ def handle_failure(event: dict, context, delete_artifacts=True) -> None:
         execution_arn,
     ) = parse_event(event)
     if "migrate" in execution_arn:
-        logger.info(f"Skipping slack notification for {execution_arn} because failure is related to a schema migration")
+        logging.info(
+            f"Skipping slack notification for {execution_arn} because failure is related to a schema migration"
+        )
     else:
         trigger_slack_notification(
             dataset_version_id,

--- a/backend/layers/processing/upload_failures/app.py
+++ b/backend/layers/processing/upload_failures/app.py
@@ -29,14 +29,17 @@ def handle_failure(event: dict, context, delete_artifacts=True) -> None:
         error_cause,
         execution_arn,
     ) = parse_event(event)
-    trigger_slack_notification(
-        dataset_version_id,
-        collection_version_id,
-        error_step_name,
-        error_job_id,
-        error_aws_regions,
-        execution_arn,
-    )
+    if "migrate" in execution_arn:
+        logger.info(f"Skipping slack notification for {execution_arn} because failure is related to a schema migration")
+    else:
+        trigger_slack_notification(
+            dataset_version_id,
+            collection_version_id,
+            error_step_name,
+            error_job_id,
+            error_aws_regions,
+            execution_arn,
+        )
     update_dataset_processing_status_to_failed(dataset_version_id)
     if delete_artifacts:
         cleanup_artifacts(dataset_version_id, error_step_name)

--- a/tests/unit/processing/test_handle_error.py
+++ b/tests/unit/processing/test_handle_error.py
@@ -217,7 +217,7 @@ def test_migration_event_does_not_trigger_slack():
             "dataset_version_id": "123",
             "collection_version_id": "456",
             "error": {},
-            "execution_arn": "arn:aws:states:us-west-2:migrate_123456789012:execution:MyStateMachine",
+            "execution_id": "arn:aws:states:us-west-2:migrate_123456789012:execution:MyStateMachine",
         }
         handle_failure(event, mock_context)
         mock_notify_slack.assert_not_called()
@@ -231,7 +231,7 @@ def test_non_migration_event_triggers_slack():
             "dataset_version_id": "123",
             "collection_version_id": "456",
             "error": {},
-            "execution_arn": "arn:aws:states:us-west-2:123456789012:execution:MyStateMachine",
+            "execution_id": "arn:aws:states:us-west-2:123456789012:execution:MyStateMachine",
         }
         handle_failure(event, mock_context)
         mock_notify_slack.assert_called_once()

--- a/tests/unit/processing/test_handle_error.py
+++ b/tests/unit/processing/test_handle_error.py
@@ -210,9 +210,9 @@ def mock_get_dataset_version(collection_id):
 
 
 def test_migration_event_does_not_trigger_slack():
-    mock_notify_slack = Mock()
+    mock_trigger_slack = Mock()
     mock_context = Mock()
-    with patch("backend.common.utils.result_notification.notify_slack", mock_notify_slack):
+    with patch("backend.layers.processing.upload_failures.app.trigger_slack_notification", mock_trigger_slack):
         event = {
             "dataset_version_id": "123",
             "collection_version_id": "456",
@@ -220,13 +220,13 @@ def test_migration_event_does_not_trigger_slack():
             "execution_id": "arn:aws:states:us-west-2:migrate_123456789012:execution:MyStateMachine",
         }
         handle_failure(event, mock_context)
-        mock_notify_slack.assert_not_called()
+        mock_trigger_slack.assert_not_called()
 
 
 def test_non_migration_event_triggers_slack():
-    mock_notify_slack = Mock()
+    mock_trigger_slack = Mock()
     mock_context = Mock()
-    with patch("backend.common.utils.result_notification.notify_slack", mock_notify_slack):
+    with patch("backend.layers.processing.upload_failures.app.trigger_slack_notification", mock_trigger_slack):
         event = {
             "dataset_version_id": "123",
             "collection_version_id": "456",
@@ -234,7 +234,7 @@ def test_non_migration_event_triggers_slack():
             "execution_id": "arn:aws:states:us-west-2:123456789012:execution:MyStateMachine",
         }
         handle_failure(event, mock_context)
-        mock_notify_slack.assert_called_once()
+        mock_trigger_slack.assert_called_once()
 
 
 def test_get_failure_slack_notification_message_with_dataset_version_id_none(

--- a/tests/unit/processing/test_handle_error.py
+++ b/tests/unit/processing/test_handle_error.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import os
 from typing import Dict
-from unittest import mock
 from unittest.mock import Mock, patch
 
 import pytest
@@ -210,28 +209,30 @@ def mock_get_dataset_version(collection_id):
     return MockDatasetVersionId
 
 
-@mock.patch("backend.common.utils.result_notification")
-def test_migration_event_does_not_trigger_slack(self, mock_notify_slack: Mock):
-    event = {
-        "dataset_version_id": "123",
-        "collection_version_id": "456",
-        "error": {},
-        "execution_arn": "arn:aws:states:us-west-2:migrate_123456789012:execution:MyStateMachine",
-    }
-    handle_failure(event)
-    mock_notify_slack.assert_not_called()
+def test_migration_event_does_not_trigger_slack():
+    mock_notify_slack = Mock()
+    with patch("backend.common.utils.result_notification", mock_notify_slack):
+        event = {
+            "dataset_version_id": "123",
+            "collection_version_id": "456",
+            "error": {},
+            "execution_arn": "arn:aws:states:us-west-2:migrate_123456789012:execution:MyStateMachine",
+        }
+        handle_failure(event)
+        mock_notify_slack.assert_not_called()
 
 
-@mock.patch("backend.common.utils.result_notification")
-def test_non_migration_event_triggers_slack(self, mock_notify_slack: Mock):
-    event = {
-        "dataset_version_id": "123",
-        "collection_version_id": "456",
-        "error": {},
-        "execution_arn": "arn:aws:states:us-west-2:123456789012:execution:MyStateMachine",
-    }
-    handle_failure(event)
-    mock_notify_slack.assert_called_once()
+def test_non_migration_event_triggers_slack():
+    mock_notify_slack = Mock()
+    with patch("backend.common.utils.result_notification", mock_notify_slack):
+        event = {
+            "dataset_version_id": "123",
+            "collection_version_id": "456",
+            "error": {},
+            "execution_arn": "arn:aws:states:us-west-2:123456789012:execution:MyStateMachine",
+        }
+        handle_failure(event)
+        mock_notify_slack.assert_called_once()
 
 
 def test_get_failure_slack_notification_message_with_dataset_version_id_none(

--- a/tests/unit/processing/test_handle_error.py
+++ b/tests/unit/processing/test_handle_error.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 from typing import Dict
+from unittest import mock
 from unittest.mock import Mock, patch
 
 import pytest
@@ -21,6 +22,7 @@ from backend.layers.processing.upload_failures.app import (
     FAILED_DATASET_CLEANUP_MESSAGE,
     cleanup_artifacts,
     get_failure_slack_notification_message,
+    handle_failure,
     parse_event,
 )
 
@@ -206,6 +208,30 @@ def mock_get_dataset_version(collection_id):
     MockDatasetVersionId.collection_id = collection_id
     MockDatasetVersionId.status = DatasetStatus(None, None, None, None, None, None)
     return MockDatasetVersionId
+
+
+@mock.patch("backend.common.utils.result_notification")
+def test_migration_event_does_not_trigger_slack(self, mock_notify_slack: Mock):
+    event = {
+        "dataset_version_id": "123",
+        "collection_version_id": "456",
+        "error": {},
+        "execution_arn": "arn:aws:states:us-west-2:migrate_123456789012:execution:MyStateMachine",
+    }
+    handle_failure(event)
+    mock_notify_slack.assert_not_called()
+
+
+@mock.patch("backend.common.utils.result_notification")
+def test_non_migration_event_triggers_slack(self, mock_notify_slack: Mock):
+    event = {
+        "dataset_version_id": "123",
+        "collection_version_id": "456",
+        "error": {},
+        "execution_arn": "arn:aws:states:us-west-2:123456789012:execution:MyStateMachine",
+    }
+    handle_failure(event)
+    mock_notify_slack.assert_called_once()
 
 
 def test_get_failure_slack_notification_message_with_dataset_version_id_none(

--- a/tests/unit/processing/test_handle_error.py
+++ b/tests/unit/processing/test_handle_error.py
@@ -211,6 +211,7 @@ def mock_get_dataset_version(collection_id):
 
 def test_migration_event_does_not_trigger_slack():
     mock_notify_slack = Mock()
+    mock_context = Mock()
     with patch("backend.common.utils.result_notification", mock_notify_slack):
         event = {
             "dataset_version_id": "123",
@@ -218,12 +219,13 @@ def test_migration_event_does_not_trigger_slack():
             "error": {},
             "execution_arn": "arn:aws:states:us-west-2:migrate_123456789012:execution:MyStateMachine",
         }
-        handle_failure(event)
+        handle_failure(event, mock_context)
         mock_notify_slack.assert_not_called()
 
 
 def test_non_migration_event_triggers_slack():
     mock_notify_slack = Mock()
+    mock_context = Mock()
     with patch("backend.common.utils.result_notification", mock_notify_slack):
         event = {
             "dataset_version_id": "123",
@@ -231,7 +233,7 @@ def test_non_migration_event_triggers_slack():
             "error": {},
             "execution_arn": "arn:aws:states:us-west-2:123456789012:execution:MyStateMachine",
         }
-        handle_failure(event)
+        handle_failure(event, mock_context)
         mock_notify_slack.assert_called_once()
 
 

--- a/tests/unit/processing/test_handle_error.py
+++ b/tests/unit/processing/test_handle_error.py
@@ -212,7 +212,7 @@ def mock_get_dataset_version(collection_id):
 def test_migration_event_does_not_trigger_slack():
     mock_notify_slack = Mock()
     mock_context = Mock()
-    with patch("backend.common.utils.result_notification", mock_notify_slack):
+    with patch("backend.common.utils.result_notification.notify_slack", mock_notify_slack):
         event = {
             "dataset_version_id": "123",
             "collection_version_id": "456",
@@ -226,7 +226,7 @@ def test_migration_event_does_not_trigger_slack():
 def test_non_migration_event_triggers_slack():
     mock_notify_slack = Mock()
     mock_context = Mock()
-    with patch("backend.common.utils.result_notification", mock_notify_slack):
+    with patch("backend.common.utils.result_notification.notify_slack", mock_notify_slack):
         event = {
             "dataset_version_id": "123",
             "collection_version_id": "456",


### PR DESCRIPTION
## Reason for Change

suppresses the slack message from being sent out if the dataset failure to process comes from a schema migration

## Changes

when running a schema migration, we prefix the SFN with `migrate` here: https://github.com/chanzuckerberg/single-cell-data-portal/blob/main/backend/layers/processing/schema_migration.py#L126

we can then use this naming convention to determine if the individual dataset failure we're handling in `handle_failure` comes from a migration or not.

it may be slightly better / more correct to pass in the metadata of "is from migration or not" more explicitly, but after looking at the terraform declarations for the dataset processing step function and the schema migration step function i'm not entirely sure how that would work tbh. if that's a similar level of lift i'm happy to change the approach

## Testing steps

added unit testing
