### PR TITLE
fix: use github.sha to avoid concurrency collisions when building images on main

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -18,7 +18,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The recent change to [concurrency groups ](https://github.com/chanzuckerberg/single-cell-data-portal/pull/6840)has caused [build-image jobs](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/8396464523) on main to be canceled. To fix this we are using `github.sha` when `github.event.number` is not availible. This means when a pull_requests triggers the workflow `github.event.number` should be used. If this workflow was not triggered by a pull_request, then `github.sha` will be used. The likely hood of a concurrency group name collision using `github.sha` is very low. 