### PR TITLE
chore: stop auto-deploys to dev

### DIFF
--- a/.github/workflows/build-images-and-create-deployment.yml
+++ b/.github/workflows/build-images-and-create-deployment.yml
@@ -45,7 +45,7 @@ jobs:
         uses: avakar/create-deployment@v1
         # To stop deployment to a specific DEPLOYMENT_STAGE remove it from condition below.
         # The DEPLOYMENT_STAGE that should be present are dev, stage, prod.
-        if: env.DEPLOYMENT_STAGE == 'prod' || env.DEPLOYMENT_STAGE == 'stage' || env.DEPLOYMENT_STAGE == 'dev'
+        if: env.DEPLOYMENT_STAGE == 'prod' || env.DEPLOYMENT_STAGE == 'stage'
         with:
           auto_merge: false
           environment: ${{ env.DEPLOYMENT_STAGE }}


### PR DESCRIPTION
This reverts commit e7e9651ef3708e612c36eb8ad16d7a97be2da21f.

## Reason for Change

- Isolating dev environment for testing integration with cellxgene-ontology-guide using deployed env + prod data. 

## Changes

- stop auto-deploys to dev from merges to main. deploys to staging off of merges to main will continue.
