### PR TITLE
chore: switch mock census version parameter to stable

### DIFF
--- a/tests/test_utils/mocks.py
+++ b/tests/test_utils/mocks.py
@@ -53,7 +53,7 @@ def mock_bootstrap_rows_percentiles(
 
 
 class MockCensusParameters:
-    census_version = "latest"
+    census_version = "stable"
 
     def value_filter(organism: str) -> str:
         organism_mapping = {

--- a/tests/test_utils/mocks.py
+++ b/tests/test_utils/mocks.py
@@ -53,6 +53,8 @@ def mock_bootstrap_rows_percentiles(
 
 
 class MockCensusParameters:
+    # NOTE: THIS SHOULD BE REVERTED BACK TO 'latest' ONCE THE PIPELINE HAS BEEN UPDATED
+    # TO BE COMPATIBLE WITH THE LATEST CENSUS VERSION (2.0 schema).
     census_version = "stable"
 
     def value_filter(organism: str) -> str:


### PR DESCRIPTION
## Reason for Change

- Tests are failing because the WMG pipeline is currently forbidden from reading the latest Census 2.0 build.
- This will be reverted once the pipeline has been updated