### PR TITLE
feat: update schema version on discover UX download modal

### DIFF
--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/components/CopyCaption/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/components/CopyCaption/index.tsx
@@ -4,9 +4,9 @@ import { DATASET_ASSET_FORMAT } from "src/common/entities";
 
 const DISCOVER_API_URL = "https://api.cellxgene.cziscience.com/curation/ui/#/";
 const SCHEMA_URL =
-  "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md";
+  "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.0.0/schema.md";
 const SEURAT_SCHEMA_URL =
-  "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/seurat_encoding.md";
+  "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.0.0/seurat_encoding.md";
 
 interface Props {
   selectedFormat: DATASET_ASSET_FORMAT | "";


### PR DESCRIPTION
## Reason for Change

https://github.com/chanzuckerberg/single-cell-data-portal/issues/6629

## Changes

Updates to the 5.0.0 schema in this modal

## Testing steps

Went to the rdev build and:
1. Navigate to https://cellxgene.cziscience.com/datasets
2. Press one of the Download buttons.
3. Select h5ad format.
4. Click the "dataset schema" text
5. Verify that this links to a 5.0.0 URL