### PR TITLE
feat: timestamp format without milliseconds

### DIFF
--- a/backend/common/utils/json.py
+++ b/backend/common/utils/json.py
@@ -20,10 +20,10 @@ class CustomJSONEncoder(JSONEncoder):
 
 
 class CurationJSONEncoder(CustomJSONEncoder):
-    "Add support for serializing DateTime into isoformat"
+    "Add support for serializing DateTime into isoformat, dropping milliseconds"
 
     def default(self, obj):
         if isinstance(obj, datetime):
-            return obj.replace(tzinfo=time_zone_info).isoformat()
+            return obj.replace(microsecond=0, tzinfo=time_zone_info).isoformat()
         else:
             return super().default(obj)

--- a/backend/common/utils/json.py
+++ b/backend/common/utils/json.py
@@ -20,7 +20,7 @@ class CustomJSONEncoder(JSONEncoder):
 
 
 class CurationJSONEncoder(CustomJSONEncoder):
-    "Add support for serializing DateTime into isoformat, dropping milliseconds"
+    "Add support for serializing DateTime into isoformat, to second precision"
 
     def default(self, obj):
         if isinstance(obj, datetime):

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -809,7 +809,7 @@ components:
       description: The name of the primary contact for the Collection
       type: string
     created_at:
-      description: A timestamp of when the resource was created.
+      description: A timestamp of when the resource was created. The timestamp conforms to the ISO 8601 format to second precision. For example, 2023-05-10T17:22:42+00:00.
       type: string
     curator_name:
       description: The name of the curator for the Collection.
@@ -820,26 +820,26 @@ components:
       nullable: true
       type: string
     published_at:
-      description: A timestamp of when the Collection was first published.
+      description: A timestamp of when the Collection was first published. The timestamp conforms to the ISO 8601 format to second precision. For example, 2023-05-10T17:22:42+00:00.
       nullable: true
       type: string
     dataset_published_at:
-      description: A timestamp of when the Dataset was first published.
+      description: A timestamp of when the Dataset was first published. The timestamp conforms to the ISO 8601 format to second precision. For example, 2023-05-10T17:22:42+00:00.
       nullable: true
       type: string
     dataset_version_published_at:
-      description: A timestamp of when this Dataset Version was published.
+      description: A timestamp of when this Dataset Version was published. The timestamp conforms to the ISO 8601 format to second precision. For example, 2023-05-10T17:22:42+00:00.
       type: string
     collection_revised_at:
       description: A timestamp indicating the last time a Revision for this Collection was published.
       nullable: true
       type: string
     dataset_revised_at:
-      description: A timestamp indicating the last time a Revision for this Dataset was published.
+      description: A timestamp indicating the last time a Revision for this Dataset was published. The timestamp conforms to the ISO 8601 format to second precision. For example, 2023-05-10T17:22:42+00:00.
       nullable: true
       type: string
     collection_version_published_at:
-      description: A timestamp of when this Collection Version was published.
+      description: A timestamp of when this Collection Version was published. The timestamp conforms to the ISO 8601 format to second precision. For example, 2023-05-10T17:22:42+00:00.
       type: string
     collection_revising_in:
       type: string

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import time
 import uuid
 from collections import defaultdict
 from dataclasses import asdict
@@ -25,7 +26,6 @@ from backend.layers.thirdparty.crossref_provider import CrossrefDOINotFoundExcep
 from tests.unit.backend.layers.api.test_portal_api import generate_mock_publisher_metadata
 from tests.unit.backend.layers.common.base_api_test import BaseAPIPortalTest
 from tests.unit.backend.layers.common.base_test import DatasetArtifactUpdate, DatasetStatusUpdate
-import time
 
 
 class TestDeleteCollection(BaseAPIPortalTest):

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -25,6 +25,7 @@ from backend.layers.thirdparty.crossref_provider import CrossrefDOINotFoundExcep
 from tests.unit.backend.layers.api.test_portal_api import generate_mock_publisher_metadata
 from tests.unit.backend.layers.common.base_api_test import BaseAPIPortalTest
 from tests.unit.backend.layers.common.base_test import DatasetArtifactUpdate, DatasetStatusUpdate
+import time
 
 
 class TestDeleteCollection(BaseAPIPortalTest):
@@ -2117,6 +2118,9 @@ class TestGetDatasetIdVersions(BaseAPIPortalTest):
         dataset_id = collection.datasets[0].dataset_id
         dataset_version_id = collection.datasets[0].version_id
         published_revision = self.generate_revision(collection_id)
+        # Add delay here to ensure published_at timestamps are different (as millis are
+        # no longer returned in API response).
+        time.sleep(1)
         published_dataset_revision = self.generate_dataset(
             collection_version=published_revision, replace_dataset_version_id=dataset_version_id, publish=True
         )

--- a/tests/unit/backend/layers/utils/test_json.py
+++ b/tests/unit/backend/layers/utils/test_json.py
@@ -79,6 +79,12 @@ class TestCuratorJSONEncoder(unittest.TestCase):
         expected_datetime = '"1970-01-01T00:00:00+00:00"'
         self._verify_json_encoding(test_datetime_value, expected_datetime)
 
+    def test_datetime_with_millis(self):
+        test_datetime_value = datetime.datetime.fromtimestamp(0.1)
+        # ISO format with UTC time zone; will fail if testing environment time zone is *not* UTC
+        expected_datetime = '"1970-01-01T00:00:00+00:00"'
+        self._verify_json_encoding(test_datetime_value, expected_datetime)
+
     def _verify_json_encoding(self, test_value, expected_value):
         actual_value = json.dumps(test_value, cls=CurationJSONEncoder, sort_keys=True)
         self.assertEqual(expected_value, actual_value)


### PR DESCRIPTION
## Reason for Change

- #5203 
- #5202 

## Changes

- Updated JSON encoder to format dates to a timestamp without milliseconds.

## Testing steps

- Updated existing unit tests.
- Tested on rdev.

## Checklist 🛎️

- [x] Add product, design, and eng as reviewers for rdev review (see [Slack](https://clevercanary.slack.com/archives/C06AVGFV222/p1712014462016439?thread_ts=1711990499.919889&cid=C06AVGFV222))
