### PR TITLE
fix: pull descendants before running staging e2e tests

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -237,6 +237,7 @@ jobs:
           npm ci
           npx playwright install --with-deps
           cp src/configs/local.js src/configs/configs.js
+          make retrieve-descendants
 
       # Run e2e tests
       - name: Run e2e tests


### PR DESCRIPTION
## Reason for Change

- e2e tests in staging fail because we were not pulling in descendant-mappings before running e2e tests in GHA