### PR TITLE
feat: Add support for the new Census embeddings API

### DIFF
--- a/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/connect.ts
+++ b/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/connect.ts
@@ -19,15 +19,13 @@ const MAINTAINED_R_NOTEBOOK_LINK =
 const HOSTED_PYTHON_NOTEBOOK_LINK =
   "https://chanzuckerberg.github.io/cellxgene-census/notebooks/api_demo/census_embedding.html";
 
-function pythonCodeSnippet(project: UnionProject, uri: string): string {
-  const censusVersion = project.census_version;
+function pythonCodeSnippet(project: UnionProject): string {
   const organism = project.experiment_name;
   const measurement = project.measurement_name;
 
   const axis = project.data_type === "obs_embedding" ? "obs" : "var";
 
-  return project.tier === "maintained"
-    ? `import cellxgene_census
+  return `import cellxgene_census
 
 census = cellxgene_census.open_soma(census_version="${project.census_version}")
 adata = cellxgene_census.get_anndata(
@@ -35,25 +33,11 @@ adata = cellxgene_census.get_anndata(
     organism = "${organism}",
     measurement_name = "${measurement}",
     obs_value_filter = "tissue_general == 'central nervous system'",
-    ${axis}m_layers = ["${project.embedding_name}"]
-)`
-    : `import cellxgene_census
-from cellxgene_census.experimental import get_embedding
-
-embedding_uri = \\
-    "${uri}"
-census = cellxgene_census.open_soma(census_version="${censusVersion}")
-
-adata = cellxgene_census.get_anndata(
-    census,
-    organism = "${organism}",
-    measurement_name = "${measurement}",
-    obs_value_filter = "tissue_general == 'central nervous system'",
-)
-embeddings = get_embedding("${censusVersion}", embedding_uri, adata.${axis}["soma_joinid"].to_numpy())
-adata.${axis}m["emb"] = embeddings`;
+    ${axis}_embeddings = ["${project.embedding_name}"]
+)`;
 }
 
+// Currently unused. Will be used when R support will be added back.
 function rCodeSnippet(project: UnionProject): string {
   const censusVersion = project.census_version;
   const organism = project.experiment_name;
@@ -94,9 +78,7 @@ export const useConnect = ({ project }: EmbeddingButtonProps) => {
   const uri = `s3://cellxgene-contrib-public/contrib/cell-census/soma/${project.census_version}/${project.id}`;
 
   const codeSnippet =
-    language === "python"
-      ? pythonCodeSnippet(project, uri)
-      : rCodeSnippet(project);
+    language === "python" ? pythonCodeSnippet(project) : rCodeSnippet(project);
 
   const codeSnippetRef = useCallback(
     (node: HTMLDivElement) => {

--- a/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/index.tsx
+++ b/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/index.tsx
@@ -8,7 +8,13 @@ import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
 import Highlight from "react-highlight";
 import { RadioGroup } from "@mui/material";
-import { StyledDialogContent, Label, CodeSnippet, Break, StyledCallout } from "./style";
+import {
+  StyledDialogContent,
+  Label,
+  CodeSnippet,
+  Break,
+  StyledCallout,
+} from "./style";
 import { StyledButton } from "../../style";
 
 function EmbeddingButton(props: EmbeddingButtonProps) {

--- a/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/index.tsx
+++ b/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Dialog, InputRadio, DialogTitle } from "@czi-sds/components";
+import { Dialog, InputRadio, DialogTitle, Callout } from "@czi-sds/components";
 import { useConnect } from "./connect";
 import { EmbeddingButtonProps } from "./types";
 import CopyButton from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/components/CopyButton";
@@ -18,7 +18,6 @@ function EmbeddingButton(props: EmbeddingButtonProps) {
     language,
     codeSnippet,
     projectTier,
-    uri,
     notebookLink,
     codeSnippetRef,
     uriTopPosition,
@@ -40,6 +39,10 @@ function EmbeddingButton(props: EmbeddingButtonProps) {
       </StyledButton>
       <Dialog open={isOpen} onClose={handleButtonClick}>
         <DialogTitle title="Embedding" onClose={handleButtonClick} />
+        <Callout intent="warning">
+          Code example requires the latest version (1.13.0) of the Census API
+          package.
+        </Callout>
         <StyledDialogContent>
           <div>
             <Label>Language</Label>
@@ -49,11 +52,7 @@ function EmbeddingButton(props: EmbeddingButtonProps) {
               row
             >
               <InputRadio label="Python" value="python" />
-              <InputRadio
-                disabled={projectTier !== "maintained"}
-                label={projectTier === "maintained" ? "R" : "R (coming soon)"}
-                value="r"
-              />
+              <InputRadio disabled={true} label={"R (coming soon)"} value="r" />
             </RadioGroup>
           </div>
           <div>
@@ -76,22 +75,6 @@ function EmbeddingButton(props: EmbeddingButtonProps) {
                   })
                 }
               />
-              {projectTier === "hosted" && (
-                <div>
-                  <CopyButton
-                    downloadLink={uri}
-                    label="Copy URI"
-                    handleAnalytics={() =>
-                      track(EVENTS.CENSUS_EMBEDDING_COPIED, {
-                        project: project.title,
-                        category: projectTier,
-                        version: "URI",
-                        ...uniqueMetadata,
-                      })
-                    }
-                  />
-                </div>
-              )}
             </CodeSnippet>
           </div>
           <Break />

--- a/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/index.tsx
+++ b/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Dialog, InputRadio, DialogTitle, Callout } from "@czi-sds/components";
+import { Dialog, InputRadio, DialogTitle } from "@czi-sds/components";
 import { useConnect } from "./connect";
 import { EmbeddingButtonProps } from "./types";
 import CopyButton from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/components/CopyButton";
@@ -8,7 +8,7 @@ import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
 import Highlight from "react-highlight";
 import { RadioGroup } from "@mui/material";
-import { StyledDialogContent, Label, CodeSnippet, Break } from "./style";
+import { StyledDialogContent, Label, CodeSnippet, Break, StyledCallout } from "./style";
 import { StyledButton } from "../../style";
 
 function EmbeddingButton(props: EmbeddingButtonProps) {
@@ -39,10 +39,10 @@ function EmbeddingButton(props: EmbeddingButtonProps) {
       </StyledButton>
       <Dialog open={isOpen} onClose={handleButtonClick}>
         <DialogTitle title="Embedding" onClose={handleButtonClick} />
-        <Callout intent="warning">
+        <StyledCallout intent="warning">
           Code example requires the latest version (1.13.0) of the Census API
           package.
-        </Callout>
+        </StyledCallout>
         <StyledDialogContent>
           <div>
             <Label>Language</Label>

--- a/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/style.ts
+++ b/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/style.ts
@@ -91,4 +91,4 @@ export const Break = styled.hr`
 `;
 export const StyledCallout = styled(Callout)`
   width: 100%;
-`
+`;

--- a/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/style.ts
+++ b/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/components/EmbeddingButton/style.ts
@@ -3,6 +3,7 @@ import {
   CommonThemeProps,
   fontCapsXxxs,
   fontCapsXxs,
+  Callout,
 } from "@czi-sds/components";
 import styled from "@emotion/styled";
 import {
@@ -88,3 +89,6 @@ export const Break = styled.hr`
     top: -10px;
   }
 `;
+export const StyledCallout = styled(Callout)`
+  width: 100%;
+`


### PR DESCRIPTION
## Reason for Change

Add support for the new Census embedding API.

## Changes

- Modify collaborations embeddings to use the `obs_embedding` field 
- Modify hosted embeddings to also use the `obs_embedding`/`var_embedding` field
- Remove R support 
- Add callout to use the latest version of the census API.

## Testing steps

- Manual QA
