### PR TITLE
chore: clean-up processing docker image

### DIFF
--- a/Dockerfile.processing
+++ b/Dockerfile.processing
@@ -8,21 +8,19 @@ RUN apt-get update && \
 	apt-get upgrade -y && \
 	apt install software-properties-common -y && \
 	add-apt-repository ppa:deadsnakes/ppa && \
-	apt-get install -y python3.10 python3-pip
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 \
-  && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+	apt-get update && apt-get install -y python3.10 python3.10-dev python3.10-venv && \
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    python3.10 get-pip.py
 
 # For lighter weight Docker images
 ENV PIP_NO_CACHE_DIR=1
 
-# Install python dependencies
-# Remove packaging dependency once pyparser>3 is supported.
-RUN pip3 install python-igraph==0.8.3 louvain==0.7.0 packaging==21.0 awscli
-
+# Activate virtual environment for subsequent commands
+RUN python3.10 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 COPY /python_dependencies/processing/ .
-RUN pip3 install -r requirements.txt
+RUN python3.10 -m pip install -r requirements.txt
 
 ADD backend/__init__.py backend/__init__.py
 ADD backend/layers backend/layers
@@ -35,4 +33,4 @@ LABEL commit=${HAPPY_COMMIT}
 ENV COMMIT_SHA=${HAPPY_COMMIT}
 ENV COMMIT_BRANCH=${HAPPY_BRANCH}
 
-CMD ["python3", "-m", "backend.layers.processing.process"]
+CMD ["python3.10", "-m", "backend.layers.processing.process"]

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,6 +1,7 @@
 alembic>=1.9, <2
 anndata==0.8.0
 allure-pytest<3
+awscli
 black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
 boto3>=1.11.17
 botocore>=1.14.17
@@ -11,7 +12,7 @@ dataclasses-json
 ddtrace==2.1.4
 furl
 jsonschema
-matplotlib==3.6.3 # 3.7.0 isn't compatible with scanpy: https://github.com/scverse/scanpy/issues/2411
+matplotlib==3.7.3
 moto>=5.0.0
 numba==0.56.2
 numpy==1.23.2


### PR DESCRIPTION
## Reason for Change

- Processing docker image was only installing PyPI package versions with python requirements <=3.8 when calling pip install, this should configure python3.10 + pip3.10 completely and set-up a virtual env for easier dependency management within the dockerfile in the future.
- Removing unused dependencies

## Changes

- refactored Dockerfile.processing
- removed louvain, python-igraph, packaging dependencies
- use PyPi packages with python requirements >=3.10 if available (required for 5.1 cellxgene-schema release)

## Testing steps

- images build and post-deploy tests pass