### PR TITLE
fix: create render state for failed collection metadata fetching

### DIFF
--- a/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/SourceData/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/SourceData/index.tsx
@@ -8,6 +8,7 @@ import {
   StyledDivTableRow,
   StyledLabel,
   StyledLink,
+  StyledSpan,
   StyledValue,
   Wrapper,
 } from "./style";
@@ -48,18 +49,22 @@ export default function SourceData(): JSX.Element {
           {Object.values(collections).map(({ name, url, datasets }) => (
             <StyledDivTableRow key={name}>
               <StyledDivTableCell>
-                <StyledLink
-                  href={url}
-                  target="_blank"
-                  rel="noopener"
-                  onClick={() => {
-                    track(EVENTS.VIEW_COLLECTION_PAGE_CLICKED, {
-                      collection_name: name,
-                    });
-                  }}
-                >
-                  {name}
-                </StyledLink>
+                {name ? (
+                  <StyledLink
+                    href={url}
+                    target="_blank"
+                    rel="noopener"
+                    onClick={() => {
+                      track(EVENTS.VIEW_COLLECTION_PAGE_CLICKED, {
+                        collection_name: name,
+                      });
+                    }}
+                  >
+                    {name}
+                  </StyledLink>
+                ) : (
+                  <StyledSpan>Failed to load collection information</StyledSpan>
+                )}
               </StyledDivTableCell>
               <StyledDivTableCell align>
                 <Tooltip

--- a/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/SourceData/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/SourceData/style.ts
@@ -41,7 +41,7 @@ export const StyledLink = styled.a`
 export const StyledSpan = styled.span`
   font-size: 14px;
   font-weight: 400;
-  color: ${() => warning500};
+  color: ${warning500};
 `;
 
 export const StyledDivTableRow = styled(DivTableRow)`

--- a/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/SourceData/style.ts
+++ b/frontend/src/views/WheresMyGeneV2/components/InfoPanel/components/SourceData/style.ts
@@ -4,7 +4,7 @@ import {
   Content as CommonContent,
   Header as CommonHeader,
 } from "../../common/style";
-import { gray600 } from "src/common/theme";
+import { gray600, warning500 } from "src/common/theme";
 import {
   DivTableCell,
   DivTableRow,
@@ -36,6 +36,12 @@ export const StyledLink = styled.a`
   color: #0073ff;
   font-size: 14px;
   font-weight: 400;
+`;
+
+export const StyledSpan = styled.span`
+  font-size: 14px;
+  font-weight: 400;
+  color: ${() => warning500};
 `;
 
 export const StyledDivTableRow = styled(DivTableRow)`


### PR DESCRIPTION
#6852 

There's an edge case where collection metadata fails to load for a number of datasets. This adds a render state for that case instead of just rendering an empty row in the source data sidebar.

![image](https://github.com/chanzuckerberg/single-cell-data-portal/assets/8716829/6a30caff-c29f-4863-a510-56efa81e7d25)
