### PR TITLE
chore: update wmg pipeline to handle categorical data types in Census

### DIFF
--- a/backend/wmg/pipeline/cell_counts.py
+++ b/backend/wmg/pipeline/cell_counts.py
@@ -32,6 +32,10 @@ def create_cell_counts_cube(*, query: ExperimentAxisQuery, corpus_path: str, org
     obs_df = query.obs().concat().to_pandas()
     obs_df = obs_df.rename(columns=DIMENSION_NAME_MAP_CENSUS_TO_WMG)
     obs_df["organism_ontology_term_id"] = organismId
+    # TODO: eventually, we should keep categorical data types and modify downstream
+    # code to handle them properly. For now, we convert them to strings.
+    categorical_columns = obs_df.select_dtypes(include=["category"]).columns
+    obs_df[categorical_columns] = obs_df[categorical_columns].astype(str)
 
     logger.info("Creating the cell counts cube.")
 

--- a/backend/wmg/pipeline/expression_summary.py
+++ b/backend/wmg/pipeline/expression_summary.py
@@ -41,6 +41,10 @@ class ExpressionSummaryCubeBuilder:
         self.obs_df = query.obs().concat().to_pandas()
         self.obs_df = self.obs_df.rename(columns=DIMENSION_NAME_MAP_CENSUS_TO_WMG)
         self.obs_df["organism_ontology_term_id"] = organismId
+        # TODO: eventually, we should keep categorical data types and modify downstream
+        # code to handle them properly. For now, we convert them to strings.
+        categorical_columns = self.obs_df.select_dtypes(include=["category"]).columns
+        self.obs_df[categorical_columns] = self.obs_df[categorical_columns].astype(str)
 
         self.var_df = query.var().concat().to_pandas()
         self.query = query
@@ -133,7 +137,7 @@ class ExpressionSummaryCubeBuilder:
         )
 
         # number of cells with specific tuple of dims
-        cube_index = pd.DataFrame(cell_labels.value_counts(), columns=["n"])
+        cube_index = pd.DataFrame(cell_labels.value_counts(), columns=["count"]).rename(columns={"count": "n"})
 
         # add cube_idx column
         cube_index["cube_idx"] = range(len(cube_index))

--- a/python_dependencies/wmg/requirements.txt
+++ b/python_dependencies/wmg/requirements.txt
@@ -16,7 +16,7 @@ numba>=0.58.0
 numpy==1.23.5
 openai==0.27.7
 owlready2==0.45.0
-pandas==1.5.3
+pandas==2.2.1
 parameterized
 pronto==2.5.4
 psutil==5.9.5


### PR DESCRIPTION
## Reason for Change

- Categorical encoding in census obs df broke things

## Changes

- Update pandas to >2 and convert categorical dtypes to strings

## Testing steps

- Previously failing tests now pass