### PR TITLE
chore: previous tag was not fetched when releasing prod

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -102,15 +102,17 @@ jobs:
     needs:
       - upgrade
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.deployment.sha }}
+          fetch-tags: true
       - name: Get most recent tag
         id: "fetch_tag"
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           echo "PREVIOUS_TAG=$(git describe --tags $(git rev-list --tags=sha\* --max-count=1))" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
       - name: Push Tag with latest prod commit SHA
         uses: rickstaa/action-create-tag@v1
         id: "tag_create"


### PR DESCRIPTION
## Reason for Change
fixes https://github.com/chanzuckerberg/single-cell-data-portal/issues/6201

The previous tag was not fetched when releasing prod. This results in a [release](https://github.com/chanzuckerberg/single-cell-data-portal/releases/tag/sha-5d992477) with no change log.
<img width="860" alt="Screenshot 2024-04-04 at 12 31 28 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/1429913/91c072fe-4c9e-403c-bb4f-0a1a6869c8be">

This GHA job step:
https://github.com/chanzuckerberg/single-cell-data-portal/blob/d8f4a8bce2c76c0e13c6bdad8f31894d38a3b92a/.github/workflows/deploy-happy-stack.yml#L108-L113
is[ failing silently](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/8559629696/job/23457114380) with `fatal: No names found, cannot describe anything.`

## Changes

- upgrade checkout to v4
- add fetch-tags
- print `$GITHUB_OUTPUT` to make debugging in the future easier.

## Testing steps

- verified using this simplified [workflow](https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/8560186425/workflow) which outputs:
<img width="728" alt="Screenshot 2024-04-04 at 12 44 03 PM" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/1429913/56aadbfc-3cce-4a7b-8a94-7495f461229d">

```
PREVIOUS_TAG=sha-5d992477
```

## Notes for Reviewer
This has not been tested with prod, but it can't make it any worse than it already it.
