### PR TITLE
chore: extract test + lint requirements into requirements-dev.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,14 @@ updates:
       day: "sunday"
     assignees:
       - "danieljhegeman"
+  - package-ecosystem: pip
+    directory: "/python_dependencies/common/"
+    open-pull-requests-limit: 3
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    assignees:
+      - "nayib-jose-gloria"
   - package-ecosystem: npm
     directory: "/frontend/"
     open-pull-requests-limit: 3

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -90,6 +90,11 @@ jobs:
             **/Dockerfile
             requirements*.txt
             **/requirements*.txt
+      - name: Check if containers need to be rebuilt
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          make local-rebuild-backend
       - name: Run unit tests
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
@@ -144,6 +149,11 @@ jobs:
             **/Dockerfile
             requirements*.txt
             **/requirements*.txt
+      - name: Check if containers need to be rebuilt
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          make local-rebuild-backend
       - name: Run unit tests
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
@@ -286,6 +296,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod')
+
   cellguide-pipeline-unit-test:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
@@ -368,6 +379,11 @@ jobs:
             **/Dockerfile
             requirements*.txt
             **/requirements*.txt
+      - name: Check if containers need to be rebuilt
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          make local-rebuild-backend
       - name: Run unit tests
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -12,12 +12,15 @@ RUN apt-get update && \
 # Don't re-run pip install unless either requirements.txt has changed.
 WORKDIR /single-cell-data-portal
 COPY /python_dependencies/backend/ .
+COPY /python_dependencies/common/ .
+ARG INSTALL_DEV=false
 RUN python3 -m pip install --upgrade pip setuptools
 
 # TODO: Determine if cmake is really needed for ddtrace
 # see ticket: https://github.com/chanzuckerberg/single-cell-data-portal/issues/5821
 RUN python3 -m pip install cmake
 RUN python3 -m pip install -r requirements.txt
+RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt
 # Install awscli to download wmg snapshot to the local disk
 RUN python3 -m pip install awscli
 EXPOSE 5000

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -20,7 +20,7 @@ RUN python3 -m pip install --upgrade pip setuptools
 # see ticket: https://github.com/chanzuckerberg/single-cell-data-portal/issues/5821
 RUN python3 -m pip install cmake
 RUN python3 -m pip install -r requirements.txt
-RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt
+RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt; fi
 # Install awscli to download wmg snapshot to the local disk
 RUN python3 -m pip install awscli
 EXPOSE 5000

--- a/Dockerfile.cellguide_pipeline
+++ b/Dockerfile.cellguide_pipeline
@@ -11,7 +11,10 @@ ENV PIP_NO_CACHE_DIR=1
 WORKDIR /
 
 COPY /python_dependencies/cellguide_pipeline/ .
+COPY /python_dependencies/common/ .
+ARG INSTALL_DEV=false
 RUN pip3 install -r requirements.txt
+RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt
 
 ADD backend/__init__.py backend/__init__.py
 ADD backend/wmg/config.py backend/wmg/config.py

--- a/Dockerfile.cellguide_pipeline
+++ b/Dockerfile.cellguide_pipeline
@@ -14,7 +14,7 @@ COPY /python_dependencies/cellguide_pipeline/ .
 COPY /python_dependencies/common/ .
 ARG INSTALL_DEV=false
 RUN pip3 install -r requirements.txt
-RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt
+RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt; fi
 
 ADD backend/__init__.py backend/__init__.py
 ADD backend/wmg/config.py backend/wmg/config.py

--- a/Dockerfile.processing
+++ b/Dockerfile.processing
@@ -23,7 +23,7 @@ COPY /python_dependencies/processing/ .
 COPY /python_dependencies/common/ .
 ARG INSTALL_DEV=false
 RUN python3.10 -m pip install -r requirements.txt
-RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt
+RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt; fi
 
 ADD backend/__init__.py backend/__init__.py
 ADD backend/layers backend/layers

--- a/Dockerfile.processing
+++ b/Dockerfile.processing
@@ -20,7 +20,10 @@ RUN python3.10 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 COPY /python_dependencies/processing/ .
+COPY /python_dependencies/common/ .
+ARG INSTALL_DEV=false
 RUN python3.10 -m pip install -r requirements.txt
+RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt
 
 ADD backend/__init__.py backend/__init__.py
 ADD backend/layers backend/layers

--- a/Dockerfile.wmg_pipeline
+++ b/Dockerfile.wmg_pipeline
@@ -16,7 +16,10 @@ ENV PIP_NO_CACHE_DIR=1
 WORKDIR /
 
 COPY /python_dependencies/wmg/ .
+COPY /python_dependencies/common/ .
+ARG INSTALL_DEV=false
 RUN pip3 install -r requirements.txt
+RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt
 
 ADD backend/__init__.py backend/__init__.py
 ADD backend/wmg/__init__.py backend/wmg/__init__.py

--- a/Dockerfile.wmg_pipeline
+++ b/Dockerfile.wmg_pipeline
@@ -19,7 +19,7 @@ COPY /python_dependencies/wmg/ .
 COPY /python_dependencies/common/ .
 ARG INSTALL_DEV=false
 RUN pip3 install -r requirements.txt
-RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt
+RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt; fi
 
 ADD backend/__init__.py backend/__init__.py
 ADD backend/wmg/__init__.py backend/wmg/__init__.py

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ local-cxguser-cookie: ## Get cxguser-cookie
 	docker compose $(COMPOSE_OPTS) run --rm backend bash -c "cd /single-cell-data-portal && python login.py"
 
 .PHONY: coverage/combine
-coverage/combine:
+coverage/combine: .env.ecr
 	- docker compose $(COMPOSE_OPTS) run --rm -T backend bash -c "cd /single-cell-data-portal && coverage combine --data-file=$(COVERAGE_DATA_FILE)"
 
 .PHONY: coverage/report

--- a/Makefile
+++ b/Makefile
@@ -100,20 +100,20 @@ local-status: ## Show the status of the containers in the dev environment.
 
 .PHONY: local-rebuild
 local-rebuild: .env.ecr local-ecr-login ## Rebuild local dev without re-importing data
-	docker compose $(COMPOSE_OPTS) build frontend backend processing wmg_processing database oidc localstack
+	docker compose $(COMPOSE_OPTS) build --build-arg INSTALL_DEV=true frontend backend processing wmg_processing database oidc localstack
 	docker compose $(COMPOSE_OPTS) up -d frontend backend processing database oidc localstack
 
 local-rebuild-backend: .env.ecr local-ecr-login
-	docker compose $(COMPOSE_OPTS) build backend
+	docker compose $(COMPOSE_OPTS) build --build-arg INSTALL_DEV=true backend
 
 local-rebuild-processing: .env.ecr local-ecr-login
-	docker compose $(COMPOSE_OPTS) build processing
+	docker compose $(COMPOSE_OPTS) build --build-arg INSTALL_DEV=true processing
 
 local-rebuild-wmg-processing: .env.ecr local-ecr-login
-	docker compose $(COMPOSE_OPTS) build wmg_processing
+	docker compose $(COMPOSE_OPTS) build --build-arg INSTALL_DEV=true wmg_processing
 
 local-rebuild-cellguide-pipeline: .env.ecr local-ecr-login
-	docker compose $(COMPOSE_OPTS) build cellguide_pipeline
+	docker compose $(COMPOSE_OPTS) build --build-arg INSTALL_DEV=true cellguide_pipeline
 
 .PHONY: local-sync
 local-sync: local-rebuild local-init  ## Re-sync the local-environment state after modifying library deps or docker configs

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ oauth/pkcs12/certificate.pfx:
 .PHONY: .env.ecr
 .env.ecr:
 	echo DOCKER_REPO=$$(aws sts get-caller-identity --profile single-cell-dev | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com/ > .env.ecr;
+	echo "INSTALL_DEV=true" >> .env.ecr
 	echo "HAPPY_COMMIT=$(shell git rev-parse --verify HEAD)" >> .env.ecr
 	echo "HAPPY_BRANCH=$(shell git branch --show-current)" >> .env.ecr
 
@@ -100,20 +101,20 @@ local-status: ## Show the status of the containers in the dev environment.
 
 .PHONY: local-rebuild
 local-rebuild: .env.ecr local-ecr-login ## Rebuild local dev without re-importing data
-	docker compose $(COMPOSE_OPTS) build --build-arg INSTALL_DEV=true frontend backend processing wmg_processing database oidc localstack
+	docker compose $(COMPOSE_OPTS) build frontend backend processing wmg_processing database oidc localstack
 	docker compose $(COMPOSE_OPTS) up -d frontend backend processing database oidc localstack
 
 local-rebuild-backend: .env.ecr local-ecr-login
-	docker compose $(COMPOSE_OPTS) build --build-arg INSTALL_DEV=true backend
+	docker compose $(COMPOSE_OPTS) build backend
 
 local-rebuild-processing: .env.ecr local-ecr-login
-	docker compose $(COMPOSE_OPTS) build --build-arg INSTALL_DEV=true processing
+	docker compose $(COMPOSE_OPTS) build processing
 
 local-rebuild-wmg-processing: .env.ecr local-ecr-login
-	docker compose $(COMPOSE_OPTS) build --build-arg INSTALL_DEV=true wmg_processing
+	docker compose $(COMPOSE_OPTS) build wmg_processing
 
 local-rebuild-cellguide-pipeline: .env.ecr local-ecr-login
-	docker compose $(COMPOSE_OPTS) build --build-arg INSTALL_DEV=true cellguide_pipeline
+	docker compose $(COMPOSE_OPTS) build cellguide_pipeline
 
 .PHONY: local-sync
 local-sync: local-rebuild local-init  ## Re-sync the local-environment state after modifying library deps or docker configs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,7 +194,7 @@ services:
         - BUILDKIT_INLINE_CACHE=1
         - HAPPY_COMMIT=$HAPPY_COMMIT
         - HAPPY_BRANCH=$HAPPY_BRANCH
-        - INSTALL_DEV=${INSTALL_DEV:false}
+        - INSTALL_DEV=$INSTALL_DEV
         - HAPPY_TAG
     restart: "no"
     volumes:
@@ -232,7 +232,7 @@ services:
         - BUILDKIT_INLINE_CACHE=1
         - HAPPY_COMMIT=$HAPPY_COMMIT
         - HAPPY_BRANCH=$HAPPY_BRANCH
-        - INSTALL_DEV=${INSTALL_DEV:false}
+        - INSTALL_DEV=$INSTALL_DEV
         - HAPPY_TAG
     restart: "no"
     command: ["sleep", "infinity"]
@@ -268,7 +268,7 @@ services:
         - BUILDKIT_INLINE_CACHE=1
         - HAPPY_COMMIT=$HAPPY_COMMIT
         - HAPPY_BRANCH=$HAPPY_BRANCH
-        - INSTALL_DEV=${INSTALL_DEV:false}
+        - INSTALL_DEV=$INSTALL_DEV
         - HAPPY_TAG
     restart: "no"
     command: ["sleep", "infinity"]
@@ -305,7 +305,7 @@ services:
         - BUILDKIT_INLINE_CACHE=1
         - HAPPY_COMMIT=$HAPPY_COMMIT
         - HAPPY_BRANCH=$HAPPY_BRANCH
-        - INSTALL_DEV=${INSTALL_DEV:false}
+        - INSTALL_DEV=$INSTALL_DEV
         - HAPPY_TAG
     restart: always
     command: ["./container_init.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,6 +194,7 @@ services:
         - BUILDKIT_INLINE_CACHE=1
         - HAPPY_COMMIT=$HAPPY_COMMIT
         - HAPPY_BRANCH=$HAPPY_BRANCH
+        - INSTALL_DEV=${INSTALL_DEV:false}
         - HAPPY_TAG
     restart: "no"
     volumes:
@@ -231,6 +232,7 @@ services:
         - BUILDKIT_INLINE_CACHE=1
         - HAPPY_COMMIT=$HAPPY_COMMIT
         - HAPPY_BRANCH=$HAPPY_BRANCH
+        - INSTALL_DEV=${INSTALL_DEV:false}
         - HAPPY_TAG
     restart: "no"
     command: ["sleep", "infinity"]
@@ -266,6 +268,7 @@ services:
         - BUILDKIT_INLINE_CACHE=1
         - HAPPY_COMMIT=$HAPPY_COMMIT
         - HAPPY_BRANCH=$HAPPY_BRANCH
+        - INSTALL_DEV=${INSTALL_DEV:false}
         - HAPPY_TAG
     restart: "no"
     command: ["sleep", "infinity"]
@@ -302,6 +305,7 @@ services:
         - BUILDKIT_INLINE_CACHE=1
         - HAPPY_COMMIT=$HAPPY_COMMIT
         - HAPPY_BRANCH=$HAPPY_BRANCH
+        - INSTALL_DEV=${INSTALL_DEV:false}
         - HAPPY_TAG
     restart: always
     command: ["./container_init.sh"]

--- a/python_dependencies/backend/requirements.txt
+++ b/python_dependencies/backend/requirements.txt
@@ -1,10 +1,8 @@
 alembic>=1.9, <2
 anndata==0.8.0
-allure-pytest<3
 Authlib==0.14.3
 boto3>=1.11.17
 botocore>=1.14.17
-click==8.1.7
 connexion[swagger-ui]==2.14.2
 coverage>=6.5.0
 dataclasses-json==0.6.4
@@ -29,13 +27,10 @@ psycopg2-binary>=2.8.5
 pyarrow==15.0.2 # required for where's my gene
 PyMySQL==1.1.0
 pydantic>=1.10.7, <2
-pytest
-pytest-subtests
 python-jose[cryptography]>=3.1.0
 python-json-logger
 requests>=2.22.0
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
-ruff==0.0.239 # Must be kept in sync with ruff version in .pre-commit-config.yaml
 s3fs==0.4.2
 scanpy>=1.9.8, <2
 setproctitle>1.3,<2 # for gunicorn integration with datadog

--- a/python_dependencies/backend/requirements.txt
+++ b/python_dependencies/backend/requirements.txt
@@ -4,7 +4,6 @@ Authlib==0.14.3
 boto3>=1.11.17
 botocore>=1.14.17
 connexion[swagger-ui]==2.14.2
-coverage>=6.5.0
 dataclasses-json==0.6.4
 cellxgene-ontology-guide==0.8.0
 # TODO: Check if this is really essential for APM tracing

--- a/python_dependencies/cellguide_pipeline/requirements.txt
+++ b/python_dependencies/cellguide_pipeline/requirements.txt
@@ -33,9 +33,5 @@ tiledb
 typing_extensions==4.7.1
 tzdata==2023.3
 urllib3==1.26.16
-coverage==7.2.7
-pytest==7.4.0
-pytest-subtests==0.11.0
-allure-pytest==2.13.2
 pyarrow==12.0.0
 dask==2023.8.1

--- a/python_dependencies/common/requirements-dev.txt
+++ b/python_dependencies/common/requirements-dev.txt
@@ -1,0 +1,8 @@
+allure-pytest<3
+black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
+click
+coverage
+parameterized
+pytest
+pytest-subtests
+ruff==0.0.239 # Must be kept in sync with ruff version in .pre-commit-config.yaml

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,13 +1,9 @@
 alembic>=1.9, <2
 anndata==0.8.0
-allure-pytest<3
 awscli
-black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
 boto3>=1.11.17
 botocore>=1.14.17
 cellxgene-schema
-click==8.1.3
-coverage>=6.5.0
 dataclasses-json
 ddtrace==2.1.4
 furl
@@ -17,19 +13,15 @@ moto>=5.0.0
 numba==0.56.2
 numpy==1.23.2
 pandas==1.4.4
-parameterized
 psutil>=5.9.0
 psycopg2-binary>=2.8.5
 pyarrow>=1.0
 pydantic>=1.9.0
 PyMySQL==0.9.3
-pytest==8.0.2
-pytest-subtests
 python-json-logger
 requests>=2.22.0
 rpy2==3.5.14
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
-ruff==0.0.239 # Must be kept in sync with ruff version in .pre-commit-config.yaml
 s3fs==0.4.2
 scanpy==1.9.3
 SQLAlchemy>=1.4.0,<1.5

--- a/python_dependencies/wmg/requirements.txt
+++ b/python_dependencies/wmg/requirements.txt
@@ -1,13 +1,9 @@
 alembic==1.11.1
 anndata==0.8.0
-allure-pytest==2.13.2
-black==22.3.0  # Must be kept in sync with black version in .pre-commit-config.yaml
 boto3==1.28.7
 botocore>=1.31.7, <1.32.0
-click==8.1.3
 cellxgene-census>=1.10.0 # WMG pipeline always reads the latest version of Census so we need to use the latest package version
 cellxgene-ontology-guide==0.8.0
-coverage==7.4.3
 dataclasses-json==0.5.7
 ddtrace==2.1.4
 furl==2.1.3
@@ -17,18 +13,14 @@ numba>=0.58.0
 numpy==1.23.5
 openai==0.27.7
 pandas==2.2.1
-parameterized
 psutil==5.9.5
 pyarrow==12.0.0
 pydantic==1.10.7
 pygraphviz==1.11
 PyMySQL==0.9.3
-pytest==7.4.0
-pytest-subtests==0.11.0
 python-json-logger==2.0.7
 requests>=2.22.0
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
-ruff==0.0.239 # Must be kept in sync with ruff version in .pre-commit-config.yaml
 scanpy==1.9.3
 scipy==1.10.1
 SQLAlchemy==1.4.49


### PR DESCRIPTION
## Reason for Change

- Inflated docker image sizes due to installing dev-specific packages (i.e. pytest, coverage) in deployed images
- Easier to manage dev-specific dependencies if we consolidate versions + group them in one file

## Changes

- extract dev-specific dependencies into python_dependencies/common/requirements-dev.txt, removing them from other requirements.txt
- add new build arg INSTALL_DEV to Dockerfiles for backend, processing, wmg-processing, and cellguide that only installs dev-specific packages if docker build is incurred with INSTALL_DEV=true 
- only call INSTALL_DEV=true to build images during push-tests.yml
- update push-tests.yml to check for whether to rebuild images for unit-test steps that were checking for changed files but not using that value anywhere

## Testing steps

- unit tests + inspecting docker image build step in rdev deploy