### PR TITLE
feat(cellguide): fix zoom centering when interacting with nodes in OntologyDagView

### DIFF
--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/components/AnimatedNodes/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/components/AnimatedNodes/index.tsx
@@ -38,6 +38,7 @@ interface AnimatedNodesProps {
   hideTooltip: () => void;
   cellTypesWithMarkerGeneStats: MarkerGeneStatsByCellType | null;
   setCellInfoCellType?: (props: CellType | null) => void;
+  setLastNodeClicked: (nodeId: string) => void;
 }
 
 interface AnimationState {
@@ -64,6 +65,7 @@ export default function AnimatedNodes({
   hideTooltip,
   cellTypesWithMarkerGeneStats,
   setCellInfoCellType,
+  setLastNodeClicked,
 }: AnimatedNodesProps) {
   const [timerId, setTimerId] = useState<number | null>(null); // For hover event
   const router = useRouter();
@@ -231,6 +233,7 @@ export default function AnimatedNodes({
         collapseAllDescendants(node);
       }
       toggleTriggerRender();
+      setLastNodeClicked(node.data.id);
     }
   }
 

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useState } from "react";
+import React, { useMemo, useEffect, useState, useRef } from "react";
 import { Group } from "@visx/group";
 import { Global } from "@emotion/react";
 import { useTooltip, useTooltipInPortal } from "@visx/tooltip";
@@ -70,6 +70,13 @@ import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
 import HelpTooltip from "../../CellGuideCard/components/common/HelpTooltip";
 import { getFormattedExplorerUrl } from "./utils";
+import { TransformMatrix, ProvidedZoom } from "@visx/zoom/lib/types";
+
+interface ZoomState {
+  initialTransformMatrix: TransformMatrix;
+  transformMatrix: TransformMatrix;
+  isDragging: boolean;
+}
 
 interface TreeProps {
   skinnyMode?: boolean;
@@ -84,16 +91,6 @@ interface TreeProps {
   setCellInfoCellType?: (props: CellType | null) => void;
   geneDropdownComponent?: React.ReactNode;
 }
-
-// This determines the initial Zoom position and scale
-const initialTransformMatrixDefault = {
-  scaleX: 1,
-  scaleY: 1,
-  translateX: 10,
-  translateY: 500 / 2,
-  skewX: 0,
-  skewY: 0,
-};
 
 export default function OntologyDagView({
   cellTypeId,
@@ -112,13 +109,13 @@ export default function OntologyDagView({
   const [width, setWidth] = useState(inputWidth);
   const [height, setHeight] = useState(inputHeight);
 
-  const [initialTransformMatrix, setInitialTransformMatrix] = useState<
-    typeof initialTransformMatrixDefault
-  >(initialTransformMatrixDefault);
+  const zoomRef = useRef<(ProvidedZoom<SVGSVGElement> & ZoomState) | null>(
+    null
+  );
 
+  const [lastNodeClicked, setLastNodeClicked] = useState<string | null>(null);
   // This toggler is used for centering the Zoom component on the target cell type.
-  // It triggers a re-render of the Zoom component so that updates to the initialTransformMatrix
-  // take effect.
+  // It triggers a re-render of the Zoom component.
   const [centeredNodeCoords, setCenteredNodeCoords] = useState<boolean>(false);
 
   const {
@@ -388,24 +385,30 @@ export default function OntologyDagView({
         .descendants()
         .find(
           (node) =>
-            node.data.id.split("__").at(0) === cellTypeId && node.data.children
+            (lastNodeClicked
+              ? node.data.id === lastNodeClicked
+              : node.data.id.split("__").at(0) === cellTypeId) &&
+            node.data.children
         ) as HierarchyPointNode<TreeNodeWithState> | undefined;
       // If no target nodes have children, just pick any target node.
       if (!targetNode) {
         targetNode = data
           .descendants()
-          .find((node) => node.data.id.split("__").at(0) === cellTypeId) as
-          | HierarchyPointNode<TreeNodeWithState>
-          | undefined;
+          .find(
+            (node) =>
+              node.data.id.split("__").at(0) ===
+              (lastNodeClicked ? lastNodeClicked.split("__").at(0) : cellTypeId)
+          ) as HierarchyPointNode<TreeNodeWithState> | undefined;
       }
       // If the target node is found and its position is known, set the initial transform matrix.
       // This will always be false when in tissue mode.
       if (
         targetNode &&
         targetNode.x !== undefined &&
-        targetNode.y !== undefined
+        targetNode.y !== undefined &&
+        zoomRef.current
       ) {
-        setInitialTransformMatrix({
+        zoomRef.current.setTransformMatrix({
           scaleX: 1,
           scaleY: 1,
           translateX: width / 2 - targetNode.y,
@@ -416,7 +419,15 @@ export default function OntologyDagView({
         setCenteredNodeCoords(true);
       }
     }
-  }, [data, cellTypeId, width, height]);
+  }, [
+    data,
+    cellTypeId,
+    zoomRef,
+    width,
+    height,
+    lastNodeClicked,
+    centeredNodeCoords,
+  ]);
 
   // Hover over node tooltip
   const {
@@ -562,126 +573,137 @@ export default function OntologyDagView({
           scaleXMax={4}
           scaleYMin={0.25}
           scaleYMax={4}
-          initialTransformMatrix={initialTransformMatrix}
           wheelDelta={(event: WheelEvent | React.WheelEvent<Element>) => {
             const newScale = event.deltaY > 0 ? 0.95 : 1.05;
             return { scaleX: newScale, scaleY: newScale };
           }}
         >
-          {(zoom) => (
-            <HoverContainer
-              height={height}
-              width={width}
-              ref={containerRef}
-              onMouseDown={() => {
-                hideTooltip();
-              }}
-              isFullScreen={isFullScreen}
-              data-testid={CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_HOVER_CONTAINER}
-            >
-              {data && initialTreeState && (
-                <Legend isTissue={!cellTypeId} selectedGene={selectedGene} />
-              )}
-              <RightAligned>
-                {geneDropdownComponent}
-                <FullscreenButton
-                  data-testid={
-                    CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_FULLSCREEN_BUTTON
-                  }
-                  onClick={isFullScreen ? disableFullScreen : enableFullScreen}
-                >
-                  {isFullScreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
-                </FullscreenButton>
-              </RightAligned>
+          {(zoom) => {
+            zoomRef.current = zoom;
+            return (
+              <HoverContainer
+                height={height}
+                width={width}
+                ref={containerRef}
+                onMouseDown={() => {
+                  hideTooltip();
+                }}
+                isFullScreen={isFullScreen}
+                data-testid={CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_HOVER_CONTAINER}
+              >
+                {data && initialTreeState && (
+                  <Legend isTissue={!cellTypeId} selectedGene={selectedGene} />
+                )}
+                <RightAligned>
+                  {geneDropdownComponent}
+                  <FullscreenButton
+                    data-testid={
+                      CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_FULLSCREEN_BUTTON
+                    }
+                    onClick={
+                      isFullScreen ? disableFullScreen : enableFullScreen
+                    }
+                  >
+                    {isFullScreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
+                  </FullscreenButton>
+                </RightAligned>
 
-              {tooltipOpen && (
-                <TooltipInPortal
-                  // set this to random so it correctly updates with parent bounds
-                  key={Math.random()}
-                  top={tooltipTop}
-                  left={tooltipLeft}
-                >
-                  <div data-testid={CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_TOOLTIP}>
-                    <b>{tooltipData?.n_cells}</b>
-                    {" cells"}
-                    {tissueName ? ` in ${selectedTissue.toLowerCase()}` : ""}
-                    {tooltipData?.n_cells !== tooltipData?.n_cells_rollup && (
-                      <>
-                        <br />
-                        <b>{tooltipData?.n_cells_rollup}</b>
-                        {" descendant cells"}
-                        {tissueName
-                          ? ` in ${selectedTissue.toLowerCase()}`
-                          : ""}
-                      </>
-                    )}
-                    {tooltipData &&
-                      !!tooltipData.marker_score &&
-                      !!tooltipData.me &&
-                      !!tooltipData.pc && (
+                {tooltipOpen && (
+                  <TooltipInPortal
+                    // set this to random so it correctly updates with parent bounds
+                    key={Math.random()}
+                    top={tooltipTop}
+                    left={tooltipLeft}
+                  >
+                    <div
+                      data-testid={CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_TOOLTIP}
+                    >
+                      <b>{tooltipData?.n_cells}</b>
+                      {" cells"}
+                      {tissueName ? ` in ${selectedTissue.toLowerCase()}` : ""}
+                      {tooltipData?.n_cells !== tooltipData?.n_cells_rollup && (
                         <>
                           <br />
-                          <br />
-                          <b>{selectedGene} stats</b>
-                          <br />
-                          {"Marker score: "}
-                          <b>{tooltipData.marker_score.toFixed(2)}</b>
-
-                          <br />
-                          {"Expression score: "}
-                          <b>{tooltipData.me.toFixed(2)}</b>
-                          <br />
-                          {"% of cells: "}
-                          <b>{(tooltipData.pc * 100).toFixed(2)}</b>
+                          <b>{tooltipData?.n_cells_rollup}</b>
+                          {" descendant cells"}
+                          {tissueName
+                            ? ` in ${selectedTissue.toLowerCase()}`
+                            : ""}
                         </>
                       )}
-                  </div>
-                </TooltipInPortal>
-              )}
-              <StyledSVG
-                width={width}
-                height={height}
-                ref={zoom.containerRef}
-                isDragging={zoom.isDragging}
-                data-testid={CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_CONTENT}
-              >
-                <RectClipPath id="zoom-clip" width={width} height={height} />
-                <rect
+                      {tooltipData &&
+                        !!tooltipData.marker_score &&
+                        !!tooltipData.me &&
+                        !!tooltipData.pc && (
+                          <>
+                            <br />
+                            <br />
+                            <b>{selectedGene} stats</b>
+                            <br />
+                            {"Marker score: "}
+                            <b>{tooltipData.marker_score.toFixed(2)}</b>
+
+                            <br />
+                            {"Expression score: "}
+                            <b>{tooltipData.me.toFixed(2)}</b>
+                            <br />
+                            {"% of cells: "}
+                            <b>{(tooltipData.pc * 100).toFixed(2)}</b>
+                          </>
+                        )}
+                    </div>
+                  </TooltipInPortal>
+                )}
+                <StyledSVG
                   width={width}
                   height={height}
-                  rx={isFullScreen ? 0 : 14}
-                  fill={backgroundColor}
-                />
-                <g transform={zoom.toString()}>
-                  <Tree<TreeNodeWithState>
-                    root={data}
-                    size={[yMax, xMax]}
-                    nodeSize={NODE_SPACINGS as [number, number]}
-                  >
-                    {(tree) => (
-                      <Group top={defaultMargin.top} left={defaultMargin.left}>
-                        <AnimatedLinks tree={tree} duration={duration} />
-                        <AnimatedNodes
-                          tree={tree}
-                          tissueId={tissueId}
-                          cellTypeId={cellTypeId}
-                          duration={duration}
-                          setDuration={setDuration}
-                          toggleTriggerRender={toggleTriggerRender}
-                          showTooltip={showTooltip}
-                          hideTooltip={hideTooltip}
-                          setCellInfoCellType={setCellInfoCellType}
-                          cellTypesWithMarkerGeneStats={
-                            cellTypesWithMarkerGeneStats
-                          }
-                        />
-                      </Group>
-                    )}
-                  </Tree>
-                </g>
-              </StyledSVG>
-            </HoverContainer>
-          )}
+                  ref={zoom.containerRef}
+                  isDragging={zoom.isDragging}
+                  transformMatrix={zoom.transformMatrix}
+                  data-testid={CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_CONTENT}
+                >
+                  <RectClipPath id="zoom-clip" width={width} height={height} />
+                  <rect
+                    width={width}
+                    height={height}
+                    rx={isFullScreen ? 0 : 14}
+                    fill={backgroundColor}
+                  />
+                  <g transform={zoom.toString()}>
+                    <Tree<TreeNodeWithState>
+                      root={data}
+                      size={[yMax, xMax]}
+                      nodeSize={NODE_SPACINGS as [number, number]}
+                    >
+                      {(tree) => (
+                        <Group
+                          top={defaultMargin.top}
+                          left={defaultMargin.left}
+                        >
+                          <AnimatedLinks tree={tree} duration={duration} />
+                          <AnimatedNodes
+                            tree={tree}
+                            tissueId={tissueId}
+                            cellTypeId={cellTypeId}
+                            duration={duration}
+                            setLastNodeClicked={setLastNodeClicked}
+                            setDuration={setDuration}
+                            toggleTriggerRender={toggleTriggerRender}
+                            showTooltip={showTooltip}
+                            hideTooltip={hideTooltip}
+                            setCellInfoCellType={setCellInfoCellType}
+                            cellTypesWithMarkerGeneStats={
+                              cellTypesWithMarkerGeneStats
+                            }
+                          />
+                        </Group>
+                      )}
+                    </Tree>
+                  </g>
+                </StyledSVG>
+              </HoverContainer>
+            );
+          }}
         </Zoom>
       ) : (
         <TableUnavailableContainer>

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -389,7 +389,6 @@ export default function OntologyDagView({
         targetNode.y !== undefined &&
         zoomRef.current
       ) {
-        console.log("TRIGGER", targetNode);
         zoomRef.current.setTransformMatrix({
           scaleX: 1,
           scaleY: 1,
@@ -641,7 +640,6 @@ export default function OntologyDagView({
                   height={height}
                   ref={zoom.containerRef}
                   isDragging={zoom.isDragging}
-                  transformMatrix={zoom.transformMatrix}
                   data-testid={CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_CONTENT}
                 >
                   <RectClipPath id="zoom-clip" width={width} height={height} />

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/style.ts
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/style.ts
@@ -4,7 +4,6 @@ import { IconButton } from "@mui/material";
 import { ButtonIcon, Icon } from "@czi-sds/components";
 import { spacesL } from "src/common/theme";
 import { HEADER_HEIGHT_PX } from "src/components/Header/style";
-import { TransformMatrix } from "@visx/zoom/lib/types";
 
 export const FullscreenButton = styled(IconButton)`
   visibility: hidden;
@@ -74,16 +73,10 @@ export const WarningTooltipIcon = styled(Icon)`
 
 interface StyledSVGProps {
   isDragging: boolean;
-  transformMatrix: TransformMatrix;
 }
 export const StyledSVG = styled.svg<StyledSVGProps>`
   cursor: ${({ isDragging }) => (isDragging ? "grabbing" : "grab")};
   touch-action: none;
-  g {
-    transform: ${({ transformMatrix }) => {
-      return `scale(${transformMatrix.scaleX}, ${transformMatrix.scaleY}) translate(${transformMatrix.translateX}, ${transformMatrix.translateY}) !important`;
-    }};
-  }
   position: absolute;
   top: 0;
   left: 0;

--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/style.ts
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/style.ts
@@ -4,6 +4,7 @@ import { IconButton } from "@mui/material";
 import { ButtonIcon, Icon } from "@czi-sds/components";
 import { spacesL } from "src/common/theme";
 import { HEADER_HEIGHT_PX } from "src/components/Header/style";
+import { TransformMatrix } from "@visx/zoom/lib/types";
 
 export const FullscreenButton = styled(IconButton)`
   visibility: hidden;
@@ -73,10 +74,16 @@ export const WarningTooltipIcon = styled(Icon)`
 
 interface StyledSVGProps {
   isDragging: boolean;
+  transformMatrix: TransformMatrix;
 }
 export const StyledSVG = styled.svg<StyledSVGProps>`
   cursor: ${({ isDragging }) => (isDragging ? "grabbing" : "grab")};
   touch-action: none;
+  g {
+    transform: ${({ transformMatrix }) => {
+      return `scale(${transformMatrix.scaleX}, ${transformMatrix.scaleY}) translate(${transformMatrix.translateX}, ${transformMatrix.translateY}) !important`;
+    }};
+  }
   position: absolute;
   top: 0;
   left: 0;

--- a/frontend/tests/features/cellGuide/cellGuide.test.ts
+++ b/frontend/tests/features/cellGuide/cellGuide.test.ts
@@ -88,6 +88,7 @@ import {
 const { describe } = test;
 
 const NEURON_CELL_TYPE_ID = "CL_0000540";
+const NEURAL_CELL_CELL_TYPE_ID = "CL_0002319";
 const GLIOBLAST_CELL_TYPE_ID = "CL_0000030";
 const T_CELL_CELL_TYPE_ID = "CL_0000084";
 const BRAIN_TISSUE_ID = "UBERON_0000955";
@@ -670,9 +671,9 @@ describe("Cell Guide", () => {
               `${TEST_URL}${ROUTES.CELL_GUIDE_TISSUE_SPECIFIC_CELL_TYPE.replace(
                 ":tissueId",
                 BRAIN_TISSUE_ID
-              ).replace(":cellTypeId", NEURON_CELL_TYPE_ID)}`
+              ).replace(":cellTypeId", NEURAL_CELL_CELL_TYPE_ID)}`
             ),
-            page.getByText("neuron", { exact: true }).click(),
+            page.getByText("neural cell", { exact: true }).click(),
           ]);
 
           await tryUntil(

--- a/frontend/tests/features/cellGuide/cellGuide.test.ts
+++ b/frontend/tests/features/cellGuide/cellGuide.test.ts
@@ -94,7 +94,6 @@ const BRAIN_TISSUE_ID = "UBERON_0000955";
 const LUNG_TISSUE_ID = "UBERON_0002048";
 const SALIVARY_ACINAR_GLAND_CELL_TYPE_ID = "CL_0002623";
 const ABNORMAL_CELL_TYPE_ID = "CL_0001061";
-const PROGENITOR_CELL_CELL_TYPE_ID = "CL_0011026";
 const CELL_CELL_TYPE_ID = "CL_0000000";
 const LUNG_CILIATED_CELL_CELL_TYPE_ID = "CL_1000271";
 
@@ -669,17 +668,9 @@ describe("Cell Guide", () => {
               `${TEST_URL}${ROUTES.CELL_GUIDE_TISSUE_SPECIFIC_CELL_TYPE.replace(
                 ":tissueId",
                 BRAIN_TISSUE_ID
-              ).replace(":cellTypeId", PROGENITOR_CELL_CELL_TYPE_ID)}`
+              ).replace(":cellTypeId", NEURON_CELL_TYPE_ID)}`
             ),
-            page
-              .getByText(
-                "progenitor cell",
-                /**
-                 * (thuang): There is "neural progenitor cell" that we don't want to match
-                 */
-                { exact: true }
-              )
-              .click(),
+            page.getByText("neuron", { exact: true }).click(),
           ]);
 
           await tryUntil(

--- a/frontend/tests/features/cellGuide/cellGuide.test.ts
+++ b/frontend/tests/features/cellGuide/cellGuide.test.ts
@@ -97,6 +97,8 @@ const ABNORMAL_CELL_TYPE_ID = "CL_0001061";
 const CELL_CELL_TYPE_ID = "CL_0000000";
 const LUNG_CILIATED_CELL_CELL_TYPE_ID = "CL_1000271";
 
+const NODES_LOCATOR = `[data-testid^='${CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}']`;
+
 describe("Cell Guide", () => {
   describe("Landing Page", () => {
     test("All LandingPage components are present", async ({ page }) => {
@@ -745,37 +747,39 @@ describe("Cell Guide", () => {
           .getByTestId(CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW)
           .waitFor({ timeout: WAIT_FOR_TIMEOUT_MS });
 
-        const nodesLocator = `[data-testid^='${CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}']`;
+        const node = page.getByTestId(
+          `${CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}-CL:0000540__0-has-children-isTargetNode=true`
+        );
+
+        let numNodesBefore = 0;
+        await tryUntil(
+          async () => {
+            const nodesBefore = await getVisibleNodes(page);
+            numNodesBefore = nodesBefore.length;
+            expect(numNodesBefore).toBeGreaterThan(0);
+          },
+          { page }
+        );
+
+        await waitForElementAndClick(node);
+
+        let numNodesAfter = 0;
+        await tryUntil(
+          async () => {
+            const nodesAfter = await getVisibleNodes(page);
+            numNodesAfter = nodesAfter.length;
+            expect(numNodesBefore).toBeGreaterThan(numNodesAfter);
+          },
+          { page }
+        );
+
+        await waitForElementAndClick(node);
 
         // Collapse node's children
         await tryUntil(
           async () => {
-            const nodesBefore = await page.locator(nodesLocator).all();
-            const numNodesBefore = nodesBefore.length;
-
-            /**
-             * (thuang): This is needed to ensure that we don't query the tree
-             * before it's rendered
-             */
-            expect(numNodesBefore).toBeGreaterThan(0);
-
-            const node = page.getByTestId(
-              `${CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}-CL:0000540__0-has-children-isTargetNode=true`
-            );
-
-            await waitForElementAndClick(node);
-
-            const nodesAfter = await page.locator(nodesLocator).all();
-            const numNodesAfter = nodesAfter.length;
-
-            expect(numNodesBefore).toBeGreaterThan(numNodesAfter);
-
-            // expand node's children
-            await waitForElementAndClick(node);
-
-            const nodesAfter2 = await page.locator(nodesLocator).all();
+            const nodesAfter2 = await getVisibleNodes(page);
             const numNodesAfter2 = nodesAfter2.length;
-
             expect(numNodesAfter2).toBeGreaterThan(numNodesAfter);
           },
           { page }
@@ -822,8 +826,7 @@ describe("Cell Guide", () => {
           .getByTestId(CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW)
           .waitFor({ timeout: WAIT_FOR_TIMEOUT_MS });
 
-        const nodesLocator = `[data-testid^='${CELL_GUIDE_CARD_ONTOLOGY_DAG_VIEW_RECT_OR_CIRCLE_PREFIX_ID}']`;
-        const nodesBefore = await page.locator(nodesLocator).all();
+        const nodesBefore = await getVisibleNodes(page);
         const numNodesBefore = nodesBefore.length;
 
         // check that dummyChild is clickable
@@ -832,7 +835,7 @@ describe("Cell Guide", () => {
         );
         await dummyChildLocator.click();
 
-        const nodesAfter = await page.locator(nodesLocator).all();
+        const nodesAfter = await getVisibleNodes(page);
         const numNodesAfter = nodesAfter.length;
 
         expect(numNodesAfter).toBeGreaterThan(numNodesBefore);
@@ -1607,4 +1610,21 @@ async function assertAllCellCardComponentsArePresent(page: Page) {
   const headerName = page.getByTestId(CELL_GUIDE_CARD_HEADER_NAME);
   const headerNameText = await headerName.textContent();
   expect(headerNameText).toBe("Neuron");
+}
+
+async function getVisibleNodes(page: Page) {
+  const nodes = await page.locator(NODES_LOCATOR).all();
+  const visibilityStatuses = await Promise.all(
+    nodes.map(async (node) => {
+      const parent = await node.evaluateHandle((el) => el.parentElement);
+      const opacity = await page.evaluate(
+        (el) => el && getComputedStyle(el).opacity,
+        parent
+      );
+      return opacity !== "0"; // true if visible, false if not
+    })
+  );
+
+  // Filter the nodes array based on visibilityStatuses
+  return nodes.filter((_, index) => visibilityStatuses[index]);
 }


### PR DESCRIPTION
# Changes
- This PR fixes node centering when nodes are collapsed and expanded, which should reduce test flakiness.
- This PR also fixes failing e2e tests related to node collapse. Hidden nodes were still visible by the locator as they were hidden with opacity 0, so now we added logic to filter out nodes that had 0 opacity in the tests.

# Testing steps
 - tests pass