### PR TITLE
fix: set envfile before running unit tests in containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,39 +156,39 @@ local-unit-test: local-unit-test-backend local-unit-test-wmg-backend local-unit-
 # Run all backend and processing unit tests in the dev environment, with code coverage
 
 .PHONY: local-unit-test-backend
-local-unit-test-backend: 
+local-unit-test-backend: .env.ecr
 	docker compose run --rm -T backend bash -c \
 	"cd /single-cell-data-portal && coverage run  $(COVERAGE_RUN_ARGS) -m pytest --alluredir=./allure-results tests/unit/backend/layers/ tests/unit/backend/common/";
 
 .PHONY: local-unit-test-wmg-backend
-local-unit-test-wmg-backend: 
+local-unit-test-wmg-backend: .env.ecr
 	docker compose run --rm -T backend bash -c \
 	"cd /single-cell-data-portal && coverage run $(COVERAGE_RUN_ARGS) -m pytest --alluredir=./allure-results tests/unit/backend/wmg/";
 
 .PHONY: local-integration-test-backend
-local-integration-test-backend:
+local-integration-test-backend: .env.ecr
 	docker compose run --rm -e INTEGRATION_TEST=true -e DB_URI=postgresql://corpora:test_pw@database -T backend \
 	bash -c "cd /single-cell-data-portal && coverage run $(COVERAGE_RUN_ARGS) -m pytest tests/unit/backend/layers/ tests/unit/backend/common/";
 
 .PHONY: local-unit-test-processing
-local-unit-test-processing: # Run processing-unittest target in `processing` Docker container
+local-unit-test-processing: .env.ecr # Run processing-unittest target in `processing` Docker container
 	docker compose $(COMPOSE_OPTS) run --rm -e DEV_MODE_COOKIES= -T processing \
 	bash -c "cd /single-cell-data-portal && coverage run $(COVERAGE_RUN_ARGS) -m pytest --alluredir=./allure-results tests/unit/processing/";
 
 .PHONY: local-unit-test-wmg-processing
-local-unit-test-wmg-processing: # Run processing-unittest target in `wmg_processing` Docker container
+local-unit-test-wmg-processing: .env.ecr # Run processing-unittest target in `wmg_processing` Docker container
 	echo "Running all wmg processing unit tests"; \
 	docker compose $(COMPOSE_OPTS) run --rm -e DEV_MODE_COOKIES= -T wmg_processing \
 	bash -c "cd /single-cell-data-portal && make wmg-processing-unittest;"
 
 .PHONY: local-unit-test-cellguide-pipeline
-local-unit-test-cellguide-pipeline: # Run processing-unittest target in `cellguide_pipeline` Docker container
+local-unit-test-cellguide-pipeline: .env.ecr # Run processing-unittest target in `cellguide_pipeline` Docker container
 	echo "Running all cellguide pipeline unit tests"; \
 	docker compose $(COMPOSE_OPTS) run --rm -e DEV_MODE_COOKIES= -T cellguide_pipeline \
 	bash -c "cd /single-cell-data-portal && make cellguide-pipeline-unittest;"	
 
 .PHONY: local-unit-test-cxg-admin
-local-unit-test-cxg-admin:
+local-unit-test-cxg-admin: .env.ecr
 	docker compose run --rm -T backend bash -c \
 	"cd /single-cell-data-portal && coverage run  $(COVERAGE_RUN_ARGS) -m pytest --alluredir=./allure-results tests/unit/scripts/";
 


### PR DESCRIPTION
## Reason for Change

- Bug introduced in https://github.com/chanzuckerberg/single-cell-data-portal/commit/55c92dca316eeafe358ec3393edf5f713411ddbe was causing unit tests to fail due to missing test dependency installation 

## Changes

- set envfile explicitly before all unit test makefile commands

## Testing steps
- unit tests pass here; previously the unit tests were passing because the PR included changes to Dockerfiles, which automatically triggers a full container rebuild with the appropriate envfile. If the unit tests in the PR work with the right build args while using cached layers, it should work in all cases going forward