### PR TITLE
chore: fix node centering to be on expanded node on page load

### DIFF
--- a/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
+++ b/frontend/src/views/CellGuide/components/common/OntologyDagView/index.tsx
@@ -917,7 +917,7 @@ function getCenteringNode(
   cellTypeId?: string
 ) {
   // We find the target node that has children visible.
-  // By construction, only one copy of the target node in the tree will have children visible.
+  // By construction, only one copy of the target node in the tree will be expanded at first.
   // The target node is the node corresponding to the cell type id of the CellGuideCard.
   // If lastNodeClicked is not null, the target node is the last node that was clicked.
 
@@ -927,8 +927,10 @@ function getCenteringNode(
       (node) =>
         (lastNodeClicked
           ? node.data.id === lastNodeClicked
-          : node.data.id.split("__").at(0) === cellTypeId) && node.data.children
+          : node.data.id.split("__").at(0) === cellTypeId) &&
+        node.data.isExpanded
     ) as HierarchyPointNode<TreeNodeWithState> | undefined;
+
   // If no target nodes have children, just pick any target node.
   if (!targetNode) {
     targetNode = data


### PR DESCRIPTION
## Reason for Change

- Node centering logic was prioritizing nodes that had children but even non-expanded nodes in the DAG technically had children. This PR fixes this to center on nodes that are _expanded_

## Changes

- use `isExpanded` property to determine which node to center on

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."
