### PR TITLE
fix: exclude public revision datasets from private datasets endpoint

### DIFF
--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -278,8 +278,8 @@ def reshape_dataset_for_curation_datasets_index_api(
     :param dataset_version: a dataset version to be included in the API response.
     :return: A dictionary shaped for inclusion in the datasets index API response.
     """
-    # Create base dataset response shape. use_canonical is true only for datasets with a calculated visibility of
-    # public; for datasets with a calculated visibility of private, corresponding fields are calculated below.
+    # Create base dataset response shape. use_canonical is true only for datasets with a visibility of
+    # public; for datasets with a visibility of private, corresponding fields are calculated below.
     is_dataset_visibility_public = visibility == Visibility.PUBLIC.name
     ds = reshape_dataset_for_curation_api(dataset_version, index=True, use_canonical_url=is_dataset_visibility_public)
 

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -646,8 +646,12 @@ class BusinessLogic(BusinessLogicInterface):
         self, owner: str = None
     ) -> List[CollectionVersionWithPrivateDatasets]:
         """
-        Returns collection versions with their datasets for private collections. If `owner` is provided,
-        collections owned by that user are returned.
+        Returns collection versions with their datasets for private collections. Only private collections with datasets, or
+        unpublished revisions with new or updated datasets are returned; unpublished revisions with no new datasets, and
+        no changed datasets are not returned.
+
+        If `owner` is provided, collections owned by that user are returned.
+
         :param owner: The owner of the collections to retrieve. None if user is super use.
         :return: A list of CollectionVersionWithPrivateDatasets objects.
         """

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -2028,15 +2028,14 @@ class TestGetDatasets(BaseAPIPortalTest):
                 visibility=Visibility.PRIVATE.name, headers=self.make_super_curator_header()
             )
 
-            # Create the list of the 7 expected datasets: 4 (3 + 1) from unpublished collections and 3 from
-            # the revision of published_collection_1
+            # Create the list of the 6 expected datasets: 4 (3 + 1) from unpublished collections and 2 from
+            # the revision of published_collection_1 (one new, one updated).
             expected_dataset_ids = [
                 unpublished_collection_1_dataset_added.dataset_version_id,
                 unpublished_collection_1.datasets[0].version_id.id,
                 unpublished_collection_1.datasets[1].version_id.id,
                 unpublished_collection_2.datasets[0].version_id.id,
                 revision_1_dataset_updated.dataset_version_id,
-                revision_1.datasets[1].version_id.id,
                 revision_1_dataset_new.dataset_version_id,
             ]
             _validate_datasets(response_datasets, expected_dataset_ids)
@@ -2046,14 +2045,13 @@ class TestGetDatasets(BaseAPIPortalTest):
 
         # Owner
         with self.subTest("With owner credentials"):
-            # Create the list of the 6 expected datasets: 3 from unpublished collections and 3 from
-            # the revision of published_collection_1.
+            # Create the list of the 5 expected datasets: 3 from unpublished collections and 2 from
+            # the revision of published_collection_1 (one new, one updated).
             expected_dataset_ids = [
                 unpublished_collection_1_dataset_added.dataset_version_id,
                 unpublished_collection_1.datasets[0].version_id.id,
                 unpublished_collection_1.datasets[1].version_id.id,
                 revision_1_dataset_updated.dataset_version_id,
-                revision_1.datasets[1].version_id.id,
                 revision_1_dataset_new.dataset_version_id,
             ]
             _validate_datasets(response_datasets, expected_dataset_ids)
@@ -2070,7 +2068,6 @@ class TestGetDatasets(BaseAPIPortalTest):
                 ],
                 reverse=True,
             )
-            expected_sorted_dataset_ids.append(revision_1.datasets[1].dataset_id.id)
 
             response_dataset_ids = []
             for dataset in response_datasets:
@@ -2130,24 +2127,6 @@ class TestGetDatasets(BaseAPIPortalTest):
             self.assertIn(revision_1_dataset_updated.dataset_version_id, response_dataset["explorer_url"])
             self.assertIsNone(response_dataset["published_at"])
             self.assertIsNone(response_dataset["revised_at"])
-
-        # Verify fields for a unchanged dataset of a revision
-        # visibility - PUBLIC
-        # collection_id - collection_version_id
-        # collection_version_id - collection_version_id
-        # revision_of_collection - collection_id
-        # revision_of_dataset - null
-        with self.subTest("Verify expected fields for revision, unchanged dataset"):
-            expected_dataset = revision_1.datasets[1]
-            response_dataset = datasets_by_version_id[expected_dataset.version_id.id]
-            self.assertEqual(Visibility.PUBLIC.name, response_dataset["visibility"])
-            self.assertEqual(revision_1.version_id.id, response_dataset["collection_id"])
-            self.assertEqual(revision_1.version_id.id, response_dataset["collection_version_id"])
-            self.assertEqual(revision_1.collection_id.id, response_dataset["revision_of_collection"])
-            self.assertIsNone(response_dataset["revision_of_dataset"])
-            self.assertIn(expected_dataset.dataset_id.id, response_dataset["explorer_url"])
-            self.assertIsNotNone(response_dataset["published_at"])
-            self.assertIsNone(response_dataset["revised_at"])  # Not revised
 
     def test_get_private_datasets_400(self):
         # 400 if PRIVATE and schema version.

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1604,7 +1604,7 @@ class TestGetAllDatasets(BaseBusinessLogicTestCase):
                     [d.version_id for d in datasets],
                 )
 
-        # Create the expected shape of revision_1_updated: datasets should only be the replacement dataset as well as the new dataset.
+        # Create the expected shape of revision_1_updated: datasets should only include the replacement dataset as well as the new dataset.
         revision_1_updated_expected = deepcopy(revision_1_updated)
         revision_1_updated_expected.datasets = [
             self.database_provider.get_dataset_version(updated_dataset_version_id),
@@ -1619,7 +1619,7 @@ class TestGetAllDatasets(BaseBusinessLogicTestCase):
 
         with self.subTest("With owner"):
             collection_versions = self.business_logic.get_private_collection_versions_with_datasets(owner=test_user_1)
-            # Owner should see their private collections, and their updated revision.
+            # Owner should see their private collection, and their revision that has been udpated.
             expected = [private_cv_1, revision_1_updated_expected]
             _validate(collection_versions, expected)
 


### PR DESCRIPTION
## Reason for Change

- #6942 

## Changes

- Updated business logic to exclude public revision datasets from the `datasets?visibility=PRIVATE` response.

## Testing steps

- Unit tests covering business layer and controller

### rdev Test Cases/Data

The following test data is set up on [rdev](https://pr-6982-frontend.rdev.single-cell.czi.technology)https://pr-6982-frontend.rdev.single-cell.czi.technology/:

1. Public collection, never revised ([Link](https://pr-6982-frontend.rdev.single-cell.czi.technology/collections/a467ca3c-9a8c-49b7-91c2-fe480f6e2939))
1. Public collection, revised and published
1. Public collection, revision in progress ([Link](https://pr-6982-frontend.rdev.single-cell.czi.technology/collections/991c1744-8a98-4699-9de9-76c7ce2edc87))
1. Revision (of 3), three datasets: one new, one updated and one unchanged ([Link](https://pr-6982-frontend.rdev.single-cell.czi.technology/collections/b97e5550-5c90-481c-8115-c67345ae7c33))
1. Public collection, revision in progress ([Link](https://pr-6982-frontend.rdev.single-cell.czi.technology/collections/991c1744-8a98-4699-9de9-76c7ce2edc87))
1. Revision (of 5), one dataset: unchanged ([Link](https://pr-6982-frontend.rdev.single-cell.czi.technology/collections/b97e5550-5c90-481c-8115-c67345ae7c33))
1. Private collection ([Link](https://pr-6982-frontend.rdev.single-cell.czi.technology/collections/9023cd28-ba0b-4d96-9df0-133a0d41e6ab))

See [test case cheat sheet](https://docs.google.com/spreadsheets/d/1cRcNee6QiAM1EI-_pULQTuq1GzWkOKNWkWM4aMC9ouA/edit#gid=1860519502).

## Checklist 🛎️

- [ ] ~~Add product, design, and eng as reviewers for rdev review~~ Product review will be completed in staging.
