### PR TITLE
fix: schema migration error reporting

### DIFF
--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -290,7 +290,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                   },
                   {
                     "Name": "EXECUTION_ID",
-                    "Value.$": "$$.Execution.Name"
+                    "Value.$": "$.execution_id"
                   }
                 ]
               }
@@ -351,7 +351,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                   },
                   {
                     "Name": "EXECUTION_ID",
-                    "Value.$": "$$.Execution.Name"
+                    "Value.$": "$.execution_id"
                   }
                 ]
               }
@@ -418,7 +418,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                         },
                         {
                           "Name": "EXECUTION_ID",
-                          "Value.$": "$$.Execution.Name"
+                          "Value.$": "$.execution_id"
                         }
                       ]
                     }

--- a/backend/layers/processing/schema_migration.py
+++ b/backend/layers/processing/schema_migration.py
@@ -180,6 +180,7 @@ class SchemaMigrate(ProcessingLogic):
                         "collection_version_id": private_collection_version_id,
                         "dataset_id": dataset.dataset_id.id,
                         "dataset_version_id": dataset.version_id.id,
+                        "execution_id": self.execution_id,
                     }
                     for dataset in datasets
                     if dataset.status.processing_status == DatasetProcessingStatus.SUCCESS

--- a/backend/layers/processing/schema_migration.py
+++ b/backend/layers/processing/schema_migration.py
@@ -84,6 +84,7 @@ class SchemaMigrate(ProcessingLogic):
             _resp.update(
                 collection_id=collection.collection_id.id,
                 collection_version_id=collection.version_id.id,
+                execution_id=self.execution_id,
             )
             response.append(_resp)
 
@@ -129,6 +130,7 @@ class SchemaMigrate(ProcessingLogic):
             "dataset_version_id": new_dataset_version_id.id,
             "uri": uri,
             "sfn_name": sfn_name,
+            "execution_id": self.execution_id,
         }
 
     def collection_migrate(self, collection_id: str, collection_version_id: str, can_publish: bool) -> Dict[str, Any]:
@@ -189,6 +191,7 @@ class SchemaMigrate(ProcessingLogic):
             if not response["datasets"]:
                 # Handles the case were the collection has no processed datasets
                 response["no_datasets"] = str(True)
+        response["execution_id"] = self.execution_id
         self._store_sfn_response("publish_and_cleanup", version.collection_id.id, response)
         return response
 

--- a/tests/unit/processing/schema_migration/test_collection_migrate.py
+++ b/tests/unit/processing/schema_migration/test_collection_migrate.py
@@ -17,6 +17,7 @@ class TestCollectionMigrate:
                 "dataset_id": dataset.dataset_id.id,
                 "dataset_version_id": dataset.version_id.id,
                 "collection_url": f"https://collections_domain/collections/{published.collection_id.id}",
+                "execution_id": "test-execution-arn",
             }
             for dataset in published.datasets
         ]
@@ -44,6 +45,7 @@ class TestCollectionMigrate:
                 "dataset_id": dataset.dataset_id.id,
                 "dataset_version_id": dataset.version_id.id,
                 "collection_url": f"https://collections_domain/collections/{private.collection_id.id}",
+                "execution_id": "test-execution-arn",
             }
             for dataset in private.datasets
         ]

--- a/tests/unit/processing/schema_migration/test_gather_collections.py
+++ b/tests/unit/processing/schema_migration/test_gather_collections.py
@@ -9,11 +9,13 @@ class TestGatherCollections:
             "can_publish": "True",
             "collection_id": published.collection_id.id,
             "collection_version_id": published.collection_id.id,
+            "execution_id": "test-execution-arn",
         } not in response
         assert {
             "can_publish": "False",
             "collection_id": revision.collection_id.id,
             "collection_version_id": revision.version_id.id,
+            "execution_id": "test-execution-arn",
         } in response
         assert len(response) == 1
 
@@ -27,6 +29,7 @@ class TestGatherCollections:
             "can_publish": "True",
             "collection_id": published[0].collection_id.id,
             "collection_version_id": published[0].version_id.id,
+            "execution_id": "test-execution-arn",
         } in response
         assert len(response) == 1
 
@@ -40,6 +43,7 @@ class TestGatherCollections:
             "can_publish": "False",
             "collection_id": private[0].collection_id.id,
             "collection_version_id": private[0].version_id.id,
+            "execution_id": "test-execution-arn",
         } in response
         assert len(response) == 1
 
@@ -59,16 +63,19 @@ class TestGatherCollections:
                 "can_publish": "False",
                 "collection_id": published_no_revision.collection_id.id,
                 "collection_version_id": published_no_revision.version_id.id,
+                "execution_id": "test-execution-arn",
             },
             {
                 "can_publish": "False",
                 "collection_id": private.collection_id.id,
                 "collection_version_id": private.version_id.id,
+                "execution_id": "test-execution-arn",
             },
             {
                 "can_publish": "False",
                 "collection_id": revision.collection_id.id,
                 "collection_version_id": revision.version_id.id,
+                "execution_id": "test-execution-arn",
             },
         ]:
             assert obj in response


### PR DESCRIPTION
## Reason for Change

- #6917 

## Changes

- Passing execution_id to mapped async step functions steps. This is to allow logs message to be stored under the same s3 to suffix for schema migration reporting purposes.

## Testing steps

- run a small migration and verify all of the expected log messages are returned. The reporter now returns errors for failed jobs 
```json
{
    "errors": [
        [
            {
                "collection_id": "45f0f67d-4b69-4a3c-a4e8-a63b962e843f",
                "collection_version_id": "104a13bf-bb4e-41af-971b-2d5fc3c48c17",
                "dataset_id": "28c696bb-9549-434b-9340-dc745a846f9a",
                "dataset_status": {
                    "cxg_status": null,
                    "h5ad_status": "UPLOADED",
                    "processing_status": "FAILURE",
                    "rds_status": null,
                    "upload_status": "UPLOADED",
                    "validation_message": "ERROR: Column 'schema_version' is a reserved column name of 'uns'. Remove it from h5ad and try again.\nERROR: Checking values with dependencies failed for adata.obs['tissue_ontology_term_id'], this is likely due to missing dependent column in adata.obs.\nERROR: Dataframe 'obs' is missing column 'tissue_type'.",
                    "validation_status": "INVALID"
                },
                "dataset_version_id": "fc2bd33b-2eef-4725-a0e6-3a7f1cbb2d6d",
                "message": "ERROR: Column 'schema_version' is a reserved column name of 'uns'. Remove it from h5ad and try again.\nERROR: Checking values with dependencies failed for adata.obs['tissue_ontology_term_id'], this is likely due to missing dependent column in adata.obs.\nERROR: Dataframe 'obs' is missing column 'tissue_type'.",
                "rollback": false
            }
        ],
        [
            {
                "collection_id": "125eef58-0f61-4963-9b08-53e851ab65fb",
                "collection_version_id": "145518fe-3947-4eec-8bfe-dfd1d1f427b7",
                "dataset_id": "105c7dad-0468-4628-a5be-2bb42c6a8ae4",
                "dataset_status": {
                    "cxg_status": null,
                    "h5ad_status": "UPLOADED",
                    "processing_status": "FAILURE",
                    "rds_status": null,
                    "upload_status": "UPLOADED",
                    "validation_message": "ERROR: Column 'schema_version' is a reserved column name of 'uns'. Remove it from h5ad and try again.\nERROR: Checking values with dependencies failed for adata.obs['tissue_ontology_term_id'], this is likely due to missing dependent column in adata.obs.\nERROR: Dataframe 'obs' is missing column 'tissue_type'.",
                    "validation_status": "INVALID"
                },
                "dataset_version_id": "643b012c-2bd2-4a42-9a7a-90ea1b44e7b0",
                "message": "ERROR: Column 'schema_version' is a reserved column name of 'uns'. Remove it from h5ad and try again.\nERROR: Checking values with dependencies failed for adata.obs['tissue_ontology_term_id'], this is likely due to missing dependent column in adata.obs.\nERROR: Dataframe 'obs' is missing column 'tissue_type'.",
                "rollback": false
            }
        ],
        [
            {
                "collection_id": "5d445965-6f1a-4b68-ba3a-b8f765155d3a",
                "collection_version_id": "fe2339c8-99e7-4cf4-ab06-3d1431acefe0",
                "dataset_id": "e04daea4-4412-45b5-989e-76a9be070a89",
                "dataset_status": {
                    "cxg_status": null,
                    "h5ad_status": "UPLOADED",
                    "processing_status": "FAILURE",
                    "rds_status": null,
                    "upload_status": "UPLOADED",
                    "validation_message": "ERROR: Column 'schema_version' is a reserved column name of 'uns'. Remove it from h5ad and try again.\nERROR: Checking values with dependencies failed for adata.obs['tissue_ontology_term_id'], this is likely due to missing dependent column in adata.obs.\nERROR: Dataframe 'obs' is missing column 'tissue_type'.",
                    "validation_status": "INVALID"
                },
                "dataset_version_id": "ee0ba574-a0c5-46a1-a153-f1c9c8714d70",
                "message": "ERROR: Column 'schema_version' is a reserved column name of 'uns'. Remove it from h5ad and try again.\nERROR: Checking values with dependencies failed for adata.obs['tissue_ontology_term_id'], this is likely due to missing dependent column in adata.obs.\nERROR: Dataframe 'obs' is missing column 'tissue_type'.",
                "rollback": false
            },
            {
                "collection_id": "5d445965-6f1a-4b68-ba3a-b8f765155d3a",
                "collection_version_id": "fe2339c8-99e7-4cf4-ab06-3d1431acefe0",
                "dataset_id": "8c42cfd0-0b0a-46d5-910c-fc833d83c45e",
                "dataset_status": {
                    "cxg_status": null,
                    "h5ad_status": "UPLOADED",
                    "processing_status": "FAILURE",
                    "rds_status": null,
                    "upload_status": "UPLOADED",
                    "validation_message": "ERROR: Column 'schema_version' is a reserved column name of 'uns'. Remove it from h5ad and try again.\nERROR: Checking values with dependencies failed for adata.obs['tissue_ontology_term_id'], this is likely due to missing dependent column in adata.obs.\nERROR: Dataframe 'obs' is missing column 'tissue_type'.",
                    "validation_status": "INVALID"
                },
                "dataset_version_id": "1984bf1e-91bb-434d-bc9f-5f18361f3533",
                "message": "ERROR: Column 'schema_version' is a reserved column name of 'uns'. Remove it from h5ad and try again.\nERROR: Checking values with dependencies failed for adata.obs['tissue_ontology_term_id'], this is likely due to missing dependent column in adata.obs.\nERROR: Dataframe 'obs' is missing column 'tissue_type'.",
                "rollback": false
            }
        ]
    ],
    "migrate_changes": []
}
```

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
