### PR TITLE
feat: generalized .rds unavailable messaging

### DIFF
--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/constants.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/constants.ts
@@ -7,4 +7,4 @@ export const TOOLTIP_SLOT_PROPS = {
 };
 
 export const TOOLTIP_TITLE =
-  ".rds (Seurat v5) is unavailable due to limitations in the R dgCMatrix sparse matrix class.";
+  ".rds (Seurat v5) is unavailable.";

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/constants.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/constants.ts
@@ -6,5 +6,4 @@ export const TOOLTIP_SLOT_PROPS = {
   },
 };
 
-export const TOOLTIP_TITLE =
-  ".rds (Seurat v5) is unavailable.";
+export const TOOLTIP_TITLE = ".rds (Seurat v5) is unavailable.";


### PR DESCRIPTION
## Reason for Change

- #6752 

## Changes

- Updated ".rds unavailable" tooltip text.

#### UI Updates
<img width="938" alt="image" src="https://github.com/chanzuckerberg/single-cell-data-portal/assets/2446424/9354d189-0050-492b-b775-29692bc6f56f">

## Testing steps

- Tested locally and in rdev.

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review