### PR TITLE
fix: case where uns['spatial']['is_single'] is True and no library_id key

### DIFF
--- a/backend/layers/processing/process_validate.py
+++ b/backend/layers/processing/process_validate.py
@@ -118,7 +118,7 @@ class ProcessValidate(ProcessingLogic):
         is_single = spatial_dict.get("is_single")
         has_fullres = False
         spatial_library_ids = [key for key in spatial_dict if key != "is_single"]
-        # schema validation ensures there can only be max. one other key in uns["spatial"] if "is_single" is True
+        # schema validation ensures there can only be at max, one other key in uns["spatial"] if "is_single" is True
         library_id = spatial_library_ids.pop() if spatial_library_ids else None
         if library_id and "images" in spatial_dict[library_id] and "fullres" in spatial_dict[library_id]["images"]:
             has_fullres = True

--- a/backend/layers/processing/process_validate.py
+++ b/backend/layers/processing/process_validate.py
@@ -117,12 +117,11 @@ class ProcessValidate(ProcessingLogic):
         """
         is_single = spatial_dict.get("is_single")
         has_fullres = False
-        # schema validation ensures nested 'fullres' key is only included when is_single is True
-        if is_single:
-            # schema validation ensures there can only be one other key in uns["spatial"] if "is_single" is True
-            library_id = [key for key in spatial_dict if key != "is_single"][0]
-            if "fullres" in spatial_dict[library_id]["images"]:
-                has_fullres = True
+        spatial_library_ids = [key for key in spatial_dict if key != "is_single"]
+        # schema validation ensures there can only be max. one other key in uns["spatial"] if "is_single" is True
+        library_id = spatial_library_ids.pop() if spatial_library_ids else None
+        if library_id and "images" in spatial_dict[library_id] and "fullres" in spatial_dict[library_id]["images"]:
+            has_fullres = True
         return SpatialMetadata(is_single=bool(is_single), has_fullres=has_fullres)
 
     @logit

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -290,11 +290,17 @@ class TestProcessingValidate(BaseProcessingTest):
         }
         self.assertEqual(self.pdv.get_spatial_metadata(spatial_dict), SpatialMetadata(is_single=True, has_fullres=True))
 
-    def test_get_spatial_metadata__is_single_true_fullres_false(self):
+    def test_get_spatial_metadata__is_single_true_and_fullres_false(self):
         spatial_dict = {
             "is_single": True,
             "dummy_library_id": {"images": {}},
         }
+        self.assertEqual(
+            self.pdv.get_spatial_metadata(spatial_dict), SpatialMetadata(is_single=True, has_fullres=False)
+        )
+
+    def test_get_spatial_metadata__is_single_true_and_no_library_id(self):
+        spatial_dict = {"is_single": np.bool_(True)}
         self.assertEqual(
             self.pdv.get_spatial_metadata(spatial_dict), SpatialMetadata(is_single=True, has_fullres=False)
         )


### PR DESCRIPTION
## Reason for Change

- Bug caught when processing a Slide-Seq-v2 dataset that has is_single: True and no library_id in uns['spatial']. Expected behavior: Should be valid, Actual Behavior: IndexError due to missing a library_id

## Changes

- modify check in extract_metadata step of DownloadValidate to account for cases where there are no library_ids, removed 1 bit of logic that was making (inaccurate) assumption about the uns shape post-validation
- added unit test to cover case