### PR TITLE
chore: make valid_explorer_cxg.json agnostic to snapshot id

### DIFF
--- a/frontend/src/common/queries/cellGuide.ts
+++ b/frontend/src/common/queries/cellGuide.ts
@@ -187,6 +187,7 @@ export interface ValidExplorerCxgsQueryResponse {
 export const useValidExplorerCxgs = () => {
   return useCellGuideQuery<ValidExplorerCxgsQueryResponse>({
     dataType: TYPES.VALID_EXPLORER_CXGS,
+    queryLatestSnapshotIdentifier: false,
   });
 };
 /* ========== ontology_tree ========== */

--- a/scripts/populate_rdev_with_cellguide_data.sh
+++ b/scripts/populate_rdev_with_cellguide_data.sh
@@ -60,6 +60,7 @@ if [ -n "$LATEST_SNAPSHOT_IDENTIFIER" ]; then
   aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/gpt_seo_descriptions s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/gpt_seo_descriptions
   aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/gpt_descriptions s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/gpt_descriptions
   aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/validated_descriptions s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/validated_descriptions
+  aws s3 cp s3://cellguide-data-public-${SRC_DEPLOYMENT}/valid_explorer_cxgs.json s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/valid_explorer_cxgs.json
   if [ "$POPULATE_ONLY_GPT" = false ]; then
     aws s3 rm s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/${LATEST_SNAPSHOT_IDENTIFIER} --recursive
     aws s3 sync s3://cellguide-data-public-${SRC_DEPLOYMENT}/${LATEST_SNAPSHOT_IDENTIFIER} s3://cellguide-data-public-dev/env-rdev-cellguide/${STACK_NAME}/${LATEST_SNAPSHOT_IDENTIFIER}


### PR DESCRIPTION
## Reason for Change

 - `staging` and `dev` cannot access the prod bucket `s3://hosted-cellxgene-prod/cellguide-cxgs/...`so valid_explorer_cxgs.json cannot be generated in `dev` and `staging`
 -  This file is a constant to begin with since the cellguide CXGs are currently a one-time pipeline run and are not scheduled on any recurring cadence. 
 - This fix is temporary while we work on adding the appropriate IAM permissions to let `dev` read the prod bucket.

## Changes
 - Update the valid explorer cxg hook to read from the root directory in S3
 - Update the rdev data population script to copy the valid explorer cxg json from root to root directories