### PR TITLE
fix: bust cache on processing image rebuild workflow only

### DIFF
--- a/.github/workflows/rebuild-processing-image.yml
+++ b/.github/workflows/rebuild-processing-image.yml
@@ -49,6 +49,8 @@ jobs:
         shell: bash
         run: |
           export BRANCH_SHA=$(git rev-parse --short=8 HEAD)
+          # Cache busting to ensure the image is always rebuilt.
+          export CACHEBUST=$(date +%s)
           happy push "" --aws-profile "" --tag sha-${BRANCH_SHA} --slice processing
       - name: Alert in Slack
         uses: 8398a7/action-slack@v3

--- a/Dockerfile.processing
+++ b/Dockerfile.processing
@@ -22,7 +22,10 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY /python_dependencies/processing/ .
 COPY /python_dependencies/common/ .
 ARG INSTALL_DEV=false
+
+ARG CACHEBUST=1
 RUN python3.10 -m pip install -r requirements.txt
+
 RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt; fi
 
 ADD backend/__init__.py backend/__init__.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,6 +196,7 @@ services:
         - HAPPY_BRANCH=$HAPPY_BRANCH
         - INSTALL_DEV=$INSTALL_DEV
         - HAPPY_TAG
+        - CACHEBUST=$CACHEBUST
     restart: "no"
     volumes:
       - ./backend/portal/pipeline/processing:/backend/portal/pipeline/processing


### PR DESCRIPTION
## Reason for Change

- we depend on the processing image rebuilder to install the latest release of cellxgene-schema, which is unpinned in requirements.txt, as part of the migration automation workflow. However, the rebuild workflow we call after a new PyPI release will cache the install step since we are not committing changes to the processing container. 
- however, we do want to keep caching processing images in all other scenarios when the container is not explicitly updated (push tests, deploys, etc.) 

## Changes

- add CACHEBUST arg to the processing dockerfile + docker-compose, and only pass a new value (date) when running the rebuild workflow triggered as part of a schema migration after a new cellxgene-schema CLI release.

## Testing steps

- running workflows, ensuring it is cached as expected in push tests + deploys and not cached during rebuild processing image workflows.