### PR TITLE
chore: calculate 2-sided p-values for DE

### DIFF
--- a/backend/de/api/v1.py
+++ b/backend/de/api/v1.py
@@ -395,7 +395,9 @@ def _calculate_t_test_metrics(sum1, sumsq1, n1, sum2, sumsq2, n2):
         # this is log fold change because mean1 and mean2 are already log transformed
         log_fold_changes = mean1 - mean2
 
-        pvals_adj = _benjamini_hochberg_correction(stats.t.sf(tscores, dof))
+        # two-sided test
+        pvals = 2 * stats.t.sf(np.abs(tscores), dof)
+        pvals_adj = _benjamini_hochberg_correction(pvals)
 
     return log_fold_changes, effects, pvals_adj
 

--- a/tests/unit/backend/de/api/test_v1.py
+++ b/tests/unit/backend/de/api/test_v1.py
@@ -170,7 +170,7 @@ class DeAPIV1Tests(unittest.TestCase):
 
         expected_effect_size_sums = [-334, 648, 71, 2654, 696, 2763, 2021]
         expected_log_fold_change_sums = [-54, 102, 66, 491, 199, 532, 483]
-        expected_log_p_value_sums = [123276, 118181, 100175, 26160, 107902, 8908, 7560]
+        expected_log_p_value_sums = [348318, 133077, 195787, 125959, 134096, 69440, 123317]
         expected_n_overlap = [0, 0, 0, 0, 0, 0, 37]
 
         with load_realistic_test_snapshot(TEST_SNAPSHOT) as snapshot:


### PR DESCRIPTION
## Reason for Change

- We need two-sided p-values so that negative effect sizes have non-1 p-values.

## Changes

- updated p-value calculation to be 2-sided

## Testing steps

- updated unit test expected values

