### PR TITLE
chore: remove unused requirements.txt

### DIFF
--- a/backend/wmg/pipeline/cell_counts.py
+++ b/backend/wmg/pipeline/cell_counts.py
@@ -1,8 +1,14 @@
 import logging
 import os
+from sys import platform
 
-import tiledb
-from tiledbsoma import ExperimentAxisQuery
+if platform == "darwin":
+    # tiledbsome must be imported before tiledb. This only affects Macs.
+    from tiledbsoma import ExperimentAxisQuery  # noqa
+    import tiledb  # noqa
+else:
+    import tiledb
+    from tiledbsoma import ExperimentAxisQuery
 
 from backend.wmg.data.schemas.cube_schema import (
     cell_counts_logical_dims,

--- a/backend/wmg/pipeline/expression_summary.py
+++ b/backend/wmg/pipeline/expression_summary.py
@@ -1,13 +1,20 @@
 import logging
 import math
 import os
+from sys import platform
 
 import numpy as np
 import pandas as pd
-import tiledb
+
+if platform == "darwin":
+    # tiledbsome must be imported before tiledb. This only affects Macs.
+    from tiledbsoma import ExperimentAxisQuery  # noqa
+    import tiledb  # noqa
+else:
+    import tiledb
+    from tiledbsoma import ExperimentAxisQuery
 from numba import njit
 from scipy import sparse
-from tiledbsoma import ExperimentAxisQuery
 
 from backend.wmg.data.schemas.cube_schema import (
     expression_summary_indexed_dims_no_gene_ontology,

--- a/backend/wmg/pipeline/expression_summary_and_cell_counts.py
+++ b/backend/wmg/pipeline/expression_summary_and_cell_counts.py
@@ -1,8 +1,15 @@
 import os
+from sys import platform
 
 import cellxgene_census
-import tiledb
-import tiledbsoma as soma
+
+if platform == "darwin":
+    # tiledbsome must be imported before tiledb. This only affects Macs.
+    import tiledbsoma as soma  # noqa
+    import tiledb  # noqa
+else:
+    import tiledb
+    import tiledbsoma as soma
 from packaging import version
 
 from backend.wmg.data.snapshot import (

--- a/python_dependencies/wmg/requirements.txt
+++ b/python_dependencies/wmg/requirements.txt
@@ -1,14 +1,8 @@
-alembic==1.11.1
-anndata==0.8.0
 boto3==1.28.7
 botocore>=1.31.7, <1.32.0
 cellxgene-census>=1.10.0 # WMG pipeline always reads the latest version of Census so we need to use the latest package version
 cellxgene-ontology-guide==0.8.0
-dataclasses-json==0.5.7
 ddtrace==2.1.4
-furl==2.1.3
-jsonschema==4.18.4
-moto>=5.0.0
 numba>=0.58.0
 numpy==1.23.5
 openai==0.27.7
@@ -17,14 +11,8 @@ psutil==5.9.5
 pyarrow==12.0.0
 pydantic==1.10.7
 pygraphviz==1.11
-PyMySQL==0.9.3
 python-json-logger==2.0.7
 requests>=2.22.0
-rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
-scanpy==1.9.3
 scipy==1.10.1
-SQLAlchemy==1.4.49
-SQLAlchemy-Utils==0.41.1
-tenacity==8.2.2
 tiledbsoma>=1.7.0 # WMG pipeline always reads the latest version of Census so we need to use the latest package version
 dask==2023.8.1

--- a/python_dependencies/wmg/requirements.txt
+++ b/python_dependencies/wmg/requirements.txt
@@ -10,7 +10,7 @@ pandas==2.2.1
 psutil==5.9.5
 pyarrow==12.0.0
 pydantic==1.10.7
-
+pygraphviz==1.11
 python-json-logger==2.0.7
 requests>=2.22.0
 scipy==1.10.1

--- a/python_dependencies/wmg/requirements.txt
+++ b/python_dependencies/wmg/requirements.txt
@@ -10,9 +10,10 @@ pandas==2.2.1
 psutil==5.9.5
 pyarrow==12.0.0
 pydantic==1.10.7
-pygraphviz==1.11
+
 python-json-logger==2.0.7
 requests>=2.22.0
 scipy==1.10.1
 tiledbsoma>=1.7.0 # WMG pipeline always reads the latest version of Census so we need to use the latest package version
+tiledb
 dask==2023.8.1


### PR DESCRIPTION
## Reason for Change

- remove unnecessary requirements from WMG 

## Changes

- remove extra requirements from wmg
- added tiledb as a dependency

## Testing
- Ran `python -m scripts.generate_realistic_test_snapshot tests/unit/backend/wmg/fixtures/realistic-test-snapshot` on a python environment with the dependencies installed. Need to install the graphviz-dev requirements