### PR TITLE
chore: Remove PyMySQL python package from WMG

### DIFF
--- a/DEV_ENV_WITHOUT_DOCKER.md
+++ b/DEV_ENV_WITHOUT_DOCKER.md
@@ -37,8 +37,8 @@
    - `brew install graphviz`
    - `pip install --global-option=build_ext --global-option="-I$(brew --prefix graphviz)/include/" --global-option="-L$(brew --prefix graphviz)/lib/" pygraphviz==1.11`
 
-1. Install packages for WMG api - `pip install -r requirements-backend.txt`
-1. Install packages for WMG pipeline - `pip install -r requirements-wmg-pipeline.txt`
+1. Install packages for WMG api - `pip install -r python_dependencies/backend/requirements.txt`
+1. Install packages for WMG pipeline - `pip install -r python_dependencies/wmg/requirements.txt`
 
 ### Run unit tests for WMG
 

--- a/python_dependencies/wmg/requirements.txt
+++ b/python_dependencies/wmg/requirements.txt
@@ -17,7 +17,6 @@ psutil==5.9.5
 pyarrow==12.0.0
 pydantic==1.10.7
 pygraphviz==1.11
-PyMySQL==0.9.3
 python-json-logger==2.0.7
 requests>=2.22.0
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Reason for Change

`PyMySQL 0.9.3` was [reported as a security vulnerability by dependabot](https://github.com/chanzuckerberg/single-cell-data-portal/security/dependabot/95). However, WMG application has no need for the package and therefore this PR removes it.

## Changes

- remove `PyMySQL` python package from `python_depenedencies/wmg/requirements.txt` file
- update docs

## Testing steps

- Check that CI passes

## Checklist 🛎️

## Notes for Reviewer
