### PR TITLE
feat: add a visium dataset to our functional tests

### DIFF
--- a/tests/functional/backend/common.py
+++ b/tests/functional/backend/common.py
@@ -42,6 +42,10 @@ class BaseFunctionalTestCase(unittest.TestCase):
             "https://www.dropbox.com/scl/fi/y50umqlcrbz21a6jgu99z/"
             "5_0_0_example_valid.h5ad?rlkey=s7p6ybyx082hswix26hbl11pm&dl=0"
         )
+        cls.test_visium_dataset_uri = (
+            "https://www.dropbox.com/scl/fi/y3rtmmwg4wdlfatqifq9a/visium.h5ad?rlkey=lp3hbexcdrg08bistwa66vesc&st"
+            "=7kkzjvd1&dl=0"
+        )
         cls.session = requests.Session()
         # apply retry config to idempotent http methods we use + POST requests, which are currently all either
         # idempotent (wmg queries) or low risk to rerun in dev/staging. Update if this changes in functional tests.


### PR DESCRIPTION
## Reason for Change

- with the additional of spatial support a new bucket has been created that stores data during the cxg conversion stage. To ensure all of the infrastructure is configured correct, a new test need to be added

## Changes

- add a functional tests that uploads a visium dataset to the data portal.
- added a visium dataset to the test folder in [dropbox](https://www.dropbox.com/home/Trent%20Smith/Upload%20Dataset%20Test%20Kit%20(1)/Schema%205.0)

## Testing steps

- verify test pass in rdev.
