### PR TITLE
fix: use dataset_version_id as deep-zoom spatial bucket directory name for spatial assets

### DIFF
--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -54,7 +54,9 @@ class H5ADDataFile:
 
         self.validate_anndata()
 
-    def to_cxg(self, output_cxg_directory, sparse_threshold, convert_anndata_colors_to_cxg_colors=True):
+    def to_cxg(
+        self, output_cxg_directory, sparse_threshold, dataset_version_id, convert_anndata_colors_to_cxg_colors=True
+    ):
         """
         Writes the following attributes of the anndata to CXG: 1) the metadata as metadata attached to an empty
         DenseArray, 2) the obs DataFrame as a DenseArray, 3) the var DataFrame as a DenseArray, 4) all valid
@@ -80,7 +82,7 @@ class H5ADDataFile:
         convert_dataframe_to_cxg_array(output_cxg_directory, "var", self.var, self.var_index_column_name, ctx)
         logging.info("\t...dataset var dataframe saved")
 
-        convert_uns_to_cxg_group(output_cxg_directory, self.anndata.uns, "uns", ctx)
+        convert_uns_to_cxg_group(output_cxg_directory, self.anndata.uns, dataset_version_id, "uns", ctx)
         logging.info("\t...dataset uns dataframe saved")
 
         self.write_anndata_embeddings_to_cxg(output_cxg_directory, ctx)

--- a/backend/layers/processing/process_cxg.py
+++ b/backend/layers/processing/process_cxg.py
@@ -75,7 +75,7 @@ class ProcessCxg(ProcessingLogic):
         cxg_output_container = local_filename.replace(".h5ad", ".cxg")
         try:
             h5ad_data_file = H5ADDataFile(local_filename, var_index_column_name="feature_name")
-            h5ad_data_file.to_cxg(cxg_output_container, dataset_version_id, sparse_threshold=25.0)
+            h5ad_data_file.to_cxg(cxg_output_container, sparse_threshold=25.0, dataset_version_id=dataset_version_id.id)
         except Exception as ex:
             # TODO use a specialized exception
             msg = "CXG conversion failed."

--- a/backend/layers/processing/process_cxg.py
+++ b/backend/layers/processing/process_cxg.py
@@ -67,7 +67,7 @@ class ProcessCxg(ProcessingLogic):
         self.process_cxg(labeled_h5ad_filename, dataset_version_id, cellxgene_bucket, current_artifacts)
 
     @logit
-    def make_cxg(self, local_filename):
+    def make_cxg(self, local_filename, dataset_version_id):
         """
         Convert the uploaded H5AD file to the CXG format servicing the cellxgene Explorer.
         """
@@ -75,7 +75,7 @@ class ProcessCxg(ProcessingLogic):
         cxg_output_container = local_filename.replace(".h5ad", ".cxg")
         try:
             h5ad_data_file = H5ADDataFile(local_filename, var_index_column_name="feature_name")
-            h5ad_data_file.to_cxg(cxg_output_container, sparse_threshold=25.0)
+            h5ad_data_file.to_cxg(cxg_output_container, dataset_version_id, sparse_threshold=25.0)
         except Exception as ex:
             # TODO use a specialized exception
             msg = "CXG conversion failed."

--- a/backend/layers/processing/process_logic.py
+++ b/backend/layers/processing/process_logic.py
@@ -114,7 +114,7 @@ class ProcessingLogic:  # TODO: ProcessingLogicBase
         start = datetime.now()
         try:
             self.update_processing_status(dataset_version_id, processing_status_key, DatasetConversionStatus.CONVERTING)
-            file_dir = converter(local_filename)
+            file_dir = converter(local_filename, dataset_version_id)
             self.update_processing_status(dataset_version_id, processing_status_key, DatasetConversionStatus.CONVERTED)
             self.logger.info(f"Finished converting {converter} in {datetime.now() - start}")
         except Exception:

--- a/backend/layers/processing/process_seurat.py
+++ b/backend/layers/processing/process_seurat.py
@@ -96,7 +96,7 @@ class ProcessSeurat(ProcessingLogic):
         )
 
     @logit
-    def make_seurat(self, local_filename):
+    def make_seurat(self, local_filename, *args, **kwargs):
         """
         Create a Seurat rds file from the AnnData file.
         """

--- a/backend/layers/processing/utils/cxg_generation_utils.py
+++ b/backend/layers/processing/utils/cxg_generation_utils.py
@@ -34,7 +34,7 @@ def convert_dictionary_to_cxg_group(cxg_container, metadata_dict, group_metadata
             metadata_array.meta[key] = value
 
 
-def convert_uns_to_cxg_group(cxg_container, metadata_dict, group_metadata_name="uns", ctx=None):
+def convert_uns_to_cxg_group(cxg_container, metadata_dict, dataset_version_id, group_metadata_name="uns", ctx=None):
     """
     Convert uns (unstructured) metadata to CXG output directory specified
     Generate deep zoom assets for spatial data
@@ -53,7 +53,7 @@ def convert_uns_to_cxg_group(cxg_container, metadata_dict, group_metadata_name="
                 for object_id, content in value.items():
                     if object_id not in SPATIAL_KEYS_EXCLUDE:
                         object_filtered = spatial_processor.filter_spatial_data(content, object_id)
-                        spatial_processor.create_deep_zoom_assets(cxg_container, content)
+                        spatial_processor.create_deep_zoom_assets(cxg_container, content, dataset_version_id)
 
                 metadata_array.meta[key] = pickle.dumps(object_filtered)
 

--- a/backend/layers/processing/utils/spatial.py
+++ b/backend/layers/processing/utils/spatial.py
@@ -124,7 +124,8 @@ class SpatialDataProcessor:
             assets_folder (str): The folder containing the assets.
             dataset_version_id (str): The UUID uniquely identifying the dataset version.
         """
-        s3_uri = f"s3://{self.bucket_name}/{self.asset_directory}/{dataset_version_id}"
+        version_id = dataset_version_id.replace(".cxg", "")
+        s3_uri = f"s3://{self.bucket_name}/{self.asset_directory}/{version_id}"
         self.s3_provider.upload_directory(assets_folder, s3_uri)
 
     def create_deep_zoom_assets(self, container_name, content, dataset_version_id):

--- a/backend/layers/processing/utils/spatial.py
+++ b/backend/layers/processing/utils/spatial.py
@@ -103,23 +103,25 @@ class SpatialDataProcessor:
         image = pyvips.Image.new_from_memory(linear.data, w, h, bands, "uchar")
         image.dzsave(os.path.join(assets_folder, "spatial"), suffix=".webp")
 
-    def _upload_assets(self, assets_folder):
+    def _upload_assets(self, assets_folder, dataset_version_id):
         """
         Upload the deep zoom assets to the S3 bucket.
 
         Args:
             assets_folder (str): The folder containing the assets.
+            dataset_version_id (str): The UUID uniquely identifying the dataset version.
         """
-        s3_uri = f"s3://{self.bucket_name}/{self.asset_directory}/{os.path.basename(assets_folder)}"
+        s3_uri = f"s3://{self.bucket_name}/{self.asset_directory}/{dataset_version_id}"
         self.s3_provider.upload_directory(assets_folder, s3_uri)
 
-    def create_deep_zoom_assets(self, container_name, content):
+    def create_deep_zoom_assets(self, container_name, content, dataset_version_id):
         """
         Create deep zoom assets for a container.
 
         Args:
             container_name (str): The name of the container.
             content (dict): The content dictionary containing the image array.
+            dataset_version_id (str): The UUID uniquely identifying the dataset version.
         """
         try:
             with tempfile.TemporaryDirectory() as temp_dir:
@@ -129,7 +131,7 @@ class SpatialDataProcessor:
                 image_array = self._fetch_image(content)
                 processed_image = self._process_and_flip_image(image_array)
                 self._generate_deep_zoom_assets(processed_image, assets_folder)
-                self._upload_assets(assets_folder)
+                self._upload_assets(assets_folder, dataset_version_id)
         except Exception as e:
             logger.exception(f"Failed to create and upload deep zoom assets: {e}")
             raise

--- a/tests/unit/processing/test_h5ad_data_file.py
+++ b/tests/unit/processing/test_h5ad_data_file.py
@@ -20,6 +20,7 @@ class TestH5ADDataFile(unittest.TestCase):
         self.sample_h5ad_filename = self._write_anndata_to_file(self.sample_anndata)
 
         self.sample_output_directory = path.splitext(self.sample_h5ad_filename)[0] + ".cxg"
+        self.dataset_version_id = "test_dataset_version_id"
 
     def tearDown(self):
         if self.sample_h5ad_filename:
@@ -108,31 +109,31 @@ class TestH5ADDataFile(unittest.TestCase):
 
     def test__to_cxg__simple_anndata_no_corpora_and_sparse(self):
         h5ad_file = H5ADDataFile(self.sample_h5ad_filename)
-        h5ad_file.to_cxg(self.sample_output_directory, 100)
+        h5ad_file.to_cxg(self.sample_output_directory, 100, self.dataset_version_id)
 
         self._validate_cxg_and_h5ad_content_match(self.sample_h5ad_filename, self.sample_output_directory, True)
 
     def test__to_cxg__simple_anndata_with_corpora_and_sparse(self):
         h5ad_file = H5ADDataFile(self.sample_h5ad_filename)
-        h5ad_file.to_cxg(self.sample_output_directory, 100)
+        h5ad_file.to_cxg(self.sample_output_directory, 100, self.dataset_version_id)
 
         self._validate_cxg_and_h5ad_content_match(self.sample_h5ad_filename, self.sample_output_directory, True)
 
     def test__to_cxg__simple_anndata_no_corpora_and_dense(self):
         h5ad_file = H5ADDataFile(self.sample_h5ad_filename)
-        h5ad_file.to_cxg(self.sample_output_directory, 0)
+        h5ad_file.to_cxg(self.sample_output_directory, 0, self.dataset_version_id)
 
         self._validate_cxg_and_h5ad_content_match(self.sample_h5ad_filename, self.sample_output_directory, False)
 
     def test__to_cxg__simple_anndata_with_corpora_and_dense(self):
         h5ad_file = H5ADDataFile(self.sample_h5ad_filename)
-        h5ad_file.to_cxg(self.sample_output_directory, 0)
+        h5ad_file.to_cxg(self.sample_output_directory, 0, self.dataset_version_id)
 
         self._validate_cxg_and_h5ad_content_match(self.sample_h5ad_filename, self.sample_output_directory, False)
 
     def test__to_cxg__simple_anndata_with_corpora_and_dense_using_feature_name_var_index(self):
         h5ad_file = H5ADDataFile(self.sample_h5ad_filename, var_index_column_name="feature_name")
-        h5ad_file.to_cxg(self.sample_output_directory, 0)
+        h5ad_file.to_cxg(self.sample_output_directory, 0, self.dataset_version_id)
 
         self._validate_cxg_and_h5ad_content_match(self.sample_h5ad_filename, self.sample_output_directory, False)
         self._validate_cxg_var_index_column_match(
@@ -142,7 +143,7 @@ class TestH5ADDataFile(unittest.TestCase):
 
     def test__to_cxg__simple_anndata_with_different_var_index_than_h5ad(self):
         h5ad_file = H5ADDataFile(self.sample_h5ad_filename, var_index_column_name="int_category")
-        h5ad_file.to_cxg(self.sample_output_directory, 0)
+        h5ad_file.to_cxg(self.sample_output_directory, 0, self.dataset_version_id)
 
         self._validate_cxg_var_index_column_match(
             self.sample_output_directory,
@@ -155,7 +156,7 @@ class TestH5ADDataFile(unittest.TestCase):
         sparse_with_column_shift_filename = self._write_anndata_to_file(anndata)
 
         h5ad_file = H5ADDataFile(sparse_with_column_shift_filename)
-        h5ad_file.to_cxg(self.sample_output_directory, 50)
+        h5ad_file.to_cxg(self.sample_output_directory, 50, self.dataset_version_id)
 
         self._validate_cxg_and_h5ad_content_match(
             sparse_with_column_shift_filename, self.sample_output_directory, False, has_column_encoding=True


### PR DESCRIPTION
## Reason for Change

- Bug found while testing https://github.com/chanzuckerberg/single-cell-data-portal/pull/7023 
- uses "local" as directory name for all assets across all datasets, meaning assets are overwritten rather than appropriately distinguished by a unique ID

## Changes

- use dataset_version_id as unique directory identifier when uploading spatial assets to deep zoom bucket in s3

## Testing steps
- unit tests + integration tests (TBD)