### PR TITLE
fix: collections and datasets sidebar sds components and associated styles

### DIFF
--- a/frontend/src/components/common/Filter/common/style.ts
+++ b/frontend/src/components/common/Filter/common/style.ts
@@ -1,9 +1,10 @@
 import styled from "@emotion/styled";
 import { Popover } from "@mui/material";
-import { shadowM, spacesXxs } from "src/common/theme";
+import { shadowM, spacesXxs, spacesXxxs } from "src/common/theme";
 
 export const Filter = styled.div`
   font-feature-settings: normal; /* required; overrides layout.css specification */
+  margin: ${spacesXxxs}px 0;
 `;
 
 export const FilterPopover = styled(Popover)`

--- a/frontend/src/components/common/Filter/components/FilterLabel/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterLabel/index.tsx
@@ -1,6 +1,6 @@
 import React, { MouseEvent } from "react";
 import FilterLabelTooltip from "src/components/common/Filter/components/FilterLabel/components/FilterLabelTooltip";
-import { ButtonDropdown } from "./style";
+import { InputDropdown } from "src/components/common/Filter/components/FilterLabel/style";
 
 type OnOpenFilterFn = (event: MouseEvent<HTMLElement>) => void;
 
@@ -19,17 +19,19 @@ export default function FilterLabel({
 }: Props): JSX.Element {
   return (
     <FilterLabelTooltip tooltip={tooltip}>
-      {/* The dropdown button is enclosed within a <span> tag to enable tooltip functionality when the button is disabled. */}
+      {/* The InputDropdown is enclosed within a <span> tag to enable tooltip functionality when the component is disabled. */}
       {/* See https://github.com/chanzuckerberg/sci-components/blob/main/packages/components/src/core/Tooltip/index.tsx#L28. */}
       <span>
-        <ButtonDropdown
+        <InputDropdown
           disabled={isDisabled}
+          intent="default"
+          label={label}
           onClick={onOpenFilter}
+          sdsStage="default"
           sdsStyle="minimal"
-          sdsType="secondary"
-        >
-          {label}
-        </ButtonDropdown>
+          sdsType="label"
+          state="default"
+        />
       </span>
     </FilterLabelTooltip>
   );

--- a/frontend/src/components/common/Filter/components/FilterLabel/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterLabel/style.ts
@@ -1,15 +1,14 @@
 import styled from "@emotion/styled";
-import {
-  ButtonDropdown as SDSButtonDropdown,
-  fontBodyS,
-} from "@czi-sds/components";
-import { grey500, spacesS } from "src/common/theme";
+import { InputDropdown as SDSInputDropdown } from "@czi-sds/components";
+import { spacesXxs } from "src/common/theme";
 
-export const ButtonDropdown = styled(SDSButtonDropdown)`
-  ${fontBodyS}
-  color: ${grey500};
-  font-weight: 500;
-  margin: 0 0 ${spacesS}px 0;
-  padding: 0;
-  text-transform: capitalize;
+export const InputDropdown = styled(SDSInputDropdown)`
+  &.MuiButton-root {
+    padding-bottom: ${spacesXxs}px;
+    padding-top: ${spacesXxs}px;
+
+    .styled-label {
+      font-weight: 500;
+    }
+  }
 `;

--- a/frontend/src/components/common/Filter/components/FilterTags/index.tsx
+++ b/frontend/src/components/common/Filter/components/FilterTags/index.tsx
@@ -1,5 +1,4 @@
 import { TagFilter } from "@czi-sds/components";
-import { SelectedTags } from "./style";
 
 type OnRemoveFn = () => void;
 
@@ -14,7 +13,7 @@ interface Props {
 
 export default function FilterTags({ tags }: Props): JSX.Element | null {
   return tags && tags.length ? (
-    <SelectedTags>
+    <div>
       {tags.map(({ label, onRemove }, i) => (
         <TagFilter
           clickable={false}
@@ -24,7 +23,7 @@ export default function FilterTags({ tags }: Props): JSX.Element | null {
           onDelete={onRemove}
         />
       ))}
-    </SelectedTags>
+    </div>
   ) : null;
 }
 

--- a/frontend/src/components/common/Filter/components/FilterTags/style.ts
+++ b/frontend/src/components/common/Filter/components/FilterTags/style.ts
@@ -1,6 +1,0 @@
-import styled from "@emotion/styled";
-import { spacesXxxs } from "src/common/theme";
-
-export const SelectedTags = styled.div`
-  margin-bottom: ${spacesXxxs}px;
-`;

--- a/frontend/src/components/common/SideBar/index.tsx
+++ b/frontend/src/components/common/SideBar/index.tsx
@@ -1,11 +1,10 @@
 import { ReactNode, useEffect, useState } from "react";
-import { Button, Icon } from "@czi-sds/components";
+import { Icon } from "@czi-sds/components";
 import {
   Position,
   SideBar as SideBarWrapper,
-  SideBarClosedButtonWrapper,
-  SideBarOpenButtonWrapper,
   SideBarPositioner,
+  ToggleButton,
   ToggleButtonText,
 } from "src/components/common/SideBar/style";
 import { noop } from "src/common/constants/utils";
@@ -18,7 +17,7 @@ export const FILTERS_PANEL_EXPANDED_WIDTH_PX = 240;
  */
 export type SideBarToggleFn = (expanded: boolean) => void;
 
-export interface Props {
+export interface SidebarProps {
   children: ReactNode;
   className?: string;
   label: ReactNode;
@@ -50,13 +49,10 @@ export default function SideBar({
   wmgSideBar,
   truncatedLabel = "",
   onWidthChange = noop,
-}: Props): JSX.Element {
+}: SidebarProps): JSX.Element {
   // seve: wmgSideBar does not have isOpen prop, so we need to set default to true/open
   const [isExpanded, setIsExpanded] = useState(isOpen || !!wmgSideBar);
   const sideBarWidth = isExpanded ? width : COLLAPSED_WIDTH_PX;
-  const SideBarToggleButtonWrapper = isExpanded
-    ? SideBarOpenButtonWrapper
-    : SideBarClosedButtonWrapper;
 
   /**
    * Handle click on open/close icon; update state.
@@ -81,33 +77,33 @@ export default function SideBar({
       data-testid={testId}
     >
       <SideBarPositionerComponent isExpanded={isExpanded}>
-        <SideBarToggleButtonWrapper>
-          <Button
-            data-testid="side-bar-toggle-button"
-            disabled={disabled}
-            endIcon={
-              <Icon
-                color="gray"
-                sdsIcon={
-                  (position === Position.LEFT ? isExpanded : !isExpanded)
-                    ? "ChevronLeft"
-                    : "ChevronRight"
-                }
-                sdsSize="xs"
-                sdsType="static"
-                shade={500}
-              />
-            }
-            isAllCaps={false}
-            onClick={() => handleExpandedClick(!isExpanded)}
-            sdsStyle="minimal"
-            sdsType="secondary"
-          >
-            <ToggleButtonText>
-              {!isExpanded && truncatedLabel ? truncatedLabel : label}
-            </ToggleButtonText>
-          </Button>
-        </SideBarToggleButtonWrapper>
+        <ToggleButton
+          data-testid="side-bar-toggle-button"
+          disabled={disabled}
+          endIcon={
+            <Icon
+              color="gray"
+              sdsIcon={
+                (position === Position.LEFT ? isExpanded : !isExpanded)
+                  ? "ChevronLeft"
+                  : "ChevronRight"
+              }
+              sdsSize="s"
+              sdsType="static"
+              shade={500}
+            />
+          }
+          fullWidth
+          isAllCaps={false}
+          isExpanded={isExpanded}
+          onClick={() => handleExpandedClick(!isExpanded)}
+          sdsStyle="minimal"
+          sdsType="secondary"
+        >
+          <ToggleButtonText>
+            {!isExpanded && truncatedLabel ? truncatedLabel : label}
+          </ToggleButtonText>
+        </ToggleButton>
         {isExpanded ? content : null}
       </SideBarPositionerComponent>
     </SideBarWrapperComponent>

--- a/frontend/src/components/common/SideBar/style.ts
+++ b/frontend/src/components/common/SideBar/style.ts
@@ -1,15 +1,17 @@
 import styled from "@emotion/styled";
 import { LIGHT_GRAY } from "src/components/common/theme";
 import { HEADER_HEIGHT_PX } from "src/components/Header/style";
-import { CommonThemeProps, fontBodyS } from "@czi-sds/components";
+import { CommonThemeProps, fontHeaderM } from "@czi-sds/components";
 import {
-  fontWeightSemibold,
   grey300,
   grey500,
   spacesL,
   spacesS,
   spacesXl,
+  spacesXxxs,
 } from "src/common/theme";
+import { css, SerializedStyles } from "@emotion/react";
+import { Button } from "src/components/common/Button";
 
 export enum Position {
   LEFT = "left",
@@ -63,51 +65,59 @@ export const SideBarPositioner = styled.div<PositionerProps>`
   }
 `;
 
-export const SideBarToggleButtonWrapper = styled.span`
-  display: block;
+export const ToggleButtonText = styled.span`
+  ${fontHeaderM}
+  color: #000000;
+`;
 
-  .MuiButton-root {
-    width: 100%;
+export const ToggleButton = styled(Button, {
+  shouldForwardProp: (prop) => prop !== "isExpanded",
+})<PositionerProps>`
+  .MuiButton-endIcon {
+    margin: 0;
+  }
 
+  &:hover {
     .MuiButton-endIcon {
-      margin: 0;
-      width: 16px;
-    }
-
-    &:hover {
-      .MuiButton-endIcon .MuiSvgIcon-root {
+      .MuiSvgIcon-root {
         color: ${grey500};
       }
     }
   }
+
+  ${(props) =>
+    props.isExpanded &&
+    css`
+      justify-content: space-between;
+      margin-bottom: ${spacesS(props)}px;
+      padding: 0;
+    `}
+  ${(props) =>
+    !props.isExpanded &&
+    css`
+      flex-direction: column-reverse;
+      gap: ${spacesS(props)}px;
+      min-width: 0;
+      padding: ${spacesXl(props)}px ${spacesS(props)}px;
+
+      ${ToggleButtonText} {
+        transform: scale(-1);
+        writing-mode: vertical-rl;
+      }
+    `}
 `;
 
-export const ToggleButtonText = styled.span`
-  ${fontBodyS}
-  color: #000000;
-  font-weight: ${fontWeightSemibold};
-  letter-spacing: -0.006em;
-  text-transform: capitalize; /* required; SDS Button props isAllCaps for sdsType "minimal" does not currently facilitate text-transformation see https://github.com/chanzuckerberg/sci-components/blob/main/packages/components/src/core/Button/style.ts#L219 */
-`;
+export function sideBarPositionerPadding(
+  props: PositionerProps
+): SerializedStyles | undefined {
+  if (props.isExpanded) {
+    return css`
+      padding: ${spacesL(props)}px ${spacesS(props)}px;
 
-export const SideBarClosedButtonWrapper = styled(SideBarToggleButtonWrapper)`
-  .MuiButton-root {
-    flex-direction: column-reverse;
-    gap: ${spacesS}px;
-    min-width: 0;
-    padding: ${spacesXl}px ${spacesS}px;
-
-    ${ToggleButtonText} {
-      transform: scale(-1);
-      writing-mode: vertical-rl;
-    }
+      ${ToggleButton} {
+        margin-bottom: ${spacesXxxs(props)}px;
+        padding: 0 ${spacesS(props)}px;
+      }
+    `;
   }
-`;
-
-export const SideBarOpenButtonWrapper = styled(SideBarToggleButtonWrapper)`
-  .MuiButton-root {
-    justify-content: space-between;
-    margin-bottom: ${spacesS}px;
-    padding: 0;
-  }
-`;
+}

--- a/frontend/src/views/Collections/index.tsx
+++ b/frontend/src/views/Collections/index.tsx
@@ -29,7 +29,10 @@ import NTagCell from "src/components/common/Grid/components/NTagCell";
 import { Title } from "src/components/common/Grid/components/Title";
 import CreateCollection from "src/components/CreateCollectionModal";
 import SideBar from "src/components/common/SideBar";
-import { CollectionsView as View } from "./style";
+import {
+  CollectionsSideBarPositioner as SideBarPositioner,
+  CollectionsView as View,
+} from "./style";
 import { RightAlignCell } from "src/components/common/Grid/components/RightAlignCell";
 import CountCell from "src/components/common/Grid/components/CountCell";
 import {
@@ -357,6 +360,7 @@ export default function Collections(): JSX.Element {
               label="Filters"
               isOpen={isSideBarOpen}
               onToggle={storeIsSideBarOpen}
+              SideBarPositionerComponent={SideBarPositioner}
             >
               <CategoryFilters
                 filters={partitionCategoryViews(categoryViews, mode)}

--- a/frontend/src/views/Collections/style.ts
+++ b/frontend/src/views/Collections/style.ts
@@ -1,9 +1,17 @@
 import styled from "@emotion/styled";
 import { View } from "src/views/globalStyle";
 import { spacesXl } from "src/common/theme";
+import {
+  SideBarPositioner,
+  sideBarPositionerPadding,
+} from "src/components/common/SideBar/style";
 
 export const CollectionsView = styled(View)`
   display: grid;
   gap: ${spacesXl}px;
   place-content: flex-start stretch;
+`;
+
+export const CollectionsSideBarPositioner = styled(SideBarPositioner)`
+  ${sideBarPositionerPadding}
 `;

--- a/frontend/src/views/Datasets/index.tsx
+++ b/frontend/src/views/Datasets/index.tsx
@@ -37,7 +37,10 @@ import SideBar from "src/components/common/SideBar";
 import { ALIGNMENT } from "src/components/common/Grid/common/entities";
 import { CATEGORY_FILTER_DENY_LIST } from "src/views/Datasets/common/constants";
 import { useViewMode, VIEW_MODE } from "src/common/hooks/useViewMode";
-import { DatasetsView as View } from "./style";
+import {
+  DatasetsSideBarPositioner as SideBarPositioner,
+  DatasetsView as View,
+} from "./style";
 import { GridLoader as Loader } from "src/components/common/Grid/components/Loader/style";
 
 /**
@@ -388,6 +391,7 @@ export default function Datasets(): JSX.Element {
               label="Filters"
               isOpen={isSideBarOpen}
               onToggle={storeIsSideBarOpen}
+              SideBarPositionerComponent={SideBarPositioner}
             >
               <Filter {...filterInstance} />
             </SideBar>

--- a/frontend/src/views/Datasets/style.ts
+++ b/frontend/src/views/Datasets/style.ts
@@ -1,9 +1,17 @@
 import styled from "@emotion/styled";
 import { View } from "src/views/globalStyle";
 import { spacesXl } from "src/common/theme";
+import {
+  SideBarPositioner,
+  sideBarPositionerPadding,
+} from "src/components/common/SideBar/style";
 
 export const DatasetsView = styled(View)`
   display: grid;
   gap: ${spacesXl}px;
   place-content: flex-start stretch;
+`;
+
+export const DatasetsSideBarPositioner = styled(SideBarPositioner)`
+  ${sideBarPositionerPadding}
 `;

--- a/frontend/src/views/WheresMyGeneV2/style_old.ts
+++ b/frontend/src/views/WheresMyGeneV2/style_old.ts
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import {
   SideBar,
-  SideBarOpenButtonWrapper,
   SideBarPositioner as RawSideBarPositioner,
 } from "src/components/common/SideBar/style";
 import { FOOTER_HEIGHT_PX } from "src/components/Footer/style";
@@ -46,12 +45,6 @@ export const Top = styled.div`
 
 export const SideBarWrapper = styled(SideBar)`
   max-height: calc(100vh - ${HEADER_HEIGHT_PX}px);
-
-  ${SideBarOpenButtonWrapper} {
-    .MuiButton-root {
-      margin-bottom: 12px;
-    }
-  }
 `;
 
 export const SideBarPositioner = styled(RawSideBarPositioner)`


### PR DESCRIPTION
## Reason for Change

- See https://clevercanary.slack.com/archives/C023Q1APASK/p1717534645840959?thread_ts=1715623480.846529&cid=C023Q1APASK and [mocks](https://www.figma.com/design/jEv0ZWQd0Q53aFl9nNRbBy/Portal?node-id=1274-2358&t=J7LP4mZ8oRZiycxw-1), resolved on behalf of https://github.com/chanzuckerberg/single-cell-data-portal/issues/6999.

## Changes

- Updated `SideBar` component styles (the toggle button) and also update `FilterLabel` component to use SDS library `InputDropdown` as per slack [thread](https://clevercanary.slack.com/archives/C023Q1APASK/p1717534645840959?thread_ts=1715623480.846529&cid=C023Q1APASK).
