### PR TITLE
fix: retry schema-migration sfn on Batch.AWSBatchException

### DIFF
--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -234,7 +234,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
       },
       "Next": "SpanCollections",
       "Retry": [ {
-          "ErrorEquals": ["AWS.Batch.TooManyRequestsException", "Batch.BatchException"],
+          "ErrorEquals": ["AWS.Batch.TooManyRequestsException", "Batch.BatchException", "Batch.AWSBatchException"],
           "IntervalSeconds": 2,
           "MaxAttempts": 7,
           "BackoffRate": 5
@@ -245,7 +245,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
             "States.ALL"
           ],
           "Next": "report",
-          "ResultPath": null
+          "ResultPath": "$.error"
         }
       ]
     },
@@ -303,7 +303,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
             },
             "Next": "DatasetsExists",
             "Retry": [ {
-                "ErrorEquals": ["AWS.Batch.TooManyRequestsException", "Batch.BatchException"],
+                "ErrorEquals": ["AWS.Batch.TooManyRequestsException", "Batch.BatchException", "Batch.AWSBatchException"],
                 "IntervalSeconds": 2,
                 "MaxAttempts": 7,
                 "BackoffRate": 5
@@ -313,7 +313,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                 "ErrorEquals": [
                   "States.ALL"
                 ],
-                "ResultPath": null,
+                "ResultPath": "$.error",
                 "Next": "CollectionPublish"
               }
             ]
@@ -366,7 +366,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
             },
             "End": true,
             "Retry": [ {
-                "ErrorEquals": ["AWS.Batch.TooManyRequestsException", "Batch.BatchException"],
+                "ErrorEquals": ["AWS.Batch.TooManyRequestsException", "Batch.BatchException", "Batch.AWSBatchException"],
                 "IntervalSeconds": 2,
                 "MaxAttempts": 7,
                 "BackoffRate": 5
@@ -377,7 +377,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                   "States.ALL"
                 ],
                 "Next": "CollectionError",
-                "ResultPath": null
+                "ResultPath": "$.error"
               }
             ]
           },
@@ -439,7 +439,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                   },
                   "Next": "StepFunctionsStartExecution",
                   "Retry": [ {
-                      "ErrorEquals": ["AWS.Batch.TooManyRequestsException", "Batch.BatchException"],
+                      "ErrorEquals": ["AWS.Batch.TooManyRequestsException", "Batch.BatchException", "Batch.AWSBatchException"],
                       "IntervalSeconds": 2,
                       "MaxAttempts": 7,
                       "BackoffRate": 5
@@ -450,7 +450,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                         "States.ALL"
                       ],
                       "Next": "DatasetError",
-                      "ResultPath": null
+                      "ResultPath": "$.error"
                     }
                   ],
                   "ResultPath": "$.result"
@@ -480,7 +480,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                         "States.ALL"
                       ],
                       "Next": "DatasetError",
-                      "ResultPath": null
+                      "ResultPath": "$.error"
                     }
                   ],
                   "ResultPath": null
@@ -505,7 +505,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                   "States.ALL"
                 ],
                 "Next": "CollectionPublish",
-                "ResultPath": null
+                "ResultPath": "$.error"
               }
             ],
             "OutputPath": "$[0]",
@@ -535,7 +535,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
             "States.ALL"
           ],
           "Next": "report",
-          "ResultPath": null
+          "ResultPath": "$.error"
         }
       ],
       "ToleratedFailurePercentage": 20
@@ -578,7 +578,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
         }
       },
       "Retry": [ {
-        "ErrorEquals": ["AWS.Batch.TooManyRequestsException", "Batch.BatchException"],
+        "ErrorEquals": ["AWS.Batch.TooManyRequestsException", "Batch.BatchException", "Batch.AWSBatchException"],
         "IntervalSeconds": 2,
         "MaxAttempts": 7,
         "BackoffRate": 5


### PR DESCRIPTION


## Reason for Change

- the scheme migration can fail with the error Batch.AWSBatchException. We will now retry when this happens.

## Changes

- add Batch.AWSBatchException to retry logic for schema migration.
- pass error message so they show up in the error handling steps in the schema migration sfn
