### PR TITLE
fix: reduce schema-migration span concurrency

### DIFF
--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -44,15 +44,15 @@ resource aws_batch_job_definition schema_migrations_swap {
     resourceRequirements = [
       {
         type= "VCPU",
-        Value="8"
+        Value="32"
       },
       {
         Type="MEMORY",
-        Value = "64000"
+        Value = "256000"
       }
     ]
     linuxParameters= {
-     maxSwap= 30000,
+     maxSwap= 0,
      swappiness= 60
     },
     logConfiguration= {

--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -44,15 +44,15 @@ resource aws_batch_job_definition schema_migrations_swap {
     resourceRequirements = [
       {
         type= "VCPU",
-        Value="32"
+        Value="8"
       },
       {
         Type="MEMORY",
-        Value = "256000"
+        Value = "64000"
       }
     ]
     linuxParameters= {
-     maxSwap= 0,
+     maxSwap= 30000,
      swappiness= 60
     },
     logConfiguration= {
@@ -498,7 +498,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
               }
             },
             "Next": "CollectionPublish",
-            "MaxConcurrency": 5,
+            "MaxConcurrency": 10,
             "Catch": [
               {
                 "ErrorEquals": [

--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -498,7 +498,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
               }
             },
             "Next": "CollectionPublish",
-            "MaxConcurrency": 32,
+            "MaxConcurrency": 5,
             "Catch": [
               {
                 "ErrorEquals": [
@@ -527,7 +527,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
           "Key.$": "$.key_name"
         }
       },
-      "MaxConcurrency": 40,
+      "MaxConcurrency": 10,
       "Next": "report",
       "Catch": [
         {


### PR DESCRIPTION
## Reason for Change

- this avoid us spamming the batch queue with jobs that will state in runnable stable for days.
- It also reduces the chance of us running into rate limiting from AWS on batch API requests. 
- adjust the compute resources for dataset_migration to make better use compute.

## Changes

- modify SpanCollection Concurrency from 40 to 10
- modify SpanDataset Concurrency from 32 to 10
- reduce the memory and VCPUs used by dataset_migrate to 64000MB and 8 VCPUs.
- Add 300000MB of swap to dataset_migrate.
