### PR TITLE
chore: bump cellxgene-schema 5.1.0 related pinned versions

### DIFF
--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -5,8 +5,8 @@ botocore>=1.14.17
 cellxgene-schema
 dataclasses-json
 ddtrace==2.1.4
-numba==0.56.2
-numpy==1.23.2
+numba==0.59.1
+numpy==1.26.4
 pandas==1.4.4
 psutil>=5.9.0
 psycopg2-binary==2.*
@@ -18,7 +18,7 @@ requests>=2.22.0
 rpy2==3.5.16
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
 s3fs==0.4.2
-scanpy==1.9.3
+scanpy==1.9.8
 SQLAlchemy==2.*
 tenacity
 tiledb==0.25.0  # Portal's tiledb version should always be the same or older than Explorer's

--- a/tests/unit/processing/test_h5ad_data_file.py
+++ b/tests/unit/processing/test_h5ad_data_file.py
@@ -171,7 +171,7 @@ class TestH5ADDataFile(unittest.TestCase):
 
         col_name = "fo/o"
 
-        attrs = [tiledb.Attr(name=col_name, dtype=np.int)]
+        attrs = [tiledb.Attr(name=col_name, dtype=int)]
         domain = tiledb.Domain(tiledb.Dim(domain=(0, 99), tile=100, dtype=np.uint32))
         schema = tiledb.ArraySchema(
             domain=domain, sparse=False, attrs=attrs, cell_order="row-major", tile_order="row-major"
@@ -181,7 +181,7 @@ class TestH5ADDataFile(unittest.TestCase):
         try:
             with tiledb.open("foo", mode="w") as A:
                 value = dict()
-                value[col_name] = np.zeros((100,), dtype=np.int)
+                value[col_name] = np.zeros((100,), dtype=int)
                 A[:] = value  # if there's a regression, this statement will throw a TileDBError
                 # if we get here we're good
         finally:

--- a/tests/unit/processing/test_spatial_assets_utils.py
+++ b/tests/unit/processing/test_spatial_assets_utils.py
@@ -248,7 +248,9 @@ def test__upload_assets_failure(spatial_processor, asset_folder, dataset_version
     mock_upload.assert_called_once_with(asset_folder, expected_s3_uri)
 
 
-def test__create_deep_zoom_assets(spatial_processor, cxg_container, valid_spatial_data, dataset_version_id, mocker):
+def test__create_deep_zoom_assets(
+    spatial_processor, cxg_container, valid_spatial_data, dataset_version_id, mocker, tmpdir
+):
     mock_fetch_image = mocker.patch.object(spatial_processor, "_fetch_image")
     mock_process_and_flip_image = mocker.patch.object(spatial_processor, "_process_and_flip_image")
     mock_generate_deep_zoom_assets = mocker.patch.object(spatial_processor, "_generate_deep_zoom_assets")
@@ -256,8 +258,7 @@ def test__create_deep_zoom_assets(spatial_processor, cxg_container, valid_spatia
 
     # mock the TemporaryDirectory context manager
     mock_temp_dir = mocker.patch("tempfile.TemporaryDirectory")
-    temp_dir_name = "/mock/temp/dir"
-    mock_temp_dir.return_value.__enter__.return_value = temp_dir_name
+    mock_temp_dir.return_value.__enter__.return_value = tmpdir
 
     # mock return values for the internal methods
     mock_fetch_image.return_value = (np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8), "fullres")
@@ -266,7 +267,7 @@ def test__create_deep_zoom_assets(spatial_processor, cxg_container, valid_spatia
     # call the method under test
     spatial_processor.create_deep_zoom_assets(cxg_container, valid_spatial_data, dataset_version_id)
 
-    assets_folder = os.path.join(temp_dir_name, cxg_container.replace(".cxg", ""))
+    assets_folder = os.path.join(tmpdir, cxg_container.replace(".cxg", ""))
 
     # assertions to ensure each step is called
     mock_fetch_image.assert_called_once_with(valid_spatial_data)


### PR DESCRIPTION
## Reason for Change

- cellxgene-schema 5.1.0 requires the following dependency version pin updates to numba, numpy, and scanpy

## Changes

- bump versions for numba, numpy, and scanpy to allow install for cellxgene-schema 5.1.0
