### PR TITLE
fix: cloudfront 504 error for long backend requests.

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -31,7 +31,7 @@ locals {
   backend_wmg_workers           = var.backend_wmg_workers
   backend_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "${local.backend_workers}",
     "--bind", "0.0.0.0:5000", "backend.api_server.app:app", "--max-requests", "10000", "--timeout", "180",
-    "--keep-alive", "61", "--log-level", "info"]
+    "--keep-alive", "100", "--log-level", "info"]
   backend_de_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "${local.backend_de_workers}",
     "--bind", "0.0.0.0:5000", "backend.de.server.app:app", "--max-requests", "10000", "--timeout", "540",
     "--keep-alive", "61", "--log-level", "info"]


### PR DESCRIPTION
## Reason for Change
- partial fix for https://github.com/chanzuckerberg/single-cell-data-portal/issues/7190
- some endpoint in the backend are slow and exceed our configured timeouts.
- endpoint `/curation/v1/collections` is showing requests take as long as 78 seconds:
```
FAILED

Gateway Time-out

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<HTML><HEAD><META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
<TITLE>ERROR: The request could not be satisfied</TITLE>
</HEAD><BODY>
<H1>504 ERROR</H1>
<H2>The request could not be satisfied.</H2>
<HR noshade size="1px">
CloudFront attempted to establish a connection with the origin, but either the attempt failed or the origin closed the connection.
We can't connect to the server for this app or website at this time. There might be too much traffic or a configuration error. Try again later, or contact the app or website owner.
<BR clear="all">
If you provide content to customers through CloudFront, you can find steps to troubleshoot and help prevent this error by reviewing the CloudFront documentation.
<BR clear="all">
<HR noshade size="1px">
<PRE>
Generated by cloudfront (CloudFront)
Request ID: 2yXpvcNQKTOWmetxS34Ul-Vj8QK1J6TvOSvaVOx3THJOvMP2Y9ovzw==
</PRE>
<ADDRESS>
</ADDRESS>
</BODY></HTML>

x-request-id: None
```

## Changes

- increase keep alive time for backend server.


## Testing steps

- 


## Notes for Reviewer

https://docs.gunicorn.org/en/stable/settings.html#keepalive