### PR TITLE
fix: add more ignored keys in the Census Models page

### DIFF
--- a/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/index.tsx
+++ b/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/index.tsx
@@ -7,7 +7,7 @@ import { ButtonsColumn, ButtonsRow, StyledButton } from "./style";
 import DetailItem from "../../DetailItem";
 import { DATA_TYPE_TO_EMBEDDING } from "..";
 
-const IGNORE_DIFFERENT_METADATA_KEYS = ["model_link", "id"];
+const IGNORE_DIFFERENT_METADATA_KEYS = ["model_link", "id", "relative_uri", "indexes"];
 const ATTRIBUTE_TO_LABEL: Record<string, string> = {
   experiment_name: "Organism",
   n_cells: "Cells",

--- a/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/index.tsx
+++ b/frontend/src/views/CensusDirectory/components/Project/ProjectButtons/index.tsx
@@ -7,7 +7,12 @@ import { ButtonsColumn, ButtonsRow, StyledButton } from "./style";
 import DetailItem from "../../DetailItem";
 import { DATA_TYPE_TO_EMBEDDING } from "..";
 
-const IGNORE_DIFFERENT_METADATA_KEYS = ["model_link", "id", "relative_uri", "indexes"];
+const IGNORE_DIFFERENT_METADATA_KEYS = [
+  "model_link",
+  "id",
+  "relative_uri",
+  "indexes",
+];
 const ATTRIBUTE_TO_LABEL: Record<string, string> = {
   experiment_name: "Organism",
   n_cells: "Cells",


### PR DESCRIPTION
These keys will be added to contributions.json and they don't need to show up here.

In the future, it would be better to switch to an allow list model, since the contributions.json file isn't uniquely used by this page anymore.