### PR TITLE
feat(cxg_admin): add command to get backend logs based on a request id.

### DIFF
--- a/scripts/cxg_admin_scripts/request_logs.py
+++ b/scripts/cxg_admin_scripts/request_logs.py
@@ -1,0 +1,55 @@
+import json
+from typing import List
+
+import boto3
+
+
+def get(request_id: str, deployment_stage: str, stackname: str) -> List[dict]:
+    """
+    Get the requests from from AWS cloudwatch given the request_id
+    :param request_id:
+    :param deployment_stage:
+    :param stackname:
+    """
+
+    client = boto3.client("logs")
+    filter_pattern = f'{{$.request_id="{request_id}"}}'
+    log_group_name = f"/dp/{deployment_stage}/{stackname}/backend"
+
+    def get_logs(next_token: str = None):
+        kwargs = dict(
+            logGroupName=log_group_name,
+            logStreamNamePrefix="fargate/web/",
+            filterPattern=filter_pattern,
+            limit=100,
+            unmask=False,
+        )
+        if next_token:
+            kwargs["nextToken"] = next_token
+        return client.filter_log_events(**kwargs)
+
+    logs = get_logs()
+    result = []
+    beginning = False
+    end = False
+    while not all([beginning, end]):
+        if logs["events"]:
+            for log in logs["events"]:
+                message = json.loads(log["message"])
+                if message.get("type") == "RESPONSE":
+                    end = True
+                if message.get("type") == "REQUEST":
+                    beginning = True
+                result.append(message)
+        logs = get_logs(logs["nextToken"])
+    return result
+
+
+if __name__ == "__main__":
+    import os
+
+    os.environ["AWS_PROFILE"] = "single-cell-dev"
+    request_id = "cf017e14-7a04-426f-91a7-bf81318c27a6"
+    deployment_stage = "rdev"
+    stack_name = "pr-7217"
+    print(json.dumps(get(request_id, deployment_stage, stack_name), indent=4))

--- a/scripts/cxg_admin_scripts/request_logs.py
+++ b/scripts/cxg_admin_scripts/request_logs.py
@@ -62,8 +62,8 @@ def get(request_id: str, hours: int, deployment_stage: str, stackname: str) -> L
 if __name__ == "__main__":
     import os
 
-    os.environ["AWS_PROFILE"] = "single-cell-prod"
-    request_id = "1407b9b9-c202-4b71-adbb-b08193379e3f"
-    deployment_stage = "prod"
-    stack_name = "prodstack"
+    os.environ["AWS_PROFILE"] = "single-cell-dev"
+    request_id = "a388db58-6d5a-4e28-9aeb-140b0f42c366 "
+    deployment_stage = "rdev"
+    stack_name = "pr-7203"
     print(json.dumps(get(request_id, 3, deployment_stage, stack_name), indent=4))


### PR DESCRIPTION
## Reason for Change

- this saves developers a trip to AWS to see the request logs when they have the request_id in hand. 

## Changes

- add cxg_admin command to get backend logs from a request_id

## Testing steps

- verified the script works on dev using cxg_admin
- verified the script works on it's own using rdev.

