### PR TITLE
fix: update raw h5ad when editing dataset title

### DIFF
--- a/backend/layers/processing/dataset_metadata_update.py
+++ b/backend/layers/processing/dataset_metadata_update.py
@@ -20,6 +20,7 @@ from backend.layers.common.entities import (
     DatasetConversionStatus,
     DatasetProcessingStatus,
     DatasetStatusKey,
+    DatasetUploadStatus,
     DatasetValidationStatus,
     DatasetVersion,
     DatasetVersionId,
@@ -76,14 +77,16 @@ class DatasetMetadataUpdaterWorker(ProcessDownload):
 
         adata.write(raw_h5ad_filename, compression="gzip")
 
+        self.update_processing_status(new_dataset_version_id, DatasetStatusKey.UPLOAD, DatasetUploadStatus.UPLOADING)
         self.create_artifact(
             raw_h5ad_filename,
             DatasetArtifactType.RAW_H5AD,
             new_key_prefix,
             new_dataset_version_id,
             self.artifact_bucket,
-            DatasetStatusKey.UPLOAD,
+            DatasetStatusKey.H5AD,
         )
+        self.update_processing_status(new_dataset_version_id, DatasetStatusKey.UPLOAD, DatasetUploadStatus.UPLOADED)
         os.remove(raw_h5ad_filename)
 
     def update_h5ad(

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -79,8 +79,12 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
         )
         mock_worker = mock_worker_factory.return_value
         self.updater.has_valid_artifact_statuses = Mock(return_value=True)
-        self.updater.update_metadata(current_dataset_version_id, new_dataset_version_id, None)
+        self.updater.update_metadata(
+            current_dataset_version_id, new_dataset_version_id, DatasetArtifactMetadataUpdate(citation="New Citation")
+        )
 
+        # skip raw_h5ad update since no updated fields are expected fields in raw H5AD
+        mock_worker.update_raw_h5ad.assert_not_called()
         mock_worker.update_h5ad.assert_called_once()
         mock_worker.update_rds.assert_called_once()
         mock_worker.update_cxg.assert_called_once()
@@ -125,8 +129,11 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
         )
         mock_worker = mock_worker_factory.return_value
         self.updater.has_valid_artifact_statuses = Mock(return_value=True)
-        self.updater.update_metadata(current_dataset_version_id, new_dataset_version_id, None)
+        self.updater.update_metadata(
+            current_dataset_version_id, new_dataset_version_id, DatasetArtifactMetadataUpdate(title="New Dataset Title")
+        )
 
+        mock_worker.update_raw_h5ad.assert_called_once()
         mock_worker.update_h5ad.assert_called_once()
         mock_worker.update_rds.assert_not_called()
         mock_worker.update_cxg.assert_called_once()
@@ -349,6 +356,44 @@ class TestDatasetMetadataUpdaterWorker(BaseProcessingTest):
             return local_path
 
         self.updater.download_from_source_uri = Mock(side_effect=mock_download)
+
+    @patch("backend.common.utils.dl_sources.uri.downloader")
+    @patch("backend.layers.processing.dataset_metadata_update.os.remove")
+    @patch("scanpy.read_h5ad")
+    def test_update_raw_h5ad(self, mock_read_h5ad, *args):
+        collection_version = self.generate_unpublished_collection(add_datasets=1)
+        current_dataset_version = collection_version.datasets[0]
+        new_dataset_version_id, _ = self.business_logic.ingest_dataset(
+            collection_version_id=collection_version.version_id,
+            url=None,
+            file_size=0,
+            current_dataset_version_id=current_dataset_version.version_id,
+            start_step_function=False,
+        )
+        key_prefix = new_dataset_version_id.id
+        metadata_update = DatasetArtifactMetadataUpdate(
+            citation="Publication DOI www.doi.org/567.8", title="New Dataset Title"
+        )
+
+        # Mock anndata object
+        mock_anndata = Mock(spec=scanpy.AnnData)
+        mock_anndata.uns = {"title": "Old Dataset Title", "other_metadata": "misc."}
+        mock_anndata.write = Mock()
+        mock_read_h5ad.return_value = mock_anndata
+
+        self.updater.update_raw_h5ad(None, key_prefix, new_dataset_version_id, metadata_update)
+
+        local_filename = CorporaConstants.ORIGINAL_H5AD_ARTIFACT_FILENAME
+        # check mock_anndata object
+        mock_read_h5ad.assert_called_with(local_filename)
+        assert "citation" not in mock_anndata.uns
+        assert mock_anndata.uns["title"] == "New Dataset Title"
+        assert mock_anndata.uns["other_metadata"] == "misc"
+        # check s3 uris exist
+        assert self.updater.s3_provider.uri_exists(f"s3://artifact_bucket/{new_dataset_version_id.id}/{local_filename}")
+        # check processing status
+        new_dataset_version = self.business_logic.get_dataset_version(new_dataset_version_id)
+        assert new_dataset_version.status.upload_status == DatasetUploadStatus.UPLOADED
 
     @patch("backend.common.utils.dl_sources.uri.downloader")
     @patch("backend.layers.processing.dataset_metadata_update.os.remove")

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -431,7 +431,6 @@ class TestDatasetMetadataUpdaterWorker(BaseProcessingTest):
         assert self.updater.s3_provider.uri_exists(f"s3://artifact_bucket/{new_dataset_version_id.id}/{local_filename}")
         # check DB DatasetVersion
         new_dataset_version = self.business_logic.get_dataset_version(new_dataset_version_id)
-        assert new_dataset_version.metadata.schema_version == collection_version.datasets[0].metadata.schema_version
         artifacts = [(artifact.uri, artifact.type) for artifact in new_dataset_version.artifacts]
         assert (
             f"s3://artifact_bucket/{new_dataset_version_id.id}/{local_filename}",


### PR DESCRIPTION
## Reason for Change

- Currently, the raw.h5ad is not updated on a dataset_metadata_update batch job. This is reasonable for updates to citation or schema_version, which are not fields on the raw H5AD (only labeled), but now that we support updates to dataset title (which is on the raw.h5ad as well), we need to update the dataset title on the raw.h5ad. This is because we use the raw.h5ad as the object to migrate during a migration; in the current state, we would accidentally roll back dataset title changes done since the last schema version bump.

## Changes

- add raw_h5ad_update function 
- only trigger raw_h5ad_update if a field being updated is contained in the raw h5ad (currently, of fields on the raw h5ad, we only support updating "title")
- otherwise, retain previous behavior (that is, copy existing raw_h5ad_uri to new dataset version id directory in the artifact bucket)

## Testing steps

- unit tests