### PR TITLE
fix: account for tombstoned datasets when getting all versions of a collection

### DIFF
--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -384,7 +384,8 @@ class DatabaseProvider(DatabaseProviderInterface):
             }
             for row in collection_version_rows:
                 # filter out datasets that were not returned by get_dataset_versions_by_id
-                ds = [datasets[str(id)] for id in row.datasets if str(id) in datasets]
+                actual_datasets = filter(lambda dv_id: str(dv_id) in datasets, row.datasets)
+                ds = [datasets[str(dv_id)] for dv_id in actual_datasets]
                 version = self._row_to_collection_version_with_datasets(row, canonical_collection, ds)
                 versions.append(version)
             return versions

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -383,7 +383,7 @@ class DatabaseProvider(DatabaseProviderInterface):
                 for dv in self.get_dataset_versions_by_id(dataset_version_ids, get_tombstoned=get_tombstoned)
             }
             for row in collection_version_rows:
-                # if a dataset is tombstones it may not appear in the datasets dict depending on get_tombstoned
+                # filter out datasets that were not returned by get_dataset_versions_by_id
                 ds = [datasets[str(id)] for id in row.datasets if str(id) in datasets]
                 version = self._row_to_collection_version_with_datasets(row, canonical_collection, ds)
                 versions.append(version)

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -370,16 +370,21 @@ class DatabaseProvider(DatabaseProviderInterface):
         Retrieves all versions for a specific collections, without filtering
         """
         with self._manage_session() as session:
-            version_rows = session.query(CollectionVersionTable).filter_by(collection_id=collection_id.id).all()
+            collection_version_rows = (
+                session.query(CollectionVersionTable).filter_by(collection_id=collection_id.id).all()
+            )
             canonical_collection = self.get_canonical_collection(collection_id)
             versions = []
-            dataset_version_ids = [DatasetVersionId(str(_id)) for vr in version_rows for _id in vr.datasets]
+            dataset_version_ids = [
+                DatasetVersionId(str(_id)) for cvr in collection_version_rows for _id in cvr.datasets
+            ]
             datasets = {
                 str(dv.version_id): dv
                 for dv in self.get_dataset_versions_by_id(dataset_version_ids, get_tombstoned=get_tombstoned)
             }
-            for row in version_rows:
-                ds = [datasets[str(id)] for id in row.datasets]
+            for row in collection_version_rows:
+                # if a dataset is tombstones it may not appear in the datasets dict depending on get_tombstoned
+                ds = [datasets[str(id)] for id in row.datasets if str(id) in datasets]
                 version = self._row_to_collection_version_with_datasets(row, canonical_collection, ds)
                 versions.append(version)
             return versions


### PR DESCRIPTION
## Reason for Change

- functional tests were failing because the backend was trying to add tombstoned datasets to a collection because the dataset version was in the list of datasets in the collection

## Changes

- filter out datasets that were not returned by `get_dataset_versions_by_id` due to being tombstoned.
- modify variable names for readability

## Testing steps


## Checklist 🛎️


## Notes for Reviewer
