### PR TITLE
chore(de): remove unavailable tags from query group boxes

### DIFF
--- a/frontend/src/views/DifferentialExpression/common/store/actions.ts
+++ b/frontend/src/views/DifferentialExpression/common/store/actions.ts
@@ -1,4 +1,4 @@
-import { QueryGroup, REDUCERS, State } from "./reducer";
+import { FilterOption, QueryGroup, REDUCERS, State } from "./reducer";
 
 export function selectOrganism(
   organismId: State["organismId"]
@@ -6,6 +6,26 @@ export function selectOrganism(
   return {
     payload: organismId,
     type: "selectOrganism",
+  };
+}
+
+export function setSelectedOptionsGroup1(
+  key: keyof QueryGroup,
+  options: FilterOption[]
+): GetActionTypeOfReducer<(typeof REDUCERS)["setSelectedOptionsGroup1"]> {
+  return {
+    payload: { key, options },
+    type: "setSelectedOptionsGroup1",
+  };
+}
+
+export function setSelectedOptionsGroup2(
+  key: keyof QueryGroup,
+  options: FilterOption[]
+): GetActionTypeOfReducer<(typeof REDUCERS)["setSelectedOptionsGroup2"]> {
+  return {
+    payload: { key, options },
+    type: "setSelectedOptionsGroup2",
   };
 }
 

--- a/frontend/src/views/DifferentialExpression/common/store/reducer.ts
+++ b/frontend/src/views/DifferentialExpression/common/store/reducer.ts
@@ -5,6 +5,12 @@ export interface PayloadAction<Payload> {
   payload: Payload;
 }
 
+export interface FilterOption {
+  name: string;
+  id: string;
+  unavailable?: boolean;
+}
+
 export interface QueryGroup {
   developmentStages: string[];
   diseases: string[];
@@ -29,6 +35,12 @@ export interface State {
   submittedQueryGroupsWithNames: QueryGroupsWithNames | null;
   snapshotId: string | null;
   excludeOverlappingCells: ExcludeOverlappingCells;
+  selectedOptionsGroup1: {
+    [key in keyof QueryGroup]: FilterOption[];
+  };
+  selectedOptionsGroup2: {
+    [key in keyof QueryGroup]: FilterOption[];
+  };
 }
 
 export const EMPTY_FILTERS = {
@@ -52,6 +64,8 @@ export const INITIAL_STATE: State = {
   },
   submittedQueryGroups: null,
   submittedQueryGroupsWithNames: null,
+  selectedOptionsGroup1: EMPTY_FILTERS,
+  selectedOptionsGroup2: EMPTY_FILTERS,
 };
 
 export const REDUCERS = {
@@ -64,6 +78,8 @@ export const REDUCERS = {
   submitQueryGroups,
   clearSubmittedQueryGroups,
   setExcludeOverlappingCells,
+  setSelectedOptionsGroup1,
+  setSelectedOptionsGroup2,
 };
 
 function setSnapshotId(
@@ -99,6 +115,30 @@ function selectOrganism(
   return {
     ...state,
     organismId: action.payload,
+  };
+}
+
+function setSelectedOptionsGroup1(
+  state: State,
+  action: PayloadAction<{ key: keyof QueryGroup; options: FilterOption[] }>
+): State {
+  const { key, options } = action.payload;
+
+  return {
+    ...state,
+    selectedOptionsGroup1: { ...state.selectedOptionsGroup1, [key]: options },
+  };
+}
+
+function setSelectedOptionsGroup2(
+  state: State,
+  action: PayloadAction<{ key: keyof QueryGroup; options: FilterOption[] }>
+): State {
+  const { key, options } = action.payload;
+
+  return {
+    ...state,
+    selectedOptionsGroup2: { ...state.selectedOptionsGroup2, [key]: options },
   };
 }
 

--- a/frontend/src/views/DifferentialExpression/components/Main/components/DeResults/components/DifferentialExpressionResults/components/QueryGroupTags/index.tsx
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/DeResults/components/DifferentialExpressionResults/components/QueryGroupTags/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import {
   QueryGroup,
-  QueryGroups,
+  State,
 } from "src/views/DifferentialExpression/common/store/reducer";
 import { Tooltip } from "@czi-sds/components";
 import { StyledTag } from "./style";
@@ -11,47 +11,41 @@ import { NO_ORGAN_ID } from "src/views/CellGuide/components/CellGuideCard/compon
 import Link from "src/views/CellGuide/components/CellGuideCard/components/common/Link";
 
 const QueryGroupTags = ({
-  queryGroups,
-  queryGroupsWithNames,
-  isQueryGroup1,
+  selectedOptions,
 }: {
-  queryGroups: QueryGroups;
-  queryGroupsWithNames: QueryGroups;
-  isQueryGroup1?: boolean;
+  selectedOptions: State["selectedOptionsGroup1"];
 }) => {
-  const queryGroup = isQueryGroup1
-    ? queryGroupsWithNames.queryGroup1
-    : queryGroupsWithNames.queryGroup2;
-  const queryGroupIds = isQueryGroup1
-    ? queryGroups.queryGroup1
-    : queryGroups.queryGroup2;
   const nonEmptyQueryGroupKeys = useMemo(() => {
-    return Object.keys(queryGroup).filter(
-      (key) => queryGroup[key as keyof QueryGroup].length > 0
+    return Object.keys(selectedOptions).filter(
+      (key) => selectedOptions[key as keyof QueryGroup].length > 0
     );
-  }, [queryGroup]);
+  }, [selectedOptions]);
 
   return (
     <>
       {nonEmptyQueryGroupKeys.map((key) => {
         const queryGroupKey = key as keyof QueryGroup;
-        const selected = queryGroup[queryGroupKey];
-        const selectedId = queryGroupIds[queryGroupKey];
+        const selected = selectedOptions[queryGroupKey].filter(
+          (option) => !option.unavailable
+        );
+
         const suffix = QUERY_GROUP_KEY_TO_TAG_SUFFIX_MAP[queryGroupKey];
         const label =
-          selected.length > 1 ? `${selected.length} ${suffix}` : selected[0];
+          selected.length > 1
+            ? `${selected.length} ${suffix}`
+            : selected[0].name;
 
         const getValue = (index: number) => {
           return key === "cellTypes" ? (
             <Link
-              label={selected[index]}
+              label={selected[index].name}
               url={getCellTypeLink({
-                cellTypeId: selectedId[index],
+                cellTypeId: selected[index].id,
                 tissueId: NO_ORGAN_ID,
               })}
             />
           ) : (
-            selected[index]
+            selected[index].name
           );
         };
         const clickToViewText = "Click to view in CellGuide";
@@ -81,7 +75,7 @@ const QueryGroupTags = ({
             <span>
               <TagWrapper
                 key={`${key}-tag-wrapper`}
-                selectedId={selectedId[0]}
+                selectedId={selected[0].id}
                 isSingleCellType={isSingleCellType}
               >
                 <StyledTag

--- a/frontend/src/views/DifferentialExpression/components/Main/components/DeResults/components/DifferentialExpressionResults/connect.ts
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/DeResults/components/DifferentialExpressionResults/connect.ts
@@ -27,7 +27,11 @@ export const useConnect = ({
   nCellsOverlap: Props["nCellsOverlap"];
   sortDirection: Props["sortDirection"];
 }) => {
-  const { excludeOverlappingCells } = useContext(StateContext);
+  const {
+    excludeOverlappingCells,
+    selectedOptionsGroup1,
+    selectedOptionsGroup2,
+  } = useContext(StateContext);
   const [page, setPage] = useState(1);
 
   const { n_cells: nCellsGroup1 } = useProcessedQueryGroupFilterDimensions(
@@ -119,5 +123,7 @@ export const useConnect = ({
       datasets2.length !== 1 ? "s" : ""
     }`,
     showOverlappingCellsCallout: excludeOverlappingCells === "retainBoth",
+    selectedOptionsGroup1,
+    selectedOptionsGroup2,
   };
 };

--- a/frontend/src/views/DifferentialExpression/components/Main/components/DeResults/components/DifferentialExpressionResults/index.tsx
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/DeResults/components/DifferentialExpressionResults/index.tsx
@@ -68,6 +68,8 @@ const DifferentialExpressionResults = ({
     numDatasetsText1,
     numDatasetsText2,
     showOverlappingCellsCallout,
+    selectedOptionsGroup1,
+    selectedOptionsGroup2,
   } = useConnect({
     queryGroups,
     queryGroupsWithNames,
@@ -214,11 +216,7 @@ const DifferentialExpressionResults = ({
           </CellGroupStatsIndicator>
         </CellCountTitle>
         <FilterTagsWrapper>
-          <QueryGroupTags
-            isQueryGroup1
-            queryGroups={queryGroups}
-            queryGroupsWithNames={queryGroupsWithNames}
-          />
+          <QueryGroupTags selectedOptions={selectedOptionsGroup1} />
         </FilterTagsWrapper>
       </CellGroupWrapper>
       <CellGroupWrapper data-testid={DIFFERENTIAL_EXPRESSION_CELL_GROUP_2_INFO}>
@@ -258,10 +256,7 @@ const DifferentialExpressionResults = ({
           </CellGroupStatsIndicator>
         </CellCountTitle>
         <FilterTagsWrapper>
-          <QueryGroupTags
-            queryGroups={queryGroups}
-            queryGroupsWithNames={queryGroupsWithNames}
-          />
+          <QueryGroupTags selectedOptions={selectedOptionsGroup2} />
         </FilterTagsWrapper>
       </CellGroupWrapper>
       {!!errorMessage && (

--- a/frontend/src/views/DifferentialExpression/components/Main/components/DeResults/utils.ts
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/DeResults/utils.ts
@@ -1,6 +1,7 @@
 const parseExpressions = (expression: string) => {
   const expressions = expression
     .split(",")
+    .map((expr) => expr.replace(/\s+/g, ""))
     .map((expr) => {
       // This regex matches an expression with an optional comparison operator
       // (<, <=, >, >=) followed by an optional absolute value indicator (|),

--- a/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/CopyButton/connect.ts
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/CopyButton/connect.ts
@@ -8,7 +8,7 @@ import {
 } from "src/views/DifferentialExpression/common/store";
 import { selectQueryGroup2Filters } from "src/views/DifferentialExpression/common/store/actions";
 import { QUERY_GROUP_KEY_TO_FILTER_DIMENSION_MAP } from "../../../common/constants";
-import { FilterOption } from "../../types";
+import { FilterOption } from "src/views/DifferentialExpression/common/store/reducer";
 import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
 import { Props } from "./types";

--- a/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/FilterDropdown/connect.ts
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/FilterDropdown/connect.ts
@@ -1,16 +1,27 @@
-import { useMemo, useState } from "react";
+import { DispatchContext } from "src/views/DifferentialExpression/common/store";
+import { useContext, useMemo, useState } from "react";
 
 import { Props } from "./types";
+import {
+  setSelectedOptionsGroup1,
+  setSelectedOptionsGroup2,
+} from "src/views/DifferentialExpression/common/store/actions";
 
 export const useConnect = ({
   options,
   allAvailableOptions,
   selectedOptionIds,
+  queryGroupKey,
+  isQueryGroup1,
 }: {
   options: Props["options"];
   selectedOptionIds: Props["selectedOptionIds"];
   allAvailableOptions: Props["allAvailableOptions"];
+  queryGroupKey: Props["queryGroupKey"];
+  isQueryGroup1: Props["isQueryGroup1"];
 }) => {
+  const dispatch = useContext(DispatchContext);
+
   const [previousSelectedOptions, setPreviousSelectedOptions] = useState<
     Props["options"]
   >([]);
@@ -33,8 +44,24 @@ export const useConnect = ({
       (a, b) =>
         selectedOptionIds.indexOf(a.id) - selectedOptionIds.indexOf(b.id)
     );
+    if (dispatch) {
+      if (isQueryGroup1) {
+        dispatch(setSelectedOptionsGroup1(queryGroupKey, newOptions));
+      } else {
+        dispatch(setSelectedOptionsGroup2(queryGroupKey, newOptions));
+      }
+    }
+
     return newOptions;
-  }, [options, allAvailableOptions, selectedOptionIds]);
+  }, [
+    options,
+    allAvailableOptions,
+    selectedOptionIds,
+    queryGroupKey,
+    isQueryGroup1,
+    dispatch,
+  ]);
+
   return {
     selectedOptions,
     previousSelectedOptions,

--- a/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/FilterDropdown/index.tsx
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/FilterDropdown/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-
-import { FilterOption } from "../../types";
+import { Icon } from "@czi-sds/components";
 import {
   CloseIcon,
   PrimaryTag,
@@ -14,10 +13,10 @@ import {
   DIFFERENTIAL_EXPRESSION_FILTER_TAG_GRAY,
   DIFFERENTIAL_EXPRESSION_FILTER_TAG_PRIMARY,
 } from "src/views/DifferentialExpression/common/constants";
+import { FilterOption } from "src/views/DifferentialExpression/common/store/reducer";
 import { sortOptions } from "./utils";
 import { useConnect } from "./connect";
 import { Props } from "./types";
-import { Icon } from "@czi-sds/components";
 
 function FilterDropdown({
   options,
@@ -25,6 +24,8 @@ function FilterDropdown({
   allAvailableOptions,
   selectedOptionIds,
   handleChange,
+  isQueryGroup1,
+  queryGroupKey,
 }: Props): JSX.Element {
   const {
     selectedOptions,
@@ -34,6 +35,8 @@ function FilterDropdown({
     options,
     allAvailableOptions,
     selectedOptionIds,
+    queryGroupKey,
+    isQueryGroup1,
   });
 
   return (

--- a/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/FilterDropdown/style.ts
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/FilterDropdown/style.ts
@@ -8,7 +8,7 @@ import {
   gray500,
   primary400,
 } from "src/common/theme";
-import { FilterOption } from "../../types";
+import { FilterOption } from "src/views/DifferentialExpression/common/store/reducer";
 import { formControlClasses } from "@mui/material/FormControl";
 import { inputBaseClasses } from "@mui/material/InputBase";
 import { formLabelClasses } from "@mui/material/FormLabel";

--- a/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/FilterDropdown/types.ts
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/FilterDropdown/types.ts
@@ -1,4 +1,7 @@
-import { FilterOption } from "../../types";
+import {
+  FilterOption,
+  QueryGroup,
+} from "src/views/DifferentialExpression/common/store/reducer";
 
 export interface Props {
   label: string;
@@ -6,4 +9,6 @@ export interface Props {
   allAvailableOptions: FilterOption[];
   selectedOptionIds: string[];
   handleChange: (options: FilterOption[]) => void;
+  isQueryGroup1: boolean;
+  queryGroupKey: keyof QueryGroup;
 }

--- a/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/FilterDropdown/utils.ts
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/Filters/components/FilterDropdown/utils.ts
@@ -1,4 +1,4 @@
-import { FilterOption } from "../../types";
+import { FilterOption } from "src/views/DifferentialExpression/common/store/reducer";
 import { FilterOptionsState } from "@mui/material";
 
 export function sortOptions(

--- a/frontend/src/views/DifferentialExpression/components/Main/components/Filters/connect.ts
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/Filters/connect.ts
@@ -5,13 +5,14 @@ import { DispatchContext } from "src/views/DifferentialExpression/common/store";
 import {
   EMPTY_FILTERS,
   QueryGroup,
+  FilterOption,
 } from "src/views/DifferentialExpression/common/store/reducer";
 import {
   selectQueryGroup1Filters,
   selectQueryGroup2Filters,
 } from "src/views/DifferentialExpression/common/store/actions";
 
-import { FilterOption, Props } from "./types";
+import { Props } from "./types";
 import useProcessedQueryGroupFilterDimensions from "../common/query_group_filter_dimensions";
 
 import { QUERY_GROUP_KEYS_TO_FILTER_EVENT_MAP } from "./constants";

--- a/frontend/src/views/DifferentialExpression/components/Main/components/Filters/index.tsx
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/Filters/index.tsx
@@ -27,11 +27,13 @@ export default memo(function Filters({
       filterDropdownComponent: (
         <FilterDropdown
           key={`${queryGroupKey}-filter-dropdown`}
+          queryGroupKey={queryGroupKey}
           label={QUERY_GROUP_LABELS[index]}
           options={availableFilters[filterDimensionKey]}
           allAvailableOptions={allAvailableFilters[filterDimensionKey]}
           selectedOptionIds={queryGroup[queryGroupKey]}
           handleChange={handleFilterChange(queryGroupKey)}
+          isQueryGroup1={isQueryGroup1}
         />
       ),
       copyButtonComponent: isQueryGroup1 ? (

--- a/frontend/src/views/DifferentialExpression/components/Main/components/Filters/types.ts
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/Filters/types.ts
@@ -1,11 +1,5 @@
 import { QueryGroup } from "src/views/DifferentialExpression/common/store/reducer";
 
-export interface FilterOption {
-  name: string;
-  id: string;
-  unavailable?: boolean;
-}
-
 export interface Props {
   queryGroup: QueryGroup;
   isQueryGroup1: boolean;

--- a/frontend/src/views/DifferentialExpression/components/Main/components/common/query_group_filter_dimensions.ts
+++ b/frontend/src/views/DifferentialExpression/components/Main/components/common/query_group_filter_dimensions.ts
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import isEqual from "lodash/isEqual";
 import { useQueryGroupFilterDimensions } from "src/common/queries/differentialExpression";
-import { QueryGroup } from "src/views/DifferentialExpression/common/store/reducer";
-import { FilterOption } from "../Filters/types";
+import {
+  QueryGroup,
+  FilterOption,
+} from "src/views/DifferentialExpression/common/store/reducer";
 
 const EMPTY_FILTERS = {
   disease_terms: [],

--- a/frontend/tests/features/differentialExpression/differentialExpression.test.ts
+++ b/frontend/tests/features/differentialExpression/differentialExpression.test.ts
@@ -476,7 +476,7 @@ describe("Differential Expression", () => {
 
   describe("Results", () => {
     test("All tests", async ({ page }) => {
-      await runDEQuery(page, false);
+      await runDEQuery({ page, mode: "default" });
 
       await test.step("Cell Group 1 and 2 contain the correct number of cells and filter tags", async () => {
         // Check number of cells
@@ -741,7 +741,7 @@ describe("Differential Expression", () => {
         expect(dataRow3.length).toBe(columnNames.length);
       });
 
-      await runDEQuery(page, true);
+      await runDEQuery({ page, mode: "test_include_overlapping_cells" });
       await test.step("Overlapping cells info callout is visible when overlapping cells are not filtered", async () => {
         // Ensure the callout is not visible at first
         await expect(
@@ -754,6 +754,15 @@ describe("Differential Expression", () => {
           .locator("button:nth-child(3)")
           .click();
         await isElementVisible(page, DIFFERENTIAL_EXPRESSION_RESULTS_CALLOUT);
+      });
+
+      await runDEQuery({ page, mode: "test_exclude_unavailable_tags" });
+      await test.step("Unavailable tags are excluded from results query group boxes", async () => {
+        const cellGroup1Info = page.getByTestId(
+          DIFFERENTIAL_EXPRESSION_CELL_GROUP_1_INFO
+        );
+        await expect(cellGroup1Info).toHaveText("plasma cell");
+        await expect(cellGroup1Info).not.toHaveText("2 cell types");
       });
     });
   });
@@ -801,7 +810,16 @@ const clickOnAutocompleteDropdownItem = async (
   await waitForFiltersEndpoint(autocomplete.page());
 };
 
-const runDEQuery = async (page: Page, includeOverlappingCells = false) => {
+const runDEQuery = async ({
+  page,
+  mode = "default",
+}: {
+  page: Page;
+  mode?:
+    | "default"
+    | "test_include_overlapping_cells"
+    | "test_exclude_unavailable_tags";
+}) => {
   // Type "lung" in tissue filter for group 1
   await page.reload();
 
@@ -826,7 +844,7 @@ const runDEQuery = async (page: Page, includeOverlappingCells = false) => {
     cellTypeFilterAutocompleteGroup1,
     "plasma cell"
   );
-  if (!includeOverlappingCells) {
+  if (mode !== "test_include_overlapping_cells") {
     // Type "acinar cell" in cell type filter for group 2
     const cellTypeFilterAutocompleteGroup2 = page
       .getByTestId(DIFFERENTIAL_EXPRESSION_CELL_GROUP_2_FILTER)
@@ -836,6 +854,29 @@ const runDEQuery = async (page: Page, includeOverlappingCells = false) => {
     await clickOnAutocompleteDropdownItem(
       cellTypeFilterAutocompleteGroup2,
       "acinar cell"
+    );
+  }
+  if (mode === "test_exclude_unavailable_tags") {
+    // Type "acinar cell" in cell type filter for group 1
+    const cellTypeFilterAutocompleteGroup1 = page
+      .getByTestId(DIFFERENTIAL_EXPRESSION_CELL_GROUP_1_FILTER)
+      .getByTestId(
+        `${DIFFERENTIAL_EXPRESSION_FILTER_AUTOCOMPLETE_PREFIX}Cell Type`
+      );
+    await clickOnAutocompleteDropdownItem(
+      cellTypeFilterAutocompleteGroup1,
+      "acinar cell"
+    );
+
+    // "chronic obstructive pulmonary disease" in disease filter for group 1
+    const diseaseFilterAutocompleteGroup1 = page
+      .getByTestId(DIFFERENTIAL_EXPRESSION_CELL_GROUP_1_FILTER)
+      .getByTestId(
+        `${DIFFERENTIAL_EXPRESSION_FILTER_AUTOCOMPLETE_PREFIX}Disease`
+      );
+    await clickOnAutocompleteDropdownItem(
+      diseaseFilterAutocompleteGroup1,
+      "chronic obstructive pulmonary disease"
     );
   }
   // Hit the "Find Genes" button

--- a/scripts/cxg_admin.py
+++ b/scripts/cxg_admin.py
@@ -310,7 +310,7 @@ def rollback_datasets(ctx, report_path: str):
     """
     schema_migration.rollback_dataset(ctx, report_path)
 
-    
+
 @schema_migration_cli.command()
 @click.pass_context
 @click.argument("execution_id")
@@ -322,7 +322,7 @@ def generate_report(ctx, execution_id: str, output_path: str):
     """
     schema_migration.generate_report(ctx, execution_id, output_path, os.environ["ARTIFACT_BUCKET"])
 
-    
+
 @cli.command()
 @click.pass_context
 @click.argument("request_id")
@@ -334,7 +334,6 @@ def get_request_logs(ctx, request_id: str, hours: int):
     ./scripts/cxg_admin.py --deployment dev get-request-logs <request_id>
     """
     print(json.dumps(request_logs.get(request_id, hours, ctx.obj["deployment"], ctx.obj["stackname"]), indent=4))
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Reason for Change

- Addresses the last couple UI/UX items from the DE changes needed for MVP.
  - Unavailable (gray) tags that were cross-filtered out are not included in the filter tags on the results panel.
  - Whitespace is now trimmed out prior to regex parsing for the results table expression filter input fields

## Changes

- added reducer state required to track which tags are available or not

## Testing steps

- Local QA
- E2E test added

