### PR TITLE
chore: remove mvp related fields from cxg conversion

### DIFF
--- a/backend/layers/processing/utils/spatial.py
+++ b/backend/layers/processing/utils/spatial.py
@@ -174,7 +174,6 @@ class SpatialDataProcessor:
                     "width": width,
                     "height": height,
                 },
-                "images": {"hires": content["images"]["hires"], "fullres": []},
                 "scalefactors": {
                     "spot_diameter_fullres": content["scalefactors"]["spot_diameter_fullres"],
                     "tissue_hires_scalef": content["scalefactors"]["tissue_hires_scalef"],

--- a/tests/unit/processing/test_spatial_assets_utils.py
+++ b/tests/unit/processing/test_spatial_assets_utils.py
@@ -92,7 +92,6 @@ def test__valid_input_metadata_copy(spatial_processor, valid_spatial_data, libra
                 "width": 20,
                 "height": 20,
             },
-            "images": {"hires": valid_spatial_data["images"]["hires"], "fullres": []},
             "scalefactors": {
                 "spot_diameter_fullres": valid_spatial_data["scalefactors"]["spot_diameter_fullres"],
                 "tissue_hires_scalef": valid_spatial_data["scalefactors"]["tissue_hires_scalef"],
@@ -321,10 +320,6 @@ def test__convert_uns_to_cxg_group(
     assert "spatial" in mock_metadata_array.meta
     spatial_data = pickle.loads(mock_metadata_array.meta["spatial"])
     assert "library_id_1" in spatial_data
-    assert np.array_equal(
-        spatial_data["library_id_1"]["images"]["hires"],
-        valid_uns["spatial"]["library_id_1"]["images"]["hires"],
-    )
     assert (
         spatial_data["library_id_1"]["scalefactors"]["spot_diameter_fullres"]
         == valid_uns["spatial"]["library_id_1"]["scalefactors"]["spot_diameter_fullres"]


### PR DESCRIPTION
## Reason for Change

- #7124 
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- removed hires image from cxg


## Testing steps

- converted locally and tested dataset in explorer

