### PR TITLE
chore: speed up rdev seeding

### DIFF
--- a/scripts/smoke_tests/setup.py
+++ b/scripts/smoke_tests/setup.py
@@ -48,7 +48,7 @@ class SmokeTestsInitializer:
     def create_and_publish_collection(self, dropbox_url):
         collection_id = self.create_collection()
         for _ in range(NUM_TEST_DATASETS):
-            upload_and_wait(collection_id, dropbox_url, cleanup=False)
+            upload_and_wait(self.session, self.api, self.curator_cookie, collection_id, dropbox_url)
         self.publish_collection(collection_id)
         print(f"created and published collection {collection_id}")
 

--- a/scripts/smoke_tests/setup.py
+++ b/scripts/smoke_tests/setup.py
@@ -47,8 +47,15 @@ class SmokeTestsInitializer:
 
     def create_and_publish_collection(self, dropbox_url):
         collection_id = self.create_collection()
+        _threads = []
         for _ in range(NUM_TEST_DATASETS):
-            upload_and_wait(self.session, self.api, self.curator_cookie, collection_id, dropbox_url)
+            _thread = threading.Thread(
+                target=upload_and_wait, args=(self.session, self.api, self.curator_cookie, collection_id, dropbox_url)
+            )
+            _threads.append(_thread)
+            _thread.start()
+        for _thread in _threads:
+            _thread.join()
         self.publish_collection(collection_id)
         print(f"created and published collection {collection_id}")
 


### PR DESCRIPTION
- use threads when uploading datasets to speed up rdev database seeding.