### PR TITLE
feat: rollback errored migration DatasetVersions during a migration run

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -943,6 +943,14 @@ class BusinessLogic(BusinessLogicInterface):
             )
         )
 
+    def delete_dataset_versions(self, dataset_versions: List[DatasetVersion]) -> None:
+        """
+        Deletes a list of dataset versions and associated dataset artifact rows from the database, as well
+        as kicking off deletion of their corresponding assets from S3
+        """
+        self.database_provider.delete_dataset_versions(dataset_versions)
+        self.delete_dataset_version_assets(dataset_versions)
+
     def delete_dataset_version_assets(self, dataset_versions: List[DatasetVersion]) -> None:
         self.delete_dataset_versions_from_public_bucket([dv.version_id.id for dv in dataset_versions])
         self.delete_artifacts(reduce(lambda artifacts, dv: artifacts + dv.artifacts, dataset_versions, []))
@@ -1065,8 +1073,7 @@ class BusinessLogic(BusinessLogicInterface):
             version.collection_id, from_date=date_of_last_publish
         )
         versions_to_delete = list(filter(lambda dv: dv.version_id.id not in versions_to_keep, dataset_versions))
-        self.delete_dataset_version_assets(versions_to_delete)
-        self.database_provider.delete_dataset_versions(versions_to_delete)
+        self.delete_dataset_versions(versions_to_delete)
 
     def get_dataset_version(self, dataset_version_id: DatasetVersionId) -> Optional[DatasetVersion]:
         """

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1384,6 +1384,18 @@ class TestDeleteDataset(BaseBusinessLogicTestCase):
         # Act + Assert
         self.assertRaises(CollectionDeleteException, delete_artifacts, artifacts)
 
+    def test_delete_dataset_versions(self):
+        collection = self.initialize_unpublished_collection()
+        dataset_to_delete = collection.datasets[0]
+        uris_to_delete = [a.uri for a in dataset_to_delete.artifacts]
+        dataset_artifact_ids = [a.id for a in dataset_to_delete.artifacts]
+
+        self.business_logic.delete_dataset_version(dataset_to_delete.version_id)
+
+        self.assertIsNone(self.business_logic.get_dataset_version(dataset_to_delete.version_id))
+        self.assertEqual(self.database_provider.get_dataset_artifacts(dataset_artifact_ids), [])
+        [self.assertFalse(self.s3_provider.uri_exists(uri)) for uri in uris_to_delete]
+
 
 class TestGetDataset(BaseBusinessLogicTestCase):
     def test_get_all_datasets_ok(self):

--- a/tests/unit/processing/schema_migration/test_log_errors_and_cleanup.py
+++ b/tests/unit/processing/schema_migration/test_log_errors_and_cleanup.py
@@ -84,6 +84,8 @@ class TestLogErrorsAndCleanup:
         ]
         collection_version = make_mock_collection_version(datasets)
         schema_migrate.business_logic.get_collection_version.return_value = collection_version
+        schema_migrate.business_logic.restore_previous_dataset_version = Mock()
+        schema_migrate.business_logic.delete_dataset_versions = Mock()
 
         errors = schema_migrate.log_errors_and_cleanup(collection_version.version_id.id)
         assert len(errors) == 2
@@ -105,6 +107,8 @@ class TestLogErrorsAndCleanup:
             "dataset_id": non_migrated_dataset.dataset_id.id,
             "rollback": False,
         } in errors
+        assert schema_migrate.business_logic.restore_previous_dataset_version.call_count == 1
+        assert schema_migrate.business_logic.delete_dataset_versions.call_count == 1
         schema_migrate.s3_provider.delete_files.assert_any_call(
             "artifact-bucket", ["schema_migration/test-execution-arn/log_errors_and_cleanup/collection_id.json"]
         )


### PR DESCRIPTION
## Reason for Change

- #7290

## Changes

-at Collection-level error round-up step in migration run, restore previous dataset version for any processed datasets that failed post-migration processing for any reason
         - this allows future run to roll-forward with a solution for this dataset
- log this rollback state
- if rolled back, delete orphaned DatasetVersion from DB and associated artifacts in DB and S3
- consolidate steps for handling deleted DatasetVersions + artifacts from DB and S3 into a business function call

## Testing steps

- unit tests, TBD rdev testing