### PR TITLE
fix: invalidate cache without refetch on cancel revision

### DIFF
--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -350,7 +350,7 @@ export function useDeleteCollection(): UseMutationResult<
         // Invalidate the cached revision without re-fetching as:
         // 1. the revision no longer exists (requesting the canceled revision returns
         // an error status), and,
-        // 2. re-fetching causes the delete button - and the redirect-on-success 
+        // 2. re-fetching causes the delete button - and the redirect-on-success
         // function - to be unmounted.
         await queryClient.invalidateQueries(
           [USE_COLLECTION, collection.revision_of],

--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -349,7 +349,7 @@ export function useDeleteCollection(): UseMutationResult<
       if (collection.revision_of) {
         await queryClient.invalidateQueries(
           [USE_COLLECTION, collection.revision_of],
-          {refetchActive: false}
+          { refetchActive: false }
         );
       }
     },

--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -349,7 +349,7 @@ export function useDeleteCollection(): UseMutationResult<
       if (collection.revision_of) {
         await queryClient.invalidateQueries(
           [USE_COLLECTION, collection.revision_of],
-          DEFAULT_BACKGROUND_REFETCH
+          {refetchActive: false}
         );
       }
     },

--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -347,6 +347,11 @@ export function useDeleteCollection(): UseMutationResult<
         DEFAULT_BACKGROUND_REFETCH
       );
       if (collection.revision_of) {
+        // Invalidate the cached revision without re-fetching as:
+        // 1. the revision no longer exists (requesting the canceled revision returns
+        // an error status), and,
+        // 2. re-fetching causes the delete button - and the redirect-on-success 
+        // function - to be unmounted.
         await queryClient.invalidateQueries(
           [USE_COLLECTION, collection.revision_of],
           { refetchActive: false }


### PR DESCRIPTION
## Reason for Change

- #7296 

## Changes

- Updated DELETE success handler to not refetch on invalidate of revision in cache.

## Testing steps

- Manually create and cancel revision.
- Confirm edit dataset title E2E test passes.
 
## Notes for Reviewer

- A refetch of the canceled revision causes the collection actions button component to unmount, preventing a [redirect to the published collection](https://github.com/chanzuckerberg/single-cell-data-portal/blob/main/frontend/src/views/Collection/components/CollectionActions/index.tsx#L94).
