### PR TITLE
fix: update citation when updating dataset title

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -161,6 +161,11 @@ class BusinessLogic(BusinessLogicInterface):
             new_dataset_version_id = self.create_empty_dataset_version_for_current_dataset(
                 collection_version.version_id, current_dataset_version_id
             ).version_id
+            # Update citation for new dataset version
+            doi = next((link.uri for link in collection_version.metadata.links if link.type == "DOI"), None)
+            metadata_update.citation = self.generate_dataset_citation(
+                collection_version.collection_id, new_dataset_version_id, doi
+            )
 
         self.batch_job_provider.start_metadata_update_batch_job(
             current_dataset_version_id, new_dataset_version_id, metadata_update

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1819,7 +1819,7 @@ class TestUpdateDataset(BaseBusinessLogicTestCase):
         # Confirm trigger was called.
         self.business_logic.trigger_dataset_artifact_update.assert_called_once()
         # Confirm new citation was generated
-        self.assertIsNotNone(self.update.citation)
+        self.assertIsNotNone(update.citation)
 
     def test_update_dataset_artifact_metadata_sanitized_ok(self):
         """

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1818,6 +1818,8 @@ class TestUpdateDataset(BaseBusinessLogicTestCase):
 
         # Confirm trigger was called.
         self.business_logic.trigger_dataset_artifact_update.assert_called_once()
+        # Confirm new citation was generated
+        self.assertIsNotNone(self.update.citation)
 
     def test_update_dataset_artifact_metadata_sanitized_ok(self):
         """

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1818,8 +1818,6 @@ class TestUpdateDataset(BaseBusinessLogicTestCase):
 
         # Confirm trigger was called.
         self.business_logic.trigger_dataset_artifact_update.assert_called_once()
-        # Confirm new citation was generated
-        self.assertIsNotNone(update.citation)
 
     def test_update_dataset_artifact_metadata_sanitized_ok(self):
         """
@@ -3079,7 +3077,10 @@ class TestDatasetArtifactMetadataUpdates(BaseBusinessLogicTestCase):
         current_dataset_version_id = revision.datasets[0].version_id
         self.batch_job_provider.start_metadata_update_batch_job = Mock()
         self.business_logic.trigger_dataset_artifact_update(revision, metadata_update, current_dataset_version_id)
+
         self.batch_job_provider.start_metadata_update_batch_job.assert_called_once()
+        # Confirm citation is updated if new dataset version is generated as part of trigger_dataset_artifact_update
+        self.assertIsNotNone(metadata_update.citation)
 
     def test_trigger_dataset_artifact_update__with_new_dataset_version_id(self):
         metadata_update = DatasetArtifactMetadataUpdate(schema_version="4.0.0")


### PR DESCRIPTION
## Reason for Change

- New Citations must be generated whenever a new DatasetVersionId is generated; edit dataset titles represented a use-case where this was not happening

## Changes

- add path to generate a new citation when a dataset title is updated, and persist that update to artifact updates

## Testing steps

- unit + rdev
