### PR TITLE
fix: Update WMG publication format

### DIFF
--- a/frontend/src/common/queries/wheresMyGene.ts
+++ b/frontend/src/common/queries/wheresMyGene.ts
@@ -30,7 +30,6 @@ import { EMPTY_OBJECT } from "../constants/utils";
 import { DEFAULT_FETCH_OPTIONS, JSON_BODY_FETCH_OPTIONS } from "./common";
 import { ENTITIES } from "./entities";
 import { Dataset } from "@mui/icons-material";
-import { formatCitation } from "../utils/formatCitation";
 
 interface RawOntologyTerm {
   [id: string]: string;
@@ -1158,7 +1157,7 @@ function toEntity(item: RawOntologyTerm) {
 function toCitationEntity(citation: string) {
   return {
     id: citation,
-    name: formatCitation(citation),
+    name: citation,
   };
 }
 

--- a/frontend/src/common/utils/formatCitation.ts
+++ b/frontend/src/common/utils/formatCitation.ts
@@ -1,7 +1,0 @@
-export function formatCitation(str: string) {
-  const [authors, journalYear] = str.split("et al.");
-  if (!journalYear) return str;
-  const formattedYear = `(${journalYear.slice(-4)})`;
-  const journal = journalYear.slice(0, -5);
-  return `${authors} et al. ${formattedYear} ${journal}`;
-}

--- a/frontend/src/views/WheresMyGeneV2/components/HeatMap/components/YAxisChart/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/HeatMap/components/YAxisChart/index.tsx
@@ -1,11 +1,4 @@
-import {
-  memo,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { track } from "src/common/analytics";
 import { EVENTS } from "src/common/analytics/events";
 import { EXCLUDE_IN_SCREENSHOT_CLASS_NAME } from "src/views/WheresMyGeneV2/components/GeneSearchBar/components/SaveExport";
@@ -47,8 +40,6 @@ import {
   TISSUE_NAME_LABEL_CLASS_NAME,
   CELL_TYPE_NAME_LABEL_CLASS_NAME,
 } from "src/views/WheresMyGeneV2/components/HeatMap/components/YAxisChart/constants";
-import { formatCitation } from "src/common/utils/formatCitation";
-import { StateContext } from "src/views/WheresMyGeneV2/common/store";
 
 interface Props {
   cellTypes: CellTypeRow[];
@@ -81,7 +72,6 @@ export default memo(function YAxisChart({
   const cellTypeMetadata = useMemo(() => {
     return getAllSerializedCellTypeMetadata(cellTypes, tissue);
   }, [cellTypes, tissue]);
-  const { compare } = useContext(StateContext);
 
   return (
     <Wrapper id={`${hyphenize(tissue)}-y-axis`}>
@@ -93,18 +83,14 @@ export default memo(function YAxisChart({
           .slice()
           .reverse()
           .map((cellType) => {
-            const { name, isAggregated } = deserializeCellTypeMetadata(
+            const { name } = deserializeCellTypeMetadata(
               cellType as CellTypeMetadata
             );
             const { fontWeight, fontSize, fontFamily } = SELECTED_STYLE;
             const selectedFont = `${fontWeight} ${fontSize}px ${fontFamily}`;
             const expanded = expandedTissueIds.includes(tissueID);
-            let formattedName = name;
-            if (compare && compare === "publication" && !isAggregated) {
-              formattedName = formatCitation(name);
-            }
             const { text: paddedName } = formatLabel(
-              formattedName,
+              name,
               Y_AXIS_CHART_WIDTH_PX - 90, // scale based on y-axis width
               selectedFont // prevents selected style from overlapping count
             );


### PR DESCRIPTION
## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

1. BE now serves the correct publication title format, so FE no longer needs to format the string anymore, which actually caused a formatting bug

BEFORE:
<img width="689" alt="Screenshot 2024-08-07 at 1 33 14 PM" src="https://github.com/user-attachments/assets/ec5cec57-b49b-4673-ac3e-2cbddf4fe6e0">

AFTER:
<img width="851" alt="Screenshot 2024-08-07 at 2 30 47 PM" src="https://github.com/user-attachments/assets/eaf6f481-4d0e-426f-a479-f1ec4880090b">


## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
