### PR TITLE
fix: top DE gene result for e2e test

### DIFF
--- a/frontend/tests/features/differentialExpression/differentialExpression.test.ts
+++ b/frontend/tests/features/differentialExpression/differentialExpression.test.ts
@@ -586,7 +586,23 @@ describe("Differential Expression", () => {
         ]);
 
         const newPageUrl2 = newPage2.url();
-        expect(newPageUrl2).toContain("SAA1");
+
+        const effectSizeSort = page.getByTestId(
+          DIFFERENTIAL_EXPRESSION_SORT_DIRECTION
+        );
+
+        //  Sort by top negative effect size
+        await effectSizeSort.click();
+
+        const topGene = await page
+          .getByTestId("differential-expression-results-table")
+          .locator("tr:first-child td:first-child")
+          .textContent();
+
+        // Reset to sort by top positive effect size
+        await effectSizeSort.click();
+
+        expect(newPageUrl2).toContain(topGene);
         expect(newPageUrl2).toContain("tissues=UBERON%3A0002048");
         expect(newPageUrl2).toContain("cellTypes=acinar+cell");
         expect(newPageUrl2).toContain("ver=2");


### PR DESCRIPTION
## Reason for Change

Context [here](https://czi-sci.slack.com/archives/C0247APK621/p1724427880326249)

## Changes

- Added click to sort by negative effect size 
- Replaced hardcoded test value of `SAA1` with first gene returned in results table
- Added another click to sort by positive effect size to ensure subsequent assertions won't fail

