### PR TITLE
chore: Fix data mirroring script and instructions

### DIFF
--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Run e2e Logged In tests
         run: |
           DEBUG=pw:api RDEV_LINK=https://${{ env.STACK_NAME }}-frontend.rdev.single-cell.czi.technology npm run e2e-rdev-logged-in-ci
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: logged-in-test-results

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -66,12 +66,11 @@ db/connect_internal:
 
 db/console: db/connect # alias
 
+PORT:=5432
 db/dump:
   # Dump the DEPLOYMENT_STAGE database to OUTFILE
 	$(eval DB_PW = $(shell aws secretsmanager get-secret-value --secret-id corpora/backend/${DEPLOYMENT_STAGE}/database --region us-west-2 | jq -r '.SecretString | match(":([^:]*)@").captures[0].string'))
-	$(MAKE) db/tunnel/up
-	PGPASSWORD=${DB_PW} pg_dump -Fc --dbname=corpora_${DEPLOYMENT_STAGE} --file=$(OUTFILE) --host 0.0.0.0 --username corpora_${DEPLOYMENT_STAGE}
-	$(MAKE) db/tunnel/down
+	PGPASSWORD=${DB_PW} pg_dump -Fc --dbname=corpora_${DEPLOYMENT_STAGE} --file=$(OUTFILE) --host 0.0.0.0 --port $(PORT) --username corpora_${DEPLOYMENT_STAGE}
 
 db/local/load-data:
 	# Loads corpora_dev.sqlc into the local Docker env corpora database
@@ -118,13 +117,15 @@ else
 	CLUSTER_NAME=corpora-${DEPLOYMENT_STAGE}-corpora-api
 
 endif
-# TODO:
-# - add db/tunnel as a dependency for all targets so that a tunnel is automatically opened if not already
+# If running for a data mirror, must run once per SRC and DEST envs BEFORE running mirror_env_data, with different
+# local PORT values.
+# Runs in interactive mode, so each run requires separate terminal tab.
+PORT:=5432
 db/tunnel/up:
 	$(eval endpoint=$(shell aws rds describe-db-cluster-endpoints --db-cluster-identifier ${CLUSTER_NAME} | jq -r '.DBClusterEndpoints[] | select(.EndpointType | contains("WRITER")) | .Endpoint'))
 	$(eval instance_id=$(shell aws ec2 describe-instances --filters "Name=tag:Name,Values=dp-${DEPLOYMENT_STAGE}-happy" --query "Reservations[*].Instances[*].InstanceId" --output text))
 
-	aws ssm start-session --target ${instance_id} --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"portNumber":["5432"],"localPortNumber":["5432"],"host":["${endpoint}"]}'
+	aws ssm start-session --target ${instance_id} --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"portNumber":["5432"],"localPortNumber":["$(PORT)"],"host":["${endpoint}"]}'
 
 db/tunnel: db/tunnel/up # alias for backwards compatibility
 
@@ -132,6 +133,8 @@ SRC_ENV := prod
 mirror_env_data:
 	# Mirrors the SRC_ENV env's AWS RDS database and S3 data to
 	# DEST_ENV. Defaults to prod->dev.
+	# Must also provide SRC_PORT and DEST_PORT where psql is running for each env.
+	# Must also run `make db/tunnel/up` before running this command, once for the SRC_ENV and once for the DEST_ENV.
 	#
 	# If WMG_CUBE is set to any non-null value, copy the WMG cube from SRC_ENV to DEST_ENV. Works for DEST_ENV=rdev.
 	#
@@ -146,5 +149,5 @@ mirror_env_data:
 	# THIS IS DESTRUCTIVE for the DEST_ENV env! The SRC_ENV env will
 	# never be modified, but the DEST_ENV env's data will be replaced.
 	#
-	# Usage: make mirror_env_data [SRC_ENV={prod|staging|dev}] [DEST_ENV={dev|staging|rdev}] [WMG_CUBE=1] [STACK=<rdev_stack_name> [CELLGUIDE=1] [COLLECTIONS=<uuid1,uuid2,...> [DATA=1]]]
-	scripts/mirror_env_data.sh $(SRC_ENV) $(DEST_ENV) $(WMG_CUBE) $(STACK) $(CELLGUIDE) $(COLLECTIONS) $(DATA)
+	# Usage: make mirror_env_data [SRC_ENV={prod|staging|dev}] [DEST_ENV={dev|staging|rdev}] [SRC_PORT={int}] [DEST_PORT={int}] [WMG_CUBE=1] [STACK=<rdev_stack_name> [CELLGUIDE=1] [COLLECTIONS=<uuid1,uuid2,...> [DATA=1]]]
+	scripts/mirror_env_data.sh $(SRC_ENV) $(DEST_ENV) $(SRC_PORT) $(DEST_PORT) $(WMG_CUBE) $(STACK) $(CELLGUIDE) $(COLLECTIONS) $(DATA)

--- a/backend/scripts/mirror_env_data.sh
+++ b/backend/scripts/mirror_env_data.sh
@@ -2,6 +2,7 @@
 
 # Mirror S3 and RDS (postgres db) data from a source deployment environment (usually production)
 # to a specified destination deployment environment (dev or staging)
+# Must run 'make db/tunnel/up' once per SRC and DEST env before running this script, using different local ports for each.
 #
 # THIS IS DESTRUCTIVE for the destination env! The source env will
 # never be modified, but the dest env's data will be replaced.

--- a/backend/scripts/mirror_s3_data.sh
+++ b/backend/scripts/mirror_s3_data.sh
@@ -119,7 +119,7 @@ else  # i.e., if DEST_ENV != 'rdev'
   # that needs to be kept around (buckets are versioned, so we're not in
   # jeopardy of losing anything permanently). This would make the
   # operation more destructive, of course!
-
+  export AWS_PROFILE=single-cell-dev
   PARALLEL_CMD="parallel --ungroup --jobs 16"  # '--ungroup' permits stdout to stream continuously from all jobs
 
   hex_chars="0 1 2 3 4 5 6 7 8 9 a b c d e f"  # Permits running 16 concurrent aws processes -- each one syncs only uuids starting with its hex char

--- a/backend/scripts/set_src_dest_envs.sh
+++ b/backend/scripts/set_src_dest_envs.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+echo "Setting env vars for src/dest envs"
 export SRC_ENV=${1:-prod}
 export DEST_ENV=${2:-dev}
-
+export SRC_PORT=${3:-5432}
+export DEST_PORT=${4:-5433}
 
 # Forbid rdev as SRC_ENV
 if [[ "$SRC_ENV" == rdev ]]; then

--- a/python_dependencies/wmg_processing/requirements.txt
+++ b/python_dependencies/wmg_processing/requirements.txt
@@ -7,7 +7,7 @@ cellxgene-ontology-guide~=1.0.0
 dataclasses-json==0.5.7
 ddtrace==2.1.4
 numba>=0.58.0
-numpy==1.23.5
+numpy>=1.24.0,<2.1.0
 openai==0.27.7
 pandas==2.2.1
 psutil==5.9.5


### PR DESCRIPTION
## Reason for Change

- Infra team recently deprecated bastions, breaking our data mirroring and PostgreSQL ssh connection make commands
- ebezzi replaced the bastions with accessing our DBs via SSM-enabled [machines](https://github.com/chanzuckerberg/single-cell-data-portal/pull/7328)
- This PR uses those changes to fix our data mirroring script and updating its instructions, so we can continue to mirror prod data to dev/staging for testing purposes.

## Changes

- require running  `make db/tunnel/up` for both SRC and DEST env, with a different local port number forwarding to the SSM-enabled machine for each DB env.
- add port number as argument for mirroring script and tunneling command
- update 'make db/dump' to also take PORT as an arg and remove `make db/connect` call, which is now interactive-only and replaced by the new `make db/tunnel/up`.

## Testing steps

- Ran prod -> dev mirroring