### PR TITLE
fix: missing server_metadata

### DIFF
--- a/backend/common/corpora_config.py
+++ b/backend/common/corpora_config.py
@@ -88,6 +88,7 @@ class CorporaAuthConfig(SecretConfig):
             "internal_url": "{api_base_url}",
             "issuer": [],
             "retry_status_forcelist": [429, 500, 502, 503, 504],
+            "server_metadata_url": "hhtps://{auth0_domain}/.well-known/openid-configuration",
         }
         template["issuer"].append(self.api_base_url + "/" if not self.api_base_url.endswith("/") else self.api_base_url)
         template["issuer"].append("https://" + self.auth0_domain + "/")

--- a/backend/portal/api/app/v1/authentication.py
+++ b/backend/portal/api/app/v1/authentication.py
@@ -8,7 +8,6 @@ from urllib.parse import urlencode
 
 import requests
 from authlib.integrations.flask_client import OAuth
-from authlib.integrations.flask_client.remote_app import FlaskRemoteApp
 from flask import Response, after_this_request, current_app, g, jsonify, make_response, redirect, request, session
 
 from backend.common.authorizer import assert_authorized_token, get_userinfo_from_auth0
@@ -20,7 +19,7 @@ from backend.common.utils.http_exceptions import ExpiredCredentialsError, Unauth
 oauth_client = None
 
 
-def get_oauth_client(config: CorporaAuthConfig) -> FlaskRemoteApp:
+def get_oauth_client(config: CorporaAuthConfig) -> OAuth:
     """Create an oauth client on the first invocation, then return oauth client for subsequent calls.
 
     :param config:  An object containing the auth configuration.
@@ -50,6 +49,7 @@ def get_oauth_client(config: CorporaAuthConfig) -> FlaskRemoteApp:
         authorize_url=config.api_authorize_url,
         client_kwargs={"scope": "openid profile email offline_access write:collections"},
         authorize_params={"audience": config.api_audience},
+        server_metadata_url=config.server_metadata_url,
     )
     return oauth_client
 

--- a/python_dependencies/backend/requirements.txt
+++ b/python_dependencies/backend/requirements.txt
@@ -1,6 +1,5 @@
 alembic==1.*
-Authlib==0.14.3
-boto3>=1.11.17
+Authlib==1.3.1
 botocore>=1.14.17
 connexion[swagger-ui]==2.14.2
 dataclasses-json==0.6.6


### PR DESCRIPTION
## Reason for Change
rolling back to previously working version of authlib. 
Previously it was upgraded here https://github.com/chanzuckerberg/single-cell-data-portal/commit/a12556f997d9caa1cfbd52453446c5c4af460df3m which caused 502 on the frontend.

## Changes

- add server_metadata to oath config
- roll back to previous authlib version.

## Testing steps
- verify you can login on frontend
- all automated tests pass.
