### PR TITLE
chore: update schema reference urls to use 'latest-schema' redirect url

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -762,7 +762,7 @@ components:
     batch_condition:
       description: |
         These keys define the batches that a normalization or integration algorithm should be aware of.
-        [batch condition schema](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#batch_condition)
+        [batch condition schema](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#batch_condition)
 
       type: array
       items:
@@ -774,7 +774,7 @@ components:
         Citation that includes downloadable permalink to h5ad artifact for this dataset, a permalink to collection it 
         belongs to in CZ CELLxGENE Discover, and--if applicable--the Publication DOI associated with the dataset.
         See details about the exact format in the 
-        [schema definition](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#citation)
+        [schema definition](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#citation)
       type: string
       nullable: true
     collection_list:
@@ -1027,7 +1027,7 @@ components:
           type: integer
         cell_type:
           description: |
-            [cell type label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#cell_type)
+            [cell type label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#cell_type)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
@@ -1042,7 +1042,7 @@ components:
           $ref: "#/components/schemas/default_embedding"
         development_stage:
           description: |
-            [development stage label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#development_stage)
+            [development stage label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#development_stage)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
@@ -1069,7 +1069,7 @@ components:
           type: number
         title:
           description: |
-            [title](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#title)
+            [title](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#title)
           nullable: true
           type: string
         organism:
@@ -1096,14 +1096,14 @@ components:
           type: string
         self_reported_ethnicity:
           description: |
-            [self reported ethnicity label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#self_reported_ethnicity)
+            [self reported ethnicity label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#self_reported_ethnicity)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
           type: array
         sex:
           description: |
-            [sex label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#sex)
+            [sex label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#sex)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
@@ -1135,7 +1135,7 @@ components:
           type: integer
         cell_type:
           description: |
-            [cell type label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#cell_type)
+            [cell type label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#cell_type)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
@@ -1158,7 +1158,7 @@ components:
           $ref: "#/components/schemas/dataset_version_id"
         development_stage:
           description: |
-            [development stage label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#development_stage)
+            [development stage label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#development_stage)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
@@ -1177,7 +1177,7 @@ components:
           type: number
         title:
           description: |
-            [title](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#title)
+            [title](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#title)
           nullable: true
           type: string
         organism:
@@ -1205,14 +1205,14 @@ components:
           type: string
         self_reported_ethnicity:
           description: |
-            [self reported ethnicity label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#self_reported_ethnicity)
+            [self reported ethnicity label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#self_reported_ethnicity)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
           type: array
         sex:
           description: |
-            [sex label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#sex)
+            [sex label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#sex)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
@@ -1246,7 +1246,7 @@ components:
           type: integer
         cell_type:
           description: |
-            [cell type label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#cell_type)
+            [cell type label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#cell_type)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
@@ -1268,7 +1268,7 @@ components:
           $ref: "#/components/schemas/default_embedding"
         development_stage:
           description: |
-            [development stage label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#development_stage)
+            [development stage label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#development_stage)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
@@ -1293,7 +1293,7 @@ components:
           type: number
         title:
           description: |
-            [title](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#title)
+            [title](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#title)
           nullable: true
           type: string
         organism:
@@ -1310,14 +1310,14 @@ components:
           type: string
         self_reported_ethnicity:
           description: |
-            [self reported ethnicity label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#self_reported_ethnicity)
+            [self reported ethnicity label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#self_reported_ethnicity)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
           type: array
         sex:
           description: |
-            [sex label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#sex)
+            [sex label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#sex)
           default: []
           items:
             $ref: "#/components/schemas/ontology_element"
@@ -1333,21 +1333,21 @@ components:
       type: object
     dataset_assay:
       description: |
-        [assay label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#assay)
+        [assay label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#assay)
       default: []
       items:
         $ref: "#/components/schemas/ontology_element"
       type: array
     dataset_disease:
       description: |
-        [disease label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#disease)
+        [disease label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#disease)
       default: []
       items:
         $ref: "#/components/schemas/ontology_element"
       type: array
     dataset_organism:
       description: |
-        [organism label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#organism)
+        [organism label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#organism)
       default: []
       items:
         $ref: "#/components/schemas/ontology_element"
@@ -1360,7 +1360,7 @@ components:
       type: string
     dataset_tissue:
       description: |
-        [tissue label](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#tissue)
+        [tissue label](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#tissue)
       default: []
       items:
         allOf:
@@ -1421,7 +1421,7 @@ components:
         CELLxGENE Discover runs a heuristic to detect the approximate distribution
         of the data in X so that it can accurately calculate statistical properties
         of the data. This field enables the curator to override this heuristic and
-        specify the data distribution explicitly. [x_approximate_distribution](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#x_approximate_distribution)
+        specify the data distribution explicitly. [x_approximate_distribution](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#x_approximate_distribution)
       enum:
         - COUNT
         - NORMAL
@@ -1482,7 +1482,7 @@ components:
       nullable: true
     is_primary_data:
       description: |
-        [is_primary_data](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#is_primary_data)
+        [is_primary_data](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#is_primary_data)
 
         Describes whether cellular observations for this Dataset are all
         canonical (True), all non-canonical (False), or contain a mixture (True, False).
@@ -1603,21 +1603,21 @@ components:
       properties:
         is_single:
           description: |
-            [is_single](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#is_single)
+            [is_single](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#is_single)
 
             Flag indicating if a spatial dataset represents one Space Ranger output for a single tissue section or the
             output for a single array on a puck.
           type: boolean
         has_fullres:
           description: |
-            [has_fullres](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#spatiallibrary_idimagesfullres)
+            [has_fullres](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#spatiallibrary_idimagesfullres)
 
             Flag indicating if a spatial dataset's metadata includes a numpy.ndarray representing the full resolution 
             image.
           type: boolean
     suspension_type:
       description: |
-        [suspension_type](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#suspension_type)
+        [suspension_type](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#suspension_type)
 
         List of unique suspension types represented in the dataset, corresponding to dataset's assay(s).
         Possible item values are 'nucleus', 'cell', and/or 'na'.

--- a/frontend/doc-site/032__Contribute and Publish Data.mdx
+++ b/frontend/doc-site/032__Contribute and Publish Data.mdx
@@ -40,7 +40,7 @@ We need the following collection metadata (i.e. details associated with your pub
   - URLs: any additional URLs for related data or resources, such as GEO or protocols.io - can be added later
   - Consortia: optional, and can be added later. Can be one or more of those listed [here](https://github.com/chanzuckerberg/single-cell-data-portal/blob/main/backend/layers/common/validation.py#L12).
 
-Each dataset needs the following information added to a single h5ad (AnnData 0.8) format file:
+Each dataset needs the following information added to a single h5ad (AnnData 0.10) format file:
 
 - **Dataset-level metadata in uns**:
   - title: title of the individual dataset

--- a/frontend/doc-site/032__Contribute and Publish Data.mdx
+++ b/frontend/doc-site/032__Contribute and Publish Data.mdx
@@ -61,7 +61,7 @@ Each dataset needs the following information added to a single h5ad (AnnData 0.8
   - tissue_ontology_term_id: [UBERON](https://www.ebi.ac.uk/ols/ontologies/uberon)
   - cell_type_ontology_term_id: [CL](https://www.ebi.ac.uk/ols/ontologies/cl)
   - assay_ontology_term_id: [EFO](https://www.ebi.ac.uk/ols/ontologies/efo)
-  - suspension_type: `cell`, `nucleus`, or `na`, as corresponding to assay. Use [this table](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#suspension_type) defined in the data schema for guidance. If the assay does not appear in this table, the most appropriate value MUST be selected and the [curation team informed](mailto:cellxgene@chanzuckerberg.com) during submission so that the assay can be added to the table.
+  - suspension_type: `cell`, `nucleus`, or `na`, as corresponding to assay. Use [this table](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#suspension_type) defined in the data schema for guidance. If the assay does not appear in this table, the most appropriate value MUST be selected and the [curation team informed](mailto:cellxgene@chanzuckerberg.com) during submission so that the assay can be added to the table.
 - **Embeddings in obsm**:
   - One or more two-dimensional embeddings, prefixed with 'X\_'
 - **Features in var & raw.var (if present)**:

--- a/frontend/doc-site/03__Download Published Data.mdx
+++ b/frontend/doc-site/03__Download Published Data.mdx
@@ -1,6 +1,6 @@
 # Downloading Published Data on CZ CELLxGENE Discover
 
-Clicking the download button launches a dialog that enables a dataset to be downloaded in h5ad (AnnData v0.8) and rds (Seurat v5) formats. All datasets adhere to the CELLxGENE single cell annotated data schema.
+Clicking the download button launches a dialog that enables a dataset to be downloaded in h5ad (AnnData v0.10) and rds (Seurat v5) formats. All datasets adhere to the CELLxGENE single cell annotated data schema.
 
 <Image src={"/doc-site/datasetHighlight.png"} />
 
@@ -8,4 +8,4 @@ Click the white Download button for the dataset that you wish to download.
 
 <Image src={"/doc-site/downloadDialog.png"} />
 
-Select either the h5ad (AnnData v0.8) or rds (Seurat v5) download format. Click the blue Download button to download the dataset via the browser. The permanent download link can also be copied, shared, and pasted into a browser address bar.
+Select either the h5ad (AnnData v0.10) or rds (Seurat v5) download format. Click the blue Download button to download the dataset via the browser. The permanent download link can also be copied, shared, and pasted into a browser address bar.

--- a/frontend/doc-site/04__Analyze Public Data/4_2__Gene Expression Documentation/4_2_2__Cell Type and Gene Ordering.mdx
+++ b/frontend/doc-site/04__Analyze Public Data/4_2__Gene Expression Documentation/4_2_2__Cell Type and Gene Ordering.mdx
@@ -4,7 +4,7 @@ Cell types and genes shown in a dot plot can be arranged in different ways as de
 
 # Cell Type Ordering
 
-Cell types are annotated by the original data contributors and mapped to the closest cell ontology (CL) term as defined in the [data schema](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md#cell_type_ontology_term_id).
+Cell types are annotated by the original data contributors and mapped to the closest cell ontology (CL) term as defined in the [data schema](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#cell_type_ontology_term_id).
 
 In some cases there are cell types annotated with a high-level term whereas in some other cases they can be very granularly annotated. For example, there are some cells annotated as "T cells" and others annotated with children terms like "effector CD8-positive, alpha-beta T cell". All of these cell types are shown in the dot plot and they should not be interpreted as one being a subset of the other.
 

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
@@ -40,7 +40,7 @@ const DataFormat: FC<Props> = ({
       >
         <InputRadio
           disabled={isDisabled || !isH5AD}
-          label=".h5ad (AnnData v0.8)"
+          label=".h5ad (AnnData v0.10)"
           value={DATASET_ASSET_FORMAT.H5AD}
         />
         <Tooltip

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/components/CopyCaption/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/components/CopyCaption/index.tsx
@@ -4,7 +4,7 @@ import { Link } from "@czi-sds/components";
 
 const DISCOVER_API_URL = "https://api.cellxgene.cziscience.com/curation/ui/#/";
 const SCHEMA_URL =
-  "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md";
+  "https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html";
 const SEURAT_SCHEMA_URL =
   "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/seurat_encoding.md";
 


### PR DESCRIPTION
## Reason for Change

- #7329

## Changes

- use new github-pages based "latest" schema.md redirect rather than link out to a specific version and require updating every migration
- bump references to anndata 0.8 in docs/FE modals to anndata 0.10