### PR TITLE
chore: remove sever metadata field from oauth.register()

### DIFF
--- a/backend/common/corpora_config.py
+++ b/backend/common/corpora_config.py
@@ -88,7 +88,6 @@ class CorporaAuthConfig(SecretConfig):
             "internal_url": "{api_base_url}",
             "issuer": [],
             "retry_status_forcelist": [429, 500, 502, 503, 504],
-            "server_metadata_url": "{api_base_url}/.well-known/openid-configuration",
         }
         template["issuer"].append(self.api_base_url + "/" if not self.api_base_url.endswith("/") else self.api_base_url)
         template["issuer"].append("https://" + self.auth0_domain + "/")

--- a/backend/portal/api/app/v1/authentication.py
+++ b/backend/portal/api/app/v1/authentication.py
@@ -50,7 +50,6 @@ def get_oauth_client(config: CorporaAuthConfig) -> FlaskRemoteApp:
         authorize_url=config.api_authorize_url,
         client_kwargs={"scope": "openid profile email offline_access write:collections"},
         authorize_params={"audience": config.api_audience},
-        server_metadata_url=config.server_metadata_url,
     )
     return oauth_client
 


### PR DESCRIPTION
- Remove sever metadata field from oauth.register()