### PR TITLE
fix: add default values for cell guide description (SCE-22)

### DIFF
--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/Description/constants.ts
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/Description/constants.ts
@@ -12,3 +12,9 @@ export const CELL_GUIDE_CARD_SYNONYMS = "cell-guide-card-synonyms";
 
 export const CELL_GUIDE_CARD_VALIDATED_DESCRIPTION =
   "cell-guide-card-validated-description";
+
+export const CELL_GUIDE_CARD_DEFAULT_DESCRIPTION_CL =
+  "Description not available";
+
+export const getDefaultGptDescription = (cellTypeName: string) =>
+  `Description for ${cellTypeName} is not available at the moment, please check back at a later time, or click on the link below for more information.`;

--- a/frontend/src/views/CellGuide/components/CellGuideCard/components/Description/index.tsx
+++ b/frontend/src/views/CellGuide/components/CellGuideCard/components/Description/index.tsx
@@ -47,6 +47,8 @@ import {
   CELL_GUIDE_CARD_GPT_TOOLTIP_LINK,
   DESCRIPTION_BREAKPOINT_HEIGHT_PX,
   CELL_GUIDE_CARD_SYNONYMS,
+  getDefaultGptDescription,
+  CELL_GUIDE_CARD_DEFAULT_DESCRIPTION_CL,
 } from "src/views/CellGuide/components/CellGuideCard/components/Description/constants";
 import { useIsComponentPastBreakpointHeight } from "../common/hooks/useIsComponentPastBreakpoint";
 import { StyledQuestionMarkIcon } from "src/common/style";
@@ -124,11 +126,14 @@ export default function Description({
     }
   }, [isPastBreakpoint]);
 
-  const { data: rawDescriptionGpt } = useGptDescription(cellTypeId);
+  const { data: rawDescriptionGpt = getDefaultGptDescription(cellTypeName) } =
+    useGptDescription(cellTypeId);
   const { data: rawDescriptionValidated, isLoading } =
     useValidatedDescription(cellTypeId);
   const { data: cellTypesById } = useCellTypeMetadata();
-  const rawDescriptionCl = cellTypesById?.[cellTypeId].clDescription;
+  const rawDescriptionCl =
+    cellTypesById?.[cellTypeId]?.clDescription ||
+    CELL_GUIDE_CARD_DEFAULT_DESCRIPTION_CL;
 
   useEffect(() => {
     if (rawDescriptionValidated) {

--- a/frontend/src/views/WheresMyGeneV2/components/CellInfoSideBar/index.tsx
+++ b/frontend/src/views/WheresMyGeneV2/components/CellInfoSideBar/index.tsx
@@ -61,6 +61,7 @@ import {
 import Description from "src/views/CellGuide/components/CellGuideCard/components/Description";
 import { StyledQuestionMarkIcon } from "src/common/style";
 import { DIFFERENTIAL_EXPRESSION_RELEASED_FLAG } from "src/views/DifferentialExpression/common/constants";
+import { useGptDescription } from "src/common/queries/cellGuide";
 
 function CellInfoSideBar({
   cellInfoCellType,
@@ -81,6 +82,10 @@ function CellInfoSideBar({
     cellInfoCellType,
   });
 
+  const { data: rawDescriptionGpt } = useGptDescription(
+    cellInfoCellType.cellType.id
+  );
+
   if (isLoading || !data) return null;
 
   if (!cellInfoCellType) return null;
@@ -100,19 +105,21 @@ function CellInfoSideBar({
         skinnyMode={true}
         inSideBar
       />
-      <StyledLink
-        href={`${ROUTES.CELL_GUIDE}/${cellInfoCellType.cellType.id}`}
-        onClick={() =>
-          track(EVENTS.WMG_OPEN_IN_CG_CLICKED, {
-            cell_type: cellInfoCellType.cellType.id,
-          })
-        }
-        target="_blank"
-        rel="noreferrer noopener"
-      >
-        {MARKER_SCORE_CELLGUIDE_LINK_TEXT}
-        <Icon sdsIcon="ChevronRight" sdsType="static" sdsSize="xs" />
-      </StyledLink>
+      {Boolean(rawDescriptionGpt) && (
+        <StyledLink
+          href={`${ROUTES.CELL_GUIDE}/${cellInfoCellType.cellType.id}`}
+          onClick={() =>
+            track(EVENTS.WMG_OPEN_IN_CG_CLICKED, {
+              cell_type: cellInfoCellType.cellType.id,
+            })
+          }
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {MARKER_SCORE_CELLGUIDE_LINK_TEXT}
+          <Icon sdsIcon="ChevronRight" sdsType="static" sdsSize="xs" />
+        </StyledLink>
+      )}
       {DIFFERENTIAL_EXPRESSION_RELEASED_FLAG && (
         <StyledLink
           href={differentialExpressionUrl}


### PR DESCRIPTION
## Reason for Change

- When a user tries to click on a cell type in GE that doesn't exist in CG, the app would crash for missing `clDescription`
- Context: [here](https://czi.atlassian.net/jira/software/c/projects/SCE/list?selectedIssue=SCE-22)

## Changes

- Added default values for missing `clDescription` and `rawDescriptionGpt`
- Hide `Open in Cell Guide `link when a cell type is missing in Cell Guide

## Testing steps

- In GE, filter by `chondroblast` - click on info icon

