### PR TITLE
chore: seurat deprecation notice (SCE-32)

### DIFF
--- a/frontend/doc-site/05__Annotate and Analyze Your Data/5_3__Preparing Data.mdx
+++ b/frontend/doc-site/05__Annotate and Analyze Your Data/5_3__Preparing Data.mdx
@@ -112,3 +112,110 @@ _For the most up-to-date and comprehensive list of options, run `cellxgene prepa
 `--set-var-names` controls which field in `anndata.var` (gene metadata) is used as the index for genes. Default is `anndata.var.names`
 
 `--output` and `--overwrite` control where the processed data is saved.
+
+<a name="seurat-deprecated"></a>
+## Deprecation of Seurat Downloads on CELLxGENE Discover
+
+We are deprecating Seurat downloads on the CELLxGENE Discover platform, effective late 2024. While Seurat support has served many of our users, ongoing support has become unsustainable due to limitations in conversion tools and cross-ecosystem interoperability.This decision aligns with our shift towards a Python-based ecosystem, consistent with our Virtual Cell Platform (VCP) and Census strategies. As our platform increasingly supports new types of spatial and multimodal assays, focusing on Python will enable us to deliver a more consistent and scalable user experience.
+
+### Availability of Earlier Seurat Downloads
+
+Please note that earlier Seurat downloads will continue to be available. Previous versions of datasets will not be removed, and any Seurat RDS files that were previously downloaded will remain accessible. These can still be accessed via their URL (encoded as a citation in the dataset's @misc slot) or through the Discover API (`GET dataset versions`). This ensures that any ongoing research is not disrupted.
+
+### Recommended Alternatives
+
+For users seeking alternatives, we recommend leveraging the AnnData format, which integrates well with the Python-based scverse toolchain (including scanpy and squidpy). For R users, the preferred approach is to utilize the CELLxGENE Census R API or tools such as the cellxgenedp package, which can convert AnnData datasets into formats compatible with R toolchains like Bioconductor. This solution allows continued access to high-quality data and analytical capabilities without the challenges associated with Seurat conversions.
+
+If you need to convert h5ad files to Seurat, there are some community-supported tools that can assist with this task, though we caution that these tools may be less stable. Please reach out to the Seurat community for supported methods of conversion from AnnData to Seurat formats. We appreciate your understanding as we continue to refine our platform for reliability and future growth.
+
+### Converting `h5ad` Files to Seurat `RDS` Files
+
+To convert an `h5ad` file (used by Scanpy) to a Seurat `RDS` file (for use in R), you can follow a few key steps that involve using intermediate conversions and specific R packages.
+
+### Option 1 - Using `zellkonverter` and `SingleCellExperiment`
+
+**1. You will need `zellkonverter` and `SingleCellExperiment` installed. Run the following in R:**
+
+```R
+if (!requireNamespace("BiocManager", quietly = TRUE))
+    install.packages("BiocManager")
+
+BiocManager::install("zellkonverter")
+BiocManager::install("SingleCellExperiment")
+```
+
+**2. Load the .h5ad file and convert it**
+
+```R
+library(zellkonverter)
+library(SingleCellExperiment)
+
+# Specify the path to your .h5ad file
+h5ad_file <- "path/to/your/file.h5ad"
+
+# Read the .h5ad file into a SingleCellExperiment object
+sce <- readH5AD(h5ad_file)
+
+# Save the object as an .rds file
+saveRDS(sce, file = "output_file.rds")
+```
+
+**3. Verify and Load the RDS file**
+
+```R
+sce_loaded <- readRDS("output_file.rds")
+```
+
+### Option 2 - Using `SeuratDisk`
+
+**1. Convert the `h5ad` file into an `h5Seurat` file using the `Convert` function:**
+
+```R
+library(SeuratDisk)
+Convert("path_to_file.h5ad", dest = "h5seurat", overwrite = TRUE)
+```
+
+**2. Load the `h5Seurat` file into a Seurat object:**
+
+```R
+seurat_object <- LoadH5Seurat("path_to_file.h5seurat")
+```
+
+**3. Save the Seurat object as an `RDS` file:**
+
+```R
+saveRDS(seurat_object, file = "output_file.rds")
+```
+
+**4. Verify and Load the `RDS` file**
+
+```R
+seurat_loaded <- readRDS("output_file.rds")
+```
+
+### Option 3 - Using `reticulate` with Python's Scanpy
+
+If you encounter issues or need to customize the conversion, you can read the `h5ad` file in Python using the reticulate package and extract the necessary data into R:
+
+**1. Import the scanpy package and read the h5ad file:**
+
+```R
+library(reticulate)
+scanpy <- import("scanpy")
+adata <- scanpy$read_h5ad("path/to/your/file.h5ad")
+```
+
+**2. Extract the count data and convert it into a Seurat object:**
+
+```R
+counts <- t(adata$layers["counts"])
+colnames(counts) <- adata$obs_names$to_list()
+rownames(counts) <- adata$var_names$to_list()
+counts <- Matrix::Matrix(as.matrix(counts), sparse = TRUE)
+
+seurat_obj <- CreateSeuratObject(counts)
+saveRDS(seurat_obj, "output_file.rds")
+
+```
+
+These methods provide flexibility for handling different versions or data structures in your h5ad files. For more detailed guidance, you can refer to the documentation on [SeuratDisk's GitHub](https://mojaveazure.github.io/seurat-disk/articles/convert-anndata.html) and [discussions on GitHub](https://github.com/satijalab/seurat/issues).

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
@@ -37,6 +37,7 @@ const DataFormat: FC<Props> = ({
         onChange={handleChange}
         row
         value={selectedFormat}
+        style={{ height: "15px" }}
       >
         <InputRadio
           disabled={isDisabled || !isH5AD}

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/index.tsx
@@ -1,7 +1,13 @@
 import { FC, ReactNode } from "react";
 import { DialogLoader } from "src/components/Datasets/components/DownloadDataset/style";
 import { FormLabel } from "@mui/material";
-import { FormControl } from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/style";
+import {
+  FormControl,
+  SeuratNotice,
+  StyledIcon,
+  StyledLink,
+  TextWrapper,
+} from "./style";
 
 export const PROMPT_TEXT =
   "Select one of the data formats to view its download details.";
@@ -11,6 +17,7 @@ interface Props {
   selected: boolean;
   fileSize: number;
   isLoading: boolean;
+  selectedFormat: string;
 }
 
 const MEGA_BYTES = 2 ** 20;
@@ -20,6 +27,7 @@ const Details: FC<Props> = ({
   selected = false,
   fileSize = 0,
   isLoading = false,
+  selectedFormat,
 }) => {
   function renderContent() {
     if (isLoading) {
@@ -35,6 +43,23 @@ const Details: FC<Props> = ({
 
   return (
     <FormControl>
+      {/* TODO: Remove after Seurat has been deprecated */}
+      {selectedFormat == "RDS" && (
+        <>
+          <SeuratNotice>
+            <StyledIcon
+              sdsIcon="ExclamationMarkCircle"
+              sdsSize="l"
+              sdsType="static"
+            />
+            <TextWrapper>
+              Seurat support will be removed on [Month Day, Year]. You can
+              download and convert the .h5ad yourself by following these {""}
+              <StyledLink href="#">instructions</StyledLink>.
+            </TextWrapper>
+          </SeuratNotice>
+        </>
+      )}
       <FormLabel>Download Details</FormLabel>
       {renderContent()}
       {downloadPreview}

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/index.tsx
@@ -22,6 +22,9 @@ interface Props {
 
 const MEGA_BYTES = 2 ** 20;
 
+const DOC_SITE_URL =
+  "/docs/05__Annotate%20and%20Analyze%20Your%20Data/5_3__Preparing%20Data#seurat-deprecated";
+
 const Details: FC<Props> = ({
   downloadPreview,
   selected = false,
@@ -45,20 +48,18 @@ const Details: FC<Props> = ({
     <FormControl>
       {/* TODO: Remove after Seurat has been deprecated */}
       {selectedFormat == "RDS" && (
-        <>
-          <SeuratNotice>
-            <StyledIcon
-              sdsIcon="ExclamationMarkCircle"
-              sdsSize="l"
-              sdsType="static"
-            />
-            <TextWrapper>
-              Seurat support will be removed on [Month Day, Year]. You can
-              download and convert the .h5ad yourself by following these {""}
-              <StyledLink href="#">instructions</StyledLink>.
-            </TextWrapper>
-          </SeuratNotice>
-        </>
+        <SeuratNotice>
+          <StyledIcon
+            sdsIcon="ExclamationMarkCircle"
+            sdsSize="l"
+            sdsType="static"
+          />
+          <TextWrapper>
+            Seurat support will be removed between Nov 15 - Dec 31, 2024. You
+            can download and convert the .h5ad yourself by following these {""}
+            <StyledLink href={DOC_SITE_URL}>instructions</StyledLink>.
+          </TextWrapper>
+        </SeuratNotice>
       )}
       <FormLabel>Download Details</FormLabel>
       {renderContent()}

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/style.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/style.ts
@@ -12,7 +12,6 @@ export const SeuratNotice = styled.div`
   background-color: #ffefcf;
   border-radius: ${cornersM}px;
   display: flex;
-  margin-bottom: 8px;
   font-size: 13px;
   color: ${textPrimary};
   gap: ${spacesS}px;

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/style.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/style.ts
@@ -1,6 +1,35 @@
+import { Icon } from "@czi-sds/components";
 import styled from "@emotion/styled";
 import { FormControl as MFormControl } from "@mui/material";
+import { cornersM, spacesM, spacesS, textPrimary } from "src/common/theme";
 
 export const FormControl = styled(MFormControl)`
   min-height: 240px;
+`;
+
+export const SeuratNotice = styled.div`
+  align-items: center;
+  background-color: #ffefcf;
+  border-radius: ${cornersM}px;
+  display: flex;
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: ${textPrimary};
+  gap: ${spacesS}px;
+  margin: 0 0 ${spacesM}px;
+  padding: ${spacesS}px ${spacesM}px;
+`;
+
+export const StyledIcon = styled(Icon)`
+  color: #b77800;
+`;
+
+export const StyledLink = styled.a`
+  color: #b77800;
+  text-decoration: underline;
+  margin: 0;
+`;
+
+export const TextWrapper = styled.span`
+  display: inline;
 `;

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
@@ -148,6 +148,7 @@ const Content: FC<Props> = ({
               fileSize={fileSize}
               isLoading={isDownloadLinkLoading}
               selected={Boolean(fileSize)}
+              selectedFormat={selectedFormat}
             />
           </>
         )}


### PR DESCRIPTION
## Reason for Change

- [Ticket](https://czi.atlassian.net/browse/SCE-32)
- Notify users of upcoming Seurat deprecation

## Changes

- Add deprecation warning banner
- Add relevant docs

## Testing steps

- Visual QA for content and design
- rdev -> [here](https://pr-7365-frontend.rdev.single-cell.czi.technology/datasets)
- Docs -> [here](https://pr-7365-frontend.rdev.single-cell.czi.technology/docs/05__Annotate%20and%20Analyze%20Your%20Data/5_3__Preparing%20Data#seurat-deprecated)

## Checklist 🛎️

- [x] Add product, design, and eng as reviewers for rdev review
- [x] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
<img width="924" alt="Screenshot 2024-10-18 at 12 27 04 PM" src="https://github.com/user-attachments/assets/563429d1-989b-4a73-b57c-23235b0ac8c4">
