### PR TITLE
feat: Do not use backed mode when reading in anndata for CXG conversion

### DIFF
--- a/DEV_ENV_WITHOUT_DOCKER.md
+++ b/DEV_ENV_WITHOUT_DOCKER.md
@@ -51,3 +51,25 @@ Run functional tests for WMG api against the `dev` environment.
 **NOTE**: `dev` environment is a remote environment. These functional tests run locally against a backend in a remote environment called `dev`.
 
 1. `AWS_PROFILE=single-cell-dev DEPLOYMENT_STAGE=dev pytest -v tests/functional/backend/wmg/test_wmg_api.py`
+
+### Set up vips
+
+You may run into issues with finding `_libvips` if you're running a Jupyter notebook locally that calls `pyvips`, such as when running CXG conversion locally. The error may look like this:
+
+```
+ModuleNotFoundError                       Traceback (most recent call last)
+File ~/miniconda3/envs/py11/lib/python3.11/site-packages/pyvips/__init__.py:19
+     18 try:
+---> 19     import _libvips
+     21     logger.debug('Loaded binary module _libvips')
+
+ModuleNotFoundError: No module named '_libvips'
+```
+
+To resolve this, you'll need to install `vips` with `brew install vips`, because this is a dependency that `pyvips` has. If you're using conda, you'll have to also tell your conda environment where homebrew installed `vips`. You can do this with:
+
+```
+mkdir -p ~/miniconda3/envs/<CONDA_ENV_NAME>/etc/conda/activate.d
+touch ~/miniconda3/envs/<CONDA_ENV_NAME>/etc/conda/activate.d/env_vars.sh
+echo 'export DYLD_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_LIBRARY_PATH' >> ~/miniconda3/envs/<CONDA_ENV_NAME>/etc/conda/activate.d/env_vars.sh
+```

--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -183,7 +183,7 @@ class H5ADDataFile:
 
     def extract_anndata_elements_from_file(self):
         logging.info(f"Reading in AnnData dataset: {path.basename(self.input_filename)}")
-        self.anndata = anndata.read_h5ad(self.input_filename, backed="r")
+        self.anndata = anndata.read_h5ad(self.input_filename)
         logging.info("Completed reading in AnnData dataset!")
 
         self.obs = self.transform_dataframe_index_into_column(self.anndata.obs, "obs", self.obs_index_column_name)


### PR DESCRIPTION
## Reason for Change

https://czi.atlassian.net/browse/VC-1333

## Changes

Reverts the change to use backed mode when reading in anndata. The most time intensive part of CXG conversion is writing tiledb arrays from the anndata, and needing to read anndata in from disk instead of memory is almost certainly the cause of the performance degradation we saw.

This change will increase our memory usage, which will require us to beef up our machines to use more memory to avoid OOM errors. But it should decrease our overall time spent on CXG conversion.

I also added some documentation changes because I had to spend some time fiddling around with my local environment before I could get this to work.

## Testing steps

I wrote a very simple Jupyter notebook to time CXG conversion locally:

```
import time

from backend.layers.processing.h5ad_data_file import H5ADDataFile

start = time.time()

h5ad = H5ADDataFile("liver.h5ad")
cxg = h5ad.to_cxg("liver.cxg", 100, "dataset-id")

end = time.time()
print(end - start)
```

When we were in backed mode, this took 7.6 seconds. When we were not in backed mode, this went down to 3.2 seconds.

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

^ none applicable

## Notes for Reviewer
