### PR TITLE
fix(gha): upgrade GHA upload & download to major version 4.

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -178,12 +178,13 @@ jobs:
           npx playwright install --with-deps
           cp src/configs/${DEPLOYMENT_STAGE}.js src/configs/configs.js
           DEBUG=pw:api npm run e2e-${DEPLOYMENT_STAGE}-logged-in
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: logged-in-test-results
           path: frontend/playwright-report/
           retention-days: 30
+          if-no-files-found: error
       ### Need to write success failure way because Github API doesn't allow doing
       ### "if: always(), state: ${{ success() }}:
       - name: Set deployment status to success if no errors
@@ -256,19 +257,21 @@ jobs:
 
       - name: Upload FE test results as an artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
           retention-days: 14
+          if-no-files-found: error
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: all-blob-reports
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/blob-report
           retention-days: 1
+          if-no-files-found: error
 
   e2e-test:
     if: always()

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -262,7 +262,6 @@ jobs:
           name: playwright-report ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
           retention-days: 14
-          if-no-files-found: error
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: always()

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -11,7 +11,6 @@ on:
   workflow_call:
 
 env:
-  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   DEPLOYMENT_STAGE: test
   # Force using BuildKit instead of normal Docker, required so that metadata
   # is written/read to allow us to use layers of previous builds as cache.
@@ -103,17 +102,17 @@ jobs:
           make local-unit-test-backend
 
       - name: Upload coverage results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-backennd
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/.coverage*
           retention-days: 3
           include-hidden-files: true
 
       - name: Upload Allure results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-backed
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/allure-results
           retention-days: 20
 
@@ -164,17 +163,17 @@ jobs:
           make local-unit-test-wmg-backend
 
       - name: Upload coverage results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-wmg-backend
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/.coverage*
           retention-days: 3
           include-hidden-files: true
 
       - name: Upload Allure results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-wmg-backend
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/allure-results
           retention-days: 20
 
@@ -225,17 +224,17 @@ jobs:
           make local-unit-test-de-backend
 
       - name: Upload coverage results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-de-backend
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/.coverage*
           retention-days: 3
           include-hidden-files: true
 
       - name: Upload Allure results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-de-backend
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/allure-results
           retention-days: 20
 
@@ -286,17 +285,17 @@ jobs:
           make local-unit-test-processing
 
       - name: Upload coverage results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-processing
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/.coverage*
           retention-days: 3
           include-hidden-files: true
 
       - name: Upload Allure results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-processing
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/allure-results
           retention-days: 20
           include-hidden-files: true
@@ -347,16 +346,16 @@ jobs:
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make local-unit-test-wmg-processing
       - name: Upload coverage results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-wmg-processing
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/.coverage*
           retention-days: 3
           include-hidden-files: true
       - name: Upload Allure results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-wmg-processing
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/allure-results
           retention-days: 20
       - uses: 8398a7/action-slack@v3.15.0
@@ -405,16 +404,16 @@ jobs:
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make local-unit-test-cellguide-pipeline
       - name: Upload coverage results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-cellguide-pipeline
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/.coverage*
           retention-days: 3
           include-hidden-files: true
       - name: Upload Allure results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-cellguide-pipeline
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/allure-results
           retention-days: 20
       - uses: 8398a7/action-slack@v3.15.0
@@ -464,17 +463,17 @@ jobs:
           make local-unit-test-cxg-admin
 
       - name: Upload coverage results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-cxg-admin
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/.coverage*
           retention-days: 3
           include-hidden-files: true
 
       - name: Upload Allure results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-cxg-admin
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/allure-results
           retention-days: 20
 
@@ -524,17 +523,17 @@ jobs:
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make local-integration-test-backend
       - name: Upload coverage results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-backend-integration
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/.coverage*
           retention-days: 3
           include-hidden-files: true
 
       - name: Upload Allure results as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-backend-integration
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/allure-results
           retention-days: 20
       - uses: 8398a7/action-slack@v3.15.0
@@ -570,18 +569,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: coverage
+          name: coverage-* # Download all coverage artifacts
+          merge-multiple: true
           path: .
       - name: coverage report
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make coverage/report-xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
           files: ./coverage.xml
           flags: unittests
@@ -600,10 +599,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-* # Download all allure-results artifacts
           path: allure-results
+          merge-multiple: true
 
       # Checkout gh-pages branch and get Allure result history
       - name: Get Allure history

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -571,7 +571,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/download-artifact@v4
         with:
-          name: coverage-* # Download all coverage artifacts
+          pattern: coverage-* # Download all coverage artifacts
           merge-multiple: true
           path: .
       - name: coverage report
@@ -581,6 +581,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
           files: ./coverage.xml
           flags: unittests
@@ -601,7 +602,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: allure-results-* # Download all allure-results artifacts
+          pattern: allure-results-* # Download all allure-results artifacts
           path: allure-results
           merge-multiple: true
 

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -119,7 +119,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: all-blob-reports
+          name: all-blob-reports-${{ matrix.project }}-${{ matrix.shardCurrent }}
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/blob-report
           retention-days: 1
           if-no-files-found: error
@@ -127,7 +127,7 @@ jobs:
       # Upload Allure results as an artifact
       - uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-${{ matrix.project }}-${{ matrix.shardCurrent }}
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/allure-results
           retention-days: 20
           if-no-files-found: error
@@ -167,8 +167,9 @@ jobs:
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: all-blob-reports
+          pattern: all-blob-reports-*
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/blob-reports
+          merge-multiple: true
 
       - name: Merge into HTML Report
         run: npx playwright merge-reports --reporter html ./blob-reports

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -113,7 +113,6 @@ jobs:
           name: playwright-report ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
           retention-days: 14
-          if-no-files-found: error
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: always()

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -108,26 +108,29 @@ jobs:
 
       - name: Upload FE test results as an artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
           retention-days: 14
+          if-no-files-found: error
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: all-blob-reports
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/blob-report
           retention-days: 1
+          if-no-files-found: error
 
       # Upload Allure results as an artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: allure-results
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/allure-results
           retention-days: 20
+          if-no-files-found: error
 
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
@@ -162,7 +165,7 @@ jobs:
         run: npm ci
 
       - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: all-blob-reports
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/blob-reports
@@ -171,11 +174,12 @@ jobs:
         run: npx playwright merge-reports --reporter html ./blob-reports
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-report--attempt-${{ github.run_attempt }}
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
           retention-days: 30
+          if-no-files-found: error
 
   # https://github.com/myieye/web-languageforge/blob/develop/.github/workflows/e2e-tests.yml
   e2e-test:
@@ -232,3 +236,4 @@ jobs:
           name: logged-in-test-results
           path: frontend/playwright-report/
           retention-days: 30
+          if-no-files-found: error


### PR DESCRIPTION
## Reason for Change

- V3 was deprecated on Nov 30thm 2024.

## Changes
- upgrade actions/download-artifact to V4
- upgrade actions/upload-artifact to V4
- use unique names to upload artifacts.

## Testing steps

- verify allure report is generated
- verify code coverage is submitted
