### PR TITLE
chore: lower compute resource requirements for dataset metadata update

### DIFF
--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -108,7 +108,7 @@ resource aws_batch_job_definition dataset_metadata_update {
   "command": ["python3", "-m", "backend.layers.processing.dataset_metadata_update"],
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
-  "memory": var.batch_container_memory_limit,
+  "memory": 8000,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",
@@ -139,11 +139,7 @@ resource aws_batch_job_definition dataset_metadata_update {
       "value": "${var.remote_dev_prefix}"
     }
   ],
-  "vcpus": 8,
-  "linuxParameters": {
-     "maxSwap": 800000,
-     "swappiness": 60
-  },
+  "vcpus": 1,
   "retryStrategy": {
     "attempts": 3,
     "evaluateOnExit": [
@@ -202,10 +198,6 @@ resource aws_batch_job_definition rollback {
     }
   ],
   "vcpus": 1,
-  "linuxParameters": {
-     "maxSwap": 0,
-     "swappiness": 0
-  },
   "retryStrategy": {
     "attempts": 3,
     "evaluateOnExit": [

--- a/backend/layers/processing/dataset_metadata_update.py
+++ b/backend/layers/processing/dataset_metadata_update.py
@@ -7,8 +7,8 @@ import logging
 import os
 from multiprocessing import Process
 
-import scanpy
 import tiledb
+from cellxgene_schema.utils import read_h5ad
 
 from backend.common.utils.corpora_constants import CorporaConstants
 from backend.layers.business.business import BusinessLogic
@@ -66,7 +66,7 @@ class DatasetMetadataUpdaterWorker(ProcessValidate):
             local_path=CorporaConstants.ORIGINAL_H5AD_ARTIFACT_FILENAME,
         )
         try:
-            adata = scanpy.read_h5ad(raw_h5ad_filename)
+            adata = read_h5ad(raw_h5ad_filename)
             for key, val in metadata_update.as_dict_without_none_values().items():
                 if key in adata.uns:
                     adata.uns[key] = val
@@ -101,7 +101,7 @@ class DatasetMetadataUpdaterWorker(ProcessValidate):
             local_path=CorporaConstants.LABELED_H5AD_ARTIFACT_FILENAME,
         )
         try:
-            adata = scanpy.read_h5ad(h5ad_filename)
+            adata = read_h5ad(h5ad_filename)
             metadata = current_dataset_version.metadata
             # maps artifact name for metadata field to DB field name, if different
             for key, val in metadata_update.as_dict_without_none_values().items():

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,7 +1,7 @@
 anndata==0.11.2
 awscli
 boto3>=1.11.17
-git+https://github.com/chanzuckerberg/single-cell-curation/@nayib/test-anndata-0-11-migration#subdirectory=cellxgene_schema_cli
+git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
 dask==2024.12.0
 dataclasses-json
 ddtrace==2.1.4
@@ -15,7 +15,6 @@ pydantic>=1.9.0
 python-json-logger
 pyvips==2.2.2
 requests>=2.22.0
-rpy2==3.5.16
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
 s3fs==0.4.2
 scanpy==1.9.8

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -6,7 +6,6 @@ import pytest
 import scanpy
 import tiledb
 from parameterized import parameterized
-from rpy2.robjects.packages import importr
 
 from backend.common.utils.corpora_constants import CorporaConstants
 from backend.layers.common.entities import (
@@ -27,8 +26,6 @@ from backend.layers.processing.utils.cxg_generation_utils import convert_diction
 from backend.layers.thirdparty.s3_provider_mock import MockS3Provider
 from tests.unit.backend.layers.common.base_test import DatasetArtifactUpdate, DatasetStatusUpdate
 from tests.unit.processing.base_processing_test import BaseProcessingTest
-
-base = importr("base")
 
 
 def mock_process(target, args=()):

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -50,7 +50,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
         self.updater.download_from_source_uri = Mock(side_effect=mock_download)
 
     @patch("backend.common.utils.dl_sources.uri.downloader")
-    @patch("scanpy.read_h5ad")
+    @patch("cellxgene_schema.utils.read_h5ad")
     @patch("backend.layers.processing.dataset_metadata_update.S3Provider", Mock(side_effect=MockS3Provider))
     @patch("backend.layers.processing.dataset_metadata_update.DatabaseProvider", Mock(side_effect=DatabaseProviderMock))
     @patch("backend.layers.processing.dataset_metadata_update.DatasetMetadataUpdaterWorker")
@@ -97,7 +97,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
         assert self.updater.s3_provider.uri_exists(f"s3://artifact_bucket/{new_dataset_version_id}/raw.h5ad")
 
     @patch("backend.common.utils.dl_sources.uri.downloader")
-    @patch("scanpy.read_h5ad")
+    @patch("cellxgene_schema.utils.read_h5ad")
     @patch("backend.layers.processing.dataset_metadata_update.S3Provider", Mock(side_effect=MockS3Provider))
     @patch("backend.layers.processing.dataset_metadata_update.DatabaseProvider", Mock(side_effect=DatabaseProviderMock))
     @patch("backend.layers.processing.dataset_metadata_update.DatasetMetadataUpdaterWorker")
@@ -148,7 +148,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
         assert self.updater.s3_provider.uri_exists(f"s3://artifact_bucket/{new_dataset_version_id}/raw.h5ad")
 
     @patch("backend.common.utils.dl_sources.uri.downloader")
-    @patch("scanpy.read_h5ad")
+    @patch("cellxgene_schema.utils.read_h5ad")
     @patch("backend.layers.processing.dataset_metadata_update.S3Provider", Mock(side_effect=MockS3Provider))
     @patch("backend.layers.processing.dataset_metadata_update.DatabaseProvider", Mock(side_effect=DatabaseProviderMock))
     @patch("backend.layers.processing.dataset_metadata_update.DatasetMetadataUpdaterWorker")
@@ -251,7 +251,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             )
 
     @patch("backend.common.utils.dl_sources.uri.downloader")
-    @patch("scanpy.read_h5ad")
+    @patch("cellxgene_schema.utils.read_h5ad")
     @patch("backend.layers.processing.dataset_metadata_update.DatasetMetadataUpdater")
     def test_update_metadata__missing_labeled_h5ad(self, *args):
         current_dataset_version = self.generate_dataset(
@@ -287,7 +287,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
         assert new_dataset_version.status.rds_status == DatasetConversionStatus.SKIPPED
 
     @patch("backend.common.utils.dl_sources.uri.downloader")
-    @patch("scanpy.read_h5ad")
+    @patch("cellxgene_schema.utils.read_h5ad")
     @patch("backend.layers.processing.dataset_metadata_update.S3Provider", Mock(side_effect=MockS3Provider))
     @patch("backend.layers.processing.dataset_metadata_update.DatabaseProvider", Mock(side_effect=DatabaseProviderMock))
     @patch("backend.layers.processing.dataset_metadata_update.DatasetMetadataUpdater")
@@ -325,7 +325,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
         assert new_dataset_version.status.rds_status == DatasetConversionStatus.SKIPPED
 
     @patch("backend.common.utils.dl_sources.uri.downloader")
-    @patch("scanpy.read_h5ad")
+    @patch("cellxgene_schema.utils.read_h5ad")
     @patch("backend.layers.processing.dataset_metadata_update.DatasetMetadataUpdater")
     def test_update_metadata__invalid_artifact_status(self, *args):
         current_dataset_version = self.generate_dataset(
@@ -367,7 +367,7 @@ class TestDatasetMetadataUpdaterWorker(BaseProcessingTest):
 
     @patch("backend.common.utils.dl_sources.uri.downloader")
     @patch("backend.layers.processing.dataset_metadata_update.os.remove")
-    @patch("scanpy.read_h5ad")
+    @patch("cellxgene_schema.utils.read_h5ad")
     def test_update_raw_h5ad(self, mock_read_h5ad, *args):
         collection_version = self.generate_unpublished_collection(add_datasets=1)
         current_dataset_version = collection_version.datasets[0]
@@ -412,7 +412,7 @@ class TestDatasetMetadataUpdaterWorker(BaseProcessingTest):
 
     @patch("backend.common.utils.dl_sources.uri.downloader")
     @patch("backend.layers.processing.dataset_metadata_update.os.remove")
-    @patch("scanpy.read_h5ad")
+    @patch("cellxgene_schema.utils.read_h5ad")
     def test_update_h5ad(self, mock_read_h5ad, *args):
         collection_version = self.generate_unpublished_collection(add_datasets=1)
         current_dataset_version = collection_version.datasets[0]


### PR DESCRIPTION
## Reason for Change

- use dask/chunk based anndata reads from cellxgene_schema to lower resources required for dataset metadata update batch job

## Changes

- use dask/chunk based read_h5ad from cellxgene_schema library
- remove rpy2 dependency from processing image now that seurat is deprecated

## Testing steps

- rdev testing [tbd]