### PR TITLE
chore: pin COG to < 2

### DIFF
--- a/backend/common/census_cube/utils.py
+++ b/backend/common/census_cube/utils.py
@@ -12,7 +12,7 @@ from urllib3.util import Retry
 from backend.common.census_cube.data.snapshot import CensusCubeSnapshot
 
 # exported and used by all modules related to the census cube
-ontology_parser = OntologyParser()
+ontology_parser = OntologyParser(schema_version="v5.2.0")
 
 
 def find_all_dim_option_values(snapshot, organism: str, dimension: str) -> list:

--- a/backend/portal/api/enrichment.py
+++ b/backend/portal/api/enrichment.py
@@ -11,7 +11,7 @@ from cellxgene_ontology_guide.ontology_parser import OntologyParser
 
 from backend.layers.common.entities import DatasetVersion
 
-ONTOLOGY_PARSER = OntologyParser()
+ONTOLOGY_PARSER = OntologyParser(schema_version="v5.2.0")
 
 ACCEPTED_TISSUE_ANCESTORS = {
     term

--- a/python_dependencies/backend/de/requirements.txt
+++ b/python_dependencies/backend/de/requirements.txt
@@ -2,7 +2,7 @@ pandas~=2.2.2
 scipy~=1.13.1
 pydantic<3
 numba~=0.59.1
-cellxgene-ontology-guide~=1.0.0
+cellxgene-ontology-guide==1.3.1
 tiledb
 psutil~=5.9.8
 pyarrow==16.0.0

--- a/python_dependencies/backend/de/requirements.txt
+++ b/python_dependencies/backend/de/requirements.txt
@@ -2,7 +2,7 @@ pandas~=2.2.2
 scipy~=1.13.1
 pydantic<3
 numba~=0.59.1
-cellxgene-ontology-guide==1.3.1
+cellxgene-ontology-guide<2
 tiledb
 psutil~=5.9.8
 pyarrow==16.0.0

--- a/python_dependencies/backend/requirements.txt
+++ b/python_dependencies/backend/requirements.txt
@@ -4,7 +4,7 @@ boto3>=1.11.17
 botocore>=1.14.17
 connexion[swagger-ui]==2.14.2
 dataclasses-json==0.6.6
-cellxgene-ontology-guide==1.3.1
+cellxgene-ontology-guide<2
 # TODO: Check if this is really essential for APM tracing
 # see ticket: https://github.com/chanzuckerberg/single-cell-data-portal/issues/5821
 datadog==0.49.1

--- a/python_dependencies/backend/requirements.txt
+++ b/python_dependencies/backend/requirements.txt
@@ -4,7 +4,7 @@ boto3>=1.11.17
 botocore>=1.14.17
 connexion[swagger-ui]==2.14.2
 dataclasses-json==0.6.6
-cellxgene-ontology-guide<2
+cellxgene-ontology-guide==1.3.1
 # TODO: Check if this is really essential for APM tracing
 # see ticket: https://github.com/chanzuckerberg/single-cell-data-portal/issues/5821
 datadog==0.49.1

--- a/python_dependencies/backend/wmg/requirements.txt
+++ b/python_dependencies/backend/wmg/requirements.txt
@@ -1,7 +1,7 @@
 pandas~=2.2.2
 pydantic<3
 numba~=0.59.1
-cellxgene-ontology-guide~=1.0.0
+cellxgene-ontology-guide==1.3.1
 tiledb
 psutil~=5.9.8
 pyarrow==16.0.0

--- a/python_dependencies/backend/wmg/requirements.txt
+++ b/python_dependencies/backend/wmg/requirements.txt
@@ -1,7 +1,7 @@
 pandas~=2.2.2
 pydantic<3
 numba~=0.59.1
-cellxgene-ontology-guide==1.3.1
+cellxgene-ontology-guide<2
 tiledb
 psutil~=5.9.8
 pyarrow==16.0.0

--- a/python_dependencies/cellguide_pipeline/requirements.txt
+++ b/python_dependencies/cellguide_pipeline/requirements.txt
@@ -2,7 +2,7 @@ anndata>=0.10.1
 awscli==1.29.34
 boto3==1.28.7
 cellxgene-census>=1.16.2
-cellxgene-ontology-guide~=1.0.0
+cellxgene-ontology-guide<2
 ddtrace==2.1.4
 numba>=0.58.0
 numpy>=1.24.0,<2.1.0

--- a/python_dependencies/wmg_processing/requirements.txt
+++ b/python_dependencies/wmg_processing/requirements.txt
@@ -3,7 +3,7 @@ anndata>=0.10.1
 boto3==1.28.7
 botocore>=1.31.7, <1.32.0
 cellxgene-census>=1.16.2 # WMG pipeline always reads the latest version of Census so we need to use the latest package version
-cellxgene-ontology-guide~=1.0.0
+cellxgene-ontology-guide<2
 dataclasses-json==0.5.7
 ddtrace==2.1.4
 numba>=0.58.0


### PR DESCRIPTION
## Reason for Change

updates all of the COG versions in data portal to <2, and specifies the schema version in the OntologyParser as 5.2.0. this means we'll fetch the latest version of COG that's compliant with 5.2.0.

when we bump the schema version in the future, we'll need to bump the version specified in OntologyParser. i've added this to step 10 in the [confluence page](https://czi.atlassian.net/wiki/spaces/SCI/pages/2967797841/How+to+run+a+schema+migration)

## Testing steps

let's see what happens with the unit tests

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

not applicable here

## Notes for Reviewer
