### PR TITLE
fix: Happy upload-artifact blob name

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -267,7 +267,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: all-blob-reports
+          name: all-blob-reports-${{ matrix.project }}-${{ matrix.shardCurrent }}
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/blob-report
           retention-days: 1
           if-no-files-found: error


### PR DESCRIPTION
## Reason for Change

 Happy Deploy fails on upload artifact

## Changes

- Added dynamic name per shard for blob reports
