### PR TITLE
fix: e2e-logged-in-test failing on upload artifacts in prod

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -261,7 +261,6 @@ jobs:
           name: playwright-report ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
           retention-days: 14
-          if-no-files-found: error
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: always()

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -184,7 +184,6 @@ jobs:
           name: logged-in-test-results
           path: frontend/playwright-report/
           retention-days: 30
-          if-no-files-found: error
       ### Need to write success failure way because Github API doesn't allow doing
       ### "if: always(), state: ${{ success() }}:
       - name: Set deployment status to success if no errors
@@ -262,6 +261,7 @@ jobs:
           name: playwright-report ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
           path: /home/runner/work/single-cell-data-portal/single-cell-data-portal/frontend/playwright-report
           retention-days: 14
+          if-no-files-found: error
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: always()


### PR DESCRIPTION
## Reason for Change

- prod deployment fails because playwrite repots are not found for e2e-logged-in-test. Otherwise these test run and pass. 

## Changes

- remove requirements that artifacts are uploaded.