### PR TITLE
fix: upgrade pydantic to <3

### DIFF
--- a/backend/common/census_cube/data/criteria.py
+++ b/backend/common/census_cube/data/criteria.py
@@ -5,19 +5,19 @@ from pydantic import BaseModel, Field
 
 class BaseQueryCriteria(BaseModel):
     organism_ontology_term_id: str
-    tissue_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
-    tissue_original_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
-    dataset_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
-    development_stage_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
-    disease_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
-    self_reported_ethnicity_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
-    sex_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
-    publication_citations: List[str] = Field(default=[], unique_items=True, min_items=0)
-    cell_type_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=0)
+    tissue_ontology_term_ids: List[str] = Field(default=[], set=True, min_length=0)
+    tissue_original_ontology_term_ids: List[str] = Field(default=[], set=True, min_length=0)
+    dataset_ids: List[str] = Field(default=[], set=True, min_length=0)
+    development_stage_ontology_term_ids: List[str] = Field(default=[], set=True, min_length=0)
+    disease_ontology_term_ids: List[str] = Field(default=[], set=True, min_length=0)
+    self_reported_ethnicity_ontology_term_ids: List[str] = Field(default=[], set=True, min_length=0)
+    sex_ontology_term_ids: List[str] = Field(default=[], set=True, min_length=0)
+    publication_citations: List[str] = Field(default=[], set=True, min_length=0)
+    cell_type_ontology_term_ids: List[str] = Field(default=[], set=True, min_length=0)
 
 
 class CensusCubeQueryCriteria(BaseQueryCriteria):
-    gene_ontology_term_ids: List[str] = Field(default=[], unique_items=True, min_items=1)
+    gene_ontology_term_ids: List[str] = Field(default=[], set=True, min_length=1)
 
 
 class MarkerGeneQueryCriteria(BaseModel):

--- a/python_dependencies/backend/de/requirements.txt
+++ b/python_dependencies/backend/de/requirements.txt
@@ -1,6 +1,6 @@
 pandas~=2.2.2
 scipy~=1.13.1
-pydantic~=1.10.7
+pydantic<3
 numba~=0.59.1
 cellxgene-ontology-guide~=1.0.0
 tiledb

--- a/python_dependencies/backend/requirements.txt
+++ b/python_dependencies/backend/requirements.txt
@@ -16,7 +16,7 @@ gunicorn[gevent]==22.0.0
 matplotlib>=3.6.3, <3.7 # 3.7.0 isn't compatible with scanpy: https://github.com/scverse/scanpy/issues/2411
 psutil>=5.9.5, <6
 psycopg2-binary==2.*
-pydantic>=1.10.7, <2
+pydantic<3
 python-jose[cryptography]>=3.1.0
 python-json-logger
 requests>=2.22.0

--- a/python_dependencies/backend/wmg/requirements.txt
+++ b/python_dependencies/backend/wmg/requirements.txt
@@ -1,5 +1,5 @@
 pandas~=2.2.2
-pydantic~=1.10.7
+pydantic<3
 numba~=0.59.1
 cellxgene-ontology-guide~=1.0.0
 tiledb

--- a/python_dependencies/cellguide_pipeline/requirements.txt
+++ b/python_dependencies/cellguide_pipeline/requirements.txt
@@ -9,7 +9,7 @@ numpy>=1.24.0,<2.1.0
 openai==0.27.7
 pandas==2.2.1
 psutil==5.9.5
-ppydantic==2.6.4
+pydantic==2.6.4
 requests==2.31.0
 scipy==1.11.1
 tiledb

--- a/python_dependencies/cellguide_pipeline/requirements.txt
+++ b/python_dependencies/cellguide_pipeline/requirements.txt
@@ -9,7 +9,7 @@ numpy>=1.24.0,<2.1.0
 openai==0.27.7
 pandas==2.2.1
 psutil==5.9.5
-pydantic<3
+ppydantic==2.6.4
 requests==2.31.0
 scipy==1.11.1
 tiledb

--- a/python_dependencies/cellguide_pipeline/requirements.txt
+++ b/python_dependencies/cellguide_pipeline/requirements.txt
@@ -9,7 +9,7 @@ numpy>=1.24.0,<2.1.0
 openai==0.27.7
 pandas==2.2.1
 psutil==5.9.5
-pydantic==2.6.4
+pydantic<3
 requests==2.31.0
 scipy==1.11.1
 tiledb

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -11,7 +11,7 @@ pandas>2,<3
 psutil>=5.9.0
 psycopg2-binary==2.*
 pyarrow>=1.0
-pydantic>=1.9.0
+pydantic<3
 python-json-logger
 pyvips==2.2.2
 requests>=2.22.0

--- a/python_dependencies/wmg_processing/requirements.txt
+++ b/python_dependencies/wmg_processing/requirements.txt
@@ -12,7 +12,7 @@ openai==0.27.7
 pandas==2.2.1
 psutil==5.9.5
 pyarrow==12.0.0
-pydantic==1.10.7
+pydantic<3
 pygraphviz==1.11
 python-json-logger==2.0.7
 requests>=2.22.0


### PR DESCRIPTION
## Reason for Change

- There are some model validation and conversion function that are in pydantic V2 that would be helpful in the new manifest schema.

## Changes

- Update pydantic version to be < 3
- Update deprecated pydantic terms.

## Testing steps

- Verified unit test pass
