### PR TITLE
fix: curation api tests now run

### DIFF
--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -2853,20 +2853,15 @@ class TestPutLink(BaseAPIPortalTest):
         for auth_type, header in headers:
             with self.subTest(f"{auth_type}, unpublished collection"):
                 dataset = self.generate_dataset(
-                    statuses=[
-                        DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)
-                    ],
+                    statuses=[DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)],
                 )
                 _test_create(dataset.collection_id, dataset.dataset_id, header)
-
 
             with self.subTest(f"{auth_type}, revision"):
                 collection_id = self.generate_published_collection().collection_id
                 revision = self.generate_revision(collection_id)
                 dataset = self.generate_dataset(
-                    statuses=[
-                        DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)
-                    ],
+                    statuses=[DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)],
                     collection_version=revision,
                 )
                 _test_create(revision.version_id, dataset.dataset_id, header)
@@ -2885,7 +2880,6 @@ class TestPutLink(BaseAPIPortalTest):
                 headers=headers,
             )
             self.assertEqual(202, response.status_code)
-
 
         headers = [("owner", self.make_owner_header()), ("super curator", self.make_super_curator_header())]
         for auth_type, header in headers:

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -2848,26 +2848,28 @@ class TestPutLink(BaseAPIPortalTest):
                 headers=headers,
             )
             self.assertEqual(202, response.status_code)
-            headers = [("owner", self.make_owner_header()), ("super curator", self.make_super_curator_header())]
-            for auth_type, header in headers:
-                with self.subTest(f"{auth_type}, unpublished collection"):
-                    dataset = self.generate_dataset(
-                        statuses=[
-                            DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)
-                        ],
-                    )
-                    _test_create(dataset.collection_id, dataset.dataset_id, header)
 
-                with self.subTest(f"{auth_type}, revision"):
-                    collection_id = self.generate_published_collection().collection_id
-                    revision = self.generate_revision(collection_id)
-                    dataset = self.generate_dataset(
-                        statuses=[
-                            DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)
-                        ],
-                        collection_version=revision,
-                    )
-                    _test_create(revision.version_id, dataset.dataset_id, header)
+        headers = [("owner", self.make_owner_header()), ("super curator", self.make_super_curator_header())]
+        for auth_type, header in headers:
+            with self.subTest(f"{auth_type}, unpublished collection"):
+                dataset = self.generate_dataset(
+                    statuses=[
+                        DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)
+                    ],
+                )
+                _test_create(dataset.collection_id, dataset.dataset_id, header)
+
+
+            with self.subTest(f"{auth_type}, revision"):
+                collection_id = self.generate_published_collection().collection_id
+                revision = self.generate_revision(collection_id)
+                dataset = self.generate_dataset(
+                    statuses=[
+                        DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)
+                    ],
+                    collection_version=revision,
+                )
+                _test_create(revision.version_id, dataset.dataset_id, header)
 
     def test__existing_from_link__OK(self, *mocks):
         """
@@ -2883,22 +2885,24 @@ class TestPutLink(BaseAPIPortalTest):
                 headers=headers,
             )
             self.assertEqual(202, response.status_code)
-            headers = [("owner", self.make_owner_header()), ("super curator", self.make_super_curator_header())]
-            for auth_type, header in headers:
-                with self.subTest(f"{auth_type}, unpublished collection"):
-                    dataset = self.generate_dataset(
-                        statuses=[DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.SUCCESS)],
-                    )
-                    _test_create(dataset.collection_id, dataset.dataset_id, header)
 
-                with self.subTest(f"{auth_type}, revision"):
-                    collection_id = self.generate_published_collection().collection_id
-                    revision = self.generate_revision(collection_id)
-                    dataset = self.generate_dataset(
-                        statuses=[DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.SUCCESS)],
-                        collection_version=revision,
-                    )
-                    _test_create(revision.version_id, dataset.dataset_id, header)
+
+        headers = [("owner", self.make_owner_header()), ("super curator", self.make_super_curator_header())]
+        for auth_type, header in headers:
+            with self.subTest(f"{auth_type}, unpublished collection"):
+                dataset = self.generate_dataset(
+                    statuses=[DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.SUCCESS)],
+                )
+                _test_create(dataset.collection_id, dataset.dataset_id, header)
+
+            with self.subTest(f"{auth_type}, revision"):
+                collection_id = self.generate_published_collection().collection_id
+                revision = self.generate_revision(collection_id)
+                dataset = self.generate_dataset(
+                    statuses=[DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.SUCCESS)],
+                    collection_version=revision,
+                )
+                _test_create(revision.version_id, dataset.dataset_id, header)
 
     def test_from_link__403(self, *mocks):
         """


### PR DESCRIPTION
These tests were not running due to an indentation error, this should fix that.