### PR TITLE
feat: PUT for manifest files

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -510,6 +510,70 @@ paths:
         "410":
           $ref: "#/components/responses/410"
 
+  /v1/collections/{collection_id}/datasets/{dataset_id}/manifest:
+    put:
+      summary: Upload dataset via a manifest
+      description: |
+        Submit a manifest containing a list of files to be validated as a single dataset submission.
+        The request body must conform to the manifest schema and all files must be reachable.
+      operationId: backend.curation.api.v1.curation.collections.collection_id.datasets.dataset_id.manifest.actions.put
+      tags:
+        - Collection
+      security:
+        - curatorAccess: []
+      parameters:
+        - $ref: "#/components/parameters/path_collection_id"
+        - $ref: "#/components/parameters/path_dataset_id"
+      requestBody:
+        content:
+          application/json:
+            schema: # Schema generated from yaml.dump(IngestionManifest.model_json_schema())
+              properties:
+                anndata:
+                  anyOf:
+                    - format: uri
+                      maxLength: 2083
+                      minLength: 1
+                      type: string
+                    - format: uri
+                      minLength: 1
+                      type: string
+                  title: Anndata
+                atac_seq_fragment:
+                  type: string
+                  nullable: true
+                  # TODO: Use the more specific schema if possible
+                  # anyOf:
+                  #   - format: uri
+                  #     maxLength: 2083
+                  #     minLength: 1
+                  #     type: string
+                  #   - format: uri
+                  #     minLength: 1
+                  #     type: string
+                  #   - type: 'null'
+                  default: null
+                  title: Atac Seq Fragment
+              required:
+                - anndata
+              title: IngestionManifest
+              type: object
+      responses:
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "405":
+          $ref: "#/components/responses/405"
+        "404":
+          $ref: "#/components/responses/404"
+        "413":
+          $ref: "#/components/responses/413"
+
   /v1/collections/{collection_id}/s3-upload-credentials:
     get:
       summary: Get credentials for uploading local files

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -541,18 +541,14 @@ paths:
                   title: Anndata
                 atac_seq_fragment:
                   type: string
-                  nullable: true
-                  # TODO: Use the more specific schema if possible
-                  # anyOf:
-                  #   - format: uri
-                  #     maxLength: 2083
-                  #     minLength: 1
-                  #     type: string
-                  #   - format: uri
-                  #     minLength: 1
-                  #     type: string
-                  #   - type: 'null'
-                  default: null
+                  anyOf:
+                    - format: uri
+                      maxLength: 2083
+                      minLength: 1
+                      type: string
+                    - format: uri
+                      minLength: 1
+                      type: string
                   title: Atac Seq Fragment
               required:
                 - anndata

--- a/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
@@ -1,20 +1,16 @@
-from typing import Tuple
-
 from flask import Response, jsonify, make_response
 
 from backend.common.utils.exceptions import MaxFileSizeExceededException
 from backend.common.utils.http_exceptions import (
     ForbiddenHTTPException,
-    GoneHTTPException,
     InvalidParametersHTTPException,
     MethodNotAllowedException,
     NotFoundHTTPException,
     TooLargeHTTPException,
 )
 from backend.curation.api.v1.curation.collections.common import (
-    get_inferred_collection_version,
+    _get_collection_and_dataset,
     reshape_dataset_for_curation_api,
-    validate_uuid_else_forbidden,
 )
 from backend.layers.auth.user_info import UserInfo
 from backend.layers.business.exceptions import (
@@ -23,16 +19,12 @@ from backend.layers.business.exceptions import (
     CollectionUpdateException,
     DatasetInWrongStatusException,
     DatasetIsPrivateException,
-    DatasetIsTombstonedException,
     DatasetNotFoundException,
     InvalidMetadataException,
     InvalidURIException,
 )
 from backend.layers.common.entities import (
-    CollectionVersionWithDatasets,
     DatasetArtifactMetadataUpdate,
-    DatasetId,
-    DatasetVersion,
 )
 from backend.portal.api.providers import get_business_logic
 
@@ -47,35 +39,6 @@ def get(collection_id: str, dataset_id: str = None):
 
     response_body = reshape_dataset_for_curation_api(dataset_version, use_canonical_url)
     return make_response(jsonify(response_body), 200)
-
-
-def _get_collection_and_dataset(
-    collection_id: str, dataset_id: str
-) -> Tuple[CollectionVersionWithDatasets, DatasetVersion]:
-    """
-    Get collection and dataset by their ids. Will look up collection by version and canonical id, and dataset by
-    canonical only
-    """
-    validate_uuid_else_forbidden(collection_id)
-    validate_uuid_else_forbidden(dataset_id)
-    collection_version = get_inferred_collection_version(collection_id)
-
-    # Extract the dataset from the dataset list.
-    dataset_version = None
-    for dataset in collection_version.datasets:
-        if dataset.dataset_id.id == dataset_id:
-            dataset_version = dataset
-            break
-        if dataset.version_id.id == dataset_id:
-            raise ForbiddenHTTPException from None
-    if dataset_version is None:
-        try:
-            get_business_logic().get_dataset_version_from_canonical(DatasetId(dataset_id), get_tombstoned=True)
-        except DatasetIsTombstonedException:
-            raise GoneHTTPException() from None
-        raise NotFoundHTTPException() from None
-
-    return collection_version, dataset_version
 
 
 def delete(token_info: dict, collection_id: str, dataset_id: str, delete_published: bool = False):

--- a/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/manifest/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/manifest/actions.py
@@ -1,0 +1,58 @@
+from flask import Response
+
+from backend.common.utils.exceptions import MaxFileSizeExceededException
+from backend.common.utils.http_exceptions import (
+    ForbiddenHTTPException,
+    InvalidParametersHTTPException,
+    MethodNotAllowedException,
+    NotFoundHTTPException,
+    TooLargeHTTPException,
+)
+from backend.curation.api.v1.curation.collections.common import (
+    _get_collection_and_dataset,
+)
+from backend.layers.auth.user_info import UserInfo
+from backend.layers.business.exceptions import (
+    CollectionIsPublishedException,
+    CollectionNotFoundException,
+    DatasetInWrongStatusException,
+    DatasetNotFoundException,
+    InvalidURIException,
+)
+from backend.portal.api.providers import get_business_logic
+
+
+def put(collection_id: str, dataset_id: str, body: dict, token_info: dict):
+    # TODO: deduplicate from ApiCommon. We need to settle the class/module level debate before can do that
+    business_logic = get_business_logic()
+
+    collection_version, dataset_version = _get_collection_and_dataset(collection_id, dataset_id)
+
+    if not UserInfo(token_info).is_user_owner_or_allowed(collection_version.owner):
+        raise ForbiddenHTTPException()
+
+    try:
+        business_logic.ingest_dataset(
+            collection_version.version_id,
+            body,
+            None,
+            None if dataset_id is None else dataset_version.version_id,
+        )
+        return Response(status=202)
+    except CollectionNotFoundException:
+        raise ForbiddenHTTPException() from None
+    except CollectionIsPublishedException:
+        raise ForbiddenHTTPException() from None
+    except DatasetNotFoundException:
+        raise NotFoundHTTPException() from None
+    except InvalidURIException:
+        raise InvalidParametersHTTPException(detail="The dropbox shared link is invalid.") from None
+    except MaxFileSizeExceededException:
+        raise TooLargeHTTPException() from None
+    except DatasetInWrongStatusException:
+        raise MethodNotAllowedException(
+            detail="Submission failed. A dataset cannot be updated while a previous update for the same dataset "
+            "is in progress. Please cancel the current submission by deleting the dataset, or wait until "
+            "the submission has finished processing."
+        ) from None
+    # End of duplicate block

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -566,7 +566,7 @@ class BusinessLogic(BusinessLogicInterface):
             {
                 "message": "ingesting dataset",
                 "collection_version_id": collection_version_id,
-                "url": manifest,  # TODO: what should the behavior here be for manifest vs url?
+                "manifest": manifest,
                 "current_dataset_version_id": current_dataset_version_id,
             }
         )

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -546,7 +546,7 @@ class BusinessLogic(BusinessLogicInterface):
     def ingest_dataset(
         self,
         collection_version_id: CollectionVersionId,
-        url: str,  # TODO: change to manifest
+        manifest: dict | str,  # TODO: change to manifest
         file_size: Optional[int],
         current_dataset_version_id: Optional[DatasetVersionId],
         start_step_function: bool = True,
@@ -555,32 +555,41 @@ class BusinessLogic(BusinessLogicInterface):
         Creates a canonical dataset and starts its ingestion by invoking the step function
         If `size` is not provided, it will be inferred automatically
         """
+        # Convert old style input to new style
+        try:
+            if isinstance(manifest, str):
+                manifest = IngestionManifest(anndata=manifest)
+            else:
+                manifest = IngestionManifest(**manifest)
+        except ValidationError as e:
+            raise InvalidIngestionManifestException("Ingestion manifest is invalid.", errors=e.errors()) from e
+        urls = [str(manifest.anndata)]
+
         logger.info(
             {
                 "message": "ingesting dataset",
                 "collection_version_id": collection_version_id,
-                "url": url,  # TODO: change to manifest
+                "url": manifest,  # TODO: what should the behavior here be for manifest vs url?
                 "current_dataset_version_id": current_dataset_version_id,
             }
         )
-        try:
-            manifest = IngestionManifest(anndata=url)  # TODO: validate the json if already in manifest shape.
-        except ValidationError as e:
-            raise InvalidIngestionManifestException("Ingestion manifest is invalid.", errors=e.errors()) from e
 
         # TODO: validate all uris in the manifest
         # TODO: replace the uris with the actual uri if a uri to an existing h5ad or fragments file is provided
-        if not self.uri_provider.validate(url):
-            raise InvalidURIException(f"Trying to upload invalid URI: {url}")
+        for url in urls:
+            if not self.uri_provider.validate(url):
+                raise InvalidURIException(f"Trying to upload invalid URI: {url}")
 
         if file_size is None:
-            file_info = self.uri_provider.get_file_info(url)
+            file_info = self.uri_provider.get_file_info(str(manifest.anndata))
             file_size = file_info.size
 
         max_file_size_gb = CorporaConfig().upload_max_file_size_gb * 2**30
 
         if file_size is not None and file_size > max_file_size_gb:
-            raise MaxFileSizeExceededException(f"{url} exceeds the maximum allowed file size of {max_file_size_gb} Gb")
+            raise MaxFileSizeExceededException(
+                f"{manifest.anndata} exceeds the maximum allowed file size of {max_file_size_gb} Gb"
+            )
 
         # Ensure that the collection exists and is not published
         collection = self._assert_collection_version_unpublished(collection_version_id)

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -563,7 +563,7 @@ class BusinessLogic(BusinessLogicInterface):
                 manifest = IngestionManifest(**manifest)
         except ValidationError as e:
             raise InvalidIngestionManifestException("Ingestion manifest is invalid.", errors=e.errors()) from e
-        urls = [str(manifest.anndata)]
+        urls = [str(url) for url in manifest.dict(exclude_unset=True).values()]
 
         logger.info(
             {

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -2769,6 +2769,37 @@ class TestPostRevision(BaseAPIPortalTest):
     return_value={"size": 1, "name": "file.h5ad"},
 )
 @patch("backend.layers.thirdparty.step_function_provider.StepFunctionProvider")
+class TestPutManifest(BaseAPIPortalTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.good_h5ad_link = "https://www.dropbox.com/s/ow84zm4h0wkl409/test.h5ad?dl=0"
+        cls.dummy_h5ad_link = "https://www.dropbox.com/s/12345678901234/test.h5ad?dl=0"
+
+    def test__from_link__no_auth(self, *mocks):
+        """
+        Calling PUT /datasets/:dataset_id should fail with 401 Unauthorized if the user is not authenticated
+        """
+        dataset = self.generate_dataset(
+            statuses=[DatasetStatusUpdate(DatasetStatusKey.PROCESSING, DatasetProcessingStatus.INITIALIZED)]
+        )
+        body = {"anndata": self.good_h5ad_link}
+        headers = None
+        for id in [dataset.dataset_version_id, dataset.dataset_id]:
+            response = self.app.put(
+                f"/curation/v1/collections/{dataset.collection_id}/datasets/{id}/manifest",
+                json=body,
+                headers=headers,
+            )
+
+            self.assertEqual(401, response.status_code)
+
+
+@patch(
+    "backend.common.utils.dl_sources.uri.DropBoxURL.file_info",
+    return_value={"size": 1, "name": "file.h5ad"},
+)
+@patch("backend.layers.thirdparty.step_function_provider.StepFunctionProvider")
 class TestPutLink(BaseAPIPortalTest):
     @classmethod
     def setUpClass(cls):

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -893,7 +893,7 @@ class TestUpdateCollectionDatasets(BaseBusinessLogicTestCase):
 
         with self.assertRaises(DatasetIngestException) as ex:
             self.business_logic.ingest_dataset(version.version_id, url, None, None)
-        self.assertEqual(str(ex.exception), "Trying to upload invalid URI: http://bad.url")
+        self.assertEqual(str(ex.exception), "Trying to upload invalid URI: http://bad.url/")
 
         self.step_function_provider.start_step_function.assert_not_called()
 


### PR DESCRIPTION
## Reason for Change

- https://github.com/chanzuckerberg/single-cell/issues/738
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## TODO

- [x] Tests
  - [x] Test submission of dataset with ATAC fragments
  - [x] Fill out tests for errors at new endpoint
- [x] Features
  - ~[ ] Submit ATAC to SFN~
- [x] Open questions
  - [x] Do we need to handle file sizes for ATAC fragments? **No**

I think it would be better if `ingest_dataset` ONLY took a manifest, and that the routing layer above it had to account for transforming the JSON. But the method is called in really a lot of tests, so changing it would touch a lot of code.

## Changes

- Added a PUT endpoint for manifest files

## Testing steps

## Checklist 🛎️

## Notes for Reviewer
