### PR TITLE
fix: Census Models last-updated dates

### DIFF
--- a/frontend/src/views/CensusDirectory/components/Project/connect.ts
+++ b/frontend/src/views/CensusDirectory/components/Project/connect.ts
@@ -13,7 +13,7 @@ export const useConnect = ({ clobberedProjects }: ProjectProps) => {
       DEFAULT_EPOCH_TIME
   );
 
-  if (date.getDate() === DEFAULT_EPOCH_TIME) {
+  if (date.getTime() === DEFAULT_EPOCH_TIME) {
     clobberedProjects[1].forEach((project) => {
       const projectDate = new Date(
         project.last_updated || project.submission_date || DEFAULT_EPOCH_TIME


### PR DESCRIPTION
Several of the "Last Updated" dates on the [Census Models](https://cellxgene.cziscience.com/census-models) page show as December 31, 1969. I tracked it down to this comparison.