### PR TITLE
feat: Check other endpoints for ATAC artifacts

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -819,6 +819,7 @@ components:
         - H5AD
         - RDS
         - FRAGMENT_TSV
+        - FRAGMENT_INDEX
       type: string
       description: the file type of the asset.
     batch_condition:

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -818,8 +818,8 @@ components:
       enum:
         - H5AD
         - RDS
-        - FRAGMENT_TSV
-        - FRAGMENT_INDEX
+        - ATAC_FRAGMENT
+        - ATAC_INDEX
       type: string
       description: the file type of the asset.
     batch_condition:

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -818,6 +818,7 @@ components:
       enum:
         - H5AD
         - RDS
+        - FRAGMENT_TSV
       type: string
       description: the file type of the asset.
     batch_condition:

--- a/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/manifest/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/manifest/actions.py
@@ -45,7 +45,7 @@ def get_single_artifact_permanent_url(
         raise ValueError(f"No '{artifact_type}' artifact found.")
 
     if matches:
-        return BusinessLogic.generate_permanent_url(dataset_version.version_id, matches[0].id, artifact_type)
+        return BusinessLogic.generate_permanent_url(dataset_version, matches[0].id, artifact_type)
 
 
 def get(collection_id: str, dataset_id: str = None):

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -34,7 +34,7 @@ from backend.layers.common.entities import (
 from backend.portal.api.explorer_url import generate as generate_explorer_url
 from backend.portal.api.providers import get_business_logic
 
-allowed_dataset_asset_types = (DatasetArtifactType.H5AD, DatasetArtifactType.RDS)
+allowed_dataset_asset_types = (DatasetArtifactType.H5AD, DatasetArtifactType.RDS, DatasetArtifactType.ATAC_FRAGMENT)
 
 
 def get_collections_base_url():

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -34,7 +34,12 @@ from backend.layers.common.entities import (
 from backend.portal.api.explorer_url import generate as generate_explorer_url
 from backend.portal.api.providers import get_business_logic
 
-allowed_dataset_asset_types = (DatasetArtifactType.H5AD, DatasetArtifactType.RDS, DatasetArtifactType.ATAC_FRAGMENT)
+allowed_dataset_asset_types = (
+    DatasetArtifactType.H5AD,
+    DatasetArtifactType.RDS,
+    DatasetArtifactType.ATAC_FRAGMENT,
+    DatasetArtifactType.ATAC_INDEX,
+)
 
 
 def get_collections_base_url():
@@ -78,7 +83,7 @@ def extract_dataset_assets(dataset_version: DatasetVersion):
         filesize = get_business_logic().s3_provider.get_file_size(asset.uri)
         if filesize is None:
             filesize = -1
-        url = BusinessLogic.generate_permanent_url(dataset_version.version_id, asset.id, asset.type)
+        url = BusinessLogic.generate_permanent_url(dataset_version, asset.id, asset.type)
         result = {
             "filesize": filesize,
             "filetype": asset.type.upper(),

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -80,8 +80,8 @@ class DatasetArtifactType(str, Enum):
     H5AD = "h5ad"
     RDS = "rds"
     CXG = "cxg"
-    ATAC_FRAGMENT = "fragment_tsv"
-    ATAC_INDEX = "fragment_index"
+    ATAC_FRAGMENT = "atac_fragment"
+    ATAC_INDEX = "atac_index"
 
 
 ARTIFACT_TO_EXTENSION = {

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -81,6 +81,7 @@ class DatasetArtifactType(str, Enum):
     RDS = "rds"
     CXG = "cxg"
     ATAC_FRAGMENT = "fragment_tsv"
+    ATAC_INDEX = "fragment_index"
 
 
 ARTIFACT_TO_EXTENSION = {
@@ -89,6 +90,7 @@ ARTIFACT_TO_EXTENSION = {
     DatasetArtifactType.RDS: "rds",
     DatasetArtifactType.CXG: "cxg",
     DatasetArtifactType.ATAC_FRAGMENT: "tsv.bgz",
+    DatasetArtifactType.ATAC_INDEX: "tsv.bgz.tbi",
 }
 
 

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1824,10 +1824,10 @@ class TestGetDatasets(BaseAPIPortalTest):
 
         expected_assets = [
             {"filesize": -1, "filetype": "H5AD", "url": f"http://domain/{dataset.dataset_version_id}.h5ad"},
-            {"filesize": -1, "filetype": "FRAGMENT_TSV", "url": f"http://domain/{atac_artifact.id}.tsv.bgz"},
+            {"filesize": -1, "filetype": "ATAC_FRAGMENT", "url": f"http://domain/{atac_artifact.id}.tsv.bgz"},
             {
                 "filesize": -1,
-                "filetype": "FRAGMENT_INDEX",
+                "filetype": "ATAC_INDEX",
                 "url": f"http://domain/{atac_artifact.id}.tsv.bgz.tbi",
             },
         ]
@@ -2212,12 +2212,12 @@ class TestGetDatasets(BaseAPIPortalTest):
             },
             {
                 "filesize": -1,
-                "filetype": "FRAGMENT_TSV",
+                "filetype": "ATAC_FRAGMENT",
                 "url": f"http://domain/{atac_artifact.id}.tsv.bgz",
             },
             {
                 "filesize": -1,
-                "filetype": "FRAGMENT_INDEX",
+                "filetype": "ATAC_INDEX",
                 "url": f"http://domain/{atac_artifact.id}.tsv.bgz.tbi",
             },
         ]

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1817,26 +1817,22 @@ class TestGetDatasets(BaseAPIPortalTest):
         )
         artifacts = self.business_logic.get_dataset_artifacts(DatasetVersionId(dataset.dataset_version_id))
         atac_artifact = [a for a in artifacts if a.type == DatasetArtifactType.ATAC_FRAGMENT][0]
-        # atac_index_artifact = [a for a in artifacts if a.type == DatasetArtifactType.ATAC_INDEX][0]
 
         test_url = f"/curation/v1/collections/{dataset.collection_id}/datasets/{dataset.dataset_id}"
         response = self.app.get(test_url)
         body = response.json
 
-        # assert len(artifacts) == 3
+        expected_assets = [
+            {"filesize": -1, "filetype": "H5AD", "url": f"http://domain/{dataset.dataset_version_id}.h5ad"},
+            {"filesize": -1, "filetype": "FRAGMENT_TSV", "url": f"http://domain/{atac_artifact.id}.tsv.bgz"},
+            {
+                "filesize": -1,
+                "filetype": "FRAGMENT_INDEX",
+                "url": f"http://domain/{atac_artifact.id}.tsv.bgz.tbi",
+            },
+        ]
 
-        self.assertEqual(
-            [
-                {"filesize": -1, "filetype": "H5AD", "url": f"http://domain/{dataset.dataset_version_id}.h5ad"},
-                {"filesize": -1, "filetype": "FRAGMENT_TSV", "url": f"http://domain/{atac_artifact.id}.tsv.bgz"},
-                {
-                    "filesize": -1,
-                    "filetype": "FRAGMENT_INDEX",
-                    "url": f"http://domain/{atac_artifact.id}.tsv.bgz.tbi",
-                },
-            ],
-            body["assets"],
-        )
+        assert expected_assets == body["assets"]
 
     def test_get_all_datasets_200(self):
         crossref_return_value_1 = (generate_mock_publisher_metadata(), "12.3456/j.celrep", 17169328.664)

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1812,7 +1812,7 @@ class TestGetDatasets(BaseAPIPortalTest):
             artifacts=[
                 DatasetArtifactUpdate(DatasetArtifactType.H5AD, "http://mock.uri/asset.h5ad"),
                 DatasetArtifactUpdate(DatasetArtifactType.ATAC_FRAGMENT, "http://mock.uri/atac_frags.tsv.bgz"),
-                DatasetArtifactUpdate(DatasetArtifactType.ATAC_INDEX, "http://mock.uri/atac_frags.tsv.bgz"),
+                DatasetArtifactUpdate(DatasetArtifactType.ATAC_INDEX, "http://mock.uri/atac_frags.tsv.bgz.tbi"),
             ]
         )
         artifacts = self.business_logic.get_dataset_artifacts(DatasetVersionId(dataset.dataset_version_id))
@@ -2195,7 +2195,7 @@ class TestGetDatasets(BaseAPIPortalTest):
             artifacts=[
                 DatasetArtifactUpdate(DatasetArtifactType.H5AD, "http://mock.uri/asset.h5ad"),
                 DatasetArtifactUpdate(DatasetArtifactType.ATAC_FRAGMENT, "http://mock.uri/atac_frags.tsv.bgz"),
-                DatasetArtifactUpdate(DatasetArtifactType.ATAC_INDEX, "http://mock.uri/atac_frags.tsv.bgz"),
+                DatasetArtifactUpdate(DatasetArtifactType.ATAC_INDEX, "http://mock.uri/atac_frags.tsv.bgz.tbi"),
             ],
         )
         self.business_logic.publish_collection_version(collection.version_id)

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1812,21 +1812,28 @@ class TestGetDatasets(BaseAPIPortalTest):
             artifacts=[
                 DatasetArtifactUpdate(DatasetArtifactType.H5AD, "http://mock.uri/asset.h5ad"),
                 DatasetArtifactUpdate(DatasetArtifactType.ATAC_FRAGMENT, "http://mock.uri/atac_frags.tsv.bgz"),
+                DatasetArtifactUpdate(DatasetArtifactType.ATAC_INDEX, "http://mock.uri/atac_frags.tsv.bgz"),
             ]
         )
         artifacts = self.business_logic.get_dataset_artifacts(DatasetVersionId(dataset.dataset_version_id))
         atac_artifact = [a for a in artifacts if a.type == DatasetArtifactType.ATAC_FRAGMENT][0]
+        # atac_index_artifact = [a for a in artifacts if a.type == DatasetArtifactType.ATAC_INDEX][0]
 
         test_url = f"/curation/v1/collections/{dataset.collection_id}/datasets/{dataset.dataset_id}"
         response = self.app.get(test_url)
         body = response.json
 
-        assert len(artifacts) == 2
+        # assert len(artifacts) == 3
 
         self.assertEqual(
             [
                 {"filesize": -1, "filetype": "H5AD", "url": f"http://domain/{dataset.dataset_version_id}.h5ad"},
                 {"filesize": -1, "filetype": "FRAGMENT_TSV", "url": f"http://domain/{atac_artifact.id}.tsv.bgz"},
+                {
+                    "filesize": -1,
+                    "filetype": "FRAGMENT_INDEX",
+                    "url": f"http://domain/{atac_artifact.id}.tsv.bgz.tbi",
+                },
             ],
             body["assets"],
         )


### PR DESCRIPTION
## Reason for Change

- https://github.com/chanzuckerberg/single-cell/issues/741

## Changes

- added FRAGMENT_INDEX artifact type
- modified permanent url resolution code to account for URI for fragment indices
- added tests checking that atac artifacts are returned by the API

## Notes for reviewer

In the specification doc there is some inconsistency around what the index artifact is called. I went with `FRAGMENT_INDEX` but `FRAGMENT_TABIX` is also used in the spec.