### PR TITLE
test artifact retention after dataset deletion

### DIFF
--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1605,7 +1605,7 @@ class TestGetDatasets(BaseAPIPortalTest):
         self.business_logic.publish_collection_version(collection_original.version_id)
 
         response_original = self.app.get(
-            f"/curation/v1/collections/{collection_original.version_id}/datasets/{dataset_original.dataset_id}",
+            f"/curation/v1/collections/{collection_original.collection_id}/datasets/{dataset_original.dataset_id}",
             # f"/curation/v1/collections/{collection_original.collection_id}/datasets/{dataset_original.dataset_version_id}",
             # f"/curation/v1/collections/{collection_original.collection_id}/datasets/{dataset_original.dataset_id}",
         )
@@ -1616,18 +1616,16 @@ class TestGetDatasets(BaseAPIPortalTest):
         assert len(collection_revised.datasets) == 2
 
         response_delete = self.app.delete(
-            f"/curation/v1/collections/{collection_revised.version_id}/datasets/{dataset_original.dataset_id}",
-            headers=self.make_owner_header(),
+            f"/curation/v1/collections/{collection_revised.version_id}/datasets/{dataset_original.dataset_id}?delete_published=true",
+            headers=self.make_cxg_admin_header(),
         )
         assert response_delete.status_code == 202, response_delete
-        self.business_logic.publish_collection_version(collection_revised.version_id)
 
         response = self.app.get(
-            f"/curation/v1/collections/{collection_original.version_id}/datasets/{dataset_original.dataset_id}",
+            f"/curation/v1/collections/{collection_original.collection_id}/datasets/{dataset_original.dataset_id}",
         )
         assert response.status_code == 200
         body = response.json
-        assert False, body
         assert body_original["assets"] == body["assets"]
 
     def test_get_dataset_in_a_collection(self):


### PR DESCRIPTION
MAIN FINDINGS:

* Curators do not have access to this endpoint
* delete_published=True is required if any version of a dataset was published. E.g. if an unpublished revision of a collection is created, you cannot delete a dataset from the new revision without passing in delete_published=True (I think this is dangerous)

## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- add
- remove
- modify

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
