### PR TITLE
feat: Add DatasetStatus.atac_status and default to skipped

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -686,7 +686,7 @@ class BusinessLogic(BusinessLogicInterface):
         )
         self.update_dataset_version_status(
             new_dataset_version.version_id,
-            DatasetStatusKey.ATAC_FRAGMENT,
+            DatasetStatusKey.ATAC,
             DatasetConversionStatus.SKIPPED,
             # TODO: remove when atac is supported
         )
@@ -907,7 +907,7 @@ class BusinessLogic(BusinessLogicInterface):
             self.database_provider.update_dataset_conversion_status(
                 dataset_version_id, "h5ad_status", new_dataset_status
             )
-        elif status_key == DatasetStatusKey.ATAC_FRAGMENT and isinstance(new_dataset_status, DatasetConversionStatus):
+        elif status_key == DatasetStatusKey.ATAC and isinstance(new_dataset_status, DatasetConversionStatus):
             self.database_provider.update_dataset_conversion_status(
                 dataset_version_id, "atac_status", new_dataset_status
             )

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -684,7 +684,6 @@ class BusinessLogic(BusinessLogicInterface):
         self.database_provider.update_dataset_processing_status(
             new_dataset_version.version_id, DatasetProcessingStatus.INITIALIZED
         )
-        self.database_provider.clear_dataset_validation_message(new_dataset_version.version_id)
         self.update_dataset_version_status(
             new_dataset_version.version_id,
             DatasetStatusKey.ATAC_FRAGMENT,

--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -161,6 +161,9 @@ class BusinessLogicInterface:
     ) -> DatasetArtifactId:
         pass
 
+    def update_dataset_artifact(self, artifact_id: DatasetArtifactId, artifact_uri: str) -> None:
+        pass
+
     def get_dataset_status(self, dataset_version_id: DatasetVersionId) -> DatasetStatus:
         pass
 

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -16,6 +16,7 @@ class DatasetStatusKey(str, Enum):
     CXG = "cxg"
     RDS = "rds"
     H5AD = "h5ad"
+    ATAC_FRAGMENT = "atac_fragment"
     PROCESSING = "processing"
 
 
@@ -116,7 +117,8 @@ class DatasetStatus:
     cxg_status: Optional[DatasetConversionStatus]
     rds_status: Optional[DatasetConversionStatus]
     h5ad_status: Optional[DatasetConversionStatus]
-    processing_status: Optional[DatasetProcessingStatus]
+    atac_status: Optional[DatasetConversionStatus] = None
+    processing_status: Optional[DatasetProcessingStatus] = None
     validation_message: Optional[str] = None
 
     @staticmethod

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -16,7 +16,7 @@ class DatasetStatusKey(str, Enum):
     CXG = "cxg"
     RDS = "rds"
     H5AD = "h5ad"
-    ATAC_FRAGMENT = "atac_fragment"
+    ATAC = "atac"
     PROCESSING = "processing"
 
 

--- a/backend/layers/processing/dataset_metadata_update.py
+++ b/backend/layers/processing/dataset_metadata_update.py
@@ -341,6 +341,10 @@ class DatasetMetadataUpdater(ProcessValidateH5AD):
                 dataset_version.status.rds_status == DatasetConversionStatus.CONVERTED
                 or dataset_version.status.rds_status == DatasetConversionStatus.SKIPPED
             )
+            and (
+                dataset_version.status.atac_status == DatasetConversionStatus.UPLOADED
+                or dataset_version.status.atac_status == DatasetConversionStatus.SKIPPED
+            )
         )
 
 

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -700,6 +700,18 @@ paths:
                     enum: [VALIDATING, VALID, INVALID, NA]
                   validation_message:
                     type: string
+                  atac_status:
+                    type: string
+                    enum:
+                      [
+                        CONVERTING,
+                        CONVERTED,
+                        UPLOADING,
+                        UPLOADED,
+                        SKIPPED,
+                        FAILED,
+                        NA,
+                      ]
                   h5ad_status:
                     type: string
                     enum:

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -93,6 +93,7 @@ def _dataset_processing_status_to_response(status: DatasetStatus, dataset_id: st
     Converts a DatasetStatus object to an object compliant to the API specifications
     """
     return {
+        "atac_status": status.atac_status or "NA",
         "created_at": 0,  # NA
         "cxg_status": status.cxg_status or "NA",
         "dataset_id": dataset_id,

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -801,6 +801,7 @@ def get_status(dataset_id: str, token_info: dict):
     version, _ = _assert_dataset_has_right_owner(DatasetVersionId(dataset_id), UserInfo(token_info))
 
     response = {
+        "atac_status": version.status.atac_status or "NA",
         "cxg_status": version.status.cxg_status or "NA",
         "rds_status": version.status.rds_status or "NA",
         "h5ad_status": version.status.h5ad_status or "NA",

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -102,23 +102,28 @@ def upload_and_wait(session, api_url, curator_cookie, collection_id, dropbox_url
             cxg_status = data.get("cxg_status")
             rds_status = data.get("rds_status")
             h5ad_status = data.get("h5ad_status")
+            atac_status = data.get("atac_status")
             assert data.get("cxg_status") in expected_conversion_statuses
             if cxg_status == "FAILED":
                 errors.append(f"CXG CONVERSION FAILED. Status: {data}, Check logs for dataset: {dataset_id}")
             if h5ad_status == "FAILED":
                 errors.append(f"Anndata CONVERSION FAILED. Status: {data}, Check logs for dataset: {dataset_id}")
+            if atac_status == "FAILED":
+                errors.append(f"Atac CONVERSION FAILED. Status: {data}, Check logs for dataset: {dataset_id}")
             if rds_status == "FAILED":
                 errors.append(f"RDS CONVERSION FAILED. Status: {data}, Check logs for dataset: {dataset_id}")
             if any(
                 [
-                    cxg_status == h5ad_status == "UPLOADED" and rds_status == "SKIPPED",
+                    cxg_status == h5ad_status == "UPLOADED"
+                    and rds_status == "SKIPPED"
+                    and atac_status in ["SKIPPED", "UPLOADED"],
                     errors,
                 ]
             ):
                 keep_trying = False
         if time.time() >= timer + 1200:
             raise TimeoutError(
-                f"Dataset upload or conversion timed out after 10 min. Check logs for dataset: {dataset_id}"
+                f"Dataset upload or conversion timed out after 20 min. Check logs for dataset: {dataset_id}"
             )
         time.sleep(10)
     return {"dataset_id": dataset_id, "errors": errors}

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -101,6 +101,7 @@ class TestCollection(BaseAPIPortalTest):
                     "name": "test_dataset_name",
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
                     "processing_status": {
+                        "atac_status": "SKIPPED",
                         "created_at": 0,
                         "cxg_status": "NA",
                         "dataset_id": mock.ANY,
@@ -156,6 +157,7 @@ class TestCollection(BaseAPIPortalTest):
                     "name": "test_dataset_name",
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
                     "processing_status": {
+                        "atac_status": "SKIPPED",
                         "created_at": 0,
                         "cxg_status": "NA",
                         "dataset_id": mock.ANY,
@@ -1804,6 +1806,7 @@ class TestDataset(BaseAPIPortalTest):
         self.assertEqual(200, response.status_code)
         actual_body = json.loads(response.data)
         expected_body = {
+            "atac_status": "SKIPPED",
             "cxg_status": "NA",
             "rds_status": "NA",
             "h5ad_status": "NA",

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -588,6 +588,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
                 DatasetStatusUpdate(status_key=DatasetStatusKey.H5AD, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=rds_status),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.CXG, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC_FRAGMENT, status=DatasetConversionStatus.SKIPPED),
             ]
         )
 
@@ -602,6 +603,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
                 DatasetStatusUpdate(status_key=DatasetStatusKey.H5AD, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=rds_status),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.CXG, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC_FRAGMENT, status=DatasetConversionStatus.SKIPPED),
             ]
         )
 
@@ -616,6 +618,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
                 DatasetStatusUpdate(status_key=DatasetStatusKey.H5AD, status=h5ad_status),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.CXG, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC_FRAGMENT, status=DatasetConversionStatus.SKIPPED),
             ]
         )
 
@@ -630,6 +633,22 @@ class TestValidArtifactStatuses(BaseProcessingTest):
                 DatasetStatusUpdate(status_key=DatasetStatusKey.H5AD, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.CXG, status=cxg_status),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC_FRAGMENT, status=DatasetConversionStatus.SKIPPED),
+            ]
+        )
+
+        dataset_version_id = DatasetVersionId(dataset_version.dataset_version_id)
+        assert self.updater.has_valid_artifact_statuses(dataset_version_id) is False
+
+    @parameterized.expand([DatasetConversionStatus.CONVERTING, DatasetConversionStatus.FAILED])
+    def test_has_valid_artifact_statuses__invalid_atac_status(self, atac_status):
+        dataset_version = self.generate_dataset(
+            statuses=[
+                DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.PENDING),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.H5AD, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.CXG, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC_FRAGMENT, status=atac_status),
             ]
         )
 

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -588,7 +588,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
                 DatasetStatusUpdate(status_key=DatasetStatusKey.H5AD, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=rds_status),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.CXG, status=DatasetConversionStatus.CONVERTED),
-                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC_FRAGMENT, status=DatasetConversionStatus.SKIPPED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.SKIPPED),
             ]
         )
 
@@ -603,7 +603,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
                 DatasetStatusUpdate(status_key=DatasetStatusKey.H5AD, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=rds_status),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.CXG, status=DatasetConversionStatus.CONVERTED),
-                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC_FRAGMENT, status=DatasetConversionStatus.SKIPPED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.SKIPPED),
             ]
         )
 
@@ -618,7 +618,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
                 DatasetStatusUpdate(status_key=DatasetStatusKey.H5AD, status=h5ad_status),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.CXG, status=DatasetConversionStatus.CONVERTED),
-                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC_FRAGMENT, status=DatasetConversionStatus.SKIPPED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.SKIPPED),
             ]
         )
 
@@ -633,7 +633,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
                 DatasetStatusUpdate(status_key=DatasetStatusKey.H5AD, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.CXG, status=cxg_status),
-                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC_FRAGMENT, status=DatasetConversionStatus.SKIPPED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.SKIPPED),
             ]
         )
 
@@ -648,7 +648,7 @@ class TestValidArtifactStatuses(BaseProcessingTest):
                 DatasetStatusUpdate(status_key=DatasetStatusKey.H5AD, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.CXG, status=DatasetConversionStatus.CONVERTED),
-                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC_FRAGMENT, status=atac_status),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=atac_status),
             ]
         )
 

--- a/tests/unit/processing/test_handle_error.py
+++ b/tests/unit/processing/test_handle_error.py
@@ -47,6 +47,7 @@ def sample_slack_status_block():
         "text": {
             "type": "mrkdwn",
             "text": "```{\n"
+            '  "atac_status": null,\n'
             '  "cxg_status": null,\n'
             '  "h5ad_status": null,\n'
             '  "processing_status": null,\n'


### PR DESCRIPTION
## Reason for Change

- atac_status will be used to communicate the status of atac dataset processing to the end users.

## Changes

- add DatasetStatus.atac_status and default to skipped during ingestion

## Testing steps

- Update test cases to reflect changes