### PR TITLE
fix: ingestion error handler

### DIFF
--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -263,6 +263,7 @@ resource "aws_sfn_state_machine" "state_machine" {
     },
     "HandleErrors": {
       "Type": "Task",
+      "InputPath": "$",
       "Resource": "${var.lambda_error_handler}",
       "Parameters": {
         "execution_id.$": "$$.Execution.Id",

--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -140,7 +140,8 @@ resource "aws_sfn_state_machine" "state_machine" {
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "HandleErrors"
+          "Next": "HandleErrors",
+          "ResultPath": "$.error"
         }
       ],
       "ResultPath": null
@@ -262,7 +263,6 @@ resource "aws_sfn_state_machine" "state_machine" {
     },
     "HandleErrors": {
       "Type": "Task",
-      "InputPath": "$",
       "Resource": "${var.lambda_error_handler}",
       "Parameters": {
         "execution_id.$": "$$.Execution.Id",
@@ -280,7 +280,6 @@ resource "aws_sfn_state_machine" "state_machine" {
           "BackoffRate": 2.0
         }
       ],
-      "ResultPath": null,
       "Next": "RaiseError"
     },
     "RaiseError": {

--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -280,6 +280,7 @@ resource "aws_sfn_state_machine" "state_machine" {
           "MaxAttempts": 3,
           "BackoffRate": 2.0
         }
+      "ResultPath": null,
       ],
       "Next": "RaiseError"
     },

--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -280,8 +280,8 @@ resource "aws_sfn_state_machine" "state_machine" {
           "MaxAttempts": 3,
           "BackoffRate": 2.0
         }
-      "ResultPath": null,
       ],
+      "ResultPath": null,
       "Next": "RaiseError"
     },
     "RaiseError": {


### PR DESCRIPTION
- errors not passed correctly to error handler

## Reason for Change

- errors not passed correctly to error handler, causing the error handler to not be invoked.

## Changes

- fix how parameters are passed to the error handler