### PR TITLE
feat: Change DatasetArtifact.type from enum to String

### DIFF
--- a/backend/database/versions/92c817dddc7d_new_atac_artifact_enums.py
+++ b/backend/database/versions/92c817dddc7d_new_atac_artifact_enums.py
@@ -1,0 +1,38 @@
+"""new-atac-artifact-enums
+
+Changing DatasetArtifactTable.type from an enum to a string to allow for new ATAC artifact types.
+
+Revision ID: 92c817dddc7d
+Revises: 07_e31a29561f38
+Create Date: 2025-03-06 12:31:12.249307
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "92c817dddc7d"
+down_revision = "07_e31a29561f38"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "DatasetArtifact",
+        "type",
+        type_=sa.String(),
+        existing_type=sa.Enum("CXG", "RDS", "H5AD", "RAW_H5AD", name="datasetartifacttype"),
+        schema="persistence_schema",
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "DatasetArtifact",
+        "type",
+        type_=sa.Enum("CXG", "RDS", "H5AD", "RAW_H5AD", name="datasetartifacttype"),
+        existing_type=sa.String(),
+        schema="persistence_schema",
+    )

--- a/backend/layers/persistence/orm.py
+++ b/backend/layers/persistence/orm.py
@@ -1,9 +1,8 @@
-from sqlalchemy import Column, DateTime, Enum, ForeignKey, String
+from sqlalchemy import Column, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import ARRAY, BOOLEAN, JSON, UUID
 from sqlalchemy.orm import registry
 from sqlalchemy.schema import MetaData
 
-from backend.layers.common.entities import DatasetArtifactType
 from backend.layers.persistence.constants import SCHEMA_NAME
 
 metadata = MetaData(schema=SCHEMA_NAME)
@@ -68,5 +67,5 @@ class DatasetArtifactTable:
     __tablename__ = "DatasetArtifact"
 
     id = Column(UUID(as_uuid=True), primary_key=True)
-    type = Column(Enum(DatasetArtifactType))
+    type = Column(String)
     uri = Column(String)


### PR DESCRIPTION
## Reason for Change

- Changing `DatasetArtifact.type` from enum to String will make it easier to add new artifact types in the future without doing a database migration. This is safe because only the backend code has access to the database and will handle enforment. 

## Changes

- add database migration to change `DatasetArtifact.type` from an enum to a string
- update `orm.py` to make `DatasetArtifact.type`

## Testing steps

- tested the migration locally
- Ran the migration on dev and verified existing datasets could be retrieved and that new datasets can be created.
