### PR TITLE
fix: add new artifact types to portal API

### DIFF
--- a/backend/database/versions/92c817dddc7d_new_atac_artifact_enums.py
+++ b/backend/database/versions/92c817dddc7d_new_atac_artifact_enums.py
@@ -1,0 +1,38 @@
+"""new-atac-artifact-enums
+
+Changing DatasetArtifactTable.type from an enum to a string to allow for new ATAC artifact types.
+
+Revision ID: 92c817dddc7d
+Revises: 07_e31a29561f38
+Create Date: 2025-03-06 12:31:12.249307
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "92c817dddc7d"
+down_revision = "07_e31a29561f38"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "DatasetArtifact",
+        "type",
+        type_=sa.String(),
+        existing_type=sa.Enum("CXG", "RDS", "H5AD", "RAW_H5AD", name="datasetartifacttype"),
+        schema="persistence_schema",
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "DatasetArtifact",
+        "type",
+        type_=sa.Enum("CXG", "RDS", "H5AD", "RAW_H5AD", name="datasetartifacttype"),
+        existing_type=sa.String(),
+        schema="persistence_schema",
+    )

--- a/backend/layers/persistence/orm.py
+++ b/backend/layers/persistence/orm.py
@@ -1,9 +1,8 @@
-from sqlalchemy import Column, DateTime, Enum, ForeignKey, String
+from sqlalchemy import Column, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import ARRAY, BOOLEAN, JSON, UUID
 from sqlalchemy.orm import registry
 from sqlalchemy.schema import MetaData
 
-from backend.layers.common.entities import DatasetArtifactType
 from backend.layers.persistence.constants import SCHEMA_NAME
 
 metadata = MetaData(schema=SCHEMA_NAME)
@@ -68,5 +67,5 @@ class DatasetArtifactTable:
     __tablename__ = "DatasetArtifact"
 
     id = Column(UUID(as_uuid=True), primary_key=True)
-    type = Column(Enum(DatasetArtifactType))
+    type = Column(String)
     uri = Column(String)

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -1291,7 +1291,7 @@ components:
           type: string
         filetype:
           type: string
-          enum: [RAW_H5AD, H5AD, RDS, CXG]
+          enum: [RAW_H5AD, H5AD, RDS, CXG, ATAC_FRAGMENT, ATAC_INDEX]
         filename:
           type: string
         s3_uri:

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -2004,6 +2004,9 @@ class TestDataset(BaseAPIPortalTest):
             artifacts=[
                 DatasetArtifactUpdate(DatasetArtifactType.CXG, "s3://mock-bucket/mock-key.cxg"),
                 DatasetArtifactUpdate(DatasetArtifactType.H5AD, "s3://mock-bucket/mock-key.h5ad"),
+                DatasetArtifactUpdate(DatasetArtifactType.RDS, "s3://mock-bucket/mock-key.rds"),
+                DatasetArtifactUpdate(DatasetArtifactType.ATAC_FRAGMENT, "s3://mock-bucket/mock-key.tsv.bgz"),
+                DatasetArtifactUpdate(DatasetArtifactType.ATAC_INDEX, "s3://mock-bucket/mock-key.tsv.bgz.tbi"),
             ]
         )
 
@@ -2014,9 +2017,12 @@ class TestDataset(BaseAPIPortalTest):
         body = json.loads(response.data)
         self.assertIn("assets", body)
         assets = body["assets"]
-        self.assertEqual(len(assets), 2)
+        self.assertEqual(len(assets), 5)
         self.assertEqual(assets[0]["s3_uri"], "s3://mock-bucket/mock-key.cxg")
         self.assertEqual(assets[1]["s3_uri"], "s3://mock-bucket/mock-key.h5ad")
+        self.assertEqual(assets[2]["s3_uri"], "s3://mock-bucket/mock-key.rds")
+        self.assertEqual(assets[3]["s3_uri"], "s3://mock-bucket/mock-key.tsv.bgz")
+        self.assertEqual(assets[4]["s3_uri"], "s3://mock-bucket/mock-key.tsv.bgz.tbi")
 
     # ✅
     def test__cancel_dataset_download__ok(self):


### PR DESCRIPTION
## Reason for Change

- This allows the portal to retrieve datasets with atac assets.

## Changes

- update portal-api.yaml
- update related tests.

## Testing steps

- updated related test
