### PR TITLE
fix:  support uploading files from a cellxgene public url

### DIFF
--- a/backend/common/corpora_config.py
+++ b/backend/common/corpora_config.py
@@ -21,6 +21,7 @@ class CorporaConfig(SecretConfig):
             deployment_stage = os.environ.get("DEPLOYMENT_STAGE")
             if deployment_stage == "test":
                 collections_base_url = "https://frontend.corporanet.local:3000"
+                dataset_assets_base_url = "https://datasets.test.technology"
             elif deployment_stage == "prod":
                 collections_base_url = "https://cellxgene.cziscience.com"
             else:

--- a/backend/common/utils/dl_sources/uri.py
+++ b/backend/common/utils/dl_sources/uri.py
@@ -6,6 +6,7 @@ from urllib.parse import ParseResult, urlparse
 import boto3
 import requests
 
+from backend.common.corpora_config import CorporaConfig
 from backend.common.utils import downloader
 from backend.layers.thirdparty.s3_provider import S3Provider
 
@@ -197,6 +198,35 @@ class S3URI(URI):
         self.s3_provider.download_file(self.bucket_name, self.key, local_file_name)
 
 
+class CXGPublicURL(URI):
+    """Supports URLs from the public Cellxgene endpoint."""
+
+    _netloc = urlparse(CorporaConfig().dataset_assets_base_url).netloc
+    _scheme = "https"
+
+    @classmethod
+    def validate(cls, uri: str):
+        parsed_uri = urlparse(uri)
+        return (
+            cls(uri, parsed_uri)
+            if parsed_uri.scheme == cls._scheme and parsed_uri.netloc.endswith(cls._netloc)
+            else None
+        )
+
+    def file_info(self) -> dict:
+        resp = requests.get(self.uri, headers={"Range": "bytes=0-0"})
+        resp.raise_for_status()
+
+        return {
+            "size": int(self._get_key(resp.headers, "content-range").split("/")[1]),
+            "name": self.parsed_uri.path,
+        }
+
+    def download(self, local_file_name: str):
+        self._disk_space_check()
+        downloader.download(self.uri, local_file_name)
+
+
 class RegisteredSources:
     """Manages all of the download sources."""
 
@@ -231,3 +261,4 @@ def from_uri(uri: str) -> typing.Optional[URI]:
 RegisteredSources.add(DropBoxURL)
 RegisteredSources.add(S3URL)
 RegisteredSources.add(S3URI)
+RegisteredSources.add(CXGPublicURL)

--- a/backend/common/utils/dl_sources/uri.py
+++ b/backend/common/utils/dl_sources/uri.py
@@ -164,8 +164,15 @@ class S3URL(URI):
 class CXGPublicURL(S3URL):
     """Supports URLs from the public Cellxgene endpoint."""
 
-    _netloc = urlparse(CorporaConfig().dataset_assets_base_url).netloc
-    _scheme = urlparse(CorporaConfig().dataset_assets_base_url).scheme
+    @classmethod
+    @property
+    def _netloc(cls):
+        return urlparse(CorporaConfig().dataset_assets_base_url).netloc
+
+    @classmethod
+    @property
+    def _schema(cls):
+        return urlparse(CorporaConfig().dataset_assets_base_url).scheme
 
 
 class S3URI(URI):

--- a/backend/common/utils/dl_sources/uri.py
+++ b/backend/common/utils/dl_sources/uri.py
@@ -220,17 +220,17 @@ class RegisteredSources:
     @classmethod
     def add(cls, parser: typing.Type[URI]):
         if issubclass(parser, URI):
-            cls._registered.append(parser)
+            cls._sources.append(parser)
         else:
             raise TypeError(f"subclass type {URI.__name__} expected")
 
     @classmethod
     def remove(cls, parser: typing.Type[URI]):
-        cls._registered.remove(parser)
+        cls._sources.remove(parser)
 
     @classmethod
     def get(cls) -> typing.Iterable:
-        return cls._registered
+        return cls._sources
 
     @classmethod
     def is_empty(cls) -> bool:

--- a/tests/unit/backend/layers/utils/test_uri.py
+++ b/tests/unit/backend/layers/utils/test_uri.py
@@ -6,13 +6,6 @@ from unittest import TestCase
 import boto3
 from moto import mock_aws
 
-from backend.common.corpora_config import CorporaConfig
-
-# Mocking the DOMAIN for CXGPublicURL early to avoid import issues cause by the CorporaConfig
-DOMAIN = "datasets.test.technology"
-mock_config = CorporaConfig()
-mock_config.set({"dataset_assets_base_url": f"https://{DOMAIN}"})
-
 from backend.common.utils.dl_sources.uri import S3URI, S3URL, CXGPublicURL, DropBoxURL, RegisteredSources, from_uri
 
 
@@ -142,11 +135,11 @@ class TestCXGPubURL(TestCase):
 
     @mock_aws
     def test__validate_with_valid_url__ok(self):
-        url = f"https://{DOMAIN}/key/file.txt"
+        url = "https://datasets.test.technology/key/file.txt"
         url = CXGPublicURL.validate(url)
 
         self.assertEqual("https", url.scheme)
-        self.assertEqual(DOMAIN, url.netloc)
+        self.assertEqual("datasets.test.technology", url.netloc)
         self.assertEqual("/key/file.txt", url.path)
 
     @mock_aws

--- a/tests/unit/backend/layers/utils/test_uri.py
+++ b/tests/unit/backend/layers/utils/test_uri.py
@@ -135,7 +135,9 @@ class TestCXGPubURL(TestCase):
 
     @mock.patch("backend.common.utils.dl_sources.uri.CorporaConfig")
     def test__validate_with_valid_url__ok(self, config_mock):
-        config_mock.dataset_assets_base_url = "https://datasets.test.technology"
+        config = mock.Mock()
+        config.dataset_assets_base_url = "https://datasets.test.technology"
+        config_mock.return_value = config
 
         url = "https://datasets.test.technology/key/file.txt"
         url = CXGPublicURL.validate(url)
@@ -146,7 +148,10 @@ class TestCXGPubURL(TestCase):
 
     @mock.patch("backend.common.utils.dl_sources.uri.CorporaConfig")
     def test__validate_with_invalid_url__returns_none(self, config_mock):
-        config_mock.dataset_assets_base_url = "https://datasets.test.technology"
+        config = mock.Mock()
+        config.dataset_assets_base_url = "https://datasets.test.technology"
+        config_mock.return_value = config
+
         url = CXGPublicURL.validate("http://somebucket.s3.amazonaws.com/key")
         self.assertIsNone(url)
 

--- a/tests/unit/backend/layers/utils/test_uri.py
+++ b/tests/unit/backend/layers/utils/test_uri.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from tempfile import TemporaryDirectory
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import boto3
 from moto import mock_aws
@@ -133,8 +133,10 @@ class TestS3URL(TestCase):
 
 class TestCXGPubURL(TestCase):
 
-    @mock_aws
-    def test__validate_with_valid_url__ok(self):
+    @mock.patch("backend.common.utils.dl_sources.uri.CorporaConfig")
+    def test__validate_with_valid_url__ok(self, config_mock):
+        config_mock.dataset_assets_base_url = "https://datasets.test.technology"
+
         url = "https://datasets.test.technology/key/file.txt"
         url = CXGPublicURL.validate(url)
 
@@ -142,8 +144,9 @@ class TestCXGPubURL(TestCase):
         self.assertEqual("datasets.test.technology", url.netloc)
         self.assertEqual("/key/file.txt", url.path)
 
-    @mock_aws
-    def test__validate_with_invalid_url__returns_none(self):
+    @mock.patch("backend.common.utils.dl_sources.uri.CorporaConfig")
+    def test__validate_with_invalid_url__returns_none(self, config_mock):
+        config_mock.dataset_assets_base_url = "https://datasets.test.technology"
         url = CXGPublicURL.validate("http://somebucket.s3.amazonaws.com/key")
         self.assertIsNone(url)
 


### PR DESCRIPTION
## Reason for Change

- support uploading file using a public cellxgene url

## Changes

- add CXGPublicURL to parse public cellxgene urls
- remove import side effects when importing `backend.common.utils.dl_sources.uri` by moving `RegisteredSources.add` calls to inside `from_uri` if `RegisteredSources` has no sources.
- renamed `_registered` to `_sources` in `RegisteredSources`.
- To help with testing the `dataset_assets_base_url` is defined in `CorporaConfig` when `DEPLOYMENT_STAGE == test`

## Testing steps

- Added unit tests for `S3URL` and `CXGPublicURL`

## Checklist 🛎️

## Notes for Reviewer
