### PR TITLE
fix: Add noindex meta tag for private collections (VC-2245)

### DIFF
--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -130,6 +130,9 @@ const Collection: FC = () => {
     <>
       <Head>
         <title>{collection.name} - CZ CELLxGENE Discover</title>
+        {collection.visibility === "PRIVATE" && (
+          <meta name="robots" content="noindex" />
+        )}
       </Head>
       <CollectionView>
         {/* Notification */}


### PR DESCRIPTION
## Reason for Change

- [VC-2245 Private Collection is currently public via Google indexing](https://czi.atlassian.net/browse/VC-2245)
- Ensure private collections are not being indexed by search engines

## Changes

- Added `noindex` meta tag to Collection page if `collection.visibility == "PRIVATE"`

## Testing steps

- In `rdev` - inspect page source while viewing a private collecation

