### PR TITLE
fix: update rdev db seed to include visium and atac datasets

### DIFF
--- a/scripts/smoke_tests/setup.py
+++ b/scripts/smoke_tests/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import json
 import os
-import sys
 import threading
 
 from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
@@ -20,6 +19,8 @@ from tests.functional.backend.utils import (
 NUM_TEST_DATASETS = 3
 NUM_TEST_COLLECTIONS = 10
 TEST_ACCT_CONTACT_NAME = "Smoke Test User"
+VISIUM_ACCT_CONTACT_NAME = "Visium Test User"
+ATAC_SEQ_ACCT_CONTACT_NAME = "ATAC Seq Test User"
 
 
 class SmokeTestsInitializer:
@@ -35,17 +36,16 @@ class SmokeTestsInitializer:
         self.curation_api_access_token = get_curation_api_access_token(self.session, self.api, self.config)
         self.manifests = [DATASET_MANIFEST, VISIUM_DATASET_MANIFEST, ATAC_SEQ_MANIFEST]
         self.headers = {"Cookie": f"cxguser={self.curator_cookie}", "Content-Type": "application/json"}
-        self.collection_counter = 0
 
-    def get_collection_count(self):
+    def get_collection_count(self, contact_name=TEST_ACCT_CONTACT_NAME, expected_count=NUM_TEST_COLLECTIONS):
         res = self.session.get(f"{self.api}/curation/v1/collections?visiblity=PUBLIC", headers=self.headers)
         res.raise_for_status()
         data = json.loads(res.content)
         num_collections = 0
         for collection in data:
-            if collection["contact_name"] == TEST_ACCT_CONTACT_NAME:
+            if collection["contact_name"] == contact_name:
                 num_collections += 1
-            if num_collections == NUM_TEST_COLLECTIONS:
+            if num_collections == expected_count:
                 return num_collections
         return num_collections
 
@@ -64,27 +64,30 @@ class SmokeTestsInitializer:
         _thread.start()
         return _thread
 
-    def create_and_publish_collection(self):
-        collection_id = self.create_collection()
+    def create_and_publish_collection(
+        self,
+        contact_name=TEST_ACCT_CONTACT_NAME,
+        collection_name="test collection",
+        manifest=DATASET_MANIFEST,
+        num_datasets=NUM_TEST_DATASETS,
+    ):
+        collection_id = self.create_collection(contact_name, collection_name)
         _threads = []
-        for _ in range(NUM_TEST_DATASETS):
-            _threads.append(self.start_upload_thread(collection_id, DATASET_MANIFEST))
-        if self.collection_counter == 0:
-            _threads.append(self.start_upload_thread(collection_id, VISIUM_DATASET_MANIFEST))
-            _threads.append(self.start_upload_thread(collection_id, ATAC_SEQ_MANIFEST))
+        for _ in range(num_datasets):
+            _threads.append(self.start_upload_thread(collection_id, manifest))
         for _thread in _threads:
             _thread.join()
         self.publish_collection(collection_id)
         print(f"created and published collection {collection_id}")
 
-    def create_collection(self):
+    def create_collection(self, contact_name, collection_name):
         data = {
             "contact_email": "example@gmail.com",
-            "contact_name": TEST_ACCT_CONTACT_NAME,
+            "contact_name": contact_name,
             "curator_name": "John Smith",
             "description": "Well here are some words",
             "links": [{"link_name": "a link to somewhere", "link_type": "PROTOCOL", "link_url": "http://protocol.com"}],
-            "name": f"test collection {self.collection_counter}",
+            "name": collection_name,
         }
 
         res = self.session.post(f"{self.api}/dp/v1/collections", data=json.dumps(data), headers=self.headers)
@@ -103,14 +106,34 @@ class SmokeTestsInitializer:
 if __name__ == "__main__":
     smoke_test_init = SmokeTestsInitializer()
     # check whether we need to create collections
-    collection_count = smoke_test_init.get_collection_count()
-    if collection_count >= NUM_TEST_COLLECTIONS:
-        sys.exit(0)
-    num_to_create = NUM_TEST_COLLECTIONS - collection_count
+    test_collection_count = smoke_test_init.get_collection_count()
+    visium_collection_count = smoke_test_init.get_collection_count(VISIUM_ACCT_CONTACT_NAME, 1)
+    atac_seq_collection_count = smoke_test_init.get_collection_count(ATAC_SEQ_ACCT_CONTACT_NAME, 1)
+
     threads = []
-    for _ in range(num_to_create):
-        thread = threading.Thread(target=smoke_test_init.create_and_publish_collection)
+
+    if test_collection_count < NUM_TEST_COLLECTIONS:
+        num_to_create = NUM_TEST_COLLECTIONS - test_collection_count
+
+        for _ in range(num_to_create):
+            thread = threading.Thread(target=smoke_test_init.create_and_publish_collection)
+            threads.append(thread)
+
+    if visium_collection_count < 1:
+        thread = threading.Thread(
+            target=smoke_test_init.create_and_publish_collection,
+            args=(VISIUM_ACCT_CONTACT_NAME, "Visium Test Collection", VISIUM_DATASET_MANIFEST),
+        )
         threads.append(thread)
+
+    if atac_seq_collection_count < 1:
+        thread = threading.Thread(
+            target=smoke_test_init.create_and_publish_collection,
+            args=(ATAC_SEQ_ACCT_CONTACT_NAME, "ATAC Seq Test Collection", ATAC_SEQ_MANIFEST),
+        )
+        threads.append(thread)
+
+    for thread in threads:
         thread.start()
     for thread in threads:
         thread.join()

--- a/scripts/smoke_tests/setup.py
+++ b/scripts/smoke_tests/setup.py
@@ -122,14 +122,14 @@ if __name__ == "__main__":
     if visium_collection_count < 1:
         thread = threading.Thread(
             target=smoke_test_init.create_and_publish_collection,
-            args=(VISIUM_ACCT_CONTACT_NAME, "Visium Test Collection", VISIUM_DATASET_MANIFEST),
+            args=(VISIUM_ACCT_CONTACT_NAME, "Visium Test Collection", VISIUM_DATASET_MANIFEST, 1),
         )
         threads.append(thread)
 
     if atac_seq_collection_count < 1:
         thread = threading.Thread(
             target=smoke_test_init.create_and_publish_collection,
-            args=(ATAC_SEQ_ACCT_CONTACT_NAME, "ATAC Seq Test Collection", ATAC_SEQ_MANIFEST),
+            args=(ATAC_SEQ_ACCT_CONTACT_NAME, "ATAC Seq Test Collection", ATAC_SEQ_MANIFEST, 1),
         )
         threads.append(thread)
 

--- a/tests/functional/backend/conftest.py
+++ b/tests/functional/backend/conftest.py
@@ -7,6 +7,7 @@ from tests.functional.backend.constants import API_URL
 from tests.functional.backend.distributed import distributed_singleton
 from tests.functional.backend.utils import (
     get_auth_token,
+    get_curation_api_access_token,
     make_cookie,
     make_proxy_auth_token,
     make_session,
@@ -68,12 +69,7 @@ def api_url(deployment_stage):
 @pytest.fixture(scope="session")
 def curation_api_access_token(session, api_url, config, tmp_path_factory, worker_id):
     def _curation_api_access_token() -> str:
-        response = session.post(
-            f"{api_url}/curation/v1/auth/token",
-            headers={"x-api-key": config.super_curator_api_key},
-        )
-        response.raise_for_status()
-        return response.json()["access_token"]
+        return get_curation_api_access_token(session, api_url, config)
 
     return distributed_singleton(tmp_path_factory, worker_id, _curation_api_access_token)
 

--- a/tests/functional/backend/constants.py
+++ b/tests/functional/backend/constants.py
@@ -25,6 +25,8 @@ VISIUM_DATASET_URI = (
     "=cgwd59ouk340zlqh6fcnthizz&st=u2nyo3xp&dl=0"
 )
 
+DATASET_MANIFEST = {"anndata": DATASET_URI}
+VISIUM_DATASET_MANIFEST = {"anndata": VISIUM_DATASET_URI}
 ATAC_SEQ_MANIFEST = {
     "anndata": "https://www.dropbox.com/scl/fi/rth5ol8dyn3qypmnr3w79/atac.h5ad?rlkey=lpor3wj4he2n4dkp6pq3v4c6t&st=xs0mhcer&dl=0",
     "atac_fragment": "https://www.dropbox.com/scl/fi/p4kmriyki1xyvcc9bvwxc/fragments_sorted.tsv.gz?rlkey=hydxliidfy4yneaan2rrw2arp&dl=0",

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -195,3 +195,12 @@ def make_proxy_auth_token(config, deployment_stage) -> dict:
         access_token = res.json()["access_token"]
         return {"Authorization": f"Bearer {access_token}"}
     return {}
+
+
+def get_curation_api_access_token(session, api_url, config) -> str:
+    response = session.post(
+        f"{api_url}/curation/v1/auth/token",
+        headers={"x-api-key": config.super_curator_api_key},
+    )
+    response.raise_for_status()
+    return response.json()["access_token"]


### PR DESCRIPTION
## Reason for Change

- Updating the rdev database seed to include visium and atac datasets. This is to allow frontend developer to test their changes in an rdev without uploading additional files. It also improves our ability to test changes as the types of data we ingest continues to evolve.

## Changes
- Use the curation API to upload datasets using the manifest endpoint to the rdev database.
- make `create_and_publish_collection` reusuable
- seed db creates a collection with a visium datasets if it does not exist
- seed db creates a collection with a atac dataset if it does not exist.

## Testing steps
verified the datasets exist in the rdev environment
![Screenshot 2025-03-20 at 10 43 34 AM](https://github.com/user-attachments/assets/e884b2c0-21e8-4eb2-9e5e-f53660213c6b)
![Screenshot 2025-03-20 at 10 43 55 AM](https://github.com/user-attachments/assets/a6b61fb1-38ce-4bd4-845a-d901b7fb194d)

