### PR TITLE
fix: get asset portal endpoint

### DIFF
--- a/backend/layers/thirdparty/s3_provider.py
+++ b/backend/layers/thirdparty/s3_provider.py
@@ -57,6 +57,13 @@ class S3Provider(S3ProviderInterface):
         Returns the file size of an S3 object located at `path`
         """
         bucket, key = self.parse_s3_uri(path)
+        logger.info(
+            {
+                "message": "Getting file size",
+                "bucket": bucket,
+                "key": key,
+            }
+        )
         try:
             response = self.client.head_object(Bucket=bucket, Key=key)
         except Exception:

--- a/backend/layers/thirdparty/s3_provider.py
+++ b/backend/layers/thirdparty/s3_provider.py
@@ -67,6 +67,7 @@ class S3Provider(S3ProviderInterface):
         try:
             response = self.client.head_object(Bucket=bucket, Key=key)
         except Exception:
+            logger.exception("Failed to get file size")
             return None
         return response["ContentLength"]
 

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -1,5 +1,6 @@
 import dataclasses
 import itertools
+import logging
 from datetime import datetime
 from typing import Iterable, List, Optional, Tuple
 from urllib.parse import urlparse
@@ -739,7 +740,7 @@ def get_dataset_asset(dataset_id: str, asset_id: str):
         )
     except ArtifactNotFoundException:
         raise NotFoundHTTPException(detail=f"'dataset/{dataset_id}/asset/{asset_id}' not found.") from None
-
+    logging.info(f"Download data: {download_data}")
     if download_data.file_size is None:
         raise ServerErrorHTTPException() from None
 

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,7 +43,7 @@
         "jschardet": "^2.3.0",
         "lodash": "^4.17.21",
         "ml-hclust": "^3.1.0",
-        "next": "^14.2.12",
+        "next": "^14.2.25",
         "next-mdx-remote": "^4.4.1",
         "next-secure-headers": "^2.2.0",
         "next-sitemap": "^3.1.55",
@@ -3721,9 +3721,9 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/@next/env": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.12.tgz",
-      "integrity": "sha512-3fP29GIetdwVIfIRyLKM7KrvJaqepv+6pVodEbx0P5CaMLYBtx+7eEg8JYO5L9sveJO87z9eCReceZLi0hxO1Q=="
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.25.tgz",
+      "integrity": "sha512-JnzQ2cExDeG7FxJwqAksZ3aqVJrHjFwZQAEJ9gQZSoEhIow7SNoKZzju/AwQ+PLIR4NY8V0rhcVozx/2izDO0w=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.1.0",
@@ -3781,9 +3781,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.12.tgz",
-      "integrity": "sha512-crHJ9UoinXeFbHYNok6VZqjKnd8rTd7K3Z2zpyzF1ch7vVNKmhjv/V7EHxep3ILoN8JB9AdRn/EtVVyG9AkCXw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.25.tgz",
+      "integrity": "sha512-09clWInF1YRd6le00vt750s3m7SEYNehz9C4PUcSu3bAdCTpjIV4aTYQZ25Ehrr83VR1rZeqtKUPWSI7GfuKZQ==",
       "cpu": [
         "arm64"
       ],
@@ -3796,9 +3796,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.12.tgz",
-      "integrity": "sha512-JbEaGbWq18BuNBO+lCtKfxl563Uw9oy2TodnN2ioX00u7V1uzrsSUcg3Ep9ce+P0Z9es+JmsvL2/rLphz+Frcw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.25.tgz",
+      "integrity": "sha512-V+iYM/QR+aYeJl3/FWWU/7Ix4b07ovsQ5IbkwgUK29pTHmq+5UxeDr7/dphvtXEq5pLB/PucfcBNh9KZ8vWbug==",
       "cpu": [
         "x64"
       ],
@@ -3811,9 +3811,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.12.tgz",
-      "integrity": "sha512-qBy7OiXOqZrdp88QEl2H4fWalMGnSCrr1agT/AVDndlyw2YJQA89f3ttR/AkEIP9EkBXXeGl6cC72/EZT5r6rw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.25.tgz",
+      "integrity": "sha512-LFnV2899PJZAIEHQ4IMmZIgL0FBieh5keMnriMY1cK7ompR+JUd24xeTtKkcaw8QmxmEdhoE5Mu9dPSuDBgtTg==",
       "cpu": [
         "arm64"
       ],
@@ -3826,9 +3826,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.12.tgz",
-      "integrity": "sha512-EfD9L7o9biaQxjwP1uWXnk3vYZi64NVcKUN83hpVkKocB7ogJfyH2r7o1pPnMtir6gHZiGCeHKagJ0yrNSLNHw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.25.tgz",
+      "integrity": "sha512-QC5y5PPTmtqFExcKWKYgUNkHeHE/z3lUsu83di488nyP0ZzQ3Yse2G6TCxz6nNsQwgAx1BehAJTZez+UQxzLfw==",
       "cpu": [
         "arm64"
       ],
@@ -3841,9 +3841,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.12.tgz",
-      "integrity": "sha512-iQ+n2pxklJew9IpE47hE/VgjmljlHqtcD5UhZVeHICTPbLyrgPehaKf2wLRNjYH75udroBNCgrSSVSVpAbNoYw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.25.tgz",
+      "integrity": "sha512-y6/ML4b9eQ2D/56wqatTJN5/JR8/xdObU2Fb1RBidnrr450HLCKr6IJZbPqbv7NXmje61UyxjF5kvSajvjye5w==",
       "cpu": [
         "x64"
       ],
@@ -3856,9 +3856,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.12.tgz",
-      "integrity": "sha512-rFkUkNwcQ0ODn7cxvcVdpHlcOpYxMeyMfkJuzaT74xjAa5v4fxP4xDk5OoYmPi8QNLDs3UgZPMSBmpBuv9zKWA==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.25.tgz",
+      "integrity": "sha512-sPX0TSXHGUOZFvv96GoBXpB3w4emMqKeMgemrSxI7A6l55VBJp/RKYLwZIB9JxSqYPApqiREaIIap+wWq0RU8w==",
       "cpu": [
         "x64"
       ],
@@ -3871,9 +3871,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.12.tgz",
-      "integrity": "sha512-PQFYUvwtHs/u0K85SG4sAdDXYIPXpETf9mcEjWc0R4JmjgMKSDwIU/qfZdavtP6MPNiMjuKGXHCtyhR/M5zo8g==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.25.tgz",
+      "integrity": "sha512-ReO9S5hkA1DU2cFCsGoOEp7WJkhFzNbU/3VUF6XxNGUCQChyug6hZdYL/istQgfT/GWE6PNIg9cm784OI4ddxQ==",
       "cpu": [
         "arm64"
       ],
@@ -3886,9 +3886,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.12.tgz",
-      "integrity": "sha512-FAj2hMlcbeCV546eU2tEv41dcJb4NeqFlSXU/xL/0ehXywHnNpaYajOUvn3P8wru5WyQe6cTZ8fvckj/2XN4Vw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.25.tgz",
+      "integrity": "sha512-DZ/gc0o9neuCDyD5IumyTGHVun2dCox5TfPQI/BJTYwpSNYM3CZDI4i6TOdjeq1JMo+Ug4kPSMuZdwsycwFbAw==",
       "cpu": [
         "ia32"
       ],
@@ -3901,9 +3901,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.12.tgz",
-      "integrity": "sha512-yu8QvV53sBzoIVRHsxCHqeuS8jYq6Lrmdh0briivuh+Brsp6xjg80MAozUsBTAV9KNmY08KlX0KYTWz1lbPzEg==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.25.tgz",
+      "integrity": "sha512-KSznmS6eFjQ9RJ1nEc66kJvtGIL1iZMYmGEXsZPh2YtnLtqrgdVvKXJY2ScjjoFnG6nGLyPFR0UiEvDwVah4Tw==",
       "cpu": [
         "x64"
       ],
@@ -13168,11 +13168,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.12.tgz",
-      "integrity": "sha512-cDOtUSIeoOvt1skKNihdExWMTybx3exnvbFbb9ecZDIxlvIbREQzt9A5Km3Zn3PfU+IFjyYGsHS+lN9VInAGKA==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.25.tgz",
+      "integrity": "sha512-N5M7xMc4wSb4IkPvEV5X2BRRXUmhVHNyaXwEM86+voXthSZz8ZiRyQW4p9mwAoAPIm6OzuVZtn7idgEJeAJN3Q==",
       "dependencies": {
-        "@next/env": "14.2.12",
+        "@next/env": "14.2.25",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -13187,15 +13187,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.12",
-        "@next/swc-darwin-x64": "14.2.12",
-        "@next/swc-linux-arm64-gnu": "14.2.12",
-        "@next/swc-linux-arm64-musl": "14.2.12",
-        "@next/swc-linux-x64-gnu": "14.2.12",
-        "@next/swc-linux-x64-musl": "14.2.12",
-        "@next/swc-win32-arm64-msvc": "14.2.12",
-        "@next/swc-win32-ia32-msvc": "14.2.12",
-        "@next/swc-win32-x64-msvc": "14.2.12"
+        "@next/swc-darwin-arm64": "14.2.25",
+        "@next/swc-darwin-x64": "14.2.25",
+        "@next/swc-linux-arm64-gnu": "14.2.25",
+        "@next/swc-linux-arm64-musl": "14.2.25",
+        "@next/swc-linux-x64-gnu": "14.2.25",
+        "@next/swc-linux-x64-musl": "14.2.25",
+        "@next/swc-win32-arm64-msvc": "14.2.25",
+        "@next/swc-win32-ia32-msvc": "14.2.25",
+        "@next/swc-win32-x64-msvc": "14.2.25"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -20899,9 +20899,9 @@
       }
     },
     "@next/env": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.12.tgz",
-      "integrity": "sha512-3fP29GIetdwVIfIRyLKM7KrvJaqepv+6pVodEbx0P5CaMLYBtx+7eEg8JYO5L9sveJO87z9eCReceZLi0hxO1Q=="
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.25.tgz",
+      "integrity": "sha512-JnzQ2cExDeG7FxJwqAksZ3aqVJrHjFwZQAEJ9gQZSoEhIow7SNoKZzju/AwQ+PLIR4NY8V0rhcVozx/2izDO0w=="
     },
     "@next/eslint-plugin-next": {
       "version": "14.1.0",
@@ -20946,57 +20946,57 @@
       }
     },
     "@next/swc-darwin-arm64": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.12.tgz",
-      "integrity": "sha512-crHJ9UoinXeFbHYNok6VZqjKnd8rTd7K3Z2zpyzF1ch7vVNKmhjv/V7EHxep3ILoN8JB9AdRn/EtVVyG9AkCXw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.25.tgz",
+      "integrity": "sha512-09clWInF1YRd6le00vt750s3m7SEYNehz9C4PUcSu3bAdCTpjIV4aTYQZ25Ehrr83VR1rZeqtKUPWSI7GfuKZQ==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.12.tgz",
-      "integrity": "sha512-JbEaGbWq18BuNBO+lCtKfxl563Uw9oy2TodnN2ioX00u7V1uzrsSUcg3Ep9ce+P0Z9es+JmsvL2/rLphz+Frcw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.25.tgz",
+      "integrity": "sha512-V+iYM/QR+aYeJl3/FWWU/7Ix4b07ovsQ5IbkwgUK29pTHmq+5UxeDr7/dphvtXEq5pLB/PucfcBNh9KZ8vWbug==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.12.tgz",
-      "integrity": "sha512-qBy7OiXOqZrdp88QEl2H4fWalMGnSCrr1agT/AVDndlyw2YJQA89f3ttR/AkEIP9EkBXXeGl6cC72/EZT5r6rw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.25.tgz",
+      "integrity": "sha512-LFnV2899PJZAIEHQ4IMmZIgL0FBieh5keMnriMY1cK7ompR+JUd24xeTtKkcaw8QmxmEdhoE5Mu9dPSuDBgtTg==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.12.tgz",
-      "integrity": "sha512-EfD9L7o9biaQxjwP1uWXnk3vYZi64NVcKUN83hpVkKocB7ogJfyH2r7o1pPnMtir6gHZiGCeHKagJ0yrNSLNHw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.25.tgz",
+      "integrity": "sha512-QC5y5PPTmtqFExcKWKYgUNkHeHE/z3lUsu83di488nyP0ZzQ3Yse2G6TCxz6nNsQwgAx1BehAJTZez+UQxzLfw==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.12.tgz",
-      "integrity": "sha512-iQ+n2pxklJew9IpE47hE/VgjmljlHqtcD5UhZVeHICTPbLyrgPehaKf2wLRNjYH75udroBNCgrSSVSVpAbNoYw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.25.tgz",
+      "integrity": "sha512-y6/ML4b9eQ2D/56wqatTJN5/JR8/xdObU2Fb1RBidnrr450HLCKr6IJZbPqbv7NXmje61UyxjF5kvSajvjye5w==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.12.tgz",
-      "integrity": "sha512-rFkUkNwcQ0ODn7cxvcVdpHlcOpYxMeyMfkJuzaT74xjAa5v4fxP4xDk5OoYmPi8QNLDs3UgZPMSBmpBuv9zKWA==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.25.tgz",
+      "integrity": "sha512-sPX0TSXHGUOZFvv96GoBXpB3w4emMqKeMgemrSxI7A6l55VBJp/RKYLwZIB9JxSqYPApqiREaIIap+wWq0RU8w==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.12.tgz",
-      "integrity": "sha512-PQFYUvwtHs/u0K85SG4sAdDXYIPXpETf9mcEjWc0R4JmjgMKSDwIU/qfZdavtP6MPNiMjuKGXHCtyhR/M5zo8g==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.25.tgz",
+      "integrity": "sha512-ReO9S5hkA1DU2cFCsGoOEp7WJkhFzNbU/3VUF6XxNGUCQChyug6hZdYL/istQgfT/GWE6PNIg9cm784OI4ddxQ==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.12.tgz",
-      "integrity": "sha512-FAj2hMlcbeCV546eU2tEv41dcJb4NeqFlSXU/xL/0ehXywHnNpaYajOUvn3P8wru5WyQe6cTZ8fvckj/2XN4Vw==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.25.tgz",
+      "integrity": "sha512-DZ/gc0o9neuCDyD5IumyTGHVun2dCox5TfPQI/BJTYwpSNYM3CZDI4i6TOdjeq1JMo+Ug4kPSMuZdwsycwFbAw==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.12.tgz",
-      "integrity": "sha512-yu8QvV53sBzoIVRHsxCHqeuS8jYq6Lrmdh0briivuh+Brsp6xjg80MAozUsBTAV9KNmY08KlX0KYTWz1lbPzEg==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.25.tgz",
+      "integrity": "sha512-KSznmS6eFjQ9RJ1nEc66kJvtGIL1iZMYmGEXsZPh2YtnLtqrgdVvKXJY2ScjjoFnG6nGLyPFR0UiEvDwVah4Tw==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -27722,20 +27722,20 @@
       "dev": true
     },
     "next": {
-      "version": "14.2.12",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.12.tgz",
-      "integrity": "sha512-cDOtUSIeoOvt1skKNihdExWMTybx3exnvbFbb9ecZDIxlvIbREQzt9A5Km3Zn3PfU+IFjyYGsHS+lN9VInAGKA==",
+      "version": "14.2.25",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.25.tgz",
+      "integrity": "sha512-N5M7xMc4wSb4IkPvEV5X2BRRXUmhVHNyaXwEM86+voXthSZz8ZiRyQW4p9mwAoAPIm6OzuVZtn7idgEJeAJN3Q==",
       "requires": {
-        "@next/env": "14.2.12",
-        "@next/swc-darwin-arm64": "14.2.12",
-        "@next/swc-darwin-x64": "14.2.12",
-        "@next/swc-linux-arm64-gnu": "14.2.12",
-        "@next/swc-linux-arm64-musl": "14.2.12",
-        "@next/swc-linux-x64-gnu": "14.2.12",
-        "@next/swc-linux-x64-musl": "14.2.12",
-        "@next/swc-win32-arm64-msvc": "14.2.12",
-        "@next/swc-win32-ia32-msvc": "14.2.12",
-        "@next/swc-win32-x64-msvc": "14.2.12",
+        "@next/env": "14.2.25",
+        "@next/swc-darwin-arm64": "14.2.25",
+        "@next/swc-darwin-x64": "14.2.25",
+        "@next/swc-linux-arm64-gnu": "14.2.25",
+        "@next/swc-linux-arm64-musl": "14.2.25",
+        "@next/swc-linux-x64-gnu": "14.2.25",
+        "@next/swc-linux-x64-musl": "14.2.25",
+        "@next/swc-win32-arm64-msvc": "14.2.25",
+        "@next/swc-win32-ia32-msvc": "14.2.25",
+        "@next/swc-win32-x64-msvc": "14.2.25",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -155,6 +155,7 @@
     "type-check": "tsc --noEmit",
     "lint": "concurrently \"node_modules/.bin/next lint\" \"node_modules/.bin/stylelint '**/*.{js,ts,tsx,css}'\"  \"npm run type-check\"",
     "prettier-check": "npx prettier --check .",
+    "prettier-fix": "npx prettier --write .",
     "build-and-start-prod": "npm run build && npm run serve",
     "postbuild": "next-sitemap",
     "e2e-trace": "npx playwright show-trace"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "jschardet": "^2.3.0",
     "lodash": "^4.17.21",
     "ml-hclust": "^3.1.0",
-    "next": "^14.2.12",
+    "next": "^14.2.25",
     "next-mdx-remote": "^4.4.1",
     "next-secure-headers": "^2.2.0",
     "next-sitemap": "^3.1.55",

--- a/frontend/src/common/entities.ts
+++ b/frontend/src/common/entities.ts
@@ -157,6 +157,8 @@ export enum DATASET_ASSET_FORMAT {
   H5AD = "H5AD",
   RDS = "RDS",
   CXG = "CXG",
+  ATAC_FRAGMENT = "ATAC_FRAGMENT",
+  ATAC_INDEX = "ATAC_INDEX",
 }
 
 export enum DATASET_ASSET_TYPE {

--- a/frontend/src/common/queries/censusDirectory.ts
+++ b/frontend/src/common/queries/censusDirectory.ts
@@ -112,6 +112,7 @@ export function useProjects() {
   return useQuery<ProjectResponse | undefined>([USE_PROJECTS], fetchProjects);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function parseCrossRefResponse({ message }: any) {
   const author = message.author[0].family;
   const journal = message["short-container-title"];

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/constants.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/constants.ts
@@ -1,9 +1,17 @@
-export const TOOLTIP_SLOT_PROPS = {
-  tooltip: {
-    style: {
-      maxWidth: 332, // Override the max-width specification for dark sdsStyle.
-    },
+import { DATASET_ASSET_FORMAT } from "src/common/entities";
+export const POSSIBLE_DOWNLOAD_FORMATS = [
+  {
+    format: DATASET_ASSET_FORMAT.H5AD,
+    label: ".h5ad (AnnData v0.10)",
+    type: "RNA",
+    description:
+      "Lorem ipsum odor amet, consectetuer adipiscing elit. Augue nulla etiam dolor orci praesent.",
   },
-};
-
-export const TOOLTIP_TITLE = ".rds (Seurat v5) is unavailable.";
+  {
+    format: DATASET_ASSET_FORMAT.ATAC_INDEX,
+    label: ".tsv (Fragments w/ index)",
+    type: "DNA ACCESSIBILITY",
+    description:
+      "Turpis habitasse potenti dapibus tincidunt fames metus vulputate feugiat.",
+  },
+];

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
@@ -1,67 +1,58 @@
 import React, { FC } from "react";
 import { DATASET_ASSET_FORMAT } from "src/common/entities";
-import { FormControl, FormLabel, RadioGroup } from "@mui/material";
-import { InputRadio, Tooltip } from "@czi-sds/components";
-import {
-  TOOLTIP_SLOT_PROPS,
-  TOOLTIP_TITLE,
-} from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/constants";
-
+import { FormLabel } from "@mui/material";
+import { FormControl } from "./style";
+import { InputCheckbox } from "@czi-sds/components";
+import { DownloadLinkType } from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content";
+import { POSSIBLE_DOWNLOAD_FORMATS } from "./constants";
+import { getFileSize } from "./utils";
 interface Props {
   handleChange: (format: DATASET_ASSET_FORMAT) => void;
-  isDisabled: boolean;
-  selectedFormat: DATASET_ASSET_FORMAT | "";
-  availableFormats: DATASET_ASSET_FORMAT[];
+  isDisabled?: boolean;
+  selectedFormats: DATASET_ASSET_FORMAT[];
+  availableFormats: Set<DATASET_ASSET_FORMAT>;
+  downloadLinks: DownloadLinkType[];
 }
 
 const DataFormat: FC<Props> = ({
   handleChange: handleChangeRaw,
   isDisabled = false,
-  selectedFormat,
+  selectedFormats,
   availableFormats,
+  downloadLinks,
 }) => {
-  const isH5AD = availableFormats.includes(DATASET_ASSET_FORMAT.H5AD);
-  const isRDS = availableFormats.includes(DATASET_ASSET_FORMAT.RDS);
   const handleChange = (event: React.FormEvent<HTMLElement>) => {
     const value = (event.target as HTMLInputElement)
       .value as DATASET_ASSET_FORMAT;
-
     handleChangeRaw(value);
   };
-
   return (
     <FormControl>
-      <FormLabel>Data Format</FormLabel>
-      <RadioGroup
-        name="dataFormat"
-        onChange={handleChange}
-        row
-        value={selectedFormat}
-        style={{ height: "15px" }}
-      >
-        <InputRadio
-          disabled={isDisabled || !isH5AD}
-          label=".h5ad (AnnData v0.10)"
-          value={DATASET_ASSET_FORMAT.H5AD}
-        />
-        <Tooltip
-          arrow
-          placement="top"
-          sdsStyle="dark"
-          slotProps={TOOLTIP_SLOT_PROPS}
-          title={isRDS ? null : TOOLTIP_TITLE}
-        >
-          {/* The radio button is enclosed within a <span> tag to enable tooltip functionality when the radio button is disabled. */}
-          {/* See https://github.com/chanzuckerberg/sci-components/blob/main/packages/components/src/core/Tooltip/index.tsx#L28. */}
-          <span>
-            <InputRadio
-              disabled={isDisabled || !isRDS}
-              label=".rds (Seurat v5)"
-              value={DATASET_ASSET_FORMAT.RDS}
-            />
-          </span>
-        </Tooltip>
-      </RadioGroup>
+      {POSSIBLE_DOWNLOAD_FORMATS.map(
+        ({ format, label, type, description }) =>
+          availableFormats.has(format) && (
+            <div className="data-format-info" key={format}>
+              <FormLabel className="data-format-type">{type}</FormLabel>
+              <span className="data-format-checkbox-group">
+                <InputCheckbox
+                  disabled={isDisabled || !availableFormats.has(format)}
+                  label={
+                    <span>
+                      {label}
+                      <span className="file-size">
+                        {getFileSize(downloadLinks, format)}
+                      </span>
+                    </span>
+                  }
+                  value={format}
+                  onChange={handleChange}
+                  checked={selectedFormats.includes(format)}
+                />
+              </span>
+              <p className="data-type-description">{description}</p>
+            </div>
+          )
+      )}
     </FormControl>
   );
 };

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/style.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/style.ts
@@ -1,0 +1,36 @@
+import styled from "@emotion/styled";
+import { FormControl as MFormControl } from "@mui/material";
+import { fontBodyXxs } from "@czi-sds/components";
+
+import { spacesS, spacesXl, spacesXxl, gray500 } from "src/common/theme";
+
+export const FormControl = styled(MFormControl)`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: ${spacesXxl}px !important;
+  .data-format-info label {
+    display: flex;
+  }
+  .data-format-checkbox-group {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+  .data-format-checkbox-group label {
+    margin-bottom: 0;
+  }
+  .file-size {
+    padding-left: ${spacesS}px;
+    color: #6c6c6c;
+  }
+
+  .data-format-type {
+    margin-bottom: ${spacesS}px;
+  }
+  .data-type-description {
+    ${fontBodyXxs}
+    padding-left: ${spacesXl}px;
+    color: ${gray500};
+    margin-bottom: 0;
+  }
+`;

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/utils.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/utils.ts
@@ -1,0 +1,39 @@
+import { DATASET_ASSET_FORMAT } from "src/common/entities";
+import { DownloadLinkType } from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content";
+
+export const humanFileSize = (size: number) => {
+  const i = size == 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
+  return (
+    +(size / Math.pow(1024, i)).toFixed(0) * 1 +
+    " " +
+    ["B", "KB", "MB", "GB", "TB"][i]
+  );
+};
+
+export const getFileSize = (
+  downloadLinks: DownloadLinkType[],
+  fileType: DATASET_ASSET_FORMAT
+) => {
+  let fileSize: number | string = "--";
+  if (downloadLinks.length === 0) {
+    return fileSize;
+  }
+  if (fileType === DATASET_ASSET_FORMAT.ATAC_INDEX) {
+    fileSize = downloadLinks
+      .filter(
+        (x) =>
+          x.filetype === DATASET_ASSET_FORMAT.ATAC_INDEX ||
+          x.filetype === DATASET_ASSET_FORMAT.ATAC_FRAGMENT
+      )
+      .reduce((acc, x) => {
+        return x.fileSize ? acc + x.fileSize : acc;
+      }, 0);
+  } else {
+    fileSize =
+      downloadLinks.find((x) => x.filetype === fileType)?.fileSize || "--";
+  }
+  if (typeof fileSize === "string") {
+    return fileSize;
+  }
+  return humanFileSize(fileSize);
+};

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/index.tsx
@@ -1,79 +1,51 @@
 import { FC, ReactNode } from "react";
 import { DialogLoader } from "src/components/Datasets/components/DownloadDataset/style";
-import { FormLabel } from "@mui/material";
-import {
-  FormControl,
-  SeuratNotice,
-  StyledIcon,
-  StyledLink,
-  TextWrapper,
-} from "./style";
-import { track } from "src/common/analytics";
-import { EVENTS } from "src/common/analytics/events";
-
-export const PROMPT_TEXT =
-  "Select one of the data formats to view its download details.";
+import { FormLabel, FormControl } from "@mui/material";
+import { NoneSelected } from "./style";
 
 interface Props {
   downloadPreview?: ReactNode;
+  hasDownloadLinks: boolean;
   selected: boolean;
-  fileSize: number;
   isLoading: boolean;
-  selectedFormat: string;
 }
-
-const MEGA_BYTES = 2 ** 20;
-
-const DOC_SITE_URL = "/docs/03__Download%20Published%20Data#seurat-deprecated";
 
 const Details: FC<Props> = ({
   downloadPreview,
+  hasDownloadLinks,
   selected = false,
-  fileSize = 0,
   isLoading = false,
-  selectedFormat,
 }) => {
   function renderContent() {
     if (isLoading) {
       return <DialogLoader sdsStyle="minimal" />;
     }
 
-    if (!selected) {
-      return <div>{PROMPT_TEXT}</div>;
+    if (!isLoading && !hasDownloadLinks) {
+      return (
+        <NoneSelected>
+          <h4>No Download Links Available</h4>
+          <p>Please try again later.</p>
+        </NoneSelected>
+      );
     }
 
-    return <div>{`${Math.round(fileSize / MEGA_BYTES)}MB`}</div>;
+    if (!selected) {
+      return (
+        <NoneSelected>
+          <h4>No File Selected</h4>
+          <p>Select files to download</p>
+        </NoneSelected>
+      );
+    }
+
+    return downloadPreview;
   }
 
   return (
     <FormControl>
-      {/* TODO: Remove after Seurat has been deprecated */}
-      {selectedFormat == "RDS" && (
-        <SeuratNotice>
-          <StyledIcon
-            sdsIcon="ExclamationMarkCircle"
-            sdsSize="l"
-            sdsType="static"
-          />
-          <TextWrapper>
-            Seurat support will be removed between Nov 15 - Dec 31, 2024. You
-            can download and convert the .h5ad yourself by following these {""}
-            <StyledLink
-              href={DOC_SITE_URL}
-              target="_blank"
-              onClick={() =>
-                track(EVENTS.DOWNLOAD_DATA_SEURAT_DEPRECATION_CLICKED)
-              }
-            >
-              instructions
-            </StyledLink>
-            .
-          </TextWrapper>
-        </SeuratNotice>
-      )}
       <FormLabel>Download Details</FormLabel>
       {renderContent()}
-      {downloadPreview}
     </FormControl>
   );
 };

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/style.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details/style.ts
@@ -1,34 +1,25 @@
-import { Icon } from "@czi-sds/components";
+import { fontBodyXxs, fontHeaderS } from "@czi-sds/components";
 import styled from "@emotion/styled";
-import { FormControl as MFormControl } from "@mui/material";
-import { cornersM, spacesM, spacesS, textPrimary } from "src/common/theme";
+import { spacesS, gray100, gray500 } from "src/common/theme";
 
-export const FormControl = styled(MFormControl)`
-  min-height: 240px;
-`;
-
-export const SeuratNotice = styled.div`
+export const NoneSelected = styled.div`
   align-items: center;
-  background-color: #ffefcf;
-  border-radius: ${cornersM}px;
   display: flex;
-  font-size: 13px;
-  color: ${textPrimary};
+  flex-direction: column;
   gap: ${spacesS}px;
-  margin: 0 0 ${spacesM}px;
-  padding: ${spacesS}px ${spacesM}px;
-`;
-
-export const StyledIcon = styled(Icon)`
-  color: #b77800;
-`;
-
-export const StyledLink = styled.a`
-  color: #b77800;
-  text-decoration: underline;
-  margin: 0;
-`;
-
-export const TextWrapper = styled.span`
-  display: inline;
+  justify-content: center;
+  min-height: 150px;
+  border-radius: 8px;
+  background-color: ${gray100};
+  margin-top: ${spacesS}px;
+  h4 {
+    ${fontHeaderS}
+    font-weight: 600;
+    margin-bottom: 0;
+  }
+  p {
+    ${fontBodyXxs}
+    color: ${gray500};
+    margin-bottom: 0;
+  }
 `;

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/components/CopyCaption/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/components/CopyCaption/index.tsx
@@ -1,18 +1,11 @@
 import { Caption } from "./style";
-import { DATASET_ASSET_FORMAT } from "src/common/entities";
 import { Link } from "@czi-sds/components";
 
 const DISCOVER_API_URL = "https://api.cellxgene.cziscience.com/curation/ui/#/";
 const SCHEMA_URL =
   "https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html";
-const SEURAT_SCHEMA_URL =
-  "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/seurat_encoding.md";
 
-interface Props {
-  selectedFormat: DATASET_ASSET_FORMAT | "";
-}
-
-export default function CopyCaption({ selectedFormat }: Props): JSX.Element {
+export default function CopyCaption(): JSX.Element {
   return (
     <Caption>
       <p>
@@ -44,21 +37,6 @@ export default function CopyCaption({ selectedFormat }: Props): JSX.Element {
         </Link>{" "}
         describes the required metadata embedded in all datasets submitted to CZ
         CELLxGENE Discover.{" "}
-        {selectedFormat === DATASET_ASSET_FORMAT.RDS && (
-          <>
-            All datasets are automatically converted to a{" "}
-            <Link
-              href={SEURAT_SCHEMA_URL}
-              rel="noreferrer noopener"
-              sdsSize="xs"
-              sdsStyle="default"
-              target="_blank"
-            >
-              Seurat v5 object
-            </Link>
-            .
-          </>
-        )}
       </p>
     </Caption>
   );

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/index.tsx
@@ -1,30 +1,37 @@
 import { FC } from "react";
 import { CodeBlock } from "./style";
 import CopyButton from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/components/CopyButton";
-import { DATASET_ASSET_FORMAT } from "src/common/entities";
 import CopyCaption from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/components/CopyCaption";
-
+import type { DownloadLinkType } from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content";
 interface Props {
-  downloadLink: string;
+  downloadLinks: DownloadLinkType[];
   handleAnalytics: () => void;
-  selectedFormat: DATASET_ASSET_FORMAT | "";
+  formatsToDownload: string[];
 }
 
 const DownloadLink: FC<Props> = ({
-  downloadLink,
+  downloadLinks,
   handleAnalytics,
-  selectedFormat,
+  formatsToDownload,
 }) => {
+  const copyText = downloadLinks.reduce((acc, download) => {
+    if (!formatsToDownload.includes(download.filetype)) {
+      return acc;
+    }
+    return acc + download.downloadURL + "\n";
+  }, "");
+
   return (
     <>
       <CodeBlock>
-        <code>{downloadLink}</code>
+        <code>{copyText}</code>
         <CopyButton
-          downloadLink={downloadLink}
+          downloadLink={copyText}
           handleAnalytics={handleAnalytics}
+          label={downloadLinks.length > 1 ? "Copy All" : "Copy"}
         />
       </CodeBlock>
-      <CopyCaption selectedFormat={selectedFormat} />
+      <CopyCaption />
     </>
   );
 };

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/style.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DownloadLink/style.ts
@@ -26,9 +26,9 @@ export const CodeBlock = styled.div`
     box-sizing: content-box;
     flex: 1;
     line-height: 20px;
-    max-height: 40px;
     overflow: hidden;
     padding: ${spacesXxs}px 0 0;
+    white-space: pre-line;
   }
 
   code:before,

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/utils.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/utils.ts
@@ -1,0 +1,48 @@
+import { DATASET_ASSET_FORMAT } from "src/common/entities";
+import { DownloadLinkType } from "./index";
+import { DEFAULT_FETCH_OPTIONS } from "src/common/queries/common";
+import { apiTemplateToUrl } from "src/common/utils/apiTemplateToUrl";
+import { API_URL } from "src/configs/configs";
+import { API } from "src/common/API";
+import { DatasetAsset } from "src/common/entities";
+
+export const downloadMultipleFiles = (
+  formatsToDownload: DATASET_ASSET_FORMAT[],
+  downloadLinks: DownloadLinkType[]
+) => {
+  downloadLinks.forEach((download) => {
+    if (formatsToDownload.includes(download.filetype) && download.downloadURL) {
+      const a = document.createElement("a");
+      a.href = download.downloadURL;
+      a.download = download.downloadURL.split("/").pop() || "";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    }
+  });
+};
+
+export const getDownloadLink = async (
+  asset: DatasetAsset
+): Promise<DownloadLinkType | null> => {
+  try {
+    const url = apiTemplateToUrl(API.DATASET_ASSET_DOWNLOAD_LINK, {
+      asset_id: asset.id,
+      dataset_id: asset.dataset_id,
+    });
+
+    const result = await fetch(`${API_URL}${url}`, {
+      ...DEFAULT_FETCH_OPTIONS,
+      method: "GET",
+    }).then((res) => res.json());
+    console.log("result", result);
+    return {
+      filetype: asset.filetype,
+      fileSize: result.file_size,
+      downloadURL: result.url,
+    };
+  } catch (error) {
+    console.error("Error fetching download link for asset:", asset, error);
+    return null;
+  }
+};

--- a/frontend/src/components/Datasets/components/DownloadDataset/style.ts
+++ b/frontend/src/components/Datasets/components/DownloadDataset/style.ts
@@ -1,11 +1,18 @@
 import { fontBodyS, fontCapsXxs } from "@czi-sds/components";
 import styled from "@emotion/styled";
-import { grey500, spacesL, spacesS, spacesXl } from "src/common/theme";
+import {
+  grey500,
+  spacesL,
+  spacesS,
+  spacesXl,
+  spacesXxl,
+} from "src/common/theme";
 import Loader from "src/components/common/Grid/components/Loader";
 import { StyledDialog as CommonStyledDialog } from "src/views/Collection/common/style";
 
 export const StyledDialog = styled(CommonStyledDialog)`
   .MuiDialog-paper {
+    padding: ${spacesXxl}px;
     gap: ${spacesXl}px;
     min-height: 570px; /* min-height ensures dialog height consistency in any download state. */
   }

--- a/frontend/src/pages/collections-sitemap.xml/index.tsx
+++ b/frontend/src/pages/collections-sitemap.xml/index.tsx
@@ -7,6 +7,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     "https://api.cellxgene.cziscience.com/dp/v1/collections/index"
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const collections: any[] = await response.json();
 
   const fields: ISitemapField[] = collections.map((collection) => ({

--- a/frontend/src/views/CensusDirectory/utils.ts
+++ b/frontend/src/views/CensusDirectory/utils.ts
@@ -9,6 +9,7 @@ export const getProjectTier = (project: UnionProject) => {
 
 export type ClobberedProjects = [Partial<UnionProject>, UnionProject[]][];
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isEqual(obj1: any, obj2: any): boolean {
   Object.keys(obj1).forEach((key) => {
     if (typeof obj1[key] === "object" && typeof obj2[key] === "object") {


### PR DESCRIPTION
## Reason for Change

- A 500 error is returned when hitting the endpoint/dp/v1/datasets/f{dataset_id}/asset/{asset_id} for ATAC fragments and index files. This in turn prevent the frontend from generating download URLs for users.
- blocked by https://github.com/chanzuckerberg/single-cell-infra/pull/1047

## Changes

- add
- remove
- modify

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.
- "Unit tested only", "tested in rdev by a, b, c, verifying feature worked by... ", "manually ran pipeline locally with these results: ..."

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
- in the backend a 403 is returned from the s3.head_object for the ATAC artifacts.