### PR TITLE
feat: bump ingestion batch job resources + dataset migration step resources

### DIFF
--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -11,7 +11,7 @@ resource aws_batch_job_definition batch_job_def {
   container_properties = jsonencode({
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
-  "memory": 8000,
+  "memory": 16000,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",
@@ -42,7 +42,7 @@ resource aws_batch_job_definition batch_job_def {
       "value": "${var.frontend_url}"
     }
   ],
-  "vcpus": 1,
+  "vcpus": 2,
   "logConfiguration": {
     "logDriver": "awslogs",
     "options": {

--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -43,11 +43,11 @@ resource aws_batch_job_definition schema_migrations {
     resourceRequirements = [
         {
           type= "VCPU",
-          Value="2"
+          Value="1"
         },
         {
           Type="MEMORY",
-          Value = "16000"
+          Value = "8000"
         }
     ]
     logConfiguration= {

--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -60,6 +60,54 @@ resource aws_batch_job_definition schema_migrations {
   })
 }
 
+resource aws_batch_job_definition dataset_migrations {
+  type = "container"
+  name = "dp-${var.deployment_stage}-${var.custom_stack_name}-dataset_migrations-${local.name}"
+  container_properties = jsonencode({
+    jobRoleArn= var.batch_role_arn,
+    image= var.image,
+    environment= [
+      {
+        name= "ARTIFACT_BUCKET",
+        value= var.artifact_bucket
+      },
+      {
+        name= "DEPLOYMENT_STAGE",
+        value= var.deployment_stage
+      },
+      {
+        name= "AWS_DEFAULT_REGION",
+        value= data.aws_region.current.name
+      },
+      {
+        name= "REMOTE_DEV_PREFIX",
+        value= var.remote_dev_prefix
+      },
+      {
+        name= "DATASETS_BUCKET",
+        value= var.datasets_bucket
+      },
+    ],
+    resourceRequirements = [
+        {
+          type= "VCPU",
+          Value="2"
+        },
+        {
+          Type="MEMORY",
+          Value = "16000"
+        }
+    ]
+    logConfiguration= {
+      logDriver= "awslogs",
+      options= {
+        awslogs-group= aws_cloudwatch_log_group.batch_cloud_watch_logs_group.id,
+        awslogs-region= data.aws_region.current.name
+      }
+    }
+  })
+}
+
 resource aws_batch_job_definition pubish_revisions {
   type = "container"
   name = "dp-${var.deployment_stage}-${var.custom_stack_name}-${local.name}-publish-revisions"
@@ -332,7 +380,7 @@ resource aws_sfn_state_machine sfn_schema_migration {
                   "Type": "Task",
                   "Resource": "arn:aws:states:::batch:submitJob.sync",
                   "Parameters": {
-                    "JobDefinition": "${resource.aws_batch_job_definition.schema_migrations.arn}",
+                    "JobDefinition": "${resource.aws_batch_job_definition.dataset_migrations.arn}",
                     "JobName": "dataset_migration",
                     "JobQueue": "${var.job_queue_arn}",
                     "Timeout": {


### PR DESCRIPTION
## Reason for Change

- Need more resources for some datasets' validation, add labels, etc.
- Need resources for dataset migration step as well, but not for other steps in migration

## Changes

- bump resource allocation for ingestion batch jobs from 1vcpu, 8 gb --> 2 vcpu, 16 gb (includes both validate steps, add labels)
- refactor migration batch job allocation to have a separate batch job definition for dataset migration job, which requires more resources than other steps