### PR TITLE
fix: Newsletter Subscribe VC-2285

### DIFF
--- a/frontend/src/components/BottomBanner/components/ModalContent/connect.ts
+++ b/frontend/src/components/BottomBanner/components/ModalContent/connect.ts
@@ -4,7 +4,7 @@ import { EVENTS } from "src/common/analytics/events";
 import {
   FAILED_EMAIL_VALIDATION_STRING,
   FORM_CONTAINER_ID_QUERY,
-  HIDDEN_NEWSLETTER_SUCCESS_MESSAGE,
+  HIDDEN_NEWSLETTER_SUCCESS_CLASS,
 } from "../../constants";
 
 export const useConnect = ({
@@ -54,11 +54,14 @@ export const useConnect = ({
   };
 
   /**
-   * validate
-   * validates the email input field
-   * returns true if the email is valid, false otherwise
-   * sets the error state if the email is invalid
-   * */
+   * Validates the email input field by checking its validity state.
+   *
+   * - If the email field is missing a value or contains an invalid email format,
+   *   an error message is set, and a failure event is tracked.
+   * - If the email is valid, the error message is cleared.
+   *
+   * @returns {boolean} `true` if the email input is valid, otherwise `false`.
+   */
   const validate = () => {
     const validityState = emailRef.current?.validity;
 
@@ -100,7 +103,10 @@ export const useConnect = ({
           /**
            *  Submission success flow
            */
-          if (node?.textContent?.includes(HIDDEN_NEWSLETTER_SUCCESS_MESSAGE)) {
+          if (
+            node instanceof Element &&
+            node.classList.contains(HIDDEN_NEWSLETTER_SUCCESS_CLASS)
+          ) {
             setIsSubmitted(true);
             setError("");
             track(EVENTS.NEWSLETTER_SIGNUP_SUCCESS);

--- a/frontend/src/components/BottomBanner/constants.ts
+++ b/frontend/src/components/BottomBanner/constants.ts
@@ -18,6 +18,5 @@ export const NEWSLETTER_SIGNUP_BANNER_SUBSCRIBE_TEXT =
   "to our newsletter to receive updates about new features.";
 export const FAILED_EMAIL_VALIDATION_STRING =
   "Please provide a valid email address.";
-export const HIDDEN_NEWSLETTER_SUCCESS_MESSAGE =
-  "Thank you for joining our newsletter.";
+export const HIDDEN_NEWSLETTER_SUCCESS_CLASS = "submitted-message";
 export const HUBSPOT_URL = "https://js.hsforms.net/forms/v2.js";


### PR DESCRIPTION
## Reason for Change

- Newsletter `Subscribe` was not displaying success message upon signup

## Changes

- The script was checking for a hidden success message returned from HubSpot - since the copy of that message has changed by the provider over time, the logic that displays the success message to the user was skipped
- Updated the logic to look for `submitted-message` class name in the hidden form node upon submission instead of looking for the hidden text, as it is less likely to change over time

## Testing steps

- Click subscribe from the bottom banner - and enter a valid email
