### PR TITLE
chore: anndata version follow cellxgene-schema requirements

### DIFF
--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,4 +1,4 @@
-anndata==0.11.2
+anndata==0.11.4
 awscli
 boto3>=1.11.17
 cellxgene-schema

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,4 +1,4 @@
-anndata
+anndata # uses the version supplied by cellxgene-schema
 awscli
 boto3>=1.11.17
 cellxgene-schema

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,4 +1,4 @@
-anndata==0.11.4
+anndata
 awscli
 boto3>=1.11.17
 cellxgene-schema


### PR DESCRIPTION
## Reason for Change

- The anndata version used by the processing conrtainer follow cellxgene-schema requirements

## Changes

- unpin the anndata version for the processing container. Now it'll use the version required by cellxgene-schema.

## Testing steps
- verify tests pass.

