### PR TITLE
chore: update runners with new drop-in replacement

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -133,7 +133,7 @@ jobs:
 
   e2e-logged-in-test:
     timeout-minutes: 30
-    runs-on: x64-xl-privileged
+    runs-on: xl-amd64-privileged
     needs:
       - upgrade
     steps:
@@ -203,7 +203,7 @@ jobs:
   run-e2e-tests:
     timeout-minutes: 30
     name: e2e-tests ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
-    runs-on: x64-xl-privileged
+    runs-on: xl-amd64-privileged
     needs:
       - upgrade
     strategy:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   lint:
     if: ${{ ! startsWith(github.head_ref, 'renovate/') }}
-    runs-on: x64-xl-privileged
+    runs-on: xl-amd64-privileged
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   functional-test:
-    runs-on: x64-xl-privileged
+    runs-on: xl-amd64-privileged
     timeout-minutes: 30
     steps:
       - name: Configure AWS Credentials
@@ -40,7 +40,7 @@ jobs:
           DEPLOYMENT_STAGE=rdev STACK_NAME=${{ env.STACK_NAME }} make functional-test
 
   seed-database-e2e-tests:
-    runs-on: x64-xl-privileged
+    runs-on: xl-amd64-privileged
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -62,7 +62,7 @@ jobs:
       - seed-database-e2e-tests
     timeout-minutes: 30
     name: e2e-tests ${{ matrix.project }} ${{ matrix.shardCurrent }} of ${{ matrix.shardTotal }}
-    runs-on: x64-xl-privileged
+    runs-on: xl-amd64-privileged
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +155,7 @@ jobs:
     # Merge reports after playwright-tests, even if some shards have failed
     if: always()
     needs: run-e2e-tests
-    runs-on: x64-xl-privileged
+    runs-on: xl-amd64-privileged
     defaults:
       run:
         working-directory: frontend
@@ -191,7 +191,7 @@ jobs:
   e2e-test:
     if: always()
     name: e2e-test
-    runs-on: x64-xl-privileged
+    runs-on: xl-amd64-privileged
     needs:
       - run-e2e-tests
     steps:
@@ -208,7 +208,7 @@ jobs:
 
   e2e-logged-in-test:
     timeout-minutes: 30
-    runs-on: x64-xl-privileged
+    runs-on: xl-amd64-privileged
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/rebuild-processing-image.yml
+++ b/.github/workflows/rebuild-processing-image.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         branch: [main, staging, prod]
-    runs-on: x64-xl-privileged
+    runs-on: xl-amd64-privileged
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
We changed how to manage self-hosted runner scalesets and in doing so have a programatically generated scaleset name. This new scaleset has the same specs as the old runner scaleset.