### PR TITLE
fix: copy atac status/files when running dataset metadata update job

### DIFF
--- a/backend/layers/processing/dataset_metadata_update.py
+++ b/backend/layers/processing/dataset_metadata_update.py
@@ -333,9 +333,13 @@ class DatasetMetadataUpdater(ProcessValidateH5AD):
             self.update_processing_status(new_dataset_version_id, DatasetStatusKey.ATAC, DatasetConversionStatus.COPIED)
         else:
             self.logger.info("Main: No ATAC fragment found, copying status from current dataset version")
-            self.update_processing_status(
-                new_dataset_version_id, DatasetStatusKey.ATAC, current_dataset_version.status.atac_status
+            # account for edge case of status erroneously set to None
+            current_dataset_version_status = (
+                current_dataset_version.status.atac_status
+                if current_dataset_version.status.atac_status
+                else DatasetConversionStatus.NA
             )
+            self.update_processing_status(new_dataset_version_id, DatasetStatusKey.ATAC, current_dataset_version_status)
 
         # blocking call on async functions before checking for valid artifact statuses
         [j.join() for j in artifact_jobs]

--- a/backend/layers/processing/dataset_metadata_update.py
+++ b/backend/layers/processing/dataset_metadata_update.py
@@ -324,12 +324,10 @@ class DatasetMetadataUpdater(ProcessValidateH5AD):
                 artifact.id for artifact in current_dataset_version.artifacts if artifact.uri == fragment_uri
             ][0]
             self.business_logic.database_provider.add_artifact_to_dataset_version(new_dataset_version_id, fragment_id)
-            if DatasetArtifactType.ATAC_INDEX in artifact_uris:
-                index_uri = artifact_uris[DatasetArtifactType.ATAC_INDEX]
-                index_id = [artifact.id for artifact in current_dataset_version.artifacts if artifact.uri == index_uri][
-                    0
-                ]
-                self.business_logic.database_provider.add_artifact_to_dataset_version(new_dataset_version_id, index_id)
+            # an atac index file is always available if an atac fragment is available; copy that over as well
+            index_uri = artifact_uris[DatasetArtifactType.ATAC_INDEX]
+            index_id = [artifact.id for artifact in current_dataset_version.artifacts if artifact.uri == index_uri][0]
+            self.business_logic.database_provider.add_artifact_to_dataset_version(new_dataset_version_id, index_id)
             self.update_processing_status(new_dataset_version_id, DatasetStatusKey.ATAC, DatasetConversionStatus.COPIED)
         else:
             self.logger.info("Main: No ATAC fragment found, copying status from current dataset version")

--- a/backend/layers/processing/process_validate_atac.py
+++ b/backend/layers/processing/process_validate_atac.py
@@ -99,7 +99,6 @@ class ProcessValidateATAC(ProcessingLogic):
                 dataset_version_id,
                 DatasetStatusKey.ATAC,
                 DatasetConversionStatus.NA,
-                validation_errors=[str(e)],
             )
             return True
 

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -710,6 +710,7 @@ paths:
                         UPLOADED,
                         SKIPPED,
                         FAILED,
+                        COPIED,
                         NA,
                       ]
                   h5ad_status:

--- a/frontend/doc-site/032__Contribute and Publish Data.mdx
+++ b/frontend/doc-site/032__Contribute and Publish Data.mdx
@@ -1,105 +1,141 @@
 # Contributing Data
 
-CELLxGENE supports a rapidly growing single cell data corpus because of generous contributions from researchers like you! If you have single cell data that meet our [requirements](#dataset-requirements), please reach out to our curation team at [cellxgene@chanzuckerberg.com](mailto:cellxgene@chanzuckerberg.com).
+CELLxGENE supports a rapidly growing single-cell data corpus because of generous contributions from researchers like you!
 
-## Publishing Process
+## Submission and Publication Process
 
-The process for submission to the portal is:
-
-- You confirm we can support your submission by reaching out to our curation team at [cellxgene@chanzuckerberg.com](mailto:cellxgene@chanzuckerberg.com) with a description of the data that you'd like to contribute.
-- We confirm that we will accept your data.
-- You prepare your data according to our submission [requirements](#dataset-requirements) and send us your files.
-- We upload to a private Collection where you can review.
-- You prepare revised data and send us your revised files, as needed.
-- We publish the data when you tell us to.
+1. Review the [Data Eligibility](#data-eligibility) criteria to ensure your data complies with these requirements
+2. [Contact us] with a description of the data that you'd like to contribute to confirm that we will accept your data
+3. Once confirmed, you send us files prepared according to the submission [Requirements](#dataset-requirements)
+4. We upload to a private Collection where you can review
+5. The submission can be revised, as needed
+6. The data are made openly available when you are ready
 
 ## Dataset Requirements
 
 ### Data Eligibility
 
-CELLxGENE is focused on supporting the global community attempting to create references of human cells and tissues. As a result, there are a few kinds of datasets that we are **not** likely to accept at this time:
+CELLxGENE supports most single-cell RNA-seq and ATAC-seq data, but a few types of data are **not** accepted at this time:
 
 - drug screens
 - cell lines
-- organisms other than mouse or human
-- assays not on the [CELLxGENE Census accepted assays list](https://github.com/chanzuckerberg/cellxgene-census/blob/main/docs/census_accepted_assays.csv)
-  - These additional assays are pending Census acceptance and will be accepted:
-    - Visium (non-HD)
-    - Slide-seq
-    - Expression measurements of multi-modal assays (e.g. 10x multiome, mCT-seq)
+- species not on the [supported list](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#organism_ontology_term_id)
+- assays not on the [supported list](https://github.com/chanzuckerberg/cellxgene-census/blob/main/docs/census_accepted_assays.csv)
+  - these additional assays are pending Census acceptance and will be accepted:
+    - expression measurements from multi-modal assays (e.g. 10x multiome, mCT-seq)
+    - unpaired ATAC-seq measurements
+
+CELLxGENE continues to expand support for additional species and assays so please [contact us] if you are interested in submitting data not currently covered by the supported lists.
 
 ### Scale Constraints
 
-CELLxGENE Discover sets the maximum dataset size for submissions to 50GB. Additionally, CELLxGENE Explorer sets the maximum number of cells to 4.6 million for exploration of datasets.
+CELLxGENE Discover sets the maximum per dataset file size for submissions to 50 GB. Additionally, datasets with more than 4.6 million cells can be submitted but will not visualized in CELLxGENE Explorer.
 
 ### Formatting Requirements
 
-We need the following Collection metadata (i.e. details associated with your publication or study)
+Include the following Collection metadata in your emails to describe your publication or study, all of which can be edited as titles, abstracts, etc. change:
 
 - **Collection information**:
   - Title
   - Description
   - Contact: a single name and email
-  - Publication/preprint DOI: _optional_ can be added later
-  - URLs: _optional_ can be added later. Any links to related data or resources, such as GEO or protocols.io
-  - Consortia: _optional_ can be added later. Can be one or more of those listed [here](https://github.com/chanzuckerberg/single-cell-data-portal/blob/main/backend/layers/common/validation.py#L12)
+  - Publication/preprint DOI: _optional_
+  - URLs _optional_
+    - any links to the corresponding raw sequence data, protocols, and other related data or resources
+  - Consortia _optional_
+    - one or more of those listed [here](https://github.com/chanzuckerberg/single-cell-data-portal/blob/main/backend/layers/common/validation.py#L12)
 
 The full schema is documented [here](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html) but is summarized below. Each dataset needs the following information added to a single h5ad (AnnData 0.10) format file:
 
 - **Dataset-level metadata in uns**:
   - **title**
-    - title of the individual dataset
   - **batch_condition** _optional_
     - list of obs fields that define “batches” that a normalization or integration algorithm should be aware of
   - **default_embedding** _optional_
-    - the obsm key associated with the embeddings you would like to be displayed in CELLxGENE by default
+    - the obsm key associated with the embeddings you would like to be displayed in CELLxGENE Explorer by default
 - **Data in .X and raw.X**:
   - raw counts are required
   - normalized counts are strongly recommended
   - raw counts should be in raw.X if normalized counts are in .X
   - if there is no normalized matrix, raw counts should be in .X
-- **Cell metadata in obs (for ontology term IDs, the values MUST be the most specific term available from the specified ontology)**:
+- **Cell metadata in obs** (ontology term IDs MUST be the most specific term available from the specified ontology):
   - **organism_ontology_term_id**
-    - [NCBITaxon](https://www.ncbi.nlm.nih.gov/taxonomy) (`NCBITaxon:9606` for human, `NCBITaxon:10090` for mouse)
+    - [NCBITaxon] See [the schema](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#organism_ontology_term_id) for specific values
   - **donor_id**
-    - free-text identifier that distinguishes the unique individual that data were derived from. It is encouraged to be something not likely to be used in other studies (e.g. donor_1 is likely to not be unique in the data corpus)
+    - free-text identifier that distinguishes the unique individual that data were derived from
   - **development_stage_ontology_term_id**
-    - [HsapDv](https://www.ebi.ac.uk/ols/ontologies/hsapdv) if human, [MmusDv](https://www.ebi.ac.uk/ols/ontologies/mmusdv) if mouse, `unknown` if information unavailable
+    - human [HsapDv]
+    - mouse [MmusDv]
+    - roundworm [WBls](https://www.ebi.ac.uk/ols4/ontologies/wbls/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FWBls_0000825?lang=en)
+    - zebrafish [ZFS]
+    - fruit fly FBdv descendent of [development stage](https://www.ebi.ac.uk/ols4/ontologies/fbdv/classes?obo_id=FBdv%3A00005259) or [age](https://www.ebi.ac.uk/ols4/ontologies/fbdv/classes?obo_id=FBdv%3A00007014)
+    - other organsism [UBERON](https://www.ebi.ac.uk/ols4/ontologies/uberon/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FUBERON_0000105)
+    - `unknown` if information unavailable
   - **sex_ontology_term_id**
-    - `PATO:0000384` for male, `PATO:0000383` for female, or `unknown` if unavailable
+    - `PATO:0000384` for male, `PATO:0000383` for female, `PATO:0001340` for hermaphrodite, or `unknown` if unavailable
   - **self_reported_ethnicity_ontology_term_id**
-    - [HANCESTRO](https://www.ebi.ac.uk/ols/ontologies/hancestro) multiple comma-separated terms may be used if more than one ethnicity is reported. If human and information unavailable, use `unknown`. Use `na` if non-human
+    - human [HANCESTRO]
+    - multiple comma-separated terms may be used if more than one ethnicity is reported
+    - `unknown` if information unavailable
+    - other organisms `na`
   - **disease_ontology_term_id**
-    - [MONDO](https://www.ebi.ac.uk/ols/ontologies/mondo) or `PATO:0000461` for 'normal'
-    - Any known disease that is thought to, or is being tested to, have an impact on the measurement being taken in this experiment. Not necessarily any known disease of the donor
+    - [MONDO] or `PATO:0000461` for normal
+    - not necessarily any known disease of the donor, but rather any known disease thought to, or being tested to, have an impact on the measurement being taken
   - **tissue_type**
     - `tissue`, `organoid`, or `cell culture`
   - **tissue_ontology_term_id**
-    - [UBERON](https://www.ebi.ac.uk/ols/ontologies/uberon)
+    - round worm [WBbt](https://www.ebi.ac.uk/ols4/ontologies/wbbt/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FWBbt_0005766) or [UBERON]
+    - zebrafish [ZFA](https://www.ebi.ac.uk/ols4/ontologies/zfa/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FZFA_0100000?lang=en) or [UBERON]
+    - fruit fly [FBbt](https://www.ebi.ac.uk/ols4/ontologies/fbbt) or [UBERON]
+    - other organisms [UBERON]
   - **cell_type_ontology_term_id**
-    - [CL](https://www.ebi.ac.uk/ols/ontologies/cl)
+    - roundworm [WBbt](https://www.ebi.ac.uk/ols4/ontologies/wbbt/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FWBbt_0004017) or [CL]
+    - zebrafish [ZFA](https://www.ebi.ac.uk/ols4/ontologies/zfa/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FZFA_0009000) or [CL]
+    - fruit fly [FBbt](https://www.ebi.ac.uk/ols4/ontologies/fbbt/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FFBbt_00007002) or [CL]
+    - other organisms [CL]
   - **assay_ontology_term_id**
-    - [EFO](https://www.ebi.ac.uk/ols/ontologies/efo)
+    - [EFO]
   - **suspension_type**
-    - `cell`, `nucleus`, or `na`, as corresponding to assay. Use [this table](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#suspension_type) defined in the data schema for guidance. If the assay does not appear in this table, the most appropriate value MUST be selected and the [curation team informed](mailto:cellxgene@chanzuckerberg.com) during submission so that the assay can be added to the table
+    - `cell`, `nucleus`, or `na`
 - **Embeddings in obsm**:
-  - One or more two-dimensional embeddings, prefixed with 'X\_'
+  - one or more two-dimensional embeddings, prefixed with 'X\_'
 - **Features in var & raw.var (if present)**:
-  - index is Ensembl ID
-  - preference is that gene have not been filtered in order to maximize future data integration efforts
+  - index is Ensembl gene ID
+  - preference is that genes have not been filtered in order to maximize future data integration efforts
 - **Additional standards for single-capture area Visium datasets** (largely aligns with [scanpy’s model](https://scanpy.readthedocs.io/en/stable/generated/scanpy.read_visium.html), [this notebook](https://github.com/Lattice-Data/lattice-tools/blob/main/cellxgene_resources/curation_visium.ipynb) may be helpful to curate from Space Ranger outputs):
-  - Empty spots must be included (should be 4992 observations)
+  - empty spots must be included
+    - 4992 total observations for 6.5 mm capture areas
+    - 14336 total observations for 11 mm capture areas
   - **obsm['spatial']**
   - **obs['array_row']**
   - **obs['array_col']**
   - **obs['in_tissue']**
-  - **uns['spatial'][library_id]['images']['fullres']** _preferred_ fullres image
-  - **uns['spatial'][library_id]['images']['hires']** hires image
+  - **uns['spatial'][library_id]['images']['fullres']** _preferred_
+    - fullres image that is _input_ to Space Ranger
+  - **uns['spatial'][library_id]['images']['hires']**
+    - hires image that is _output_ from Space Ranger
   - **uns['spatial'][library_id]['scalefactors']['spot_diameter_fullres']**
   - **uns['spatial'][library_id]['scalefactors']['tissue_hires_scalef']**
+  - multiple-capture area Visium datasets are permitted if each capture area is also submitted individually
+    - the addtional Visium standards do not apply to these
 - **Additional standards for single-puck Slide-seq datasets**:
   - **obsm['spatial']**
+  - multiple-puck Slide-seq datasets are permitted if each puck is also submitted individually
+    - obsm['spatial'] is not required for these
+- **Additional ATAC-seq standards**
+  - Fragment files are required for unpaired ATAC-seq submissions, _preferred_ for multi-modal submissions
 
 ## Data Submission Policy
 
 I give CZI permission to display, distribute, and create derivative works (e.g. visualizations) of this data for purposes of offering CELLxGENE Discover, and I have the authority to give this permission. It is my responsibility to ensure that this data is not identifiable. In particular, I commit that I will remove any [direct personal identifiers](https://docs.google.com/document/d/1sboOmbafvMh3VYjK1-3MAUt0I13UUJfkQseq8ANLPl8/edit) in the metadata portions of the data, and that CZI may further contact me if it believes more work is needed to de-identify it. If I choose to publish this data publicly on CELLxGENE Discover, I understand that (1) anyone will be able to access it subject to a CC-BY 4.0 license, meaning they can download, share, and use the data without restriction beyond providing attribution to the original data contributor(s) and (2) the Collection details (including Collection name, description, my name, and the contact information for the datasets in this Collection) will be made public on CELLxGENE Discover as well. I understand that I have the ability to delete the data that I have published from CELLxGENE Discover if I later choose to. This however will not undo any prior downloads or shares of such data.
+
+[contact us]: mailto:cellxgene@chanzuckerberg.com
+[CL]: https://www.ebi.ac.uk/ols/ontologies/cl
+[EFO]: https://www.ebi.ac.uk/ols/ontologies/efo
+[HANCESTRO]: https://www.ebi.ac.uk/ols/ontologies/hancestro
+[HsapDv]: https://www.ebi.ac.uk/ols/ontologies/hsapdv
+[MONDO]: https://www.ebi.ac.uk/ols/ontologies/mondo
+[MmusDv]: https://www.ebi.ac.uk/ols/ontologies/mmusdv
+[NCBITaxon]: https://www.ncbi.nlm.nih.gov/taxonomy
+[UBERON]: https://www.ebi.ac.uk/ols/ontologies/uberon
+[ZFS]: https://www.ebi.ac.uk/ols4/ontologies/zfs

--- a/tests/functional/backend/conftest.py
+++ b/tests/functional/backend/conftest.py
@@ -93,9 +93,9 @@ def upload_dataset(session, api_url, curator_cookie, request):
 def upload_dataset_metadata(session, api_url, curator_cookie, request):
     def _upload_dataset_metadata(collection_id, metadata):
         collection_errors = update_metadata_and_wait(session, api_url, curator_cookie, collection_id, metadata)
-        dataset_ids = list(collection_errors.keys())
-        if collection_errors:
+        if any(errors for errors in collection_errors.values()):
             raise pytest.fail(str(collection_errors))
+        dataset_ids = list(collection_errors.keys())
         return collection_id, dataset_ids
 
     return _upload_dataset_metadata

--- a/tests/functional/backend/conftest.py
+++ b/tests/functional/backend/conftest.py
@@ -11,6 +11,7 @@ from tests.functional.backend.utils import (
     make_cookie,
     make_proxy_auth_token,
     make_session,
+    update_metadata_and_wait,
     upload_manifest_and_wait,
     upload_url_and_wait,
 )
@@ -86,6 +87,17 @@ def upload_dataset(session, api_url, curator_cookie, request):
         return dataset_id
 
     return _upload_dataset
+
+
+@pytest.fixture(scope="session")
+def upload_dataset_metadata(session, api_url, curator_cookie, request):
+    def _upload_dataset_metadata(collection_id, metadata):
+        collection_errors = update_metadata_and_wait(session, api_url, curator_cookie, collection_id, metadata)
+        if collection_errors:
+            raise pytest.fail(str(collection_errors))
+        return collection_id
+
+    return _upload_dataset_metadata
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/backend/conftest.py
+++ b/tests/functional/backend/conftest.py
@@ -104,8 +104,8 @@ def upload_collection_metadata(session, api_url, curator_cookie, request):
 
 @pytest.fixture(scope="session")
 def upload_dataset_title(session, api_url, curator_cookie, request):
-    def _upload_dataset_title(collection_id, title):
-        return update_title_and_wait(session, api_url, curator_cookie, collection_id, title)
+    def _upload_dataset_title(collection_id, dataset_id, title):
+        return update_title_and_wait(session, api_url, curator_cookie, collection_id, dataset_id, title)
 
     return _upload_dataset_title
 

--- a/tests/functional/backend/conftest.py
+++ b/tests/functional/backend/conftest.py
@@ -12,6 +12,7 @@ from tests.functional.backend.utils import (
     make_proxy_auth_token,
     make_session,
     update_metadata_and_wait,
+    update_title_and_wait,
     upload_manifest_and_wait,
     upload_url_and_wait,
 )
@@ -99,6 +100,14 @@ def upload_collection_metadata(session, api_url, curator_cookie, request):
         return collection_id, dataset_ids
 
     return _upload_collection_metadata
+
+
+@pytest.fixture(scope="session")
+def upload_dataset_title(session, api_url, curator_cookie, request):
+    def _upload_dataset_title(collection_id, title):
+        return update_title_and_wait(session, api_url, curator_cookie, collection_id, title)
+
+    return _upload_dataset_title
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/backend/conftest.py
+++ b/tests/functional/backend/conftest.py
@@ -90,15 +90,15 @@ def upload_dataset(session, api_url, curator_cookie, request):
 
 
 @pytest.fixture(scope="session")
-def upload_dataset_metadata(session, api_url, curator_cookie, request):
-    def _upload_dataset_metadata(collection_id, metadata):
+def upload_collection_metadata(session, api_url, curator_cookie, request):
+    def _upload_collection_metadata(collection_id, metadata):
         collection_errors = update_metadata_and_wait(session, api_url, curator_cookie, collection_id, metadata)
         if any(errors for errors in collection_errors.values()):
             raise pytest.fail(str(collection_errors))
         dataset_ids = list(collection_errors.keys())
         return collection_id, dataset_ids
 
-    return _upload_dataset_metadata
+    return _upload_collection_metadata
 
 
 @pytest.fixture(scope="session")
@@ -142,3 +142,8 @@ def collection_data_DOI_update(request):
         ],
         "name": request.function.__name__,
     }
+
+
+@pytest.fixture()
+def dataset_title_update(request):
+    return {"title": f"Updated Title for {request.function.__name__}"}

--- a/tests/functional/backend/conftest.py
+++ b/tests/functional/backend/conftest.py
@@ -93,9 +93,10 @@ def upload_dataset(session, api_url, curator_cookie, request):
 def upload_dataset_metadata(session, api_url, curator_cookie, request):
     def _upload_dataset_metadata(collection_id, metadata):
         collection_errors = update_metadata_and_wait(session, api_url, curator_cookie, collection_id, metadata)
+        dataset_ids = list(collection_errors.keys())
         if collection_errors:
             raise pytest.fail(str(collection_errors))
-        return collection_id
+        return collection_id, dataset_ids
 
     return _upload_dataset_metadata
 

--- a/tests/functional/backend/conftest.py
+++ b/tests/functional/backend/conftest.py
@@ -126,3 +126,18 @@ def collection_data(request):
         "links": [{"link_name": "a link to somewhere", "link_type": "PROTOCOL", "link_url": "https://protocol.com"}],
         "name": request.function.__name__,
     }
+
+
+@pytest.fixture()
+def collection_data_DOI_update(request):
+    return {
+        "contact_email": "lisbon@gmail.com",
+        "contact_name": "Madrid Sparkle",
+        "curator_name": "John Smith",
+        "description": "Well here are some words",
+        "links": [
+            {"link_name": "a link to somewhere", "link_type": "PROTOCOL", "link_url": "https://protocol.com"},
+            {"link_name": "", "link_type": "DOI", "link_url": "10.1093/nar/gkae1142"},
+        ],
+        "name": request.function.__name__,
+    }

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -153,23 +153,51 @@ def test_delete_private_collection(session, api_url, curator_cookie, collection_
 
 @skip_creation_on_prod
 def test_dataset_upload_flow_with_dataset(
-    session, curator_cookie, api_url, upload_dataset, upload_dataset_metadata, request, collection_data
+    session,
+    curator_cookie,
+    api_url,
+    upload_dataset,
+    upload_dataset_metadata,
+    request,
+    collection_data,
+    collection_data_DOI_update,
 ):
     headers = {"Cookie": f"cxguser={curator_cookie}", "Content-Type": "application/json"}
     collection_id = create_test_collection(headers, request, session, api_url, collection_data)
     _verify_upload_and_delete_succeeded(
-        collection_id, headers, DATASET_URI, session, api_url, upload_dataset, upload_dataset_metadata
+        collection_id,
+        headers,
+        DATASET_URI,
+        collection_data_DOI_update,
+        session,
+        api_url,
+        upload_dataset,
+        upload_dataset_metadata,
     )
 
 
 @skip_creation_on_prod
 def test_dataset_upload_flow_with_visium_dataset(
-    session, curator_cookie, api_url, upload_dataset, upload_dataset_metadata, request, collection_data
+    session,
+    curator_cookie,
+    api_url,
+    upload_dataset,
+    upload_dataset_metadata,
+    request,
+    collection_data,
+    collection_data_DOI_update,
 ):
     headers = {"Cookie": f"cxguser={curator_cookie}", "Content-Type": "application/json"}
     collection_id = create_test_collection(headers, request, session, api_url, collection_data)
     _verify_upload_and_delete_succeeded(
-        collection_id, headers, VISIUM_DATASET_URI, session, api_url, upload_dataset, upload_dataset_metadata
+        collection_id,
+        headers,
+        VISIUM_DATASET_URI,
+        collection_data_DOI_update,
+        session,
+        api_url,
+        upload_dataset,
+        upload_dataset_metadata,
     )
 
 
@@ -182,6 +210,7 @@ def test_dataset_upload_flow_with_atac_seq_dataset(
     upload_dataset_metadata,
     request,
     collection_data,
+    collection_data_DOI_update,
     curation_api_access_token,
 ):
     headers = {"Cookie": f"cxguser={curator_cookie}", "Content-Type": "application/json"}
@@ -193,12 +222,19 @@ def test_dataset_upload_flow_with_atac_seq_dataset(
         collection_data,
     )
     _verify_upload_and_delete_succeeded(
-        collection_id, headers, ATAC_SEQ_MANIFEST, session, api_url, upload_manifest, upload_dataset_metadata
+        collection_id,
+        headers,
+        ATAC_SEQ_MANIFEST,
+        collection_data_DOI_update,
+        session,
+        api_url,
+        upload_manifest,
+        upload_dataset_metadata,
     )
 
 
 def _verify_upload_and_delete_succeeded(
-    collection_id, headers, req_body, session, api_url, upload_and_wait, upload_dataset_metadata
+    collection_id, headers, req_body, metadata_update_body, session, api_url, upload_and_wait, upload_dataset_metadata
 ):
     dataset_id = upload_and_wait(collection_id, req_body)
     # test non owner cant retrieve status
@@ -208,17 +244,7 @@ def _verify_upload_and_delete_succeeded(
         res.raise_for_status()
 
     # update collection DOI and await dataset update
-    updated_data = {
-        "contact_email": "person@random.com",
-        "contact_name": "Doctor Who",
-        "description": "These are different words",
-        "links": [
-            {"link_name": "The Source", "link_type": "DATA_SOURCE", "link_url": "https://datasource.com"},
-            {"link_name": "", "link_type": "DOI", "link_url": "10.1093/nar/gkae1142"},
-        ],
-        "name": "lots of cells",
-    }
-    upload_dataset_metadata(collection_id, updated_data)
+    upload_dataset_metadata(collection_id, metadata_update_body)
 
     # Test dataset deletion
     res = session.delete(f"{api_url}/dp/v1/datasets/{dataset_id}", headers=headers)

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -168,7 +168,7 @@ def test_dataset_upload_flow_with_dataset(
     curator_cookie,
     api_url,
     upload_dataset,
-    update_title_and_wait,
+    upload_dataset_title,
     request,
     collection_data,
     dataset_title_update,
@@ -183,7 +183,7 @@ def test_dataset_upload_flow_with_dataset(
         session,
         api_url,
         upload_dataset,
-        update_title_and_wait,
+        upload_dataset_title,
     )
 
 
@@ -193,7 +193,7 @@ def test_dataset_upload_flow_with_visium_dataset(
     curator_cookie,
     api_url,
     upload_dataset,
-    update_title_and_wait,
+    upload_dataset_title,
     request,
     collection_data,
     dataset_title_update,
@@ -208,7 +208,7 @@ def test_dataset_upload_flow_with_visium_dataset(
         session,
         api_url,
         upload_dataset,
-        update_title_and_wait,
+        upload_dataset_title,
     )
 
 
@@ -218,7 +218,7 @@ def test_dataset_upload_flow_with_atac_seq_dataset(
     curator_cookie,
     api_url,
     upload_manifest,
-    update_title_and_wait,
+    upload_dataset_title,
     request,
     collection_data,
     dataset_title_update,
@@ -240,7 +240,7 @@ def test_dataset_upload_flow_with_atac_seq_dataset(
         session,
         api_url,
         upload_manifest,
-        update_title_and_wait,
+        upload_dataset_title,
     )
 
 

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -262,11 +262,10 @@ def _verify_upload_and_delete_succeeded(
         res.raise_for_status()
 
     # update title and await dataset update
-    _, updated_dataset_ids = upload_dataset_title_and_wait(collection_id, dataset_id, title_update_body)
+    updated_dataset_id = upload_dataset_title_and_wait(collection_id, dataset_id, title_update_body)
 
     # Test dataset deletion
-    dataset_to_delete_id = updated_dataset_ids[0]
-    res = session.delete(f"{api_url}/dp/v1/datasets/{dataset_to_delete_id}", headers=headers)
+    res = session.delete(f"{api_url}/dp/v1/datasets/{updated_dataset_id}", headers=headers)
     res.raise_for_status()
     assertStatusCode(requests.codes.accepted, res)
 
@@ -275,4 +274,4 @@ def _verify_upload_and_delete_succeeded(
     data = json.loads(res.content)
     datasets = data["datasets"]
     dataset_ids = [dataset.get("id") for dataset in datasets]
-    assert dataset_to_delete_id not in dataset_ids
+    assert updated_dataset_id not in dataset_ids

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -245,7 +245,14 @@ def test_dataset_upload_flow_with_atac_seq_dataset(
 
 
 def _verify_upload_and_delete_succeeded(
-    collection_id, headers, req_body, title_update_body, session, api_url, upload_and_wait, update_title_and_wait
+    collection_id,
+    headers,
+    req_body,
+    title_update_body,
+    session,
+    api_url,
+    upload_and_wait,
+    upload_dataset_title_and_wait,
 ):
     dataset_id = upload_and_wait(collection_id, req_body)
     # test non owner cant retrieve status
@@ -255,7 +262,7 @@ def _verify_upload_and_delete_succeeded(
         res.raise_for_status()
 
     # update title and await dataset update
-    _, updated_dataset_ids = update_title_and_wait(collection_id, title_update_body)
+    _, updated_dataset_ids = upload_dataset_title_and_wait(collection_id, dataset_id, title_update_body)
 
     # Test dataset deletion
     dataset_to_delete_id = updated_dataset_ids[0]

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -244,10 +244,11 @@ def _verify_upload_and_delete_succeeded(
         res.raise_for_status()
 
     # update collection DOI and await dataset update
-    upload_dataset_metadata(collection_id, metadata_update_body)
+    _, updated_dataset_ids = upload_dataset_metadata(collection_id, metadata_update_body)
 
     # Test dataset deletion
-    res = session.delete(f"{api_url}/dp/v1/datasets/{dataset_id}", headers=headers)
+    dataset_to_delete_id = updated_dataset_ids[0]
+    res = session.delete(f"{api_url}/dp/v1/datasets/{dataset_to_delete_id}", headers=headers)
     res.raise_for_status()
     assertStatusCode(requests.codes.accepted, res)
 
@@ -256,4 +257,4 @@ def _verify_upload_and_delete_succeeded(
     data = json.loads(res.content)
     datasets = data["datasets"]
     dataset_ids = [dataset.get("id") for dataset in datasets]
-    assert dataset_id not in dataset_ids
+    assert dataset_to_delete_id not in dataset_ids

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -118,7 +118,7 @@ def update_title_and_wait(session, api_url, curator_cookie, collection_id, datas
     res.raise_for_status()
     collection = json.loads(res.content)
     updated_dataset = next((dataset for dataset in collection["datasets"] if dataset["id"] == updated_dataset_id), None)
-    assert updated_dataset["title"] == dataset_title_update["title"]
+    assert updated_dataset["name"] == dataset_title_update["title"]
     assert not dataset_errors
 
     return updated_dataset_id

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -170,7 +170,7 @@ def _wait_for_dataset_status(session, api_url, dataset_id, headers):
                 errors.append(f"RDS CONVERSION FAILED. Status: {data}, Check logs for dataset: {dataset_id}")
             if any(
                 [
-                    cxg_status == h5ad_status == "UPLOADED"
+                    (cxg_status == h5ad_status == "UPLOADED" or cxg_status == h5ad_status == "CONVERTED")
                     and rds_status == "SKIPPED"
                     and atac_status in ["SKIPPED", "UPLOADED", "NA", "COPIED"],
                     errors,

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -117,11 +117,7 @@ def update_title_and_wait(session, api_url, curator_cookie, collection_id, datas
     res.raise_for_status()
     collection = json.loads(res.content)
     updated_dataset = next((dataset for dataset in collection["datasets"] if dataset["id"] == updated_dataset_id), None)
-    if updated_dataset["title"] != dataset_title_update["title"]:
-        raise pytest.fail(
-            f"Dataset title was not updated. "
-            f"Expected: {dataset_title_update['title']}, Actual: {updated_dataset['title']}"
-        )
+    assert updated_dataset["title"] == dataset_title_update["title"]
 
     if dataset_errors:
         raise pytest.fail(f"Dataset {dataset_id} encountered errors: {dataset_errors}")

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -85,8 +85,7 @@ def update_metadata_and_wait(session, api_url, curator_cookie, collection_id, me
         result = _wait_for_dataset_status(session, api_url, dataset_id, headers)
         dataset_id = result["dataset_id"]
         dataset_errors = result["errors"]
-        if dataset_errors:
-            collection_errors[dataset_id] = dataset_errors
+        collection_errors[dataset_id] = dataset_errors
 
     return collection_errors
 

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -101,6 +101,8 @@ def update_title_and_wait(session, api_url, curator_cookie, collection_id, datas
     res.raise_for_status()
 
     # ensure metadata update is queued for dataset
+    res = session.get(f"{api_url}/dp/v1/collections/{collection_id}", headers=headers)
+    res.raise_for_status()
     collection = json.loads(res.content)
     updated_dataset_id = [dataset["id"] for dataset in collection["datasets"]][0]
     res = session.get(f"{api_url}/dp/v1/datasets/{updated_dataset_id}/status", headers=headers)

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -177,11 +177,12 @@ def _wait_for_dataset_status(session, api_url, dataset_id, headers):
                 ]
             ):
                 keep_trying = False
-        if time.time() >= timer + 1200:
-            raise TimeoutError(
-                f"Dataset upload or conversion timed out after 10 min. Check logs for dataset: {dataset_id}"
-                f"upload_status: {upload_status} cxg_status: {cxg_status}, rds_status: {rds_status}, h5ad_status: {h5ad_status}"
-            )
+            if time.time() >= timer + 1200:
+                raise TimeoutError(
+                    f"Dataset upload or conversion timed out after 10 min. Check logs for dataset: {dataset_id}"
+                    f"upload_status: {upload_status} cxg_status: {cxg_status}, rds_status: {rds_status}, "
+                    f"h5ad_status: {h5ad_status}, atac_status: {atac_status}"
+                )
         time.sleep(10)
     return {"dataset_id": dataset_id, "errors": errors}
 

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -3,7 +3,6 @@ import json
 import time
 from typing import Optional
 
-import pytest
 import requests
 from requests import Session
 from requests.adapters import HTTPAdapter, Retry
@@ -118,9 +117,7 @@ def update_title_and_wait(session, api_url, curator_cookie, collection_id, datas
     collection = json.loads(res.content)
     updated_dataset = next((dataset for dataset in collection["datasets"] if dataset["id"] == updated_dataset_id), None)
     assert updated_dataset["title"] == dataset_title_update["title"]
-
-    if dataset_errors:
-        raise pytest.fail(f"Dataset {dataset_id} encountered errors: {dataset_errors}")
+    assert not dataset_errors
 
     return updated_dataset_id
 

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -147,6 +147,14 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
         new_dataset_version_id = new_dataset_version.version_id
         artifacts = [(artifact.uri, artifact.type) for artifact in new_dataset_version.artifacts]
         assert (f"s3://artifact_bucket/{new_dataset_version_id}/raw.h5ad", DatasetArtifactType.RAW_H5AD) in artifacts
+        assert (
+            f"s3://artifact_bucket/{new_dataset_version_id}/local.tsv.bgz",
+            DatasetArtifactType.ATAC_FRAGMENT,
+        ) in artifacts
+        assert (
+            f"s3://artifact_bucket/{new_dataset_version_id}/local.tsv.bgz.tbi",
+            DatasetArtifactType.ATAC_INDEX,
+        ) in artifacts
 
         assert new_dataset_version.status.upload_status == DatasetUploadStatus.UPLOADED
         assert new_dataset_version.status.processing_status == DatasetProcessingStatus.SUCCESS

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -148,11 +148,11 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
         artifacts = [(artifact.uri, artifact.type) for artifact in new_dataset_version.artifacts]
         assert (f"s3://artifact_bucket/{new_dataset_version_id}/raw.h5ad", DatasetArtifactType.RAW_H5AD) in artifacts
         assert (
-            f"s3://fake.bucket/{new_dataset_version_id}/local.tsv.bgz",
+            "s3://fake.bucket/local.tsv.bgz",
             DatasetArtifactType.ATAC_FRAGMENT,
         ) in artifacts
         assert (
-            f"s3://fake.bucket/{new_dataset_version_id}/local.tsv.bgz.tbi",
+            "s3://fake.bucket/local.tsv.bgz.tbi",
             DatasetArtifactType.ATAC_INDEX,
         ) in artifacts
 
@@ -226,7 +226,6 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             statuses=[
                 DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.SUCCESS),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
-                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.SKIPPED),
             ]
         )
         collection_version_id = CollectionVersionId(current_dataset_version.collection_version_id)
@@ -254,7 +253,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
 
         # RDS should be skipped
         assert new_dataset_version.status.rds_status == DatasetConversionStatus.SKIPPED
-        assert new_dataset_version.status.atac_status == DatasetConversionStatus.SKIPPED
+        assert new_dataset_version.status.atac_status == DatasetConversionStatus.NA
 
         assert new_dataset_version.status.processing_status == DatasetProcessingStatus.SUCCESS
 

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -148,11 +148,11 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
         artifacts = [(artifact.uri, artifact.type) for artifact in new_dataset_version.artifacts]
         assert (f"s3://artifact_bucket/{new_dataset_version_id}/raw.h5ad", DatasetArtifactType.RAW_H5AD) in artifacts
         assert (
-            f"s3://artifact_bucket/{new_dataset_version_id}/local.tsv.bgz",
+            f"s3://fake.bucket/{new_dataset_version_id}/local.tsv.bgz",
             DatasetArtifactType.ATAC_FRAGMENT,
         ) in artifacts
         assert (
-            f"s3://artifact_bucket/{new_dataset_version_id}/local.tsv.bgz.tbi",
+            f"s3://fake.bucket/{new_dataset_version_id}/local.tsv.bgz.tbi",
             DatasetArtifactType.ATAC_INDEX,
         ) in artifacts
 

--- a/tests/unit/processing/test_dataset_metadata_update.py
+++ b/tests/unit/processing/test_dataset_metadata_update.py
@@ -62,6 +62,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             statuses=[
                 DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.SUCCESS),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.NA),
             ]
         )
         collection_version_id = CollectionVersionId(current_dataset_version.collection_version_id)
@@ -114,6 +115,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             statuses=[
                 DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.SUCCESS),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.SKIPPED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.SKIPPED),
             ],
         )
         collection_version_id = CollectionVersionId(current_dataset_version.collection_version_id)
@@ -160,6 +162,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             statuses=[
                 DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.SUCCESS),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.NA),
             ]
         )
         collection_version_id = CollectionVersionId(current_dataset_version.collection_version_id)
@@ -195,6 +198,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             statuses=[
                 DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.FAILURE),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.SKIPPED),
             ]
         )
         current_dataset_version_id = DatasetVersionId(current_dataset_version.dataset_version_id)
@@ -208,6 +212,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             statuses=[
                 DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.SUCCESS),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.SKIPPED),
             ]
         )
         current_dataset_version_id = DatasetVersionId(current_dataset_version.dataset_version_id)
@@ -234,6 +239,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             statuses=[
                 DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.SUCCESS),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.NA),
             ],
         )
         collection_version_id = CollectionVersionId(current_dataset_version.collection_version_id)
@@ -266,6 +272,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             statuses=[
                 DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.SUCCESS),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.SKIPPED),
             ],
         )
         collection_version_id = CollectionVersionId(current_dataset_version.collection_version_id)
@@ -304,6 +311,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             statuses=[
                 DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.SUCCESS),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.NA),
             ],
         )
         collection_version_id = CollectionVersionId(current_dataset_version.collection_version_id)
@@ -335,6 +343,7 @@ class TestUpdateMetadataHandler(BaseProcessingTest):
             statuses=[
                 DatasetStatusUpdate(status_key=DatasetStatusKey.PROCESSING, status=DatasetProcessingStatus.SUCCESS),
                 DatasetStatusUpdate(status_key=DatasetStatusKey.RDS, status=DatasetConversionStatus.CONVERTED),
+                DatasetStatusUpdate(status_key=DatasetStatusKey.ATAC, status=DatasetConversionStatus.SKIPPED),
             ]
         )
         collection_version_id = CollectionVersionId(current_dataset_version.collection_version_id)

--- a/tests/unit/processing/test_process_validate_atac.py
+++ b/tests/unit/processing/test_process_validate_atac.py
@@ -333,7 +333,7 @@ class TestSkipATACValidation:
         # Assert
         dataset_status = setup.business_logic.get_dataset_status(dataset_version_id)
         assert setup.business_logic.get_dataset_status(dataset_version_id).atac_status == DatasetConversionStatus.NA
-        assert dataset_status.validation_message == "test"
+        assert dataset_status.validation_message is None
 
     def test_not_atac_and_fragment(self, process_validate_atac, unpublished_dataset, setup, manifest_with_fragment):
         """A manifest is provided with a fragment, and the anndata does not require one. This will fail


### PR DESCRIPTION
## Reason for Change

- Issue reported by Jenny in slack, when attempting a metadata update for datasets (non-multiome)
- Evan dug and diagnosed error as stemming from the atac status not being updated, and thus failing the check for a valid set of artifact statuses
- further investigation by me suggests that, in addition to not copying over the atac status when atac validation is skipped, when datasets with valid fragment files are updated, we were also failing to point the new dataset version produced by the metadata update job to the fragment files. No impact in prod, as the error above found by Evan would've blocked this from occurring anyway.
- https://czi-sci.slack.com/archives/C024HCSH9PT/p1744650148839419

## Changes

- when updating dataset metadata status, check for ATAC_FRAGMENT and ATAC_INDEX artifacts 
- if none found, simply copy the previous dataset's atac_status
- if found, associate the fragment and index file artifact ids to the new dataset version created by the dataset metadata batch job
- add COPIED and NA as valid atac_statuses. Remove UPLOADED, as we will only ever copy in this case (for now), as we do not currently support updating fragment file metadata.
- semi-related fix: in the validateAtac batch job, we were attaching a validation message datasets that do not have nor support a fragment file; this is not useful, and can make it appear as though these valid datasets have an error. Remove that validation message if the dataset does not support atac seq and it correctly does not have a fragment file.

## Testing steps

- Added step to update dataset metadata + check for success status in each e2e dataset workflow test (i.e. one per basic upload, visium upload, multiome w/ atac upload), as part of _verify_upload_and_delete_succeeded
- added unit tests for atac fragment copy
- Will test in rdev for now
