### PR TITLE
fix: remove species enum in curation API swagger spec

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -1532,7 +1532,8 @@ components:
       nullable: true
     feature_reference:
       description: |
-        List of NCBITaxon ontology term IDs mapping to reference organisms for features in dataset.
+        List of NCBITaxon ontology term IDs mapping to reference organisms for features in dataset. Find current list of
+        supported feature reference term IDs [here](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html#required-gene-annotations).
       type: array
       items:
         type: string

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -1532,15 +1532,9 @@ components:
       nullable: true
     feature_reference:
       description: |
-        List of NCBITaxon ontology term IDs mapping to reference organisms for features in dataset. Currently
-        supports Homo Sapiens, Mus musculus, SARS-CoV-2, and ERCC Spike-Ins.
+        List of NCBITaxon ontology term IDs mapping to reference organisms for features in dataset.
       type: array
       items:
-        enum:
-          - NCBITaxon:9606
-          - NCBITaxon:10090
-          - NCBITaxon:2697049
-          - NCBITaxon:32630
         type: string
       nullable: true
     is_primary_data:

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -708,6 +708,7 @@ paths:
                         CONVERTED,
                         UPLOADING,
                         UPLOADED,
+                        COPIED,
                         SKIPPED,
                         FAILED,
                         NA,


### PR DESCRIPTION
## Reason for Change

Report from Jim Chaffer:

> > [@Brian Mott](https://czi-sci.slack.com/team/U064K47JL56)
>  and I have come across an issue with the CXG_API in which trying a call for get_collection of a collection that has data from organisms other than human/mouse/covid/spike results in an error.
> It looks like this is originating from the feature reference value not being accepted.
> Example output:
> 
> ```
> FAILED
> 
> Internal Server Error
> 
> {
>   "detail": "'NCBITaxon:7227' is not one of ['NCBITaxon:9606', 'NCBITaxon:10090', 'NCBITaxon:2697049', 'NCBITaxon:32630']\n\nFailed validating 'enum' in schema['allOf'][0]['properties']['datasets']['items']['properties']['feature_reference']['items']:\n    {'enum': ['NCBITaxon:9606',\n              'NCBITaxon:10090',\n              'NCBITaxon:2697049',\n              'NCBITaxon:32630'],\n     'type': 'string'}\n\nOn instance['datasets'][0]['feature_reference'][0]:\n    'NCBITaxon:7227'",
>   "status": 500,
>   "title": "Response body does not conform to specification",
>   "type": "about:blank"
> }
> 
> ```

## Changes

- as we are now expecting to expand our species list more often, maintaining an enum list for feature references in the curation API is unwieldy + creates an additional manual step to pass through schema changes; it is also redundant, as validation for these values is already enforced by the cellxgene-schema CLI run upon dataset ingestion. Instead, link to latest schema to inform users on what the supported feature references are.
