### PR TITLE
fix: patch Multiome Download - front end fixes

### DIFF
--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/constants.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/constants.ts
@@ -15,3 +15,6 @@ export const POSSIBLE_DOWNLOAD_FORMATS = [
       "Tab-separated values file listing sequencing ATAC-seq fragments with an accompanying index for fast genomic range queries.",
   },
 ];
+
+export const getNotAvailableText = (filetype: string) =>
+  `${filetype} file is unavailable for download at the moment`;

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
@@ -47,7 +47,7 @@ const Content: FC<Props> = ({
     return (
       selectedFormats.length > 0 &&
       selectedFormats.every((format) => {
-        const link = downloadLinks.find((l) => l.filetype === format);
+        const link = downloadLinks.find((link) => link.filetype === format);
 
         return (
           !link || // no matching link
@@ -121,7 +121,7 @@ const Content: FC<Props> = ({
     };
     const replaceMissingURLs = (links: (DownloadLinkType | null)[]) => {
       return links
-        .filter((link) => link !== null)
+        .filter((link): link is DownloadLinkType => link !== null)
         .map((link) => ({
           ...link,
           downloadURL: link.downloadURL ?? getNotAvailableText(link.filetype),

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/utils.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/utils.ts
@@ -5,17 +5,22 @@ import { apiTemplateToUrl } from "src/common/utils/apiTemplateToUrl";
 import { API_URL } from "src/configs/configs";
 import { API } from "src/common/API";
 import { DatasetAsset } from "src/common/entities";
+import { getNotAvailableText } from "./components/DataFormat/constants";
 
 export const downloadMultipleFiles = (
   formatsToDownload: DATASET_ASSET_FORMAT[],
   downloadLinks: DownloadLinkType[]
 ) => {
-  downloadLinks.forEach((download) => {
-    if (formatsToDownload.includes(download.filetype) && download.downloadURL) {
+  formatsToDownload.forEach((format) => {
+    const downloadLink = downloadLinks.find((link) => link.filetype === format);
+    if (
+      downloadLink &&
+      downloadLink.downloadURL &&
+      downloadLink.downloadURL !== getNotAvailableText(downloadLink.filetype)
+    ) {
       const a = document.createElement("a");
-      a.href =
-        "https://datasets.cellxgene.staging.single-cell.czi.technology/542d0a93-9f13-4a77-8d3f-65172615bce8.h5ad";
-      a.download = download.downloadURL.split("/").pop() || "";
+      a.href = downloadLink.downloadURL;
+      a.download = downloadLink.downloadURL.split("/").pop() || "";
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
@@ -36,7 +41,6 @@ export const getDownloadLink = async (
       ...DEFAULT_FETCH_OPTIONS,
       method: "GET",
     }).then((res) => res.json());
-    console.log("result", result);
     return {
       filetype: asset.filetype,
       fileSize: result.file_size,


### PR DESCRIPTION
## Changes

- Fall back if download url call fails
- Disable download button when download urls are not available
- Prevent duplicate H5AD urls
- remove hard coding of download url for demonstration purposes.

https://github.com/user-attachments/assets/339ae708-889d-445c-87b8-dcad91bacb33
