### PR TITLE
fix: cache invalidation for collection deletion

### DIFF
--- a/backend/curation/api/v1/curation/collections/collection_id/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/actions.py
@@ -3,7 +3,11 @@ from dataclasses import asdict
 from flask import Response, jsonify, make_response
 
 import backend.common.doi as doi
-from backend.common.utils.http_exceptions import InvalidParametersHTTPException, MethodNotAllowedException
+from backend.common.utils.http_exceptions import (
+    ForbiddenHTTPException,
+    InvalidParametersHTTPException,
+    MethodNotAllowedException,
+)
 from backend.curation.api.v1.curation.collections.common import (
     extract_doi_from_links,
     get_inferred_collection_version,
@@ -14,7 +18,7 @@ from backend.layers.auth.user_info import UserInfo
 from backend.layers.business.entities import CollectionMetadataUpdate
 from backend.layers.business.exceptions import CollectionUpdateException, InvalidMetadataException
 from backend.layers.common.entities import CollectionId, CollectionLinkType, Link
-from backend.portal.api.providers import get_business_logic
+from backend.portal.api.providers import get_business_logic, get_cloudfront_provider
 
 
 def delete(collection_id: str, token_info: dict, delete_published: bool = False) -> Response:
@@ -24,6 +28,11 @@ def delete(collection_id: str, token_info: dict, delete_published: bool = False)
     if collection_version.published_at:
         if user_info.is_cxg_admin() and delete_published:
             get_business_logic().tombstone_collection(CollectionId(collection_id))
+            get_cloudfront_provider().create_invalidation_for_index_paths()
+        elif not user_info.is_cxg_admin() and delete_published:
+            raise ForbiddenHTTPException(
+                detail="Only CXG admins can delete a published collection. Roles are granted through Auth0"
+            )
         else:
             raise MethodNotAllowedException(detail="Cannot delete a published collection through API.")
     else:

--- a/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
@@ -51,6 +51,11 @@ def delete(token_info: dict, collection_id: str, dataset_id: str, delete_publish
     if not user_info.is_user_owner_or_allowed(collection_version.owner):
         raise ForbiddenHTTPException("Unauthorized")
 
+    if not user_info.is_cxg_admin():
+        raise ForbiddenHTTPException(
+            "Only CXG admins can delete a dataset through API. Roles are granted through Auth0"
+        )
+
     if dataset_version.version_id not in [v.version_id for v in collection_version.datasets]:
         raise ForbiddenHTTPException(f"Dataset {dataset_id} does not belong to a collection")
 

--- a/tests/unit/scripts/test_tombstone.py
+++ b/tests/unit/scripts/test_tombstone.py
@@ -25,6 +25,7 @@ class TestTombstone(BaseTest):
 
         c_v = self.business_logic.get_collection_version(c_v.version_id, get_tombstoned=True)
         self.assertTrue(c_v.canonical_collection.tombstoned)
+        context.obj["cloudfront_provider"].create_invalidation_for_index_paths.assert_called()
 
     def test__resurrect_collection(self):
         c_v = self.generate_published_collection()


### PR DESCRIPTION
## Reason for Change

we currently only invalidate these index paths when we publish (or resurrect) a collection. we should also perform a cache invalidation when we tombstone collections, that way they don't continue to pop up on the collections page even after it's been deleted

## Changes

- adds the line `get_cloudfront_provider().create_invalidation_for_index_paths()` to the collection deletion business logic
- i also made a small change to make the error message slightly different when the deletion calls (for both dataset and collection) are failing due to lack of cxg admin access or not passing in the `delete_published` param

## Testing steps

- updated the `test_tombstone` test to assert the cache invalidation is called

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

none of these are applicable to this PR

## Notes for Reviewer
i can't run tests locally, so going to be waiting for GHA lol