### PR TITLE
chore: increase aws resources of atac job

### DIFF
--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -107,7 +107,7 @@ resource aws_batch_job_definition atac_job_def {
   container_properties = jsonencode({
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
-  "memory": 84000,
+  "memory": 128000,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",
@@ -138,7 +138,7 @@ resource aws_batch_job_definition atac_job_def {
       "value": "${var.frontend_url}"
     }
   ],
-  "vcpus": 8,
+  "vcpus": 16,
   "logConfiguration": {
     "logDriver": "awslogs",
     "options": {


### PR DESCRIPTION
## Reason for Change

- this should prevent us from needing to manually rerun the SFN for larger multiome datasets
- ideally, we should not need such high resourcing, but this seems like a good short to medium term solution

## Changes

- implements the memory + vcpus specified when i needed to manually re-run the SFN for a larger dataset

## Testing steps

- n/a

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

not applicable

## Notes for Reviewer
