### PR TITLE
chore: allocate memory for CXG conversion better

### DIFF
--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -2,7 +2,7 @@
 locals {
   h5ad_timeout = 86400 # 24 hours
   atac_timeout = 86400 # 24 hours
-  cxg_timeout = 345600 # 96 hours
+  cxg_timeout = 172800 # 48 hours
 }
 
 data aws_region current {}

--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -2,7 +2,7 @@
 locals {
   h5ad_timeout = 86400 # 24 hours
   atac_timeout = 86400 # 24 hours
-  cxg_timeout = 172800 # 48 hours
+  cxg_timeout = 345600 # 96 hours
 }
 
 data aws_region current {}

--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -101,9 +101,9 @@ class H5ADDataFile:
         x_matrix_data = self.anndata.X
         with dask.config.set(
             {
-                "num_workers": 2,  # match the number of workers to the number of vCPUs
-                "threads_per_worker": 1,
-                "distributed.worker.memory.limit": "6GB",
+                "num_workers": 1,  # a single worker with as many threads as vCPUs is more memory efficient
+                "threads_per_worker": 2,  # match the number of vCPUs
+                "distributed.worker.memory.limit": "12GB",
                 "scheduler": "threads",
             }
         ):
@@ -190,7 +190,7 @@ class H5ADDataFile:
 
     def extract_anndata_elements_from_file(self):
         logging.info(f"Reading in AnnData dataset: {path.basename(self.input_filename)}")
-        self.anndata = read_h5ad(self.input_filename, chunk_size=7500)
+        self.anndata = read_h5ad(self.input_filename, chunk_size=12000)
         logging.info("Completed reading in AnnData dataset!")
 
         self.obs = self.transform_dataframe_index_into_column(self.anndata.obs, "obs", self.obs_index_column_name)

--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -190,7 +190,7 @@ class H5ADDataFile:
 
     def extract_anndata_elements_from_file(self):
         logging.info(f"Reading in AnnData dataset: {path.basename(self.input_filename)}")
-        self.anndata = read_h5ad(self.input_filename, chunk_size=12000)
+        self.anndata = read_h5ad(self.input_filename, chunk_size=15000)
         logging.info("Completed reading in AnnData dataset!")
 
         self.obs = self.transform_dataframe_index_into_column(self.anndata.obs, "obs", self.obs_index_column_name)


### PR DESCRIPTION
## Reason for Change

https://czi.atlassian.net/browse/VC-2370

## Changes

i found two improvements to CXG conversion, while staying within our current resource allocation of 2 vCPUs and 16GB of memory. these changes are:
1. increase `chunk_size` when reading h5ads to be 15000. i think this was originally set at 7500 when we had memory for this job to be 8GB. doubling this to 15000 still keeps us well within the 16GB of allocated memory and should make this operation a bit faster
2. instead of scheduling 2 workers and 1 thread per worker with 6GB of memory per worker when we write `X`, it should be a better use of memory to have 1 worker with 2 threads per worker. so if one of the threads is working on something that's more memory intensive, instead of each process having its own 6GB bucket of memory, the more memory intensive job can take more than 6GB.

## Testing steps

i did some benchmarking of `write_anndata_x_matrices_to_cxg` to compare how fast the original dask config takes vs what i have set in this PR, working with a large file that's 20GB. here is the output:
```
write_anndata_x_matrices_to_cxg in big_boi.h5ad took 1651.26 seconds (27.5 minutes) with {'num_workers': 1, 'threads_per_worker': 2, 'distributed.worker.memory.limit': '12GB', 'scheduler': 'threads'}

write_anndata_x_matrices_to_cxg in big_boi.h5ad took 3825.26 seconds (63.8 minutes) with {'num_workers': 2, 'threads_per_worker': 1, 'distributed.worker.memory.limit': '6GB', 'scheduler': 'threads'}
```

here is the full script i was running locally, which is mostly code from the actual codebase copied and pasted with some minor changes (ex: passing in `is_sparse=True` always rather than computing it):

```
import tiledb
import anndata as ad
import psutil
import dask.array as da
import dask
import time
from anndata.compat import DaskArray
from typing import Union
import numpy as np
from scipy import sparse

GB = 2**30
MB = 2**20

def virtual_memory_size(vm_fraction: float) -> int:
    mem_size_bytes = psutil.virtual_memory().total
    fractional_mem_bytes = int(vm_fraction * mem_size_bytes)
    return fractional_mem_bytes // MB * MB  # round down to MB boundary

def consolidation_buffer_size(vm_fraction: float) -> int:
    # consolidation buffer heuristic to prevent thrashing: total_mem/io_concurrency_level, rounded to GB
    io_concurrency_level = int(tiledb.Config()["sm.io_concurrency_level"])
    buffer_size = int(virtual_memory_size(vm_fraction) / io_concurrency_level) + (GB - 1)
    return buffer_size // GB * GB  # round down to GB boundary

tile_db_ctx_config = {
    "sm.consolidation.buffer_size": consolidation_buffer_size(0.1),
    "sm.consolidation.step_min_frags": 2,
    "sm.consolidation.step_max_frags": 20,  # see https://docs.tiledb.com/main/how-to/performance/performance-tips/tuning-consolidation
    "py.deduplicate": True,  # May reduce memory requirements at cost of performance
}

ctx = tiledb.Ctx(tile_db_ctx_config)

dask_config_original = {
    "num_workers": 2,
    "threads_per_worker": 1,
    "distributed.worker.memory.limit": "6GB",
    "scheduler": "threads",
}

dask_config_one_worker = {
    "num_workers": 1,
    "threads_per_worker": 2,
    "distributed.worker.memory.limit": "12GB",
    "scheduler": "threads",
}

class TileDBSparseArrayWriteWrapper:
    def __init__(self, uri, *, ctx=None):
        self.uri = uri
        self.ctx = {}
        self.ctx.update(**ctx or {})

    def __setitem__(self, k: tuple[slice, ...], v: sparse.spmatrix):
        with tiledb.scope_ctx(self.ctx):
            row_slice, col_slice = k
            row_offset = row_slice.start if row_slice.start is not None else 0
            col_offset = col_slice.start if col_slice.start is not None else 0
            v_coo = v.tocoo()
            tiledb_array = tiledb.open(self.uri, mode="w")
            tiledb_array[v_coo.row + row_offset, v_coo.col + col_offset] = v.data

def write_anndata_x_matrices_to_cxg(input_file, output_cxg_directory, ctx, dask_config):
    matrix_container = f"{output_cxg_directory}/X"
    adata = ad.read_h5ad(input_file)
    x_matrix_data = adata.X
    X_dask = da.from_array(adata.X, chunks=(25000, -1))
    with dask.config.set(dask_config):
        convert_matrices_to_cxg_arrays(matrix_container, X_dask, True, tile_db_ctx_config)

    tiledb.consolidate(matrix_container, ctx=ctx)
    if hasattr(tiledb, "vacuum"):
        tiledb.vacuum(matrix_container)

def convert_matrices_to_cxg_arrays(matrix_name: str, matrix: da.Array, encode_as_sparse_array: bool, ctx: tiledb.Ctx):
    """
    Converts a numpy array matrix into a TileDB SparseArray of DenseArray based on whether `encode_as_sparse_array`
    is true or not. Note that when the matrix is encoded as a SparseArray, it only writes the values that are
    nonzero. This means that if you count the number of elements in the SparseArray, it will not equal the total
    number of elements in the matrix, only the number of nonzero elements.
    """
    number_of_rows = matrix.shape[0]
    number_of_columns = matrix.shape[1]
    compression = 22

    dim_filters = tiledb.FilterList([tiledb.ByteShuffleFilter(), tiledb.ZstdFilter(level=compression)])
    attrs = [tiledb.Attr(dtype=np.float32, filters=tiledb.FilterList([tiledb.ZstdFilter(level=compression)]))]

    tiledb_obs_dim = tiledb.Dim(
        name="obs",
        domain=(0, number_of_rows - 1),
        tile=min(number_of_rows, 256),
        dtype=np.uint32,
        filters=dim_filters,
    )
    tiledb_var_dim = tiledb.Dim(
        name="var",
        domain=(0, number_of_columns - 1),
        tile=min(number_of_columns, 2048),
        dtype=np.uint32,
        filters=dim_filters,
    )
    domain = tiledb.Domain(tiledb_obs_dim, tiledb_var_dim)

    if encode_as_sparse_array:
        array_schema_params = dict(
            sparse=True,
            allows_duplicates=True,
            capacity=1024000,
        )
    else:
        array_schema_params = dict(
            sparse=False,
            allows_duplicates=False,
            capacity=0,
        )
    schema = tiledb.ArraySchema(
        domain=domain,
        attrs=attrs,
        cell_order="row-major",
        tile_order="col-major",
        **array_schema_params,
    )
    tiledb.Array.create(matrix_name, schema)

    if encode_as_sparse_array:
        matrix_write = TileDBSparseArrayWriteWrapper(matrix_name, ctx=ctx)
        matrix.store(matrix_write, lock=False, compute=True)
    else:
        # if matrix is a scipy sparse matrix but encode_as_sparse_array is False, convert to dense array
        if get_matrix_format(matrix) != "dense":
            matrix = matrix.map_blocks(
                lambda x: x.toarray().astype(np.float32), dtype=np.float32, meta=np.array([], dtype=np.float32)
            )
        elif matrix.dtype != np.float32:
            matrix = matrix.map_blocks(lambda x: x.astype(np.float32), dtype=np.float32)
        with tiledb.open(matrix_name, "w") as A:
            matrix.to_tiledb(A, storage_options={"ctx": ctx})

start_time = time.time()
dask_config = dask_config_original
file_name = "big_boi.h5ad"
write_anndata_x_matrices_to_cxg(file_name, "output.cxg", ctx, dask_config)
end_time = time.time()

duration = end_time - start_time
print(f"write_anndata_x_matrices_to_cxg in {file_name} took {duration:.2f} seconds ({duration/60:.1f} minutes) with {dask_config}")
```

## Checklist 🛎️

n/a

## Notes for Reviewer
