### PR TITLE
fix: Up CG batch memory limit

### DIFF
--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -17,7 +17,7 @@ module stack {
   wmg_batch_container_memory_limit = 248000
   wmg_desired_vcpus                = 128
   cg_desired_vcpus                 = 128
-  cg_batch_container_memory_limit  = 248000
+  cg_batch_container_memory_limit  = 496000
   backend_memory               = 6 * 1024
   frontend_memory              = 4 * 1024
   backend_instance_count       = 2


### PR DESCRIPTION
## Reason for Change

- `cg-prod` batch job container has been [failing](https://us-west-2.console.aws.amazon.com/batch/home?region=us-west-2#jobs/ec2/detail/08da5536-8596-4e48-8897-73d357f08cac) on out of memory

## Changes

- Upped the memory for cg batch job

