### PR TITLE
fix: remove build images concurrency group

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -17,10 +17,6 @@ env:
 permissions:
   id-token: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
-
 jobs:
   build_images:
     strategy:


### PR DESCRIPTION
## Reason for Change

so on this PR: https://github.com/chanzuckerberg/single-cell-data-portal/pull/7605 my create/update rdev GHA's were failing with this issue:
Canceling since a deadlock was detected for concurrency group: 'Create/Update rdev for PR-7600' between a top level workflow and 'build_images'

since the build-images.yml workflow is only ever called by a different top-level workflow, i don't actually think build-images needs to have a concurrency group set

## Testing steps

on that PR linked, i had about 3 attempts at re-trying the rdev job fail because of the concurrency issue. i think it's possible it can eventually succeed if you get lucky, but after pushing this commit: https://github.com/chanzuckerberg/single-cell-data-portal/pull/7605/commits/30d9f930e9da0cbc33dc8238f589fe63fa9d5c0b the rdev deploy finally succeeded

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
