### PR TITLE
feat: use compression level 7 with tiledb in cxg processing

### DIFF
--- a/backend/layers/processing/utils/cxg_generation_utils.py
+++ b/backend/layers/processing/utils/cxg_generation_utils.py
@@ -123,6 +123,8 @@ def convert_dataframe_to_cxg_array(cxg_container, dataframe_name, dataframe, ind
         array.meta["cxg_schema"] = json.dumps(schema_hints)
 
     tiledb.consolidate(array_name, ctx=ctx)
+    if hasattr(tiledb, "vacuum"):
+        tiledb.vacuum(array_name)
 
 
 def convert_ndarray_to_cxg_dense_array(ndarray_name, ndarray, ctx):
@@ -155,6 +157,8 @@ def convert_ndarray_to_cxg_dense_array(ndarray_name, ndarray, ctx):
         array[:] = ndarray
 
     tiledb.consolidate(ndarray_name, ctx=ctx)
+    if hasattr(tiledb, "vacuum"):
+        tiledb.vacuum(ndarray_name)
 
 
 def convert_matrices_to_cxg_arrays(matrix_name: str, matrix: da.Array, encode_as_sparse_array: bool, ctx: tiledb.Ctx):
@@ -166,7 +170,7 @@ def convert_matrices_to_cxg_arrays(matrix_name: str, matrix: da.Array, encode_as
     """
     number_of_rows = matrix.shape[0]
     number_of_columns = matrix.shape[1]
-    compression = 22
+    compression = 7
 
     logging.info(f"create {matrix_name}")
     dim_filters = tiledb.FilterList([tiledb.ByteShuffleFilter(), tiledb.ZstdFilter(level=compression)])
@@ -192,6 +196,7 @@ def convert_matrices_to_cxg_arrays(matrix_name: str, matrix: da.Array, encode_as
         array_schema_params = dict(
             sparse=True,
             allows_duplicates=True,
+            # TODO: investigate if this is a good value for capacity, could maybe lower it to improve slicing performance
             capacity=1024000,
         )
     else:

--- a/backend/layers/processing/utils/cxg_generation_utils.py
+++ b/backend/layers/processing/utils/cxg_generation_utils.py
@@ -197,6 +197,7 @@ def convert_matrices_to_cxg_arrays(matrix_name: str, matrix: da.Array, encode_as
             sparse=True,
             allows_duplicates=True,
             # TODO: investigate if this is a good value for capacity, could maybe lower it to improve slicing performance
+            # https://czi.atlassian.net/browse/VC-2950
             capacity=1024000,
         )
     else:

--- a/backend/layers/processing/utils/dask_utils.py
+++ b/backend/layers/processing/utils/dask_utils.py
@@ -19,4 +19,4 @@ class TileDBSparseArrayWriteWrapper:
             col_offset = col_slice.start if col_slice.start is not None else 0
             v_coo = v.tocoo()
             tiledb_array = tiledb.open(self.uri, mode="w")
-            tiledb_array[v_coo.row + row_offset, v_coo.col + col_offset] = v.data
+            tiledb_array[v_coo.row + row_offset, v_coo.col + col_offset] = v_coo.data


### PR DESCRIPTION
## Reason for Change

this PR primarily implements a change to the tiledb zstandard compression level for `X`. based on investigation from bruce [here](https://czi-sci.slack.com/archives/C013K0JB8F8/p1749505133382639?thread_ts=1748544696.770799&cid=C013K0JB8F8), it seems like 7 is a reasonable value to get good value with compression and also not cost us too much in time. going down from 22 to 7 should reduce time spent on CXG processing by ~85%, while coming at the cost of files being ~20% larger

## Changes

there were some additional minor suggestions bruce had, which were:
1. calling `tiledb.vacuum` after every `tiledb.consolidate` call. i copied the logic to check if `vacuum` was available, but idk maybe we don't need to do that anymore depending on our tiledb versions
2. he found a bug in the last line of code in `TileDBSparseArrayWriteWrapper` where we're not pulling in `.data` from `v_coo`, so i fixed that.
3. he suggested investigating lowering the capacity value. he doesn't think it would improve performance much with ingestion, but it could improve performance with slice reads if we lower this number. i'm also not sure what the risks would be of doing this. 

## Testing steps

- bruce's benchmarking led us to think 7 is a good value

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
