### PR TITLE
fix: Up WMG batch memory limit

### DIFF
--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -14,7 +14,7 @@ module stack {
   backend_url                  = "https://api.cellxgene.cziscience.com"
   stack_prefix                 = ""
   batch_container_memory_limit = 63500
-  wmg_batch_container_memory_limit = 248000
+  wmg_batch_container_memory_limit = 496000
   wmg_desired_vcpus                = 128
   cg_desired_vcpus                 = 128
   cg_batch_container_memory_limit  = 496000


### PR DESCRIPTION
## Reason for Change

- `wmg-prod` batch job container has been [failing](https://us-west-2.console.aws.amazon.com/batch/home?region=us-west-2#jobs/ec2/detail/08da5536-8596-4e48-8897-73d357f08cac) on out of memory

## Changes

- Upped the memory for wmg batch job

