### PR TITLE
chore: bump to cellxgene-schema 6.0.1

### DIFF
--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,7 +1,7 @@
 anndata # uses the version supplied by cellxgene-schema
 awscli
 boto3>=1.11.17
-cellxgene-schema==6.0.0
+cellxgene-schema==6.0.1
 dask==2024.12.0
 dataclasses-json
 ddtrace==2.1.4


### PR DESCRIPTION
## Reason for Change

- patch to pick up cellxgene-schema 6.0.1 patch, to resolve memory issues with dense matrices 