### PR TITLE
Tsmith/retain artifacts

### DIFF
--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -3,7 +3,6 @@ import logging
 import os
 from collections import defaultdict
 from datetime import datetime
-from functools import reduce
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from pydantic import ValidationError
@@ -1014,20 +1013,33 @@ class BusinessLogic(BusinessLogicInterface):
             # Collection was never published; delete CollectionTable row
             self.database_provider.delete_unpublished_collection(collection_version.collection_id)
 
-    def get_atac_fragment_uris_from_dataset_version(self, dataset_version: DatasetVersion) -> List[str]:
+    def get_atac_fragment_uris_from_dataset_version(
+        self, dataset_version: DatasetVersion, artifacts_to_save: Set[DatasetArtifactId] = None
+    ) -> List[str]:
         """
         get all atac fragment files associated with a dataset version from the public bucket
         """
         object_keys = set()
+        artifacts_to_save = artifacts_to_save if artifacts_to_save else set()
         object_keys.update(
-            [a.uri.rsplit("/", 1)[-1] for a in dataset_version.artifacts if a.type == DatasetArtifactType.ATAC_FRAGMENT]
+            [
+                a.uri.rsplit("/", 1)[-1]
+                for a in dataset_version.artifacts
+                if a.type == DatasetArtifactType.ATAC_FRAGMENT and a.id not in artifacts_to_save
+            ]
         )
         object_keys.update(
-            [a.uri.rsplit("/", 1)[-1] for a in dataset_version.artifacts if a.type == DatasetArtifactType.ATAC_INDEX]
+            [
+                a.uri.rsplit("/", 1)[-1]
+                for a in dataset_version.artifacts
+                if a.type == DatasetArtifactType.ATAC_INDEX and a.id not in artifacts_to_save
+            ]
         )
         return list(object_keys)
 
-    def delete_dataset_versions_from_public_bucket(self, dataset_versions: List[DatasetVersion]) -> List[str]:
+    def delete_dataset_versions_from_public_bucket(
+        self, dataset_versions: List[DatasetVersion], artifact_to_save: Set[str] = None
+    ) -> List[str]:
         rdev_prefix = os.environ.get("REMOTE_DEV_PREFIX", "").strip("/")
         object_keys = set()
         for d_v in dataset_versions:
@@ -1036,7 +1048,7 @@ class BusinessLogic(BusinessLogicInterface):
                 if rdev_prefix:
                     dataset_version_s3_object_key = f"{rdev_prefix}/{dataset_version_s3_object_key}"
                 object_keys.add(dataset_version_s3_object_key)
-            object_keys.update(self.get_atac_fragment_uris_from_dataset_version(d_v))
+            object_keys.update(self.get_atac_fragment_uris_from_dataset_version(d_v, artifact_to_save))
         try:
             self.s3_provider.delete_files(os.getenv("DATASETS_BUCKET"), list(object_keys))
         except S3DeleteException as e:
@@ -1070,17 +1082,24 @@ class BusinessLogic(BusinessLogicInterface):
             )
         )
 
-    def delete_dataset_versions(self, dataset_versions: List[DatasetVersion]) -> None:
+    def delete_dataset_versions(
+        self, dataset_versions: List[DatasetVersion], artifacts_to_save: Set[DatasetArtifactId] = None
+    ) -> None:
         """
         Deletes a list of dataset versions and associated dataset artifact rows from the database, as well
         as kicking off deletion of their corresponding assets from S3
         """
-        self.delete_dataset_version_assets(dataset_versions)
+        self.delete_dataset_version_assets(dataset_versions, artifacts_to_save)
         self.database_provider.delete_dataset_versions(dataset_versions)
 
-    def delete_dataset_version_assets(self, dataset_versions: List[DatasetVersion]) -> None:
-        self.delete_dataset_versions_from_public_bucket(dataset_versions)
-        self.delete_artifacts(reduce(lambda artifacts, dv: artifacts + dv.artifacts, dataset_versions, []))
+    def delete_dataset_version_assets(
+        self, dataset_versions: List[DatasetVersion], artifact_to_save: Set[DatasetArtifactId] = None
+    ) -> None:
+        self.delete_dataset_versions_from_public_bucket(dataset_versions, artifact_to_save)
+
+        artifact_to_save = artifact_to_save or set()
+        artifacts = [a for dv in dataset_versions for a in dv.artifacts if a.id not in artifact_to_save]
+        self.delete_artifacts(artifacts)
 
     def tombstone_collection(self, collection_id: CollectionId) -> None:
         """
@@ -1203,7 +1222,17 @@ class BusinessLogic(BusinessLogicInterface):
             version.collection_id, from_date=date_of_last_publish
         )
         versions_to_delete = list(filter(lambda dv: dv.version_id.id not in versions_to_keep, dataset_versions))
-        self.delete_dataset_versions(versions_to_delete)
+
+        # Collect artifact ids from dataset versions to keep
+        artifacts_to_keep = {
+            artifact.id for dv in dataset_versions if dv.version_id.id in versions_to_keep for artifact in dv.artifacts
+        }
+        # Collect artifact ids from dataset versions to delete
+        artifacts_to_delete = {artifact.id for dv in versions_to_delete for artifact in dv.artifacts}
+        # Artifacts present in both sets should be saved
+        artifacts_to_save = artifacts_to_keep & artifacts_to_delete
+
+        self.delete_dataset_versions(versions_to_delete, artifacts_to_save)
 
     def get_dataset_version(self, dataset_version_id: DatasetVersionId) -> Optional[DatasetVersion]:
         """

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -137,6 +137,9 @@ class EntityId:
     def __repr__(self) -> str:
         return self.id
 
+    def __hash__(self):
+        return hash(self.id)
+
 
 class CollectionId(EntityId):
     pass

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -1412,6 +1412,18 @@ class TestDeleteDataset(BaseBusinessLogicTestCase):
         self.assertIsNone(self.business_logic.get_dataset_version(dataset_to_check_artifact_retention.version_id))
         # Artifacts for dataset_to_replace should be gone
         [self.assertFalse(self.s3_provider.uri_exists(a.uri), f"Found {a.uri}") for a in dataset_to_replace.artifacts]
+        # Some Artifact for dataset_to_check_artifact_retention should be gone
+        retained_artifacts = [DatasetArtifactType.ATAC_FRAGMENT, DatasetArtifactType.ATAC_INDEX]
+        [
+            self.assertFalse(self.s3_provider.uri_exists(a.uri), f"Found {a.uri}")
+            for a in dataset_to_check_artifact_retention.artifacts
+            if a.type not in retained_artifacts
+        ]
+        [
+            self.assertTrue(self.s3_provider.uri_exists(a.uri), f"Missing {a.uri}")
+            for a in dataset_to_check_artifact_retention.artifacts
+            if a.type in retained_artifacts
+        ]
         # Artifacts for dataset_to_keep should remain
         [self.assertTrue(self.s3_provider.uri_exists(a.uri), f"Missing {a.uri}") for a in dataset_to_keep.artifacts]
         # Artifacts for new_dataset_version should remain


### PR DESCRIPTION
## Reason for Change
There is a bug discovered which caused ATAC seq artifact to be deleted on publish. This happens if a data set featuring an ATAC data is updated with a new H5AD and the same fragement files before being published. This is because the fragement file is shared across data set version and when the collection is published, older dataset version are cleaned up if they are not part of a publish collection. This meant the fragment artifacts were cleaned up when they should have been retained.

## Changes

- add a test to verify ATAC artifacts are retained even if a dataset sharing the artifact is deleted
-add logic to publish business logic to retain artifacts if they are part of the published dataset. This includes passing around the variable `artifacts_to_save`.
- modify

## Testing steps

- Updated unit test.
- [ ] Verify in dev

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer

