### PR TITLE
fix: ATAC Process updates

### DIFF
--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -1,11 +1,11 @@
 # This is used for environment (dev, staging, prod) deployments
 locals {
-  h5ad_timeout = 86400 # 24 hours
-  atac_timeout = 86400 # 24 hours
-  cxg_timeout = 172800 # 48 hours
+  h5ad_timeout = 86400  # 24 hours
+  atac_timeout = 86400  # 24 hours
+  cxg_timeout  = 172800 # 48 hours
 }
 
-data aws_region current {}
+data "aws_region" "current" {}
 
 resource "aws_sfn_state_machine" "state_machine" {
   name     = "dp-${var.deployment_stage}-${var.custom_stack_name}-sfn"
@@ -341,10 +341,6 @@ resource "aws_sfn_state_machine" "state_machine_cxg_remaster" {
               "Value.$": "$.dataset_version_id"
             },
             {
-              "Name": "FRAGMENT_ARTIFACT_ID",
-              "Value.$": "$.fragment_artifact_id"
-            },
-            {
               "Name": "STEP_NAME",
               "Value": "cxg_remaster"
             }
@@ -358,7 +354,7 @@ resource "aws_sfn_state_machine" "state_machine_cxg_remaster" {
 EOF
 }
 
-resource aws_cloudwatch_log_group cloud_watch_logs_group {
+resource "aws_cloudwatch_log_group" "cloud_watch_logs_group" {
   retention_in_days = 365
   name              = "/dp/${var.deployment_stage}/${var.custom_stack_name}/upload-sfn"
 }

--- a/backend/layers/processing/process.py
+++ b/backend/layers/processing/process.py
@@ -102,7 +102,6 @@ class ProcessMain(ProcessingLogic):
         artifact_bucket: Optional[str],
         datasets_bucket: Optional[str],
         cxg_bucket: Optional[str],
-        fragment_artifact_id: Optional[str] = None,
     ):
         """
         Gets called by the step function at every different step, as defined by `step_name`
@@ -112,7 +111,7 @@ class ProcessMain(ProcessingLogic):
             if step_name == "validate_anndata":
                 self.process_validate_h5ad.process(dataset_version_id, manifest, artifact_bucket)
             elif step_name == "validate_atac":
-                fragment_artifact_id = self.process_validate_atac_seq.process(
+                self.process_validate_atac_seq.process(
                     collection_version_id,
                     dataset_version_id,
                     manifest,
@@ -123,11 +122,9 @@ class ProcessMain(ProcessingLogic):
                     collection_version_id, dataset_version_id, artifact_bucket, datasets_bucket
                 )
             elif step_name == "cxg":
-                self.process_cxg.process(dataset_version_id, artifact_bucket, cxg_bucket, fragment_artifact_id)
+                self.process_cxg.process(dataset_version_id, artifact_bucket, cxg_bucket)
             elif step_name == "cxg_remaster":
-                self.process_cxg.process(
-                    dataset_version_id, artifact_bucket, cxg_bucket, fragment_artifact_id, is_reprocess=True
-                )
+                self.process_cxg.process(dataset_version_id, artifact_bucket, cxg_bucket, is_reprocess=True)
             else:
                 self.logger.error(f"Step function configuration error: Unexpected STEP_NAME '{step_name}'")
 
@@ -184,7 +181,6 @@ class ProcessMain(ProcessingLogic):
             rv = self.schema_migrate.migrate(step_name)
         else:
             dataset_version_id = os.environ["DATASET_VERSION_ID"]
-            fragment_artifact_id = os.environ.get("FRAGMENT_ARTIFACT_ID")
             collection_version_id = os.environ.get("COLLECTION_VERSION_ID")
             if manifest := os.environ.get("MANIFEST"):
                 manifest = IngestionManifest.model_validate_json(manifest)
@@ -201,7 +197,6 @@ class ProcessMain(ProcessingLogic):
                 artifact_bucket=artifact_bucket,
                 datasets_bucket=datasets_bucket,
                 cxg_bucket=cxg_bucket,
-                fragment_artifact_id=fragment_artifact_id,
             )
         return 0 if rv else 1
 

--- a/backend/layers/processing/process_validate_atac.py
+++ b/backend/layers/processing/process_validate_atac.py
@@ -216,6 +216,5 @@ class ProcessValidateATAC(ProcessingLogic):
                 fragment_artifact_id,
             )
             self.update_processing_status(dataset_version_id, DatasetStatusKey.ATAC, DatasetConversionStatus.UPLOADED)
-            return fragment_artifact_id
         self.logger.info("Processing completed successfully")
         return


### PR DESCRIPTION
## Reason for Change

- https://github.com/chanzuckerberg/single-cell-data-portal/pull/7569
- This iterates on the previous implementation where `fragment_artifact_id` is being pulled from the database/artifacts

## Changes

-  CXG step now queries database directly for fragment artifacts instead of relying on parameter passing
-  Eliminated fragment_artifact_id from process() method signatures and environment variables
-  Updated ATAC validation: No longer returns fragment_artifact_id since it's not needed
-  Cleaned up infrastructure: Removed unused FRAGMENT_ARTIFACT_ID from Terraform Step Function config

## Notes for Reviewer
