### PR TITLE
chore: Update resources for CXG sfn worker

### DIFF
--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -59,7 +59,7 @@ resource aws_batch_job_definition cxg_job_def {
   container_properties = jsonencode({
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
-  "memory": 16000,
+  "memory": 32000,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",

--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -127,7 +127,7 @@ class H5ADDataFile:
             {
                 "num_workers": 1,  # a single worker with as many threads as vCPUs is more memory efficient
                 "threads_per_worker": 2,  # match the number of vCPUs
-                "distributed.worker.memory.limit": "14GB",
+                "distributed.worker.memory.limit": "28GB",
                 "scheduler": "threads",
             }
         ):


### PR DESCRIPTION
## Reason for Change

- Updating resources to cxg batch job definition to accommodate for large ATAC datasets and avoid OOM. This follows a memory optimization work [here](https://github.com/chanzuckerberg/single-cell-data-portal/pull/7621)

## Changes

- Updated cxg batch job definition for memory to 32GB
- Updated dask config to 28GB
