### PR TITLE
fix: use chunked write to tiledb to avoid OOM

### DIFF
--- a/backend/layers/processing/utils/atac.py
+++ b/backend/layers/processing/utils/atac.py
@@ -398,12 +398,13 @@ class ATACDataProcessor:
                 )
                 yield chrom, bin_id, cell_type, count, total_coverage, normalized_coverage
 
+        coverage_records = generate_coverage_records()
         while True:
-            chunk = list(itertools.islice(generate_coverage_records(), chunk_size))
+            chunk = list(itertools.islice(coverage_records, chunk_size))
             array_index += len(chunk)
             if not chunk:
                 break
-                write_range = f"{array_index-len(chunk):,}-{array_index:,}"
+            write_range = f"{array_index-len(chunk):,}-{array_index:,}"
             logger.info(f"Writing {write_range} records to TileDB as single fragment...")
             self._write_arrays_to_tiledb(array_name, *zip(*chunk, strict=False))
         return array_index

--- a/backend/layers/processing/utils/atac.py
+++ b/backend/layers/processing/utils/atac.py
@@ -406,7 +406,7 @@ class ATACDataProcessor:
                 break
             write_range = f"{array_index-len(chunk):,}-{array_index:,}"
             logger.info(f"Writing {write_range} records to TileDB as single fragment...")
-            self._write_arrays_to_tiledb(array_name, *zip(*chunk, strict=False))
+            self._write_arrays_to_tiledb(array_name, *zip(*chunk, strict=True))
         return array_index
 
     def _write_arrays_to_tiledb(


### PR DESCRIPTION
## Reason for Change

- vc-3630
- fixes an OOM error when processing ATAC fragments into CXG using a function generator instead of preallocating an array. This is slower but will be less memory intensive.

### Refactoring for memory efficiency:

* [`backend/layers/processing/utils/atac.py`](diffhunk://#diff-76e55c365137fb5f4b085debb6488c1800836a335a3becc92444b273973c1caeL389-R408): Replaced pre-allocated arrays for storing intermediate data with a generator function (`generate_coverage_records`) that dynamically yields coverage records. This eliminates the need for large in-memory arrays.

* [`backend/layers/processing/utils/atac.py`](diffhunk://#diff-76e55c365137fb5f4b085debb6488c1800836a335a3becc92444b273973c1caeL389-R408): Introduced `itertools.islice` to process records in chunks, reducing memory usage by writing smaller fragments to TileDB iteratively.

### Code improvements:

* [`backend/layers/processing/utils/atac.py`](diffhunk://#diff-76e55c365137fb5f4b085debb6488c1800836a335a3becc92444b273973c1caeR1): Added the `itertools` module to support the new generator-based chunking logic.

## Testing steps

## Checklist 🛎️


## Notes for Reviewer
