### PR TITLE
fix: OOM in ingestion pipeline

### DIFF
--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -59,7 +59,7 @@ resource aws_batch_job_definition cxg_job_def {
   container_properties = jsonencode({
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
-  "memory": 64000,
+  "memory": 32000,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",

--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -43,6 +43,16 @@ resource aws_batch_job_definition batch_job_def {
     }
   ],
   "vcpus": 2,
+  "retryStrategy": {
+  "attempts": 1,
+    "evaluateOnExit": [
+      {
+        "onStatusReason": "Essential container in task exited",
+        "action": "RETRY",
+        "exitCode": "137"
+      }
+    ]
+  },
   "logConfiguration": {
     "logDriver": "awslogs",
     "options": {
@@ -139,6 +149,16 @@ resource aws_batch_job_definition atac_job_def {
       "value": "${var.frontend_url}"
     }
   ],
+      "retryStrategy": {
+  "attempts": 1,
+    "evaluateOnExit": [
+      {
+        "onStatusReason": "Essential container in task exited",
+        "action": "RETRY",
+        "exitCode": "137"
+      }
+    ]
+  },
   "logConfiguration": {
     "logDriver": "awslogs",
     "options": {

--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -44,7 +44,7 @@ resource aws_batch_job_definition batch_job_def {
   ],
   "vcpus": 2,
   "retryStrategy": {
-  "attempts": 1,
+    "attempts": 1,
     "evaluateOnExit": [
       {
         "onStatusReason": "Essential container in task exited",
@@ -149,7 +149,7 @@ resource aws_batch_job_definition atac_job_def {
       "value": "${var.frontend_url}"
     }
   ],
-      "retryStrategy": {
+  "retryStrategy": {
   "attempts": 1,
     "evaluateOnExit": [
       {

--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -108,6 +108,7 @@ resource aws_batch_job_definition atac_job_def {
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
   "memory": 128000,
+  "vcpus": 16,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",
@@ -138,7 +139,6 @@ resource aws_batch_job_definition atac_job_def {
       "value": "${var.frontend_url}"
     }
   ],
-  "vcpus": 16,
   "logConfiguration": {
     "logDriver": "awslogs",
     "options": {

--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -46,6 +46,16 @@ resource "aws_sfn_state_machine" "state_machine" {
                 "JobDefinition": "${var.job_definition_arn}",
                 "JobName": "validate_anndata",
                 "JobQueue.$": "$.job_queue",
+                "retryStrategy": {
+                  "attempts": 2,
+                  "evaluateOnExit": [
+                    {
+                      "onStatusReason": "Essential container in task exited",
+                      "action": "RETRY",
+                      "exitCode": "137"  // Exit code 137 indicates a container killed due to OOM
+                    }
+                  ]
+                },
                 "ContainerOverrides": {
                   "Environment": [
                     {
@@ -97,6 +107,16 @@ resource "aws_sfn_state_machine" "state_machine" {
                 "JobDefinition": "${var.atac_definition_arn}",
                 "JobName": "validate_atac",
                 "JobQueue.$": "$.job_queue",
+                "retryStrategy": {
+                  "attempts": 2,
+                  "evaluateOnExit": [
+                    {
+                      "onStatusReason": "Essential container in task exited",
+                      "action": "RETRY",
+                      "exitCode": "137"  // Exit code 137 indicates a container killed due to OOM
+                    }
+                  ]
+                },
                 "ContainerOverrides": {
                   "Environment": [
                     {

--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -52,7 +52,7 @@ resource "aws_sfn_state_machine" "state_machine" {
                     {
                       "onStatusReason": "Essential container in task exited",
                       "action": "RETRY",
-                      "exitCode": "137"  // Exit code 137 indicates a container killed due to OOM
+                      "exitCode": "137"
                     }
                   ]
                 },
@@ -113,7 +113,7 @@ resource "aws_sfn_state_machine" "state_machine" {
                     {
                       "onStatusReason": "Essential container in task exited",
                       "action": "RETRY",
-                      "exitCode": "137"  // Exit code 137 indicates a container killed due to OOM
+                      "exitCode": "137"
                     }
                   ]
                 },

--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -46,16 +46,6 @@ resource "aws_sfn_state_machine" "state_machine" {
                 "JobDefinition": "${var.job_definition_arn}",
                 "JobName": "validate_anndata",
                 "JobQueue.$": "$.job_queue",
-                "retryStrategy": {
-                  "attempts": 2,
-                  "evaluateOnExit": [
-                    {
-                      "onStatusReason": "Essential container in task exited",
-                      "action": "RETRY",
-                      "exitCode": "137"
-                    }
-                  ]
-                },
                 "ContainerOverrides": {
                   "Environment": [
                     {
@@ -107,16 +97,6 @@ resource "aws_sfn_state_machine" "state_machine" {
                 "JobDefinition": "${var.atac_definition_arn}",
                 "JobName": "validate_atac",
                 "JobQueue.$": "$.job_queue",
-                "retryStrategy": {
-                  "attempts": 2,
-                  "evaluateOnExit": [
-                    {
-                      "onStatusReason": "Essential container in task exited",
-                      "action": "RETRY",
-                      "exitCode": "137"
-                    }
-                  ]
-                },
                 "ContainerOverrides": {
                   "Environment": [
                     {

--- a/backend/layers/processing/utils/atac.py
+++ b/backend/layers/processing/utils/atac.py
@@ -381,7 +381,7 @@ class ATACDataProcessor:
         coverage_aggregator: defaultdict,
         global_cell_type_totals: Dict[str, int],
         array_name: str,
-        chunk_size: int = 50000,
+        chunk_size: int = 10_000_000,
     ) -> int:
         """Streaming approach: process directly into pre-allocated numpy arrays, write once."""
 


### PR DESCRIPTION
## Reason for Change

- the 50000  chunk size for writing CXG was low and made writing take hours. Increasing to to about 300MB per chunk.
- fixing https://czi.atlassian.net/browse/VC-3722?atlOrigin=eyJpIjoiNzlkMzAwMDdkMWZkNDg5ZmJjZDU4ZjQwM2U2ZGMxOTAiLCJwIjoiaiJ9

## Changes
This pull request includes changes to optimize resource configurations and improve error handling across batch job definitions, state machine configurations, and a Python utility function. Key updates include adjustments to memory and CPU allocations, the introduction of retry strategies for state machine tasks, and an increased chunk size for processing data.

### Batch Job Definition Updates:
* [`.happy/terraform/modules/batch/main.tf`](diffhunk://#diff-79c3e8b861066ac4e8d0ecf50e8c69713501bf03de50a7c314ab02461e07f7eeL62-R62): Reduced memory allocation for `cxg_job_def` from 64,000 to 32,000 to it's previous value. 
* moved `vcpus: 16` in `atac_job_def` closer to memory to improve readability. [[1]](diffhunk://#diff-79c3e8b861066ac4e8d0ecf50e8c69713501bf03de50a7c314ab02461e07f7eeL62-R62) [[2]](diffhunk://#diff-79c3e8b861066ac4e8d0ecf50e8c69713501bf03de50a7c314ab02461e07f7eeR111) [[3]](diffhunk://#diff-79c3e8b861066ac4e8d0ecf50e8c69713501bf03de50a7c314ab02461e07f7eeL141)

### State Machine Enhancements:
* [`.happy/terraform/modules/sfn/main.tf`](diffhunk://#diff-42a692f37fc5779f53544cd86ea463dea88b94e85d4c27288efea15c7fbb09afR49-R58): Added a `retryStrategy` to state machine tasks (`validate_anndata` and `validate_atac`) to retry on specific failure conditions like OOM (exit code 137), with up to 2 attempts. [[1]](diffhunk://#diff-42a692f37fc5779f53544cd86ea463dea88b94e85d4c27288efea15c7fbb09afR49-R58) [[2]](diffhunk://#diff-42a692f37fc5779f53544cd86ea463dea88b94e85d4c27288efea15c7fbb09afR110-R119)

### Python Utility Optimization:
* [`backend/layers/processing/utils/atac.py`](diffhunk://#diff-76e55c365137fb5f4b085debb6488c1800836a335a3becc92444b273973c1caeL384-R384): Increased the default `chunk_size` in `_stream_coverage_chunks_to_tiledb` from 50,000 to 10,000,000 to improve CXG write efficiency.
