### PR TITLE
fix: ATAC processing memory optimization VC-3630

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 CELLxGENE Discover enables the publication, discovery and exploration of interoperable single-cell datasets. Data contributors can upload, review and publish datasets for private or public use. Via Discover, data consumers are able to discover, download and connect data to visualization tools such as [CELLxGENE Explorer](https://github.com/chanzuckerberg/cellxgene-documentation/blob/main/README.md) to perform further analysis. The goal of Discover is to catalyze distributed collaboration of single-cell research by providing a large, well-labeled repository of interoperable datasets.
 
+## Code of Conduct
+
+This project adheres to the Contributor Covenant [code of conduct](https://github.com/chanzuckerberg/.github/blob/master/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [opensource@chanzuckerberg.com](mailto:opensource@chanzuckerberg.com).
+
 ## Developer Guidelines
 
 ### FE Setup

--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -29,6 +29,15 @@ from backend.layers.processing.utils.cxg_generation_utils import (
 from backend.layers.processing.utils.matrix_utils import is_matrix_sparse
 
 
+def get_memory_config():
+    """Calculate memory configuration based on available system memory."""
+    total_memory = psutil.virtual_memory().total
+    # Use 70% of available memory, leaving buffer for OS and other processes
+    memory_limit_bytes = int(total_memory * 0.7)
+    memory_limit_gb = memory_limit_bytes // (1024**3)
+    return f"{memory_limit_gb}GB"
+
+
 class H5ADDataFile:
     """
     Class encapsulating required information about an H5AD datafile that ultimately will be transformed into
@@ -140,7 +149,7 @@ class H5ADDataFile:
             {
                 "num_workers": 1,  # a single worker with as many threads as vCPUs is more memory efficient
                 "threads_per_worker": 2,  # match the number of vCPUs
-                "distributed.worker.memory.limit": "28GB",
+                "distributed.worker.memory.limit": get_memory_config(),
                 "scheduler": "threads",
             }
         ):

--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -140,7 +140,7 @@ class H5ADDataFile:
             {
                 "num_workers": 1,  # a single worker with as many threads as vCPUs is more memory efficient
                 "threads_per_worker": 2,  # match the number of vCPUs
-                "distributed.worker.memory.limit": "56GB",
+                "distributed.worker.memory.limit": "28GB",
                 "scheduler": "threads",
             }
         ):

--- a/backend/layers/processing/h5ad_data_file.py
+++ b/backend/layers/processing/h5ad_data_file.py
@@ -112,6 +112,19 @@ class H5ADDataFile:
                 )
                 logging.info("\t...dataset coverage dataframe saved")
 
+                # Consolidate coverage array fragments
+                coverage_container = f"{output_cxg_directory}/coverage"
+                logging.info("Consolidating coverage array fragments...")
+                self._consolidate_tiledb_with_memory_optimization(coverage_container, ctx)
+
+                # Vacuum to physically remove old fragments
+                if hasattr(tiledb, "vacuum"):
+                    logging.info("Vacuuming coverage array to remove old fragments...")
+                    tiledb.vacuum(coverage_container, ctx=ctx)
+                    logging.info("\t...coverage array vacuumed")
+
+                logging.info("\t...coverage array consolidated")
+
         self.write_anndata_embeddings_to_cxg(output_cxg_directory, ctx)
         logging.info("\t...dataset embeddings saved")
 

--- a/backend/layers/processing/utils/atac.py
+++ b/backend/layers/processing/utils/atac.py
@@ -269,9 +269,11 @@ class ATACDataProcessor:
         fragment_file_size_gb = os.path.getsize(fragment_file_path) / (1024**3)
         available_memory_gb = 28  # Dask memory limit
         max_memory_processes = max(1, int(available_memory_gb / fragment_file_size_gb))
-        
+
         num_processes = min(cpu_count(), len(chrom_map), max_memory_processes)
-        logger.info(f"Fragment file size: {fragment_file_size_gb:.2f}GB, using {num_processes} processes (memory-limited from {cpu_count()})")
+        logger.info(
+            f"Fragment file size: {fragment_file_size_gb:.2f}GB, using {num_processes} processes (memory-limited from {cpu_count()})"
+        )
 
         fragment_file_path = self._get_fragment_file_path()
 
@@ -398,40 +400,38 @@ class ATACDataProcessor:
 
         # Write all chunks in a single TileDB session using generator
         records_processed = self._write_chunks_generator_to_tiledb(
-            array_name, 
-            self._generate_chunks(coverage_aggregator, global_cell_type_totals, chunk_size),
-            total_records
+            array_name, self._generate_chunks(coverage_aggregator, global_cell_type_totals, chunk_size), total_records
         )
-        
-        # Consolidate fragments into single fragment for optimal read performance
-        logger.info(f"Consolidating {records_processed:,} records into single fragment...")
-        tiledb.consolidate(array_name, ctx=self.ctx)
-        
+
         logger.info(f"Successfully processed {records_processed:,} records to TileDB as single fragment")
         return records_processed
 
-    def _generate_chunks(self, coverage_aggregator: defaultdict, global_cell_type_totals: Dict[str, int], chunk_size: int):
+    def _generate_chunks(
+        self, coverage_aggregator: defaultdict, global_cell_type_totals: Dict[str, int], chunk_size: int
+    ):
         """Generator that yields chunks of processed data without storing all in memory."""
         current_chunk = []
-        
+
         for (chrom, bin_id, cell_type), count in coverage_aggregator.items():
             total_coverage = global_cell_type_totals.get(cell_type, 0)
             normalized_coverage = (count / total_coverage) * self.normalization_factor if total_coverage > 0 else 0.0
 
-            current_chunk.append({
-                'chrom': chrom,
-                'bin_id': bin_id,
-                'cell_type': cell_type,
-                'coverage': count,
-                'total_coverage': total_coverage,
-                'normalized_coverage': normalized_coverage,
-            })
-            
+            current_chunk.append(
+                {
+                    "chrom": chrom,
+                    "bin_id": bin_id,
+                    "cell_type": cell_type,
+                    "coverage": count,
+                    "total_coverage": total_coverage,
+                    "normalized_coverage": normalized_coverage,
+                }
+            )
+
             # Yield chunk when it reaches chunk_size
             if len(current_chunk) >= chunk_size:
                 yield current_chunk
                 current_chunk = []
-        
+
         # Yield remaining data
         if current_chunk:
             yield current_chunk
@@ -442,34 +442,36 @@ class ATACDataProcessor:
         chunk_generator,
         total_records: int,
     ) -> int:
-        """Write chunks from generator to TileDB in a single session."""
-        
+        """Write chunks from generator to TileDB, then close and consolidate."""
+
         records_written = 0
-        
+
+        # Write all chunks to TileDB
         with tiledb.SparseArray(array_name, mode="w", ctx=self.ctx) as A:
             for chunk_idx, chunk_data in enumerate(tqdm(chunk_generator, desc="Writing chunks to TileDB")):
                 chunk_size = len(chunk_data)
                 logger.debug(f"Writing chunk {chunk_idx + 1} ({chunk_size:,} records)...")
-                
+
                 # Convert chunk data to numpy arrays
-                chroms = np.array([record['chrom'] for record in chunk_data], dtype=np.int32)
-                bins = np.array([record['bin_id'] for record in chunk_data], dtype=np.int32)
-                cell_types = np.array([record['cell_type'] for record in chunk_data], dtype=object)
-                coverages = np.array([record['coverage'] for record in chunk_data], dtype=np.int32)
-                total_coverages = np.array([record['total_coverage'] for record in chunk_data], dtype=np.int32)
-                normalized_coverages = np.array([record['normalized_coverage'] for record in chunk_data], dtype=np.float32)
-                
+                chroms = np.array([record["chrom"] for record in chunk_data], dtype=np.int32)
+                bins = np.array([record["bin_id"] for record in chunk_data], dtype=np.int32)
+                cell_types = np.array([record["cell_type"] for record in chunk_data], dtype=object)
+                coverages = np.array([record["coverage"] for record in chunk_data], dtype=np.int32)
+                total_coverages = np.array([record["total_coverage"] for record in chunk_data], dtype=np.int32)
+                normalized_coverages = np.array(
+                    [record["normalized_coverage"] for record in chunk_data], dtype=np.float32
+                )
+
                 # Write chunk to TileDB
                 A[(chroms, bins, cell_types)] = {
                     "coverage": coverages,
                     "total_coverage": total_coverages,
                     "normalized_coverage": normalized_coverages,
                 }
-                
+
                 records_written += chunk_size
                 logger.debug(f"Successfully wrote chunk {chunk_idx + 1} of {chunk_size:,} records")
-        
-        logger.info(f"Successfully wrote {records_written:,} records to TileDB as single fragment")
+
         return records_written
 
     def process_fragment_file(self, obs: pd.DataFrame, array_name: str, uns: Optional[Dict] = None) -> None:

--- a/backend/layers/processing/utils/atac.py
+++ b/backend/layers/processing/utils/atac.py
@@ -302,7 +302,7 @@ class ATACDataProcessor:
         # Memory-aware process limiting to prevent OOM
         fragment_file_path = self._get_fragment_file_path()
         fragment_file_size_gb = os.path.getsize(fragment_file_path) / (1024**3)
-        available_memory_gb = 28  # Dask memory limit
+        available_memory_gb = psutil.virtual_memory().total * 0.7 / (1024**3)  # Use 70% of available memory
         max_memory_processes = max(1, int(available_memory_gb / fragment_file_size_gb))
 
         num_processes = min(cpu_count(), len(chrom_map), max_memory_processes)


### PR DESCRIPTION
## Reason for Change

- VC-3630

## Changes

-   Dynamically limits process count based on fragment file size to prevent OOM
-   Eliminated redundant double-processing of fragment data, reducing peak memory
-   Stream 500K record chunks on-demand instead of pre-allocating arrays for 200M+ records, preventing memory exhaustion
-   Added missing TileDB consolidation + vacuum for ATAC coverage arrays, reducing multiple fragments to single fragment for optimal read performance

## Notes for Reviewer
