### PR TITLE
feat: increase to 1 retry for States.TaskFailed

### DIFF
--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -76,7 +76,8 @@ resource "aws_sfn_state_machine" "state_machine" {
                   "BackoffRate": 5
               }, {
                   "ErrorEquals": ["States.TaskFailed"],
-                  "MaxAttempts": 0
+                  "IntervalSeconds": 30,
+                  "MaxAttempts": 1
               }, {
                   "ErrorEquals": ["States.ALL"],
                   "IntervalSeconds": 2,
@@ -127,7 +128,8 @@ resource "aws_sfn_state_machine" "state_machine" {
                   "BackoffRate": 5
               }, {
                   "ErrorEquals": ["States.TaskFailed"],
-                  "MaxAttempts": 0
+                  "IntervalSeconds": 30,
+                  "MaxAttempts": 1
               }, {
                   "ErrorEquals": ["States.ALL"],
                   "IntervalSeconds": 2,
@@ -231,7 +233,8 @@ resource "aws_sfn_state_machine" "state_machine" {
           "BackoffRate": 5
       }, {
           "ErrorEquals": ["States.TaskFailed"],
-          "MaxAttempts": 0
+          "IntervalSeconds": 30,
+          "MaxAttempts": 1
       }, {
           "ErrorEquals": ["States.ALL"],
           "IntervalSeconds": 2,


### PR DESCRIPTION
## Reason for Change

https://czi.atlassian.net/browse/VC-3818

## Changes

previously, we were not retrying if `ValidateAnndata`, `ValidateAtac`, or `Cxg` failed with `States.TaskFailed`. we would only retry if it failed with `States.Timeout` or some sort of specific AWS issue (and honestly not even 100% sure if those were caught)

## Testing steps

n/a

## Checklist 🛎️

- [ ] Add product, design, and eng as reviewers for rdev review
- [ ] For UI changes, add screenshots/videos, so the reviewers know what you expect them to see
- [ ] For UI changes, add e2e tests to prevent regressions
- [ ] For UI changes, verify impacted analytics events still work

## Notes for Reviewer
