### PR TITLE
fix: Delete old cxg files on is_reprocess

### DIFF
--- a/backend/layers/processing/process_cxg.py
+++ b/backend/layers/processing/process_cxg.py
@@ -79,7 +79,12 @@ class ProcessCxg(ProcessingLogic):
 
         # Convert the labeled dataset to CXG and upload it to the cellxgene bucket
         self.process_cxg(
-            labeled_h5ad_filename, dataset_version_id, cellxgene_bucket, fragment_file_path, current_artifacts, is_reprocess
+            labeled_h5ad_filename,
+            dataset_version_id,
+            cellxgene_bucket,
+            fragment_file_path,
+            current_artifacts,
+            is_reprocess,
         )
 
     @logit
@@ -111,7 +116,7 @@ class ProcessCxg(ProcessingLogic):
         """
         bucket, prefix = self.s3_provider.parse_s3_uri(s3_uri)
         # Remove trailing slash if present for consistent prefix handling
-        prefix = prefix.rstrip('/')
+        prefix = prefix.rstrip("/")
         self.logger.info(f"Deleting existing CXG files from s3://{bucket}/{prefix}/")
         self.s3_provider.delete_prefix(bucket, prefix)
 
@@ -124,7 +129,13 @@ class ProcessCxg(ProcessingLogic):
         self.s3_provider.upload_directory(cxg_dir, s3_uri)
 
     def process_cxg(
-        self, local_filename, dataset_version_id, cellxgene_bucket, fragment_file_path=None, current_artifacts=None, is_reprocess=False
+        self,
+        local_filename,
+        dataset_version_id,
+        cellxgene_bucket,
+        fragment_file_path=None,
+        current_artifacts=None,
+        is_reprocess=False,
     ):
         cxg_dir = self.convert_file(
             self.make_cxg, local_filename, dataset_version_id, fragment_file_path, DatasetStatusKey.CXG

--- a/backend/layers/processing/process_cxg.py
+++ b/backend/layers/processing/process_cxg.py
@@ -112,10 +112,9 @@ class ProcessCxg(ProcessingLogic):
 
     def delete_existing_cxg_files(self, s3_uri):
         """
-        Delete all existing files in the CXG S3 directory
+        Delete all existing files in a given CXG S3 directory
         """
         bucket, prefix = self.s3_provider.parse_s3_uri(s3_uri)
-        # Remove trailing slash if present for consistent prefix handling
         prefix = prefix.rstrip("/")
         self.logger.info(f"Deleting existing CXG files from s3://{bucket}/{prefix}/")
         self.s3_provider.delete_prefix(bucket, prefix)


### PR DESCRIPTION
## Reason for Change

- Remove old cxg files from folder on reprocess

## Changes

- Modified `process_cxg` method to accept is_reprocess parameter
- Added `delete_existing_cxg_files` method that uses the existing delete_prefix functionality from S3Provider
- Updated `copy_cxg_files_to_cxg_bucket` method to accept a `clear_existing` parameter
- Passed the `is_reprocess` flag through the call chain
- Unit test coverage for above

## Testing steps
- Unit tests should all pass for processing
- Step function to be tested in staging, prior to deployment