### PR TITLE
fix: Revise delete_objects

### DIFF
--- a/backend/layers/thirdparty/s3_provider.py
+++ b/backend/layers/thirdparty/s3_provider.py
@@ -96,17 +96,67 @@ class S3Provider(S3ProviderInterface):
         """
         Deletes the objects `object_keys` from bucket `bucket_name`
         """
-        for i in range(0, len(object_keys), AWS_S3_MAX_ITEMS_PER_BATCH):
-            key_batch = object_keys[i:AWS_S3_MAX_ITEMS_PER_BATCH]
-            resp = self.client.delete_objects(
-                Bucket=bucket_name,
-                Delete={"Objects": [{"Key": key} for key in key_batch]},
+        # Filter out empty or invalid keys
+        valid_keys = [key.strip() for key in object_keys if key and key.strip()]
+        
+        if not valid_keys:
+            logger.info({"message": "No valid keys to delete", "bucket_name": bucket_name})
+            return
+        
+        # Safety check: prevent deletion of root-level objects without proper prefixes
+        dangerous_keys = [key for key in valid_keys if '/' not in key or len(key.split('/')[0]) < 8]
+        if dangerous_keys:
+            logger.warning({
+                "message": "Blocked deletion of potentially dangerous keys without proper directory structure",
+                "bucket_name": bucket_name,
+                "dangerous_keys": dangerous_keys[:10]
+            })
+            raise IllegalS3RecursiveDelete(
+                f"Cannot delete root-level or insufficiently prefixed objects: {dangerous_keys[:5]}"
             )
-            if deleted := resp.get("Deleted"):
-                logger.info({"deleted": deleted})
-            if errors := resp.get("Errors"):
-                logger.error({"errors": errors, "bucket_name": bucket_name})
-                raise S3DeleteException(errors)
+        
+        # Safety check: warn about large deletion operations
+        if len(valid_keys) > 10000:
+            logger.warning({
+                "message": "Large deletion operation detected - proceeding with caution",
+                "bucket_name": bucket_name,
+                "key_count": len(valid_keys),
+                "sample_keys": valid_keys[:5]
+            })
+        
+        # Log all deletion operations for audit trail
+        logger.info({
+            "message": "Starting deletion operation",
+            "bucket_name": bucket_name,
+            "key_count": len(valid_keys),
+            "sample_keys": valid_keys[:3]
+        })
+        
+        for i in range(0, len(valid_keys), AWS_S3_MAX_ITEMS_PER_BATCH):
+            key_batch = valid_keys[i:i + AWS_S3_MAX_ITEMS_PER_BATCH]
+            
+            # Ensure we have keys to delete in this batch
+            if not key_batch:
+                continue
+                
+            try:
+                resp = self.client.delete_objects(
+                    Bucket=bucket_name,
+                    Delete={"Objects": [{"Key": key} for key in key_batch]},
+                )
+                if deleted := resp.get("Deleted"):
+                    logger.info({"deleted": deleted})
+                if errors := resp.get("Errors"):
+                    logger.error({"errors": errors, "bucket_name": bucket_name})
+                    raise S3DeleteException(errors)
+            except Exception as e:
+                logger.error({
+                    "message": "Failed to delete batch of keys",
+                    "bucket_name": bucket_name,
+                    "key_batch": key_batch,
+                    "error": str(e)
+                })
+                raise
 
     def delete_prefix(self, bucket_name: str, prefix: str) -> None:
         if not re.search(ID_REGEX, prefix):

--- a/tests/unit/backend/layers/thirdparty/test_s3_provider.py
+++ b/tests/unit/backend/layers/thirdparty/test_s3_provider.py
@@ -1,24 +1,116 @@
 import unittest
 from unittest.mock import patch
 
-from backend.layers.thirdparty.s3_exceptions import S3DeleteException
+from backend.layers.thirdparty.s3_exceptions import S3DeleteException, IllegalS3RecursiveDelete
 from backend.layers.thirdparty.s3_provider import S3Provider
 
 
 class TestS3Provider(unittest.TestCase):
     @patch("backend.layers.thirdparty.s3_provider.boto3.client")
     def test__object_deletion(self, mock_client_constructor):
+        safe_key = "12345678-1234-5678-9012-123456789012/file.txt"
+        
         with self.subTest("Raises 500 when Errors list is not empty"):
             mock_client_constructor.return_value.delete_objects.return_value = {
                 "Objects": ["object"],
                 "Errors": ["error"],
             }
             with self.assertRaises(S3DeleteException):
-                S3Provider().delete_files("bucket", ["key"])
+                S3Provider().delete_files("bucket", [safe_key])
         with self.subTest("Does not raise errors when Errors list is empty and Objects list is not empty"):
             mock_client_constructor.return_value.delete_objects.return_value = {"Objects": ["object"], "Errors": []}
-            S3Provider().delete_files("bucket", ["key"])
+            S3Provider().delete_files("bucket", [safe_key])
             self.assertTrue(True)  # No exception raised
+
+    @patch("backend.layers.thirdparty.s3_provider.boto3.client")
+    def test_delete_files_empty_keys(self, mock_client_constructor):
+        """Test that delete_files handles empty key lists correctly"""
+        s3_provider = S3Provider()
+        
+        # Test with empty list
+        s3_provider.delete_files("bucket", [])
+        mock_client_constructor.return_value.delete_objects.assert_not_called()
+        
+        # Test with list of empty strings
+        s3_provider.delete_files("bucket", ["", "  ", None])
+        mock_client_constructor.return_value.delete_objects.assert_not_called()
+
+    @patch("backend.layers.thirdparty.s3_provider.boto3.client")
+    def test_delete_files_filters_invalid_keys(self, mock_client_constructor):
+        """Test that delete_files filters out empty/invalid keys"""
+        mock_client_constructor.return_value.delete_objects.return_value = {
+            "Objects": ["object"], "Errors": []
+        }
+        
+        s3_provider = S3Provider()
+        valid_key1 = "12345678-1234-5678-9012-123456789012/file1.txt"
+        valid_key2 = "87654321-4321-8765-2109-876543210987/file2.txt"
+        
+        s3_provider.delete_files("bucket", [valid_key1, "", "  ", valid_key2])
+        
+        # Should only call delete_objects with valid keys
+        mock_client_constructor.return_value.delete_objects.assert_called_once_with(
+            Bucket="bucket",
+            Delete={"Objects": [{"Key": valid_key1}, {"Key": valid_key2}]}
+        )
+
+    @patch("backend.layers.thirdparty.s3_provider.boto3.client")
+    def test_delete_files_batch_slicing_fix(self, mock_client_constructor):
+        """Test that batch slicing works correctly with the fix"""
+        mock_client_constructor.return_value.delete_objects.return_value = {
+            "Objects": ["object"], "Errors": []
+        }
+        
+        # Create more keys than batch size to test slicing - use properly prefixed keys
+        large_key_list = [f"12345678-1234-5678-9012-123456789012/key_{i}" for i in range(1500)]  # More than AWS_S3_MAX_ITEMS_PER_BATCH (1000)
+        
+        s3_provider = S3Provider()
+        s3_provider.delete_files("bucket", large_key_list)
+        
+        # Should be called twice: once for first 1000, once for remaining 500
+        self.assertEqual(mock_client_constructor.return_value.delete_objects.call_count, 2)
+
+    @patch("backend.layers.thirdparty.s3_provider.boto3.client")
+    def test_delete_files_blocks_dangerous_keys(self, mock_client_constructor):
+        """Test that delete_files blocks deletion of root-level or insufficiently prefixed objects"""
+        s3_provider = S3Provider()
+        
+        # Test root-level files (no slash)
+        with self.assertRaises(IllegalS3RecursiveDelete):
+            s3_provider.delete_files("bucket", ["file1.txt", "file2.txt"])
+        
+        # Test insufficiently prefixed files (prefix < 8 chars)
+        with self.assertRaises(IllegalS3RecursiveDelete):
+            s3_provider.delete_files("bucket", ["abc/file.txt", "short/file.txt"])
+        
+        # Test mixed dangerous and safe keys - should still raise exception
+        with self.assertRaises(IllegalS3RecursiveDelete):
+            s3_provider.delete_files("bucket", ["12345678-1234/safe.txt", "unsafe.txt"])
+        
+        # Verify delete_objects was never called for dangerous operations
+        mock_client_constructor.return_value.delete_objects.assert_not_called()
+
+    @patch("backend.layers.thirdparty.s3_provider.boto3.client")
+    def test_delete_files_allows_safe_keys(self, mock_client_constructor):
+        """Test that delete_files allows properly prefixed objects"""
+        mock_client_constructor.return_value.delete_objects.return_value = {
+            "Objects": ["object"], "Errors": []
+        }
+        
+        s3_provider = S3Provider()
+        
+        # These should be allowed (8+ character prefix before slash)
+        safe_keys = [
+            "12345678-1234-5678-9012-123456789012/file1.txt",
+            "longenoughprefix/subfolder/file2.txt",
+            "uuid-like-prefix/data/file3.txt"
+        ]
+        
+        # Should not raise exception
+        s3_provider.delete_files("bucket", safe_keys)
+        
+        # Verify delete_objects was called
+        mock_client_constructor.return_value.delete_objects.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Reason for Change

- Changes to S3 delete_files Method

## Changes

- Blocks deletion of root-level files or files with prefixes <8 characters
- **Added large batch warnings**: Logs warning for deletions >10,000 files
- All deletion operations now logged with bucket name, key count, and sample keys
- Raises IllegalS3RecursiveDelete for dangerous key patterns
- Requires proper / separated paths with sufficient prefixes
- Added tests for dangerous key blocking and safe key allowance

## Testing steps

- Unit tests should all pass for processing
- Test sfn in rdev and staging prior to deploying
