### PR TITLE
fix: errors in mirror commands

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -122,8 +122,9 @@ endif
 # Runs in interactive mode, so each run requires separate terminal tab.
 PORT:=5432
 db/tunnel/up:
+	$(eval INSTANCE_ENV := $(if $(filter staging,$(DEPLOYMENT_STAGE)),stage,$(DEPLOYMENT_STAGE)))
 	$(eval endpoint=$(shell aws rds describe-db-cluster-endpoints --db-cluster-identifier ${CLUSTER_NAME} | jq -r '.DBClusterEndpoints[] | select(.EndpointType | contains("WRITER")) | .Endpoint'))
-	$(eval instance_id=$(shell aws ec2 describe-instances --filters "Name=tag:Name,Values=dp-${DEPLOYMENT_STAGE}-happy" --query "Reservations[*].Instances[*].InstanceId" --output text))
+	$(eval instance_id=$(shell aws ec2 describe-instances --filters "Name=tag:Name,Values=dp-${INSTANCE_ENV}-happy" --query "Reservations[*].Instances[*].InstanceId" --output text))
 
 	aws ssm start-session --target ${instance_id} --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"portNumber":["5432"],"localPortNumber":["$(PORT)"],"host":["${endpoint}"]}'
 

--- a/backend/scripts/mirror_rds_data.sh
+++ b/backend/scripts/mirror_rds_data.sh
@@ -60,7 +60,9 @@ load_src_dump_to_dest_db || load_src_dump_to_dest_db  # Hack for rdev, where it 
 
 if [[ $DEST_ENV != 'rdev' ]]; then
   DB_UPDATE_CMDS=$(cat <<EOF
--c "UPDATE persistence_schema."DatasetArtifact" SET uri = regexp_replace(uri, '^(s3://[^/]*?)-${SRC_ENV}(/.+)$', '\\1-${DEST_ENV}\\2') WHERE  uri LIKE 's3://%-${SRC_ENV}/%';"
+  -c "UPDATE persistence_schema.\"DatasetArtifact\" \
+      SET uri = regexp_replace(uri, '^(s3://[^/]*?)-${SRC_ENV}(/.+)', '\1-${DEST_ENV}\2') \
+      WHERE uri LIKE 's3://%-${SRC_ENV}/%';"
 EOF
 )
 else


### PR DESCRIPTION
## Reason for Change
 - mirroring script had a couple failure points to address: 
         - Connecting to the staging DB was failing due to an inconsistency in naming (EC2 instances are named dp-STAGE-happy, DB endpoint uses STAGING).  
         - fix backslash escapes on an UPDATE statement that changes s3 uris from using SRC_ENV name to DEST_ENV name in the DEST_DB