### PR TITLE
fix: get the dataset version after submitting manifest

### DIFF
--- a/backend/layers/processing/process_validate_atac.py
+++ b/backend/layers/processing/process_validate_atac.py
@@ -169,7 +169,7 @@ class ProcessValidateATAC(ProcessingLogic):
         # Deduplicate the fragment file
         if manifest.flags and manifest.flags.deduplicate_fragments:
             try:
-                self.schema_validator.deduplicate_fragments(local_fragment_filename)
+                local_fragment_filename = self.schema_validator.deduplicate_fragments(local_fragment_filename)
             except Exception as e:
                 self.logger.exception(f"Failed to deduplicate fragment file {local_fragment_filename}")
                 self.update_processing_status(dataset_version_id, DatasetStatusKey.ATAC, DatasetConversionStatus.FAILED)

--- a/backend/layers/thirdparty/schema_validator_provider.py
+++ b/backend/layers/thirdparty/schema_validator_provider.py
@@ -114,7 +114,6 @@ class SchemaValidatorProvider(SchemaValidatorProviderInterface):
 
         import cellxgene_schema.atac_seq as atac_seq
 
-        output_file = fragment_file + ".deduplicated"
-        atac_seq.deduplicate_fragment_rows(fragment_file, output_file)
+        output_file = atac_seq.deduplicate_fragment_rows(fragment_file)
         os.remove(fragment_file)
         return output_file

--- a/backend/layers/thirdparty/schema_validator_provider.py
+++ b/backend/layers/thirdparty/schema_validator_provider.py
@@ -46,7 +46,7 @@ class SchemaValidatorProviderInterface(Protocol):
         """
         pass
 
-    def deduplicate_fragments(self, fragment_file: str) -> None:
+    def deduplicate_fragments(self, fragment_file: str) -> str:
         """
         Deduplicates and replaces the provided `fragment_file`.
         """
@@ -109,7 +109,7 @@ class SchemaValidatorProvider(SchemaValidatorProviderInterface):
 
         return atac_seq.check_anndata_requires_fragment(anndata_file)
 
-    def deduplicate_fragments(self, fragment_file: str) -> None:
+    def deduplicate_fragments(self, fragment_file: str) -> str:
         import os
 
         import cellxgene_schema.atac_seq as atac_seq
@@ -117,4 +117,4 @@ class SchemaValidatorProvider(SchemaValidatorProviderInterface):
         output_file = fragment_file + ".deduplicated"
         atac_seq.deduplicate_fragment_rows(fragment_file, output_file)
         os.remove(fragment_file)
-        os.rename(output_file, fragment_file)
+        return output_file

--- a/backend/layers/thirdparty/schema_validator_provider.py
+++ b/backend/layers/thirdparty/schema_validator_provider.py
@@ -115,5 +115,7 @@ class SchemaValidatorProvider(SchemaValidatorProviderInterface):
         import cellxgene_schema.atac_seq as atac_seq
 
         output_file = atac_seq.deduplicate_fragment_rows(fragment_file)
+        if not output_file or not os.path.exists(output_file):
+            raise RuntimeError("Deduplication failed: output file not created. Original file not removed.")
         os.remove(fragment_file)
         return output_file

--- a/backend/layers/thirdparty/schema_validator_provider.py
+++ b/backend/layers/thirdparty/schema_validator_provider.py
@@ -115,7 +115,7 @@ class SchemaValidatorProvider(SchemaValidatorProviderInterface):
         import cellxgene_schema.atac_seq as atac_seq
 
         output_file = atac_seq.deduplicate_fragment_rows(fragment_file)
-        if not output_file or not os.path.exists(output_file):
+        if not output_file or not os.path.exists(output_file) or os.path.getsize(output_file) == 0:
             raise RuntimeError("Deduplication failed: output file not created. Original file not removed.")
         os.remove(fragment_file)
         return output_file

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -5,7 +5,7 @@ import requests
 from requests import HTTPError
 
 from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
-from tests.functional.backend.constants import ATAC_SEQ_MANIFEST, DATASET_URI, VISIUM_DATASET_URI
+from tests.functional.backend.constants import ATAC_SEQ_MANIFEST, DATASET_MANIFEST, DATASET_URI, VISIUM_DATASET_URI
 from tests.functional.backend.skip_reason import skip_creation_on_prod
 from tests.functional.backend.utils import assertStatusCode, create_test_collection
 
@@ -266,7 +266,7 @@ def test_dataset_reupload_flow_from_manifest(
         api_url,
         collection_data,
     )
-    result = upload_manifest(collection_id, ATAC_SEQ_MANIFEST)
+    result = upload_manifest(collection_id, DATASET_MANIFEST)
     dataset_id = result["dataset_id"]
 
     # get the manifest and ensure it has expected content
@@ -276,12 +276,10 @@ def test_dataset_reupload_flow_from_manifest(
     )
     assertStatusCode(200, resp)
     new_manifest = resp.json()
-    assert set(new_manifest.keys()) == {
-        "anndata",
-        "atac_fragment",
-    }, f"Manifest keys do not match expected, {new_manifest=}"
+    assert set(new_manifest.keys()) == set(
+        DATASET_MANIFEST.keys()
+    ), f"Manifest keys do not match expected, {new_manifest=}"
     # re-upload the manifest from the public urls to ensure re-upload works as expected
-    new_manifest["flags"] = {"deduplicate_fragments": True}
     upload_manifest(collection_id, new_manifest, existing_dataset_id=dataset_id)
 
 

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -5,7 +5,7 @@ import requests
 from requests import HTTPError
 
 from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
-from tests.functional.backend.constants import ATAC_SEQ_MANIFEST, DATASET_MANIFEST, DATASET_URI, VISIUM_DATASET_URI
+from tests.functional.backend.constants import ATAC_SEQ_MANIFEST, DATASET_URI, VISIUM_DATASET_URI
 from tests.functional.backend.skip_reason import skip_creation_on_prod
 from tests.functional.backend.utils import assertStatusCode, create_test_collection
 
@@ -266,7 +266,7 @@ def test_dataset_reupload_flow_from_manifest(
         api_url,
         collection_data,
     )
-    result = upload_manifest(collection_id, DATASET_MANIFEST)
+    result = upload_manifest(collection_id, ATAC_SEQ_MANIFEST)
     dataset_id = result["dataset_id"]
 
     # get the manifest and ensure it has expected content
@@ -276,10 +276,12 @@ def test_dataset_reupload_flow_from_manifest(
     )
     assertStatusCode(200, resp)
     new_manifest = resp.json()
-    assert set(new_manifest.keys()) == set(
-        DATASET_MANIFEST.keys()
-    ), f"Manifest keys do not match expected, {new_manifest=}"
+    assert set(new_manifest.keys()) == {
+        "anndata",
+        "atac_fragment",
+    }, f"Manifest keys do not match expected, {new_manifest=}"
     # re-upload the manifest from the public urls to ensure re-upload works as expected
+    new_manifest["flags"] = {"deduplicate_fragments": True}
     upload_manifest(collection_id, new_manifest, existing_dataset_id=dataset_id)
 
 

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -157,6 +157,14 @@ def upload_manifest_and_wait(
     else:
         dataset_id = existing_dataset_id
 
+    # Upload manifest
+    res = session.put(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/manifest",
+        data=json.dumps(manifest),
+        headers=headers,
+    )
+    assertStatusCode(202, res)
+
     # Get dataset version id
     res = session.get(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers)
     assertStatusCode(200, res)
@@ -166,14 +174,6 @@ def upload_manifest_and_wait(
             version_id = dataset.get("dataset_version_id")
             break
     assert version_id is not None, f"Dataset version id not found for dataset {dataset_id}, we broke something"
-
-    # Upload manifest
-    res = session.put(
-        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/manifest",
-        data=json.dumps(manifest),
-        headers=headers,
-    )
-    assertStatusCode(202, res)
 
     # Wait for dataset status
     result = _wait_for_dataset_status(

--- a/tests/unit/processing/test_process_validate_atac.py
+++ b/tests/unit/processing/test_process_validate_atac.py
@@ -326,6 +326,7 @@ class TestProcessValidateAtac:
             atac_fragment="https://www.dropbox.com/s/fake_location/test.tsv.bgz?dl=0",
             flags=IngestionManifestFlags(deduplicate_fragments=True),
         )
+        process_validate_atac.schema_validator.deduplicate_fragments.return_value = "test_dedup.tsv.bgz"
 
         # Act
         process_validate_atac.process(
@@ -339,6 +340,7 @@ class TestProcessValidateAtac:
         process_validate_atac.schema_validator.deduplicate_fragments.assert_called_once_with(
             CorporaConstants.ORIGINAL_ATAC_FRAGMENT_FILENAME
         )
+        assert str(process_validate_atac.schema_validator.validate_atac.call_args[0][0]) == "test_dedup.tsv.bgz"
 
     def test_deduplicate_fragments_flag_false(self, process_validate_atac, unpublished_dataset, setup):
         """Test that the deduplicate_fragments flag is passed to the schema validator."""


### PR DESCRIPTION
## Reason for Change
- The test was existing early because we were checking the status of the old dataset version. Now we retrieve the dataset version after submitting the manifest which will be the new version if the dataset existed previously. 
- When deduplicating a fragment, the old file was not being replaced with the new file. This lead to error where the file read was empty. Now we are using the deduplicated file directly and not renaming. This was error we were getting.
```{"levelname": "ERROR", "asctime": "2025-09-10T16:14:37.010Z", "name": "cellxgene_schema.atac_seq", "message": "Error Parsing the fragment file. Check that columns match schema definition. Error: Empty CSV file", "lineno": 218, "pathname": "/opt/venv/lib/python3.10/site-packages/cellxgene_schema/atac_seq.py", "exc_info": "Traceback (most recent call last):\n File \"/opt/venv/lib/python3.10/site-packages/cellxgene_schema/atac_seq.py\", line 215, in process_fragment\n parquet_file = convert_to_parquet(fragment_file, tempdir)\n File \"/opt/venv/lib/python3.10/site-packages/cellxgene_schema/atac_seq.py\", line 252, in convert_to_parquet\n data=pa.csv.open_csv(\n File \"pyarrow/_csv.pyx\", line 1316, in pyarrow._csv.open_csv\n File \"pyarrow/_csv.pyx\", line 1174, in pyarrow._csv.CSVStreamingReader._open\n File \"pyarrow/error.pxi\", line 155, in pyarrow.lib.pyarrow_internal_check_status\n File \"pyarrow/error.pxi\", line 92, in pyarrow.lib.check_status\npyarrow.lib.ArrowInvalid: Empty CSV file"}```