### PR TITLE
fix: functional tests

### DIFF
--- a/tests/functional/backend/corpora/test_revisions.py
+++ b/tests/functional/backend/corpora/test_revisions.py
@@ -108,7 +108,7 @@ def test_revision_flow(
     public_datasets_before = session.get(f"{api_url}/dp/v1/collections/{canonical_collection_id}").json()["datasets"]
 
     # Upload a new dataset
-    another_dataset_id = upload_dataset(revision_id, dataset_1_dropbox_url)
+    another_dataset_id = upload_dataset(revision_id, dataset_1_dropbox_url)["dataset_id"]
 
     # Adding a dataset to a revision does not impact public datasets in that collection
     # Get datasets for the collection (after uploading)


### PR DESCRIPTION
This pull request makes a minor update to the way the `another_dataset_id` variable is assigned in the `test_revision_flow` function. The change ensures that the correct dataset ID is extracted from the result of `upload_dataset`.

* Assigns `another_dataset_id` to the value of the `"dataset_id"` key from the result of `upload_dataset`, instead of the entire returned object.