### PR TITLE
chore: bump mem + vcpu requests for ingestion + dataset migration jobs

### DIFF
--- a/.happy/terraform/modules/batch/main.tf
+++ b/.happy/terraform/modules/batch/main.tf
@@ -11,7 +11,7 @@ resource aws_batch_job_definition batch_job_def {
   container_properties = jsonencode({
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
-  "memory": 16000,
+  "memory": 24000,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",
@@ -42,7 +42,7 @@ resource aws_batch_job_definition batch_job_def {
       "value": "${var.frontend_url}"
     }
   ],
-  "vcpus": 2,
+  "vcpus": 3,
   "retryStrategy": {
     "attempts": 1,
     "evaluateOnExit": [
@@ -69,7 +69,7 @@ resource aws_batch_job_definition cxg_job_def {
   container_properties = jsonencode({
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
-  "memory": 64000,
+  "memory": 112000,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",
@@ -100,7 +100,7 @@ resource aws_batch_job_definition cxg_job_def {
       "value": "${var.frontend_url}"
     }
   ],
-  "vcpus": 8,
+  "vcpus": 14,
   "logConfiguration": {
     "logDriver": "awslogs",
     "options": {
@@ -117,8 +117,8 @@ resource aws_batch_job_definition atac_job_def {
   container_properties = jsonencode({
   "jobRoleArn": "${var.batch_role_arn}",
   "image": "${var.image}",
-  "memory": 64000,
-  "vcpus": 8,
+  "memory": 112000,
+  "vcpus": 14,
   "environment": [
     {
       "name": "ARTIFACT_BUCKET",

--- a/.happy/terraform/modules/schema_migration/main.tf
+++ b/.happy/terraform/modules/schema_migration/main.tf
@@ -91,11 +91,11 @@ resource aws_batch_job_definition dataset_migrations {
     resourceRequirements = [
         {
           type= "VCPU",
-          Value="2"
+          Value="3"
         },
         {
           Type="MEMORY",
-          Value = "16000"
+          Value = "24000"
         }
     ]
     logConfiguration= {


### PR DESCRIPTION
## Reason for Change

- see https://czi.atlassian.net/jira/software/c/projects/VC/boards/2818?assignee=6283554b0dae78006806c663&selectedIssue=VC-4114 and linked upstream issues
- in conjunction with this single-cell-infra pr: https://github.com/chanzuckerberg/single-cell-infra/pull/1073
- dedicated 16 vcpu machines spun up for each 14 vcpu job, 4 vcpu machines spun up for 3 vcpu jobs
- goal: fewer OOMs from jobs leaking memory on same machine