### PR TITLE
feat: extract and expose perturbation_types in dataset metadata

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -1167,6 +1167,8 @@ components:
         organism:
           $ref: "#/components/schemas/dataset_organism"
           nullable: true
+        perturbation_types:
+          $ref: "#/components/schemas/perturbation_types"
         processing_status:
           $ref: "#/components/schemas/processing_status_dataset"
         processing_status_detail:
@@ -1276,6 +1278,8 @@ components:
           type: string
         organism:
           $ref: "#/components/schemas/dataset_organism"
+        perturbation_types:
+          $ref: "#/components/schemas/perturbation_types"
         processing_status:
           $ref: "#/components/schemas/processing_status_dataset"
         processing_status_detail:
@@ -1393,6 +1397,8 @@ components:
         organism:
           $ref: "#/components/schemas/dataset_organism"
           nullable: true
+        perturbation_types:
+          $ref: "#/components/schemas/perturbation_types"
         published_at:
           $ref: "#/components/schemas/dataset_version_published_at"
         raw_data_location:
@@ -1679,6 +1685,16 @@ components:
         published_year:
           type: number
       type: object
+    perturbation_types:
+      description: |
+        List of unique perturbation types present across all observations in the dataset. Values are sourced from
+        obs['perturbation_types'], with 'na' and null values excluded. Items are in ascending lexical order.
+        If the dataset does not contain a 'perturbation_types' obs column, this field is null.
+      type: array
+      items:
+        type: string
+      nullable: true
+      example: ["CRISPR", "ORF"]
     raw_data_location:
       description: Location in dataset's AnnData artifact where raw (i.e. non-normalized) matrix data is stored
       type: string

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -1494,6 +1494,8 @@ components:
           $ref: "#/components/schemas/dataset_id"
         organism:
           $ref: "#/components/schemas/dataset_organism"
+        perturbation_types:
+          $ref: "#/components/schemas/perturbation_types"
         tissue:
           $ref: "#/components/schemas/dataset_tissue"
         suspension_type:

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -290,6 +290,8 @@ def reshape_dataset_for_curation_api(
     ds["dataset_id"] = dataset_version.dataset_id.id
     ds["dataset_version_id"] = dataset_version.version_id.id
     ds["is_pre_analysis"] = is_pre_analysis
+    if dataset_version.metadata is not None:
+        ds["perturbation_types"] = ds.get("perturbation_types")
     # Get none preview specific dataset fields
     if not preview:
         ds["assets"] = extract_dataset_assets(dataset_version)
@@ -301,7 +303,6 @@ def reshape_dataset_for_curation_api(
                 None if ds.get("x_approximate_distribution") is None else ds["x_approximate_distribution"].upper()
             )
             ds["spatial"] = None if ds.get("spatial") is None else asdict(ds["spatial"])
-            ds["perturbation_types"] = ds.get("perturbation_types")
         if not is_published and (status := dataset_version.status):
             if status.processing_status == DatasetProcessingStatus.FAILURE:
                 if status.validation_status == DatasetValidationStatus.INVALID:
@@ -425,6 +426,7 @@ class EntityColumns:
         "assay",
         "disease",
         "organism",
+        "perturbation_types",
         "suspension_type",
     ]
 

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -301,6 +301,7 @@ def reshape_dataset_for_curation_api(
                 None if ds.get("x_approximate_distribution") is None else ds["x_approximate_distribution"].upper()
             )
             ds["spatial"] = None if ds.get("spatial") is None else asdict(ds["spatial"])
+            ds["perturbation_types"] = ds.get("perturbation_types")
         if not is_published and (status := dataset_version.status):
             if status.processing_status == DatasetProcessingStatus.FAILURE:
                 if status.validation_status == DatasetValidationStatus.INVALID:

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -444,6 +444,7 @@ class EntityColumns:
         "donor_id",
         "citation",
         "spatial",
+        "perturbation_types",
     ]
 
     dataset_metadata_cols = [

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -225,6 +225,7 @@ class DatasetMetadata:
     raw_data_location: Optional[str] = None
     primary_cell_count: Optional[int] = None
     spatial: Optional[SpatialMetadata] = None
+    perturbation_types: Optional[List[str]] = None
 
 
 @dataclass

--- a/backend/layers/processing/process_add_labels.py
+++ b/backend/layers/processing/process_add_labels.py
@@ -173,8 +173,9 @@ class ProcessAddLabels(ProcessingLogic):
         def _get_perturbation_types() -> Optional[List[str]]:
             if "perturbation_types" not in adata.obs.columns:
                 return None
+            _excluded = {"na", "no perturbations"}
             values = adata.obs["perturbation_types"].dropna().unique()
-            filtered = sorted(v for v in values if v != "na")
+            filtered = sorted(v for v in values if v not in _excluded)
             return filtered if filtered else []
 
         return DatasetMetadata(

--- a/backend/layers/processing/process_add_labels.py
+++ b/backend/layers/processing/process_add_labels.py
@@ -170,6 +170,13 @@ class ProcessAddLabels(ProcessingLogic):
             else:
                 return _get_term_pairs("organism")
 
+        def _get_perturbation_types() -> Optional[List[str]]:
+            if "perturbation_types" not in adata.obs.columns:
+                return None
+            values = adata.obs["perturbation_types"].dropna().unique()
+            filtered = sorted(v for v in values if v != "na")
+            return filtered if filtered else []
+
         return DatasetMetadata(
             name=adata.uns["title"],
             organism=_get_organism_terms(),
@@ -197,6 +204,7 @@ class ProcessAddLabels(ProcessingLogic):
             raw_data_location="raw.X" if adata.raw else "X",
             citation=adata.uns.get("citation"),
             spatial=self.get_spatial_metadata(adata.uns["spatial"]) if "spatial" in adata.uns else None,
+            perturbation_types=_get_perturbation_types(),
         )
 
     def process(

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,7 +1,7 @@
 anndata # uses the version supplied by cellxgene-schema
 awscli
 boto3>=1.11.17
-cellxgene-schema @ git+https://github.com/chanzuckerberg/single-cell-curation.git@cd7ab78f83cc3c8309b1f7ff3b7ccfe517656825#subdirectory=cellxgene_schema_cli
+cellxgene-schema @ git+https://github.com/chanzuckerberg/single-cell-curation.git@a6f618560e1406624ce145a8b3f72ed5b3a386a1#subdirectory=cellxgene_schema_cli
 dask==2024.12.0
 dataclasses-json
 ddtrace==2.1.4

--- a/tests/functional/backend/constants.py
+++ b/tests/functional/backend/constants.py
@@ -21,9 +21,12 @@ VISIUM_DATASET_URI = "https://www.dropbox.com/scl/fi/a871dhnoqzzhkqz0pr3fj/small
 
 PRE_ANALYSIS_DATASET_URI = "https://www.dropbox.com/scl/fi/73zdzk3ua5vgcamhqdemx/example_pre_analysis.h5ad?rlkey=brs9qu87n6j48q55o4ymqc7l2&st=2e4rdt1z&dl=0"
 
+PERTURBATION_DATASET_URI = "https://www.dropbox.com/scl/fi/w59f6s7nd6ws9vwjlbn5z/small_perturbations_example.h5ad?rlkey=hwextcwh3p71oz1b0ulxasswy&st=xzxh91zx&dl=0"
+
 DATASET_MANIFEST = {"anndata": DATASET_URI}
 VISIUM_DATASET_MANIFEST = {"anndata": VISIUM_DATASET_URI}
 PRE_ANALYSIS_DATASET_MANIFEST = {"anndata": PRE_ANALYSIS_DATASET_URI, "is_pre_analysis": True}
+PERTURBATION_DATASET_MANIFEST = {"anndata": PERTURBATION_DATASET_URI, "is_pre_analysis": True}
 ATAC_SEQ_MANIFEST = {
     "anndata": "https://www.dropbox.com/scl/fi/1h9d1usgobiqgnin4s6ld/atac.h5ad?rlkey=o3aokwmez6a8tdip5p4vybv8a&st=nkamyl1n&dl=0",
     "atac_fragment": "https://www.dropbox.com/scl/fi/nexccttzlzwr3lt0oe7eq/fragments_sorted.tsv.gz?rlkey=wrajzdz0f1g5gpx4m1vwmvcfh&st=s3hbbajy&dl=0",

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -9,6 +9,7 @@ from tests.functional.backend.constants import (
     ATAC_SEQ_MANIFEST,
     DATASET_MANIFEST,
     DATASET_URI,
+    PERTURBATION_DATASET_MANIFEST,
     PRE_ANALYSIS_DATASET_MANIFEST,
     VISIUM_DATASET_URI,
 )
@@ -544,3 +545,99 @@ def test_pre_analysis_dataset_upload_and_process(
     res = session.get(f"{api_url}/curation/v1/datasets?analysis=post-analysis", headers=headers)
     assertStatusCode(200, res)
     assert dataset_id not in [d["dataset_id"] for d in res.json()]
+
+
+# --- perturbation_types functional tests ---
+
+
+def test_get_datasets_includes_perturbation_types_field(session, api_url):
+    """Every published dataset returned by GET /curation/v1/datasets includes a perturbation_types field."""
+    res = session.get(f"{api_url}/curation/v1/datasets")
+    assertStatusCode(requests.codes.ok, res)
+    for dataset in res.json():
+        assert "perturbation_types" in dataset
+
+
+@skip_creation_on_prod
+def test_perturbation_dataset_upload_and_process(
+    session,
+    api_url,
+    curation_api_access_token,
+    curator_cookie,
+    request,
+):
+    """
+    Upload a perturbation (pre-analysis) h5ad and verify the full pipeline succeeds and
+    perturbation_types is correctly populated and returned by all GET /collection and
+    GET /dataset endpoints.
+    """
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    headers_dp = {"Cookie": f"cxguser={curator_cookie}", "Content-Type": "application/json"}
+
+    collection_id = create_test_collection(
+        headers_dp,
+        request,
+        session,
+        api_url,
+        {
+            "contact_email": "functest@example.com",
+            "contact_name": "Func Test",
+            "curator_name": "Func Test",
+            "description": "perturbation_types functional test",
+            "name": "test_perturbation_dataset_upload_and_process",
+            "is_pre_analysis": True,
+        },
+    )
+
+    # Create dataset slot and submit manifest.
+    res = session.post(f"{api_url}/curation/v1/collections/{collection_id}/datasets", headers=headers)
+    assertStatusCode(201, res)
+    dataset_id = res.json()["dataset_id"]
+
+    res = session.put(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/manifest",
+        data=json.dumps(PERTURBATION_DATASET_MANIFEST),
+        headers=headers,
+    )
+    assertStatusCode(202, res)
+
+    result = wait_for_dataset_processing_via_curation_api(
+        session, api_url, curation_api_access_token, collection_id, dataset_id
+    )
+    assert not result["errors"], f"Perturbation dataset processing failed: {result['errors']}"
+
+    # --- Verify GET /curation/v1/collections/{id} ---
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers)
+    assertStatusCode(200, res)
+    collection_data = res.json()
+    dataset_entry = next(d for d in collection_data["datasets"] if d["dataset_id"] == dataset_id)
+    assert "perturbation_types" in dataset_entry
+    assert isinstance(dataset_entry["perturbation_types"], list)
+    assert dataset_entry["perturbation_types"] == sorted(dataset_entry["perturbation_types"])
+
+    # --- Verify GET /curation/v1/collections/{id}/datasets/{id} ---
+    res = session.get(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}",
+        headers=headers,
+    )
+    assertStatusCode(200, res)
+    dataset_data = res.json()
+    assert "perturbation_types" in dataset_data
+    assert isinstance(dataset_data["perturbation_types"], list)
+    # Values must exclude 'na'/None and be lexically sorted.
+    assert "na" not in dataset_data["perturbation_types"]
+    assert None not in dataset_data["perturbation_types"]
+    assert dataset_data["perturbation_types"] == sorted(dataset_data["perturbation_types"])
+
+    # --- Publish and verify public GET /curation/v1/collections/{id} ---
+    body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
+    res = session.post(
+        f"{api_url}/dp/v1/collections/{collection_id}/publish", headers=headers_dp, data=json.dumps(body)
+    )
+    assertStatusCode(requests.codes.accepted, res)
+
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}")
+    assertStatusCode(200, res)
+    public_collection = res.json()
+    public_dataset = next(d for d in public_collection["datasets"] if d["dataset_id"] == dataset_id)
+    assert "perturbation_types" in public_dataset

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1054,6 +1054,7 @@ class TestGetCollectionVersionID(BaseAPIPortalTest):
                     "is_primary_data": [True, False],
                     "mean_genes_per_cell": 0.5,
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
+                    "perturbation_types": None,
                     "raw_data_location": "raw.X",
                     "schema_version": "3.0.0",
                     "self_reported_ethnicity": [

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -179,6 +179,8 @@ class TestAddLabels(BaseProcessingTest):
 
         self.assertEqual(extracted_metadata.raw_data_location, "X")
         self.assertEqual(extracted_metadata.spatial, None)
+        # No perturbation_types column in obs → should be None
+        self.assertIsNone(extracted_metadata.perturbation_types)
 
     def test_extract_metadata_organism_uns(self):
         # Same setup as before, but organism terms are in uns instead of obs
@@ -446,6 +448,74 @@ class TestAddLabels(BaseProcessingTest):
         self.assertEqual(extracted_metadata.mean_genes_per_cell, 0)
 
         self.assertEqual(extracted_metadata.raw_data_location, "raw.X")
+
+    def _make_minimal_adata(self, extra_obs_cols=None):
+        """Build a minimal AnnData suitable for extract_metadata tests."""
+        n = 5
+        obs_data = {
+            "tissue": ["lung"] * n,
+            "tissue_ontology_term_id": ["UBERON:01"] * n,
+            "tissue_type": ["tissue"] * n,
+            "assay": ["10x"] * n,
+            "assay_ontology_term_id": ["EFO:001"] * n,
+            "disease": ["healthy"] * n,
+            "disease_ontology_term_id": ["MONDO:123"] * n,
+            "sex": ["male"] * n,
+            "sex_ontology_term_id": ["M"] * n,
+            "self_reported_ethnicity": ["unknown"] * n,
+            "self_reported_ethnicity_ontology_term_id": ["unknown"] * n,
+            "development_stage": ["adult"] * n,
+            "development_stage_ontology_term_id": ["HsapDv:0"] * n,
+            "organism": ["Homo sapiens"] * n,
+            "organism_ontology_term_id": ["NCBITaxon:9606"] * n,
+            "is_primary_data": [True] * n,
+            "cell_type": ["B cell"] * n,
+            "cell_type_ontology_term_id": ["CL:001"] * n,
+            "suspension_type": ["cell"] * n,
+            "donor_id": ["D1"] * n,
+        }
+        if extra_obs_cols:
+            obs_data.update(extra_obs_cols)
+        obs = pandas.DataFrame(obs_data, index=[str(i) for i in range(n)])
+        var = pandas.DataFrame(
+            {"feature_biotype": ["gene"] * 3, "feature_reference": ["NCBITaxon:9606"] * 3},
+            index=["A", "B", "C"],
+        )
+        uns = {"title": "minimal dataset", "schema_version": "3.0.0"}
+        X = from_array(np.ones((n, 3), dtype=int))
+        return anndata.AnnData(X=X, obs=obs, var=var, uns=uns)
+
+    def test_extract_metadata_perturbation_types_with_column(self):
+        """perturbation_types with mixed values: 'na' and None excluded, result sorted lexically."""
+        adata = self._make_minimal_adata(
+            extra_obs_cols={
+                "perturbation_types": ["CRISPR", "na", "ORF", "CRISPR", None],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertEqual(extracted.perturbation_types, ["CRISPR", "ORF"])
+
+    def test_extract_metadata_perturbation_types_without_column(self):
+        """When obs has no perturbation_types column, result is None."""
+        adata = self._make_minimal_adata()
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertIsNone(extracted.perturbation_types)
+
+    def test_extract_metadata_perturbation_types_all_excluded(self):
+        """When all perturbation_types values are 'na' or None, result is an empty list."""
+        adata = self._make_minimal_adata(
+            extra_obs_cols={
+                "perturbation_types": ["na", "na", None, "na", None],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertEqual(extracted.perturbation_types, [])
 
     def test_get_spatial_metadata__is_single_and_fullres_true(self):
         spatial_dict = {

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -489,7 +489,7 @@ class TestAddLabels(BaseProcessingTest):
         """perturbation_types with mixed values: excluded sentinels and None dropped, result sorted lexically."""
         adata = self._make_minimal_adata(
             extra_obs_cols={
-                "perturbation_types": ["CRISPR", "na", "ORF", "CRISPR", None, "no perturbations"],
+                "perturbation_types": ["CRISPR", "na", "ORF", "no perturbations", None],
             }
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -486,10 +486,10 @@ class TestAddLabels(BaseProcessingTest):
         return anndata.AnnData(X=X, obs=obs, var=var, uns=uns)
 
     def test_extract_metadata_perturbation_types_with_column(self):
-        """perturbation_types with mixed values: 'na' and None excluded, result sorted lexically."""
+        """perturbation_types with mixed values: excluded sentinels and None dropped, result sorted lexically."""
         adata = self._make_minimal_adata(
             extra_obs_cols={
-                "perturbation_types": ["CRISPR", "na", "ORF", "CRISPR", None],
+                "perturbation_types": ["CRISPR", "na", "ORF", "CRISPR", None, "no perturbations"],
             }
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
@@ -506,10 +506,10 @@ class TestAddLabels(BaseProcessingTest):
         self.assertIsNone(extracted.perturbation_types)
 
     def test_extract_metadata_perturbation_types_all_excluded(self):
-        """When all perturbation_types values are 'na' or None, result is an empty list."""
+        """When all perturbation_types values are excluded sentinels or None, result is an empty list."""
         adata = self._make_minimal_adata(
             extra_obs_cols={
-                "perturbation_types": ["na", "na", None, "na", None],
+                "perturbation_types": ["na", "no perturbations", None, "na", None],
             }
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:


### PR DESCRIPTION
Extracts unique perturbation_types from obs['perturbation_types'] during the metadata job, excluding 'na'/None and sorting lexically; stores as nullable List[str] on DatasetMetadata. Returns the field from all Curation API GET /collection and GET /dataset endpoints. Updates cellxgene-schema pin to HEAD of feat-schema7.1.0 branch.

  Additions                                                                                
                                                                                           
  - DatasetMetadata.perturbation_types (entities.py) — new Optional[List[str]] field on the
   dataclass; None when the obs column is absent, otherwise a deduplicated, lexically      
  sorted list excluding 'na' and None values                                               
  - _get_perturbation_types() (process_add_labels.py) — extraction helper called inside
  extract_metadata(); reads obs['perturbation_types'], drops nulls and 'na', sorts the     
  remainder
  - perturbation_types OpenAPI component schema (curation-api.yml) — nullable string array 
  with description and example; inserted between publisher_metadata and raw_data_location  
  alphabetically
  - perturbation_types field in dataset, dataset_index, dataset_version schemas            
  (curation-api.yml) — all three dataset response shapes now reference the component schema
  - PERTURBATION_DATASET_URI / PERTURBATION_DATASET_MANIFEST
  (tests/functional/backend/constants.py) — points to the small perturbation example h5ad  
  (Dropbox link provided); manifest sets is_pre_analysis: True
  - 3 unit tests (test_extract_metadata.py):                                               
    - test_extract_metadata_perturbation_types_with_column — mixed values including        
  duplicates, 'na', and None → sorted unique non-excluded list
    - test_extract_metadata_perturbation_types_without_column — column absent → None       
    - test_extract_metadata_perturbation_types_all_excluded — all values are 'na'/None →   
  empty list []
  - 2 functional tests (test_api.py):                                                      
    - test_get_datasets_includes_perturbation_types_field — passive check that every
  dataset in the public /curation/v1/datasets index contains the key
    - test_perturbation_dataset_upload_and_process — full upload → process → publish flow;
  asserts perturbation_types is present, is a list, excludes 'na'/None, is sorted, in both 
  private and public collection/dataset responses
                                                                                           
  Modifications                                             

  - EntityColumns.dataset_metadata_index_cols (common.py) — added "perturbation_types";    
  because dataset_metadata_cols inherits from index_cols, this propagates the field to all
  endpoint response tiers (index, single-lookup, version)  
