### PR TITLE
feat: extract and expose genetic_perturbation_strategy in dataset metadata

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -1167,6 +1167,8 @@ components:
         organism:
           $ref: "#/components/schemas/dataset_organism"
           nullable: true
+        genetic_perturbation_strategy:
+          $ref: "#/components/schemas/genetic_perturbation_strategy"
         perturbation_types:
           $ref: "#/components/schemas/perturbation_types"
         processing_status:
@@ -1278,6 +1280,8 @@ components:
           type: string
         organism:
           $ref: "#/components/schemas/dataset_organism"
+        genetic_perturbation_strategy:
+          $ref: "#/components/schemas/genetic_perturbation_strategy"
         perturbation_types:
           $ref: "#/components/schemas/perturbation_types"
         processing_status:
@@ -1397,6 +1401,8 @@ components:
         organism:
           $ref: "#/components/schemas/dataset_organism"
           nullable: true
+        genetic_perturbation_strategy:
+          $ref: "#/components/schemas/genetic_perturbation_strategy"
         perturbation_types:
           $ref: "#/components/schemas/perturbation_types"
         published_at:
@@ -1494,6 +1500,8 @@ components:
           $ref: "#/components/schemas/dataset_id"
         organism:
           $ref: "#/components/schemas/dataset_organism"
+        genetic_perturbation_strategy:
+          $ref: "#/components/schemas/genetic_perturbation_strategy"
         perturbation_types:
           $ref: "#/components/schemas/perturbation_types"
         tissue:
@@ -1687,6 +1695,16 @@ components:
         published_year:
           type: number
       type: object
+    genetic_perturbation_strategy:
+      description: |
+        List of unique genetic perturbation strategies present across all observations in the dataset. Values are
+        sourced from obs['genetic_perturbation_strategy'], with null values excluded. Items are in ascending lexical
+        order. If the dataset does not contain a 'genetic_perturbation_strategy' obs column, this field is null.
+      type: array
+      items:
+        type: string
+      nullable: true
+      example: ["CRISPR", "CRISPRi"]
     perturbation_types:
       description: |
         List of unique perturbation types present across all observations in the dataset. Values are sourced from

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -1698,8 +1698,9 @@ components:
     genetic_perturbation_strategy:
       description: |
         List of unique genetic perturbation strategies present across all observations in the dataset. Values are
-        sourced from obs['genetic_perturbation_strategy'], with null values excluded. Items are in ascending lexical
-        order. If the dataset does not contain a 'genetic_perturbation_strategy' obs column, this field is null.
+        sourced from obs['genetic_perturbation_strategy'], with 'no perturbations' and null values excluded. Items
+        are in ascending lexical order. If the dataset does not contain a 'genetic_perturbation_strategy' obs
+        column, this field is null.
       type: array
       items:
         type: string

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -291,6 +291,7 @@ def reshape_dataset_for_curation_api(
     ds["dataset_version_id"] = dataset_version.version_id.id
     ds["is_pre_analysis"] = is_pre_analysis
     if dataset_version.metadata is not None:
+        ds["genetic_perturbation_strategy"] = ds.get("genetic_perturbation_strategy")
         ds["perturbation_types"] = ds.get("perturbation_types")
     # Get none preview specific dataset fields
     if not preview:
@@ -426,6 +427,7 @@ class EntityColumns:
         "assay",
         "disease",
         "organism",
+        "genetic_perturbation_strategy",
         "perturbation_types",
         "suspension_type",
     ]

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -226,6 +226,7 @@ class DatasetMetadata:
     primary_cell_count: Optional[int] = None
     spatial: Optional[SpatialMetadata] = None
     perturbation_types: Optional[List[str]] = None
+    genetic_perturbation_strategy: Optional[List[str]] = None
 
 
 @dataclass

--- a/backend/layers/processing/process_add_labels.py
+++ b/backend/layers/processing/process_add_labels.py
@@ -181,7 +181,9 @@ class ProcessAddLabels(ProcessingLogic):
         def _get_genetic_perturbation_strategy() -> Optional[List[str]]:
             if "genetic_perturbation_strategy" not in adata.obs.columns:
                 return None
-            return sorted(adata.obs["genetic_perturbation_strategy"].dropna().unique())
+            _excluded = {"no perturbations"}
+            values = adata.obs["genetic_perturbation_strategy"].dropna().unique()
+            return sorted(v for v in values if v not in _excluded)
 
         return DatasetMetadata(
             name=adata.uns["title"],

--- a/backend/layers/processing/process_add_labels.py
+++ b/backend/layers/processing/process_add_labels.py
@@ -178,6 +178,11 @@ class ProcessAddLabels(ProcessingLogic):
             filtered = sorted(v for v in values if v not in _excluded)
             return filtered if filtered else []
 
+        def _get_genetic_perturbation_strategy() -> Optional[List[str]]:
+            if "genetic_perturbation_strategy" not in adata.obs.columns:
+                return None
+            return sorted(adata.obs["genetic_perturbation_strategy"].dropna().unique())
+
         return DatasetMetadata(
             name=adata.uns["title"],
             organism=_get_organism_terms(),
@@ -206,6 +211,7 @@ class ProcessAddLabels(ProcessingLogic):
             citation=adata.uns.get("citation"),
             spatial=self.get_spatial_metadata(adata.uns["spatial"]) if "spatial" in adata.uns else None,
             perturbation_types=_get_perturbation_types(),
+            genetic_perturbation_strategy=_get_genetic_perturbation_strategy(),
         )
 
     def process(

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -641,3 +641,101 @@ def test_perturbation_dataset_upload_and_process(
     public_collection = res.json()
     public_dataset = next(d for d in public_collection["datasets"] if d["dataset_id"] == dataset_id)
     assert "perturbation_types" in public_dataset
+
+
+# --- genetic_perturbation_strategy functional tests ---
+
+
+def test_get_datasets_includes_genetic_perturbation_strategy_field(session, api_url):
+    """Every published dataset returned by GET /curation/v1/datasets includes a genetic_perturbation_strategy field."""
+    res = session.get(f"{api_url}/curation/v1/datasets")
+    assertStatusCode(requests.codes.ok, res)
+    for dataset in res.json():
+        assert "genetic_perturbation_strategy" in dataset
+
+
+@skip_creation_on_prod
+def test_genetic_perturbation_strategy_upload_and_process(
+    session,
+    api_url,
+    curation_api_access_token,
+    curator_cookie,
+    request,
+):
+    """
+    Upload a perturbation (pre-analysis) h5ad and verify the full pipeline succeeds and
+    genetic_perturbation_strategy is correctly populated and returned by all GET /collection and
+    GET /dataset endpoints.
+    """
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    headers_dp = {"Cookie": f"cxguser={curator_cookie}", "Content-Type": "application/json"}
+
+    collection_id = create_test_collection(
+        headers_dp,
+        request,
+        session,
+        api_url,
+        {
+            "contact_email": "functest@example.com",
+            "contact_name": "Func Test",
+            "curator_name": "Func Test",
+            "description": "genetic_perturbation_strategy functional test",
+            "name": "test_genetic_perturbation_strategy_upload_and_process",
+            "is_pre_analysis": True,
+        },
+    )
+
+    # Create dataset slot and submit manifest.
+    res = session.post(f"{api_url}/curation/v1/collections/{collection_id}/datasets", headers=headers)
+    assertStatusCode(201, res)
+    dataset_id = res.json()["dataset_id"]
+
+    res = session.put(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/manifest",
+        data=json.dumps(PERTURBATION_DATASET_MANIFEST),
+        headers=headers,
+    )
+    assertStatusCode(202, res)
+
+    result = wait_for_dataset_processing_via_curation_api(
+        session, api_url, curation_api_access_token, collection_id, dataset_id
+    )
+    assert not result["errors"], f"Perturbation dataset processing failed: {result['errors']}"
+
+    # --- Verify GET /curation/v1/collections/{id} ---
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers)
+    assertStatusCode(200, res)
+    collection_data = res.json()
+    dataset_entry = next(d for d in collection_data["datasets"] if d["dataset_id"] == dataset_id)
+    assert "genetic_perturbation_strategy" in dataset_entry
+    gps = dataset_entry["genetic_perturbation_strategy"]
+    assert gps is None or isinstance(gps, list)
+    if isinstance(gps, list):
+        assert gps == sorted(gps)
+
+    # --- Verify GET /curation/v1/collections/{id}/datasets/{id} ---
+    res = session.get(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}",
+        headers=headers,
+    )
+    assertStatusCode(200, res)
+    dataset_data = res.json()
+    assert "genetic_perturbation_strategy" in dataset_data
+    gps = dataset_data["genetic_perturbation_strategy"]
+    assert gps is None or isinstance(gps, list)
+    if isinstance(gps, list):
+        assert None not in gps
+        assert gps == sorted(gps)
+
+    # --- Publish and verify public GET /curation/v1/collections/{id} ---
+    body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
+    res = session.post(
+        f"{api_url}/dp/v1/collections/{collection_id}/publish", headers=headers_dp, data=json.dumps(body)
+    )
+    assertStatusCode(requests.codes.accepted, res)
+
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}")
+    assertStatusCode(200, res)
+    public_collection = res.json()
+    public_dataset = next(d for d in public_collection["datasets"] if d["dataset_id"] == dataset_id)
+    assert "genetic_perturbation_strategy" in public_dataset

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1054,6 +1054,7 @@ class TestGetCollectionVersionID(BaseAPIPortalTest):
                     "is_primary_data": [True, False],
                     "mean_genes_per_cell": 0.5,
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
+                    "genetic_perturbation_strategy": None,
                     "perturbation_types": None,
                     "raw_data_location": "raw.X",
                     "schema_version": "3.0.0",

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -541,7 +541,7 @@ class TestAddLabels(BaseProcessingTest):
         """When all genetic_perturbation_strategy values are null, result is an empty list."""
         adata = self._make_minimal_adata(
             extra_obs_cols={
-                "genetic_perturbation_strategy": [None, None, None, None, None],
+                "genetic_perturbation_strategy": pandas.array([pandas.NA] * 5, dtype="string"),
             }
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -517,6 +517,38 @@ class TestAddLabels(BaseProcessingTest):
             extracted = self.pal.extract_metadata(f.name)
         self.assertEqual(extracted.perturbation_types, [])
 
+    def test_extract_metadata_genetic_perturbation_strategy_with_column(self):
+        """genetic_perturbation_strategy with several values across obs: result is unique, sorted, NaN dropped."""
+        adata = self._make_minimal_adata(
+            extra_obs_cols={
+                "genetic_perturbation_strategy": ["CRISPR", "CRISPRi", "CRISPR", None, "ORF"],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertEqual(extracted.genetic_perturbation_strategy, ["CRISPR", "CRISPRi", "ORF"])
+
+    def test_extract_metadata_genetic_perturbation_strategy_without_column(self):
+        """When obs has no genetic_perturbation_strategy column, result is None."""
+        adata = self._make_minimal_adata()
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertIsNone(extracted.genetic_perturbation_strategy)
+
+    def test_extract_metadata_genetic_perturbation_strategy_all_null(self):
+        """When all genetic_perturbation_strategy values are null, result is an empty list."""
+        adata = self._make_minimal_adata(
+            extra_obs_cols={
+                "genetic_perturbation_strategy": [None, None, None, None, None],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertEqual(extracted.genetic_perturbation_strategy, [])
+
     def test_get_spatial_metadata__is_single_and_fullres_true(self):
         spatial_dict = {
             "is_single": np.bool_(True),

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -518,10 +518,10 @@ class TestAddLabels(BaseProcessingTest):
         self.assertEqual(extracted.perturbation_types, [])
 
     def test_extract_metadata_genetic_perturbation_strategy_with_column(self):
-        """genetic_perturbation_strategy with several values across obs: result is unique, sorted, NaN dropped."""
+        """Unique valid values are returned deduped and in ascending lexical order."""
         adata = self._make_minimal_adata(
             extra_obs_cols={
-                "genetic_perturbation_strategy": ["CRISPR", "CRISPRi", "CRISPR", None, "ORF"],
+                "genetic_perturbation_strategy": ["CRISPR", "CRISPRi", "CRISPR", "no perturbations", "ORF"],
             }
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
@@ -537,17 +537,17 @@ class TestAddLabels(BaseProcessingTest):
             extracted = self.pal.extract_metadata(f.name)
         self.assertIsNone(extracted.genetic_perturbation_strategy)
 
-    def test_extract_metadata_genetic_perturbation_strategy_all_null(self):
-        """When all genetic_perturbation_strategy values are null, result is an empty list."""
+    def test_extract_metadata_genetic_perturbation_strategy_no_perturbations_excluded(self):
+        """'no perturbations' sentinel values are excluded from the result."""
         adata = self._make_minimal_adata(
             extra_obs_cols={
-                "genetic_perturbation_strategy": pandas.array([pandas.NA] * 5, dtype="string"),
+                "genetic_perturbation_strategy": ["CRISPR", "no perturbations", "no perturbations"],
             }
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
             extracted = self.pal.extract_metadata(f.name)
-        self.assertEqual(extracted.genetic_perturbation_strategy, [])
+        self.assertEqual(extracted.genetic_perturbation_strategy, ["CRISPR"])
 
     def test_get_spatial_metadata__is_single_and_fullres_true(self):
         spatial_dict = {

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -540,9 +540,8 @@ class TestAddLabels(BaseProcessingTest):
     def test_extract_metadata_genetic_perturbation_strategy_no_perturbations_excluded(self):
         """'no perturbations' sentinel values are excluded from the result."""
         adata = self._make_minimal_adata(
-            n=3,
             extra_obs_cols={
-                "genetic_perturbation_strategy": ["CRISPR", "no perturbations", "no perturbations"],
+                "genetic_perturbation_strategy": ["CRISPR", "no perturbations", "no perturbations", "CRISPR", "CRISPR"],
             },
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -540,9 +540,10 @@ class TestAddLabels(BaseProcessingTest):
     def test_extract_metadata_genetic_perturbation_strategy_no_perturbations_excluded(self):
         """'no perturbations' sentinel values are excluded from the result."""
         adata = self._make_minimal_adata(
+            n=3,
             extra_obs_cols={
                 "genetic_perturbation_strategy": ["CRISPR", "no perturbations", "no perturbations"],
-            }
+            },
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)


### PR DESCRIPTION
Extracts the unique set of obs['genetic_perturbation_strategy'] values (null-dropped, ascending lexical order, None if column absent) from h5ad during metadata processing and surfaces it on all Curation API GET /collection and /dataset endpoints including dataset preview responses.