### PR TITLE
feat: extract and store genetic_perturbations dict as typed model + expose via dedicated endpoint

### DIFF
--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -510,6 +510,34 @@ paths:
         "410":
           $ref: "#/components/responses/410"
 
+  /v1/collections/{collection_id}/datasets/{dataset_id}/genetic_perturbations:
+    get:
+      summary: Fetch the full genetic_perturbations dictionary for a Dataset.
+      description: |
+        Returns the complete `uns['genetic_perturbations']` dictionary for the Dataset, keyed by perturbation ID.
+        If the Dataset was not processed from a file containing `uns['genetic_perturbations']`, the
+        `genetic_perturbations` field in the response will be `null`.
+      operationId: backend.curation.api.v1.curation.collections.collection_id.datasets.dataset_id.genetic_perturbations.actions.get
+      tags:
+        - Collection
+      parameters:
+        - $ref: "#/components/parameters/path_collection_id"
+        - $ref: "#/components/parameters/path_dataset_id"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  genetic_perturbations:
+                    $ref: "#/components/schemas/genetic_perturbations_dict"
+        "404":
+          $ref: "#/components/responses/404"
+        "410":
+          $ref: "#/components/responses/410"
+
   /v1/collections/{collection_id}/datasets/{dataset_id}/manifest:
     get:
       summary: Get manifest for a dataset
@@ -1695,6 +1723,43 @@ components:
         published_year:
           type: number
       type: object
+    genetic_perturbation_entry:
+      description: |
+        Metadata for a single genetic perturbation, as defined in uns['genetic_perturbations'] per the
+        CELLxGENE schema.
+      type: object
+      properties:
+        role:
+          type: string
+          description: The role of the perturbation (e.g. "KO", "overexpression").
+        protospacer_sequence:
+          type: string
+          nullable: true
+          description: The protospacer sequence for CRISPR-based perturbations.
+        protospacer_adjacent_motif:
+          type: string
+          nullable: true
+          description: The PAM sequence for the protospacer.
+        derived_genomic_regions:
+          type: array
+          items:
+            type: string
+          description: Genomic regions derived from this perturbation.
+        derived_features:
+          type: object
+          additionalProperties:
+            type: string
+          description: Map of feature IDs to feature names derived from this perturbation.
+      required:
+        - role
+    genetic_perturbations_dict:
+      description: |
+        The full uns['genetic_perturbations'] dictionary from the dataset, keyed by perturbation ID.
+        Each value is a genetic_perturbation_entry. Null if the dataset has no genetic perturbations data.
+      nullable: true
+      type: object
+      additionalProperties:
+        $ref: "#/components/schemas/genetic_perturbation_entry"
     genetic_perturbation_strategy:
       description: |
         List of unique genetic perturbation strategies present across all observations in the dataset. Values are

--- a/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/genetic_perturbations/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/genetic_perturbations/actions.py
@@ -1,0 +1,10 @@
+from flask import jsonify, make_response
+
+from backend.curation.api.v1.curation.collections.common import _get_collection_and_dataset
+from backend.portal.api.providers import get_business_logic
+
+
+def get(collection_id: str, dataset_id: str):
+    _, dataset_version = _get_collection_and_dataset(collection_id, dataset_id)
+    gp_metadata = get_business_logic().get_dataset_genetic_perturbations(dataset_version.version_id)
+    return make_response(jsonify({"genetic_perturbations": gp_metadata.to_dict() if gp_metadata else None}), 200)

--- a/backend/database/versions/10_add_genetic_perturbations.py
+++ b/backend/database/versions/10_add_genetic_perturbations.py
@@ -1,0 +1,30 @@
+"""add genetic_perturbations column to DatasetVersion
+
+Revision ID: 10_add_genetic_perturbations
+Revises: 09_add_is_pre_analysis
+Create Date: 2026-04-09
+
+Stores the full uns['genetic_perturbations'] dictionary as a separate nullable JSON column
+to avoid bloating the existing dataset_metadata column (~6.5 MB serialized per perturbation dataset).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "10_add_genetic_perturbations"
+down_revision = "09_add_is_pre_analysis"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "DatasetVersion",
+        sa.Column("genetic_perturbations", sa.JSON(), nullable=True),
+        schema="persistence_schema",
+    )
+
+
+def downgrade():
+    op.drop_column("DatasetVersion", "genetic_perturbations", schema="persistence_schema")

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -74,6 +74,7 @@ from backend.layers.common.entities import (
     DatasetValidationStatus,
     DatasetVersion,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
     Link,
     PrivateDatasetVersion,
     PublishedDatasetVersion,
@@ -774,6 +775,22 @@ class BusinessLogic(BusinessLogicInterface):
         Sets the metadata for a dataset version
         """
         self.database_provider.set_dataset_metadata(dataset_version_id, metadata)
+
+    def set_dataset_genetic_perturbations(
+        self, dataset_version_id: DatasetVersionId, genetic_perturbations: Optional[GeneticPerturbationMetadata]
+    ) -> None:
+        """
+        Sets the genetic_perturbations for a dataset version
+        """
+        self.database_provider.set_dataset_genetic_perturbations(dataset_version_id, genetic_perturbations)
+
+    def get_dataset_genetic_perturbations(
+        self, dataset_version_id: DatasetVersionId
+    ) -> Optional[GeneticPerturbationMetadata]:
+        """
+        Returns the genetic_perturbations for a dataset version, or None if not present
+        """
+        return self.database_provider.get_dataset_genetic_perturbations(dataset_version_id)
 
     def update_dataset_artifact_metadata(
         self,

--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -22,6 +22,7 @@ from backend.layers.common.entities import (
     DatasetStatusKey,
     DatasetVersion,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
     PublishedDatasetVersion,
 )
 from backend.layers.common.ingestion_manifest import IngestionManifest
@@ -153,6 +154,16 @@ class BusinessLogicInterface:
         pass
 
     def set_dataset_metadata(self, dataset_version_id: DatasetVersionId, metadata: DatasetMetadata) -> None:
+        pass
+
+    def set_dataset_genetic_perturbations(
+        self, dataset_version_id: DatasetVersionId, genetic_perturbations: Optional[GeneticPerturbationMetadata]
+    ) -> None:
+        pass
+
+    def get_dataset_genetic_perturbations(
+        self, dataset_version_id: DatasetVersionId
+    ) -> Optional[GeneticPerturbationMetadata]:
         pass
 
     def get_dataset_artifacts(self, dataset_version_id: DatasetVersionId) -> Iterable[DatasetArtifact]:

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -2,7 +2,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
 from dataclasses_json import dataclass_json
@@ -194,6 +194,33 @@ class TissueOntologyTermId(OntologyTermId):
 class SpatialMetadata:
     is_single: bool
     has_fullres: bool
+
+
+@dataclass_json
+@dataclass
+class GeneticPerturbationEntry:
+    role: str
+    protospacer_sequence: Optional[str] = None
+    protospacer_adjacent_motif: Optional[str] = None
+    derived_genomic_regions: List[str] = field(default_factory=list)
+    derived_features: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class GeneticPerturbationMetadata:
+    """
+    Typed container for uns['genetic_perturbations'].
+    Top-level keys are perturbation IDs; values are GeneticPerturbationEntry instances.
+    """
+
+    perturbations: Dict[str, GeneticPerturbationEntry]
+
+    def to_dict(self) -> dict:
+        return {pid: entry.to_dict() for pid, entry in self.perturbations.items()}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "GeneticPerturbationMetadata":
+        return cls(perturbations={pid: GeneticPerturbationEntry.from_dict(v) for pid, v in data.items()})
 
 
 @dataclass_json

--- a/backend/layers/persistence/orm.py
+++ b/backend/layers/persistence/orm.py
@@ -59,6 +59,7 @@ class DatasetVersionTable:
     collection_id = Column(UUID(as_uuid=True))
     created_at = Column(DateTime)
     dataset_metadata = Column(JSON)
+    genetic_perturbations = Column(JSON)
     artifacts = Column(ARRAY(UUID(as_uuid=True)))
     status = Column(JSON)
 

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -36,6 +36,7 @@ from backend.layers.common.entities import (
     DatasetValidationStatus,
     DatasetVersion,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
 )
 from backend.layers.common.helpers import set_revised_at_field, sort_datasets_by_cell_count
 from backend.layers.persistence.constants import SCHEMA_NAME
@@ -1036,6 +1037,26 @@ class DatabaseProvider(DatabaseProviderInterface):
         with self._manage_session() as session:
             dataset_version = session.query(DatasetVersionTable).filter_by(id=version_id.id).one()
             dataset_version.dataset_metadata = metadata.to_dict()
+
+    def set_dataset_genetic_perturbations(
+        self, version_id: DatasetVersionId, genetic_perturbations: Optional[GeneticPerturbationMetadata]
+    ) -> None:
+        """
+        Sets the genetic_perturbations for a dataset version
+        """
+        with self._manage_session() as session:
+            dataset_version = session.query(DatasetVersionTable).filter_by(id=version_id.id).one()
+            dataset_version.genetic_perturbations = genetic_perturbations.to_dict() if genetic_perturbations else None
+
+    def get_dataset_genetic_perturbations(self, version_id: DatasetVersionId) -> Optional[GeneticPerturbationMetadata]:
+        """
+        Returns the genetic_perturbations for a dataset version, or None if not present
+        """
+        with self._manage_session() as session:
+            result = session.query(DatasetVersionTable.genetic_perturbations).filter_by(id=version_id.id).one_or_none()
+        if result is None or result[0] is None:
+            return None
+        return GeneticPerturbationMetadata.from_dict(result[0])
 
     def add_dataset_to_collection_version_mapping(
         self, collection_version_id: CollectionVersionId, dataset_version_id: DatasetVersionId

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -20,6 +20,7 @@ from backend.layers.common.entities import (
     DatasetValidationStatus,
     DatasetVersion,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
 )
 
 
@@ -297,6 +298,18 @@ class DatabaseProviderInterface:
     def set_dataset_metadata(self, version_id: DatasetVersionId, metadata: DatasetMetadata) -> None:
         """
         Sets the metadata for a dataset version
+        """
+
+    def set_dataset_genetic_perturbations(
+        self, version_id: DatasetVersionId, genetic_perturbations: Optional[GeneticPerturbationMetadata]
+    ) -> None:
+        """
+        Sets the genetic_perturbations for a dataset version
+        """
+
+    def get_dataset_genetic_perturbations(self, version_id: DatasetVersionId) -> Optional[GeneticPerturbationMetadata]:
+        """
+        Returns the genetic_perturbations for a dataset version, or None if not present
         """
 
     def add_dataset_to_collection_version_mapping(

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -23,6 +23,7 @@ from backend.layers.common.entities import (
     DatasetValidationStatus,
     DatasetVersion,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
 )
 from backend.layers.common.helpers import sort_datasets_by_cell_count
 from backend.layers.persistence.persistence import DatabaseProviderInterface
@@ -55,6 +56,9 @@ class DatabaseProviderMock(DatabaseProviderInterface):
     # Dataset artifacts
     dataset_artifacts: Dict[str, DatasetArtifact]
 
+    # genetic_perturbations keyed by dataset_version_id
+    dataset_genetic_perturbations: Dict[str, Optional[GeneticPerturbationMetadata]]
+
     def __init__(self) -> None:
         super().__init__()
         self.collections = {}  # rename to: active_collections
@@ -62,6 +66,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
         self.datasets = {}  # rename to: active_datasets
         self.datasets_versions = {}
         self.dataset_artifacts = {}
+        self.dataset_genetic_perturbations = {}
 
     # TODO: add publisher_metadata here?
     def create_canonical_collection(
@@ -591,6 +596,14 @@ class DatabaseProviderMock(DatabaseProviderInterface):
     def set_dataset_metadata(self, version_id: DatasetVersionId, metadata: DatasetMetadata) -> None:
         version = self.datasets_versions[version_id.id]
         version.metadata = copy.deepcopy(metadata)
+
+    def set_dataset_genetic_perturbations(
+        self, version_id: DatasetVersionId, genetic_perturbations: Optional[GeneticPerturbationMetadata]
+    ) -> None:
+        self.dataset_genetic_perturbations[version_id.id] = copy.deepcopy(genetic_perturbations)
+
+    def get_dataset_genetic_perturbations(self, version_id: DatasetVersionId) -> Optional[GeneticPerturbationMetadata]:
+        return copy.deepcopy(self.dataset_genetic_perturbations.get(version_id.id))
 
     def update_dataset_processing_status(self, version_id: DatasetVersionId, status: DatasetProcessingStatus) -> None:
         dataset_version = self.datasets_versions[version_id.id]

--- a/backend/layers/processing/process_add_labels.py
+++ b/backend/layers/processing/process_add_labels.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import h5py
 import numpy
@@ -14,6 +14,7 @@ from backend.layers.common.entities import (
     DatasetStatusKey,
     DatasetValidationStatus,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
     OntologyTermId,
     SpatialMetadata,
     TissueOntologyTermId,
@@ -111,7 +112,7 @@ class ProcessAddLabels(ProcessingLogic):
         return SpatialMetadata(is_single=bool(is_single), has_fullres=has_fullres)
 
     @logit
-    def extract_metadata(self, filename) -> DatasetMetadata:
+    def extract_metadata(self, filename) -> Tuple[DatasetMetadata, Optional[GeneticPerturbationMetadata]]:
         """Pull metadata out of the AnnData file to insert into the dataset table."""
 
         adata = read_h5ad(filename)
@@ -185,7 +186,13 @@ class ProcessAddLabels(ProcessingLogic):
             values = adata.obs["genetic_perturbation_strategy"].dropna().unique()
             return sorted(v for v in values if v not in _excluded)
 
-        return DatasetMetadata(
+        def _get_genetic_perturbation_metadata() -> Optional[GeneticPerturbationMetadata]:
+            gp = adata.uns.get("genetic_perturbations")
+            if gp is None:
+                return None
+            return GeneticPerturbationMetadata.from_dict(dict(gp))
+
+        dataset_metadata = DatasetMetadata(
             name=adata.uns["title"],
             organism=_get_organism_terms(),
             tissue=_get_tissue_terms(),
@@ -215,6 +222,7 @@ class ProcessAddLabels(ProcessingLogic):
             perturbation_types=_get_perturbation_types(),
             genetic_perturbation_strategy=_get_genetic_perturbation_strategy(),
         )
+        return dataset_metadata, _get_genetic_perturbation_metadata()
 
     def process(
         self,
@@ -255,8 +263,9 @@ class ProcessAddLabels(ProcessingLogic):
             self.logger.exception(f"An unexpected error occurred while adding labels to the data set: {e}")
             raise AddLabelsFailed() from e
         # Process metadata
-        metadata = self.extract_metadata(file_with_labels)
+        metadata, gp_metadata = self.extract_metadata(file_with_labels)
         self.business_logic.set_dataset_metadata(dataset_version_id, metadata)
+        self.business_logic.set_dataset_genetic_perturbations(dataset_version_id, gp_metadata)
         # Upload the labeled dataset to the artifact bucket
         self.create_artifact(
             file_with_labels,

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -739,3 +739,111 @@ def test_genetic_perturbation_strategy_upload_and_process(
     public_collection = res.json()
     public_dataset = next(d for d in public_collection["datasets"] if d["dataset_id"] == dataset_id)
     assert "genetic_perturbation_strategy" in public_dataset
+
+
+@skip_creation_on_prod
+def test_genetic_perturbations_dict_endpoint(
+    session,
+    api_url,
+    curation_api_access_token,
+    curator_cookie,
+    request,
+):
+    """
+    Upload a perturbation (pre-analysis) h5ad, process it, then verify
+    GET /curation/v1/collections/{id}/datasets/{id}/genetic_perturbations returns
+    the expected shape (dict keyed by perturbation ID with typed entry fields).
+    Also verifies that a dataset without genetic_perturbations returns null.
+    """
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    headers_dp = {"Cookie": f"cxguser={curator_cookie}", "Content-Type": "application/json"}
+
+    # --- Collection + dataset with perturbations ---
+    collection_id = create_test_collection(
+        headers_dp,
+        request,
+        session,
+        api_url,
+        {
+            "contact_email": "functest@example.com",
+            "contact_name": "Func Test",
+            "curator_name": "Func Test",
+            "description": "genetic_perturbations dict functional test",
+            "name": "test_genetic_perturbations_dict_endpoint",
+            "is_pre_analysis": True,
+        },
+    )
+
+    res = session.post(f"{api_url}/curation/v1/collections/{collection_id}/datasets", headers=headers)
+    assertStatusCode(201, res)
+    dataset_id = res.json()["dataset_id"]
+
+    res = session.put(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/manifest",
+        data=json.dumps(PERTURBATION_DATASET_MANIFEST),
+        headers=headers,
+    )
+    assertStatusCode(202, res)
+
+    result = wait_for_dataset_processing_via_curation_api(
+        session, api_url, curation_api_access_token, collection_id, dataset_id
+    )
+    assert not result["errors"], f"Perturbation dataset processing failed: {result['errors']}"
+
+    # --- Verify GET .../genetic_perturbations response shape ---
+    gp_url = f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/genetic_perturbations"
+    res = session.get(gp_url, headers=headers)
+    assertStatusCode(200, res)
+    body = res.json()
+
+    assert "genetic_perturbations" in body
+    gp = body["genetic_perturbations"]
+
+    if gp is not None:
+        assert isinstance(gp, dict), "genetic_perturbations should be a dict keyed by perturbation ID"
+        for pid, entry in gp.items():
+            assert isinstance(pid, str), "perturbation ID must be a string"
+            assert "role" in entry, f"entry {pid} missing 'role'"
+            assert "derived_genomic_regions" in entry, f"entry {pid} missing 'derived_genomic_regions'"
+            assert "derived_features" in entry, f"entry {pid} missing 'derived_features'"
+            assert isinstance(entry["derived_genomic_regions"], list)
+            assert isinstance(entry["derived_features"], dict)
+
+    # --- Dataset without genetic_perturbations returns null ---
+    collection_id_plain = create_test_collection(
+        headers_dp,
+        request,
+        session,
+        api_url,
+        {
+            "contact_email": "functest@example.com",
+            "contact_name": "Func Test",
+            "curator_name": "Func Test",
+            "description": "plain dataset for genetic_perturbations null check",
+            "name": "test_genetic_perturbations_dict_endpoint_null",
+        },
+    )
+
+    res = session.post(f"{api_url}/curation/v1/collections/{collection_id_plain}/datasets", headers=headers)
+    assertStatusCode(201, res)
+    plain_dataset_id = res.json()["dataset_id"]
+
+    res = session.put(
+        f"{api_url}/curation/v1/collections/{collection_id_plain}/datasets/{plain_dataset_id}/manifest",
+        data=json.dumps(DATASET_MANIFEST),
+        headers=headers,
+    )
+    assertStatusCode(202, res)
+
+    result = wait_for_dataset_processing_via_curation_api(
+        session, api_url, curation_api_access_token, collection_id_plain, plain_dataset_id
+    )
+    assert not result["errors"], f"Plain dataset processing failed: {result['errors']}"
+
+    gp_url_plain = (
+        f"{api_url}/curation/v1/collections/{collection_id_plain}/datasets/{plain_dataset_id}/genetic_perturbations"
+    )
+    res = session.get(gp_url_plain, headers=headers)
+    assertStatusCode(200, res)
+    plain_body = res.json()
+    assert plain_body["genetic_perturbations"] is None

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -6,7 +6,13 @@ import numpy as np
 import pandas
 from dask.array import from_array
 
-from backend.layers.common.entities import OntologyTermId, SpatialMetadata, TissueOntologyTermId
+from backend.layers.common.entities import (
+    GeneticPerturbationEntry,
+    GeneticPerturbationMetadata,
+    OntologyTermId,
+    SpatialMetadata,
+    TissueOntologyTermId,
+)
 from backend.layers.processing.process_add_labels import ProcessAddLabels
 from backend.layers.thirdparty.schema_validator_provider import SchemaValidatorProvider
 from tests.unit.processing.base_processing_test import BaseProcessingTest
@@ -106,7 +112,7 @@ class TestAddLabels(BaseProcessingTest):
 
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted_metadata = self.pal.extract_metadata(f.name)
+            extracted_metadata, _ = self.pal.extract_metadata(f.name)
 
         self.assertEqual(extracted_metadata.organism, [OntologyTermId("Homo sapiens", "NCBITaxon:8505")])
 
@@ -270,7 +276,7 @@ class TestAddLabels(BaseProcessingTest):
 
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted_metadata = self.pal.extract_metadata(f.name)
+            extracted_metadata, _ = self.pal.extract_metadata(f.name)
 
         self.assertEqual(extracted_metadata.organism, [OntologyTermId("Homo sapiens", "NCBITaxon:8505")])
 
@@ -441,7 +447,7 @@ class TestAddLabels(BaseProcessingTest):
 
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted_metadata = self.pal.extract_metadata(f.name)
+            extracted_metadata, _ = self.pal.extract_metadata(f.name)
 
         # Verify that the "my_awesome_wonky_layer" was read and not the default X layer. The layer contains only zeros
         # which should result in a mean_genes_per_cell value of 0 compared to 3 if the X layer was read.
@@ -494,7 +500,7 @@ class TestAddLabels(BaseProcessingTest):
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertEqual(extracted.perturbation_types, ["CRISPR", "ORF"])
 
     def test_extract_metadata_perturbation_types_without_column(self):
@@ -502,7 +508,7 @@ class TestAddLabels(BaseProcessingTest):
         adata = self._make_minimal_adata()
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertIsNone(extracted.perturbation_types)
 
     def test_extract_metadata_perturbation_types_all_excluded(self):
@@ -514,7 +520,7 @@ class TestAddLabels(BaseProcessingTest):
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertEqual(extracted.perturbation_types, [])
 
     def test_extract_metadata_genetic_perturbation_strategy_with_column(self):
@@ -526,7 +532,7 @@ class TestAddLabels(BaseProcessingTest):
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertEqual(extracted.genetic_perturbation_strategy, ["CRISPR", "CRISPRi", "ORF"])
 
     def test_extract_metadata_genetic_perturbation_strategy_without_column(self):
@@ -534,7 +540,7 @@ class TestAddLabels(BaseProcessingTest):
         adata = self._make_minimal_adata()
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertIsNone(extracted.genetic_perturbation_strategy)
 
     def test_extract_metadata_genetic_perturbation_strategy_no_perturbations_excluded(self):
@@ -546,7 +552,7 @@ class TestAddLabels(BaseProcessingTest):
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertEqual(extracted.genetic_perturbation_strategy, ["CRISPR"])
 
     def test_get_spatial_metadata__is_single_and_fullres_true(self):
@@ -576,3 +582,77 @@ class TestAddLabels(BaseProcessingTest):
         self.assertEqual(
             self.pal.get_spatial_metadata(spatial_dict), SpatialMetadata(is_single=False, has_fullres=False)
         )
+
+    # --- GeneticPerturbationMetadata extraction tests ---
+
+    def test_extract_metadata_genetic_perturbation_metadata_absent(self):
+        """Returns None as the second tuple element when uns has no 'genetic_perturbations' key."""
+        adata = self._make_minimal_adata()
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            _, gp_metadata = self.pal.extract_metadata(f.name)
+        self.assertIsNone(gp_metadata)
+
+    def test_extract_metadata_genetic_perturbation_metadata_present(self):
+        """Returns a GeneticPerturbationMetadata with correctly typed entries when uns has 'genetic_perturbations'."""
+        gp_dict = {
+            "p1": {
+                "role": "KO",
+                "protospacer_sequence": "ACGTACGT",
+                "protospacer_adjacent_motif": "NGG",
+                "derived_genomic_regions": ["chr1:100-200"],
+                "derived_features": {"ENSG00000001": "GENE1"},
+            },
+            "p2": {
+                "role": "overexpression",
+                "protospacer_sequence": None,
+                "protospacer_adjacent_motif": None,
+                "derived_genomic_regions": [],
+                "derived_features": {},
+            },
+        }
+        adata = self._make_minimal_adata()
+        adata.uns["genetic_perturbations"] = gp_dict
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            _, gp_metadata = self.pal.extract_metadata(f.name)
+
+        self.assertIsInstance(gp_metadata, GeneticPerturbationMetadata)
+        self.assertIn("p1", gp_metadata.perturbations)
+        self.assertIn("p2", gp_metadata.perturbations)
+
+        p1 = gp_metadata.perturbations["p1"]
+        self.assertIsInstance(p1, GeneticPerturbationEntry)
+        self.assertEqual(p1.role, "KO")
+        self.assertEqual(p1.protospacer_sequence, "ACGTACGT")
+        self.assertEqual(p1.protospacer_adjacent_motif, "NGG")
+        self.assertEqual(p1.derived_genomic_regions, ["chr1:100-200"])
+        self.assertEqual(p1.derived_features, {"ENSG00000001": "GENE1"})
+
+        p2 = gp_metadata.perturbations["p2"]
+        self.assertEqual(p2.role, "overexpression")
+        self.assertEqual(p2.derived_genomic_regions, [])
+        self.assertEqual(p2.derived_features, {})
+
+    def test_extract_metadata_genetic_perturbation_metadata_to_dict_roundtrip(self):
+        """GeneticPerturbationMetadata.to_dict() / from_dict() round-trips correctly."""
+        original = {
+            "p1": {
+                "role": "KO",
+                "protospacer_sequence": "ACGT",
+                "protospacer_adjacent_motif": None,
+                "derived_genomic_regions": ["chr2:500-600"],
+                "derived_features": {"ENSG00000002": "GENE2"},
+            }
+        }
+        gp_metadata = GeneticPerturbationMetadata.from_dict(original)
+        self.assertEqual(gp_metadata.to_dict(), original)
+
+    def test_extract_metadata_returns_tuple(self):
+        """extract_metadata always returns a 2-tuple of (DatasetMetadata, Optional[GeneticPerturbationMetadata])."""
+        adata = self._make_minimal_adata()
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            result = self.pal.extract_metadata(f.name)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)

--- a/tests/unit/processing/test_process_add_labels.py
+++ b/tests/unit/processing/test_process_add_labels.py
@@ -42,7 +42,7 @@ class ProcessingTest(BaseProcessingTest):
 
         # TODO: ideally use a real h5ad
         processor = ProcessAddLabels(self.business_logic, self.uri_provider, self.s3_provider, self.schema_validator)
-        processor.extract_metadata = Mock()
+        processor.extract_metadata = Mock(return_value=(Mock(), None))
         processor.populate_dataset_citation = Mock()
         processor.process(collection.version_id, dataset_version_id, "fake_bucket_name", "fake_datasets_bucket")
 

--- a/tests/unit/processing/test_processing.py
+++ b/tests/unit/processing/test_processing.py
@@ -72,6 +72,7 @@ class ProcessingTest(BaseProcessingTest):
     @patch("backend.layers.processing.process_cxg.ProcessCxg.make_cxg")
     def test_process_anndata(self, mock_cxg, mock_extract_h5ad, mock_dataset_citation):
         mock_cxg.return_value = "local.cxg"
+        mock_extract_h5ad.return_value = (Mock(), None)
 
         dropbox_uri = "https://www.dropbox.com/s/ow84zm4h0wkl409/test.h5ad?dl=0"
         manifest = IngestionManifest(anndata=dropbox_uri)


### PR DESCRIPTION

- Add GeneticPerturbationEntry (@dataclass_json) and GeneticPerturbationMetadata (manual to_dict/from_dict) to entities.py
- Add separate nullable `genetic_perturbations` JSON column to DatasetVersionTable (migration 10_add_genetic_perturbations) to avoid bloating the shared dataset_metadata column (~6.5 MB serialized per perturbation dataset)
- extract_metadata now returns Tuple[DatasetMetadata, Optional[GeneticPerturbationMetadata]]; process() unpacks and stores both with zero additional file I/O
- Add set/get_dataset_genetic_perturbations through persistence interface, impl, mock, and business logic layers
- New endpoint GET /v1/curation/collections/{id}/datasets/{id}/genetic_perturbations returns full dict or {"genetic_perturbations": null}; no pagination needed (single document resource, not a list)
- Unit tests: 4 new tests for extraction/roundtrip; all existing extract_metadata callsites updated to unpack tuple
- Functional test: perturbation dataset upload → process → assert response shape; plain dataset asserts null