### PR TITLE
perf: store artifact filesize in DB to eliminate S3 HEAD requests at query time

### DIFF
--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -80,9 +80,13 @@ def extract_dataset_assets(dataset_version: DatasetVersion):
     for asset in dataset_version.artifacts:
         if asset.type not in allowed_dataset_asset_types:
             continue
-        filesize = get_business_logic().s3_provider.get_file_size(asset.uri)
-        if filesize is None:
-            filesize = -1
+        if asset.filesize is not None:
+            filesize = asset.filesize
+        else:
+            # Fallback for rows not yet backfilled; remove once backfill is confirmed complete.
+            filesize = get_business_logic().s3_provider.get_file_size(asset.uri)
+            if filesize is None:
+                filesize = -1
         url = BusinessLogic.generate_permanent_url(dataset_version, asset.id, asset.type)
         result = {
             "filesize": filesize,

--- a/backend/database/versions/09_add_artifact_filesize.py
+++ b/backend/database/versions/09_add_artifact_filesize.py
@@ -1,0 +1,32 @@
+"""Add filesize column to DatasetArtifact
+
+Stores artifact file size in the database so it can be served directly without
+a live S3 HEAD request per artifact. Nullable to allow zero-downtime rollout
+and backfill of existing rows.
+
+Revision ID: 09_add_artifact_filesize
+Revises: 08_92c817dddc7d
+Create Date: 2026-04-10
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "09_add_artifact_filesize"
+down_revision = "08_92c817dddc7d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "DatasetArtifact",
+        sa.Column("filesize", sa.BigInteger(), nullable=True),
+        schema="persistence_schema",
+    )
+
+
+def downgrade():
+    op.drop_column("DatasetArtifact", "filesize", schema="persistence_schema")

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -959,6 +959,7 @@ class BusinessLogic(BusinessLogicInterface):
         artifact_type: DatasetArtifactType,
         artifact_uri: str,
         artifact_id: Optional[DatasetArtifactId] = None,
+        filesize: Optional[int] = None,
     ) -> DatasetArtifactId:
         """
         Registers an artifact to a dataset version.
@@ -967,7 +968,7 @@ class BusinessLogic(BusinessLogicInterface):
             raise DatasetIngestException(f"Wrong artifact type for {dataset_version_id}: {artifact_type}")
 
         return self.database_provider.create_dataset_artifact(
-            dataset_version_id, artifact_type, artifact_uri, artifact_id
+            dataset_version_id, artifact_type, artifact_uri, artifact_id, filesize
         )
 
     def update_dataset_artifact(self, artifact_id: DatasetArtifactId, artifact_uri: str) -> None:

--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -174,6 +174,7 @@ class BusinessLogicInterface:
         artifact_type: str,
         artifact_uri: str,
         artifact_id: Optional[DatasetArtifactId] = None,
+        filesize: Optional[int] = None,
     ) -> DatasetArtifactId:
         pass
 

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -166,6 +166,7 @@ class DatasetArtifact:
     id: DatasetArtifactId
     type: DatasetArtifactType
     uri: str
+    filesize: Optional[int] = None
 
     def get_file_name(self):
         return urlparse(self.uri).path.split("/")[-1]

--- a/backend/layers/persistence/orm.py
+++ b/backend/layers/persistence/orm.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, ForeignKey, String
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import ARRAY, BOOLEAN, JSON, UUID
 from sqlalchemy.orm import registry
 from sqlalchemy.schema import MetaData
@@ -69,3 +69,4 @@ class DatasetArtifactTable:
     id = Column(UUID(as_uuid=True), primary_key=True)
     type = Column(String)
     uri = Column(String)
+    filesize = Column(BigInteger, nullable=True)

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -157,6 +157,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             DatasetArtifactId(str(row.id)),
             DatasetArtifactType[row.type],
             row.uri,
+            row.filesize,
         )
 
     def _row_to_dataset_version(self, row: Any, canonical_dataset: CanonicalDataset, artifacts: List[DatasetArtifact]):
@@ -927,12 +928,13 @@ class DatabaseProvider(DatabaseProviderInterface):
         artifact_type: DatasetArtifactType,
         artifact_uri: str,
         artifact_id: Optional[DatasetArtifactId] = None,
+        filesize: Optional[int] = None,
     ) -> DatasetArtifactId:
         """
         Adds a dataset artifact to an existing dataset version.
         """
         artifact_id = artifact_id if artifact_id else DatasetArtifactId()
-        artifact = DatasetArtifactTable(id=artifact_id.id, type=artifact_type.name, uri=artifact_uri)
+        artifact = DatasetArtifactTable(id=artifact_id.id, type=artifact_type.name, uri=artifact_uri, filesize=filesize)
         with self._get_serializable_session() as session:
             session.add(artifact)
             dataset_version = session.query(DatasetVersionTable).filter_by(id=dataset_version_id.id).one()

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -243,6 +243,7 @@ class DatabaseProviderInterface:
         artifact_type: str,
         artifact_uri: str,
         artifact_id: Optional[DatasetArtifactId] = None,
+        filesize: Optional[int] = None,
     ) -> DatasetArtifactId:
         """
         Create a dataset artifact to add to a dataset version.

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -563,10 +563,11 @@ class DatabaseProviderMock(DatabaseProviderInterface):
         artifact_type: str,
         artifact_uri: str,
         artifact_id: Optional[DatasetArtifactId] = None,
+        filesize: Optional[int] = None,
     ) -> DatasetArtifactId:
         version = self.datasets_versions[dataset_version_id.id]
         artifact_id = artifact_id if artifact_id else DatasetArtifactId()
-        dataset_artifact = DatasetArtifact(artifact_id, artifact_type, artifact_uri)
+        dataset_artifact = DatasetArtifact(artifact_id, artifact_type, artifact_uri, filesize)
         version.artifacts.append(dataset_artifact)
         self.dataset_artifacts[artifact_id.id] = dataset_artifact
         return artifact_id

--- a/backend/layers/processing/process_logic.py
+++ b/backend/layers/processing/process_logic.py
@@ -95,10 +95,11 @@ class ProcessingLogic:  # TODO: ProcessingLogicBase
     ):
         self.update_processing_status(dataset_version_id, processing_status_key, DatasetConversionStatus.UPLOADING)
         try:
+            filesize = os.path.getsize(file_name)
             key = "/".join([key_prefix, basename(file_name)])
             s3_uri = self.upload_artifact(file_name, key, artifact_bucket)
             self.logger.info(f"Uploaded [{dataset_version_id}/{file_name}] to {s3_uri}")
-            self.business_logic.add_dataset_artifact(dataset_version_id, artifact_type, s3_uri)
+            self.business_logic.add_dataset_artifact(dataset_version_id, artifact_type, s3_uri, filesize=filesize)
             self.logger.info(f"Updated database with {artifact_type}.")
             if datasets_bucket:
                 key = ".".join([key_prefix, ARTIFACT_TO_EXTENSION[artifact_type]])

--- a/backend/layers/processing/process_logic.py
+++ b/backend/layers/processing/process_logic.py
@@ -95,7 +95,7 @@ class ProcessingLogic:  # TODO: ProcessingLogicBase
     ):
         self.update_processing_status(dataset_version_id, processing_status_key, DatasetConversionStatus.UPLOADING)
         try:
-            filesize = os.path.getsize(file_name)
+            filesize = os.path.getsize(file_name) if os.path.exists(file_name) else None
             key = "/".join([key_prefix, basename(file_name)])
             s3_uri = self.upload_artifact(file_name, key, artifact_bucket)
             self.logger.info(f"Uploaded [{dataset_version_id}/{file_name}] to {s3_uri}")

--- a/backend/layers/processing/process_validate_atac.py
+++ b/backend/layers/processing/process_validate_atac.py
@@ -61,9 +61,12 @@ class ProcessValidateATAC(ProcessingLogic):
             else:
                 key_prefix = self.get_key_prefix(artifact_id.id)
             key = f"{key_prefix}-fragment.{ARTIFACT_TO_EXTENSION[artifact_type]}"
+            filesize = os.path.getsize(file_name)
             datasets_s3_uri = self.upload_artifact(file_name, key, datasets_bucket)
             self.logger.info(f"Uploaded [{dataset_version_id}/{artifact_type}] to {datasets_s3_uri}")
-            self.business_logic.add_dataset_artifact(dataset_version_id, artifact_type, datasets_s3_uri, artifact_id)
+            self.business_logic.add_dataset_artifact(
+                dataset_version_id, artifact_type, datasets_s3_uri, artifact_id, filesize=filesize
+            )
             self.logger.info(f"Updated database with {artifact_type}.")
             return artifact_id
         except Exception as e:

--- a/backend/layers/processing/process_validate_atac.py
+++ b/backend/layers/processing/process_validate_atac.py
@@ -61,7 +61,7 @@ class ProcessValidateATAC(ProcessingLogic):
             else:
                 key_prefix = self.get_key_prefix(artifact_id.id)
             key = f"{key_prefix}-fragment.{ARTIFACT_TO_EXTENSION[artifact_type]}"
-            filesize = os.path.getsize(file_name)
+            filesize = os.path.getsize(file_name) if os.path.exists(file_name) else None
             datasets_s3_uri = self.upload_artifact(file_name, key, datasets_bucket)
             self.logger.info(f"Uploaded [{dataset_version_id}/{artifact_type}] to {datasets_s3_uri}")
             self.business_logic.add_dataset_artifact(

--- a/backend/scripts/backfill_artifact_filesizes.py
+++ b/backend/scripts/backfill_artifact_filesizes.py
@@ -1,0 +1,81 @@
+"""
+Backfill filesize for existing DatasetArtifact rows.
+
+Fetches the size of each artifact from S3 using concurrent HEAD requests and
+writes the result back to the database. Safe to re-run: rows with a non-NULL
+filesize are skipped.
+
+Usage (from repo root, with DB and AWS credentials available):
+    python -m backend.scripts.backfill_artifact_filesizes
+
+Optional env vars:
+    BACKFILL_WORKERS   number of concurrent S3 threads (default: 50)
+    BACKFILL_DRY_RUN   if set to "1", print counts but make no DB writes
+"""
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from backend.layers.persistence.orm import DatasetArtifactTable
+from backend.layers.persistence.persistence import DatabaseProvider
+from backend.layers.thirdparty.s3_provider import S3Provider
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+MAX_WORKERS = int(os.environ.get("BACKFILL_WORKERS", 50))
+DRY_RUN = os.environ.get("BACKFILL_DRY_RUN", "") == "1"
+
+
+def _fetch_filesize(s3: S3Provider, artifact_id: str, uri: str):
+    """Return (artifact_id, filesize) or (artifact_id, None) on failure."""
+    try:
+        size = s3.get_file_size(uri)
+        return artifact_id, size
+    except Exception as exc:
+        logger.warning("S3 HEAD failed for %s (%s): %s", artifact_id, uri, exc)
+        return artifact_id, None
+
+
+def backfill():
+    db = DatabaseProvider()
+    s3 = S3Provider()
+
+    with db._manage_session() as session:
+        rows = (
+            session.query(DatasetArtifactTable.id, DatasetArtifactTable.uri)
+            .filter(DatasetArtifactTable.filesize.is_(None))
+            .all()
+        )
+
+    total = len(rows)
+    logger.info("Found %d artifact(s) with NULL filesize%s", total, " (DRY RUN)" if DRY_RUN else "")
+    if total == 0 or DRY_RUN:
+        return
+
+    succeeded = 0
+    failed = 0
+
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = {executor.submit(_fetch_filesize, s3, str(row.id), row.uri): str(row.id) for row in rows}
+        for future in as_completed(futures):
+            artifact_id, filesize = future.result()
+            if filesize is None:
+                failed += 1
+                continue
+            with db._manage_session() as session:
+                session.query(DatasetArtifactTable).filter_by(id=artifact_id).update(
+                    {"filesize": filesize}, synchronize_session=False
+                )
+            succeeded += 1
+            if succeeded % 100 == 0:
+                logger.info("Progress: %d/%d updated, %d failed", succeeded, total, failed)
+
+    logger.info("Done. %d updated, %d failed out of %d total.", succeeded, failed, total)
+    if failed:
+        logger.warning("%d artifacts could not be resolved — re-run to retry.", failed)
+
+
+if __name__ == "__main__":
+    backfill()


### PR DESCRIPTION
Curation /curation/v1/datasets was taking 42-173s because extract_dataset_assets() fired a synchronous S3 HEAD per artifact (~4000 calls for 2089 datasets). Fix stores filesize at ingest time (captured via os.path.getsize before upload, so no extra S3 call) and reads it directly from the DB at query time.

- Migration 09: add nullable BigInteger filesize to DatasetArtifact
- ORM, entity, persistence, business layer: thread filesize through write path
- process_logic + process_validate_atac: capture local file size before upload
- extract_dataset_assets: read from DB; fall back to S3 HEAD only if NULL (backfill window)
- scripts/backfill_artifact_filesizes.py: concurrent idempotent backfill for existing rows