### PR TITLE
perf: address curation API index endpoint perf and eliminate N+1 DB queries in curation collections and datasets endpoints

### DIFF
--- a/backend/curation/api/v1/curation/collections/actions.py
+++ b/backend/curation/api/v1/curation/collections/actions.py
@@ -41,8 +41,26 @@ def get(visibility: str, token_info: dict, curator: str = None):
 
     logging.info(filters)
 
+    business_logic = get_business_logic()
+
+    # Buffer all matching collection versions so we can bulk-load their datasets in one shot.
+    collection_versions = list(business_logic.get_collections(CollectionQueryFilter(**filters)))
+
+    # Collect every dataset version ID across all collections and load them in a single DB round-trip
+    # (3 queries total instead of 3 queries × N collections).
+    all_dv_ids = []
+    for cv in collection_versions:
+        all_dv_ids.extend(cv.datasets)  # DatasetVersionId objects
+
+    if all_dv_ids:
+        dataset_map = {
+            dv.version_id.id: dv for dv in business_logic.database_provider.get_dataset_versions_by_id(all_dv_ids)
+        }
+        for cv in collection_versions:
+            cv.datasets = [dataset_map[dvid.id] for dvid in cv.datasets if dvid.id in dataset_map]
+
     resp_collections = []
-    for collection_version in get_business_logic().get_collections(CollectionQueryFilter(**filters)):
+    for collection_version in collection_versions:
         resp_collection = reshape_for_curation_api(collection_version, user_info, preview=True)
         resp_collections.append(resp_collection)
     return jsonify(resp_collections)

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -375,6 +375,8 @@ class BusinessLogic(BusinessLogicInterface):
         # TODO: instead of `is_published`, we should probably call this `is_active_and_published`
         if filter.is_published is True:
             iterable = self.database_provider.get_all_mapped_collection_versions()
+        elif filter.is_published is False:
+            iterable = self.database_provider.get_unpublished_collection_versions()
         else:
             iterable = self.database_provider.get_all_collections_versions()
 

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -801,15 +801,11 @@ class BusinessLogic(BusinessLogicInterface):
         datasets, _ = self.database_provider.get_all_mapped_datasets_and_collections()
         return datasets
 
-    def get_datasets_for_collections(self, collections: Iterable[CollectionVersion]) -> Iterable[DatasetVersion]:
-        datasets = []
+    def get_datasets_for_collections(self, collections: Iterable[CollectionVersion]) -> List[DatasetVersion]:
+        all_ids: List[DatasetVersionId] = []
         for collection in collections:
-            datasest_ids = [d.id for d in collection.datasets]
-            collection_datasets: List[DatasetVersion] = [
-                self.database_provider.get_dataset_version(DatasetVersionId(id)) for id in datasest_ids
-            ]
-            datasets.extend(collection_datasets)
-        return datasets
+            all_ids.extend(collection.datasets)
+        return self.database_provider.get_dataset_versions_by_id(all_ids) if all_ids else []
 
     def get_private_collection_versions_with_datasets(
         self, owner: str = None
@@ -1497,7 +1493,12 @@ class BusinessLogic(BusinessLogicInterface):
         [datasets_by_collection_id[d.collection_id.id].append(d) for d in mapped_dataset_versions]
 
         # Construct dict of collection_id: [all published Collection versions]
-        all_collections_versions = self.database_provider.get_all_collections_versions()
+        # Use a targeted query instead of get_all_collections_versions() to avoid 4 full-table scans;
+        # we only need published versions for the active collection IDs.
+        relevant_collection_ids = [c.collection_id.id for c in mapped_collection_versions]
+        all_collections_versions = self.database_provider.get_published_collection_versions_for_collections(
+            relevant_collection_ids
+        )
         collection_versions_by_collection_id = defaultdict(list)
         [collection_versions_by_collection_id[c.collection_id.id].append(c) for c in all_collections_versions]
 

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -475,6 +475,40 @@ class DatabaseProvider(DatabaseProviderInterface):
 
             return result
 
+    def get_unpublished_collection_versions(self) -> List[CollectionVersion]:
+        """
+        Returns all collection versions with published_at IS NULL (unpublished/draft).
+
+        Targeted alternative to get_all_collections_versions() for the is_published=False filter case.
+        Runs 2 filtered queries instead of 4 full-table scans: unpublished CVs filtered at the DB
+        level, plus their canonical collections. Tombstone dataset pre-filtering (queries 3 & 4 in
+        get_all_collections_versions) is skipped because get_dataset_versions_by_id already excludes
+        tombstoned datasets downstream.
+        """
+        with self._manage_session() as session:
+            versions = session.query(CollectionVersionTable).filter(CollectionVersionTable.published_at.is_(None)).all()
+            if not versions:
+                return []
+            collection_ids = list({str(v.collection_id) for v in versions})
+            canonical_map = {
+                str(row.id): CanonicalCollection(
+                    CollectionId(str(row.id)),
+                    CollectionVersionId(str(row.version_id)) if row.version_id else None,
+                    row.originally_published_at,
+                    row.revised_at,
+                    row.tombstone,
+                )
+                for row in session.query(CollectionTable)
+                .filter(CollectionTable.id.in_(collection_ids))
+                .filter(CollectionTable.tombstone.isnot(True))
+                .all()
+            }
+            return [
+                self._row_to_collection_version(v, canonical_map[str(v.collection_id)])
+                for v in versions
+                if str(v.collection_id) in canonical_map
+            ]
+
     def get_published_collection_versions_for_collections(self, collection_ids: List[str]) -> List[CollectionVersion]:
         """
         Returns all published (non-NULL published_at) collection versions for the given canonical collection IDs.

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -475,6 +475,37 @@ class DatabaseProvider(DatabaseProviderInterface):
 
             return result
 
+    def get_published_collection_versions_for_collections(self, collection_ids: List[str]) -> List[CollectionVersion]:
+        """
+        Returns all published (non-NULL published_at) collection versions for the given canonical collection IDs.
+
+        Targeted alternative to get_all_collections_versions() for the published_at lookup in
+        _map_collection_version_to_published_dataset_versions(). Runs 2 filtered queries instead of 4
+        full-table scans, skipping tombstone and dataset-version-mapping lookups not needed here.
+        """
+        with self._manage_session() as session:
+            canonical_map = {
+                str(row.id): CanonicalCollection(
+                    CollectionId(str(row.id)),
+                    CollectionVersionId(str(row.version_id)) if row.version_id else None,
+                    row.originally_published_at,
+                    row.revised_at,
+                    row.tombstone,
+                )
+                for row in session.query(CollectionTable).filter(CollectionTable.id.in_(collection_ids)).all()
+            }
+            versions = (
+                session.query(CollectionVersionTable)
+                .filter(CollectionVersionTable.collection_id.in_(collection_ids))
+                .filter(CollectionVersionTable.published_at.isnot(None))
+                .all()
+            )
+            return [
+                self._row_to_collection_version(v, canonical_map[str(v.collection_id)])
+                for v in versions
+                if str(v.collection_id) in canonical_map
+            ]
+
     def get_all_mapped_collection_versions(self, get_tombstoned: bool = False) -> Iterable[CollectionVersion]:
         """
         Retrieves all the collection versions that are mapped to a canonical collection. This method does not require

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -76,6 +76,12 @@ class DatabaseProviderInterface:
         TODO: for performance reasons, it might be necessary to add a filtering parameter here.
         """
 
+    def get_published_collection_versions_for_collections(self, collection_ids: List[str]) -> List[CollectionVersion]:
+        """
+        Returns all published collection versions for the given canonical collection IDs.
+        Targeted alternative to get_all_collections_versions() for published_at lookups.
+        """
+
     def get_all_mapped_collection_versions(self) -> Iterable[CollectionVersion]:
         """
         Retrieves all the collection versions that are mapped to a canonical collection.

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -76,6 +76,12 @@ class DatabaseProviderInterface:
         TODO: for performance reasons, it might be necessary to add a filtering parameter here.
         """
 
+    def get_unpublished_collection_versions(self) -> List[CollectionVersion]:
+        """
+        Returns all collection versions with published_at IS NULL.
+        Targeted alternative to get_all_collections_versions() for the is_published=False filter case.
+        """
+
     def get_published_collection_versions_for_collections(self, collection_ids: List[str]) -> List[CollectionVersion]:
         """
         Returns all published collection versions for the given canonical collection IDs.

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -149,6 +149,17 @@ class DatabaseProviderMock(DatabaseProviderInterface):
                 included_dataset_version_ids.append(d_v_id)
             yield updated_version
 
+    def get_unpublished_collection_versions(self) -> List[CollectionVersion]:
+        result = []
+        for version in self.collections_versions.values():
+            updated_version = self._update_version_with_canonical(version)
+            if updated_version.canonical_collection.tombstoned:
+                continue
+            if updated_version.published_at is not None:
+                continue
+            result.append(updated_version)
+        return result
+
     def get_published_collection_versions_for_collections(self, collection_ids: List[str]) -> List[CollectionVersion]:
         result = []
         for version in self.collections_versions.values():

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -149,6 +149,17 @@ class DatabaseProviderMock(DatabaseProviderInterface):
                 included_dataset_version_ids.append(d_v_id)
             yield updated_version
 
+    def get_published_collection_versions_for_collections(self, collection_ids: List[str]) -> List[CollectionVersion]:
+        result = []
+        for version in self.collections_versions.values():
+            updated_version = self._update_version_with_canonical(version)
+            if str(updated_version.collection_id.id) not in collection_ids:
+                continue
+            if updated_version.published_at is None:
+                continue
+            result.append(updated_version)
+        return result
+
     def get_canonical_collection(self, collection_id: CollectionId) -> Optional[CanonicalCollection]:
         return self.collections.get(collection_id.id, None)
 


### PR DESCRIPTION
Four targeted fixes for curation and portal API performance bottlenecks, continuing from #7736 (artifact filesize in DB).

## Changes

**1. `get_datasets_for_collections` bulk load (`business.py`)**
Replaces per-dataset `get_dataset_version()` calls (3 DB round-trips each) with a single `get_dataset_versions_by_id()` bulk load. Affects:
- `GET /curation/v1/datasets?visibility=PRIVATE`
- Portal `get_user_datasets_index` (combined public + private view for super curators)

**2. `GET /curation/v1/collections` pre-batch dataset load (`actions.py`)**
Previously called `get_dataset_versions_by_id` once per collection inside the reshape loop (3 queries × N collections). Now buffers all collection versions, collects every dataset version ID across all collections in one pass, and calls `get_dataset_versions_by_id` once before the loop. For 500 collections this removes ~1,500 DB round-trips.

**3. `get_published_collection_versions_for_collections` (`persistence.py`)**
`_map_collection_version_to_published_dataset_versions` (called from the public `/datasets` path) previously called `get_all_collections_versions()` which ran 4 full-table scans: all collection versions, all canonical collections, all tombstoned datasets, all dataset version mappings. Replaced with a new method that runs 2 filtered queries scoped to the active collection IDs and published versions only.
Affects: `GET /curation/v1/datasets?visibility=PUBLIC` (and the default public path).

**4. `get_unpublished_collection_versions` (`persistence.py`)**
`get_collections(is_published=False)` previously routed through `get_all_collections_versions()` (same 4 full-table scans), then discarded most of the result with a Python-side `published_at IS NULL` filter. New method runs 2 targeted queries: `CollectionVersionTable WHERE published_at IS NULL` + `CollectionTable` scoped to those collection IDs. Tombstone dataset pre-filtering is skipped because `get_dataset_versions_by_id` already handles tombstone exclusion downstream.
Affects:
- `GET /curation/v1/datasets?visibility=PRIVATE` (super curators with `owner=None` see all private datasets)
- `GET /curation/v1/collections?visibility=PRIVATE`
- Portal `get_user_datasets_index` and `get_user_collection_index`

## Summary

| Fix | Replaces | Queries before → after |
|---|---|---|
| `get_datasets_for_collections` bulk load | Per-dataset `get_dataset_version()` | 3×N → 3 |
| `/collections` pre-batch dataset load | Per-collection `get_dataset_versions_by_id()` | 3×N → 3 |
| `get_published_collection_versions_for_collections` | `get_all_collections_versions()` in public datasets path | 4 full-table scans → 2 filtered |
| `get_unpublished_collection_versions` | `get_all_collections_versions()` in private/unpublished path | 4 full-table scans → 2 filtered |

`get_all_collections_versions()` itself is unchanged — its remaining call site (`get_collections(is_published=None)`) still uses it correctly.