### PR TITLE
perf: eliminate per-collection revising_in DB query in curation collections index

### DIFF
--- a/backend/curation/api/v1/curation/collections/actions.py
+++ b/backend/curation/api/v1/curation/collections/actions.py
@@ -59,9 +59,22 @@ def get(visibility: str, token_info: dict, curator: str = None):
         for cv in collection_versions:
             cv.datasets = [dataset_map[dvid.id] for dvid in cv.datasets if dvid.id in dataset_map]
 
+    # Pre-load all unpublished collection versions in a single batch so reshape_for_curation_api
+    # can look up "revising_in" without issuing a per-collection DB query.  Only needed for
+    # authenticated users (unauthenticated callers never see revising_in).
+    revising_in_map = {}
+    if user_info and not user_info.is_none():
+        for uv in business_logic.database_provider.get_unpublished_collection_versions():
+            cid = uv.collection_id.id
+            # Keep the most-recently-created unpublished version per canonical collection.
+            if cid not in revising_in_map or uv.created_at > revising_in_map[cid].created_at:
+                revising_in_map[cid] = uv
+
     resp_collections = []
     for collection_version in collection_versions:
-        resp_collection = reshape_for_curation_api(collection_version, user_info, preview=True)
+        resp_collection = reshape_for_curation_api(
+            collection_version, user_info, preview=True, revising_in_map=revising_in_map
+        )
         resp_collections.append(resp_collection)
     return jsonify(resp_collections)
 

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -128,6 +128,7 @@ def reshape_for_curation_api(
     user_info: UserInfo = None,
     reshape_for_version_endpoint: bool = False,
     preview: bool = False,
+    revising_in_map: Optional[dict] = None,
 ) -> dict:
     """
     Reshape Collection data for the Curation API response. Remove tombstoned Datasets.
@@ -135,6 +136,11 @@ def reshape_for_curation_api(
     :param user_info:
     :param reshape_for_version_endpoint CollectionVersion is being returned in a version endpoint
     :param preview: bool - whether the dataset is in preview form or not.
+    :param revising_in_map: optional pre-loaded {canonical_collection_id: CollectionVersion} of the
+        most recently created unpublished version per collection. When provided, avoids a per-collection
+        DB call to get_unpublished_collection_version_from_canonical for every published collection the
+        user owns (critical for super curators who own all collections). Callers that omit this fall back
+        to the existing per-collection lookup.
     :return: the response.
     """
     business_logic = get_business_logic()
@@ -149,6 +155,8 @@ def reshape_for_curation_api(
             revision_of = None
             if not user_info or not user_info.is_user_owner_or_allowed(collection_version.owner):
                 _revising_in = None
+            elif revising_in_map is not None:
+                _revising_in = revising_in_map.get(collection_version.collection_id.id)
             else:
                 _revising_in = business_logic.get_unpublished_collection_version_from_canonical(
                     collection_version.collection_id


### PR DESCRIPTION
Pre-load all unpublished collection versions in a single batch before the reshape loop in GET /curation/v1/collections. Pass the resulting {collection_id: CollectionVersion} map to reshape_for_curation_api so it can resolve revising_in without issuing an individual DB query per published collection.

Without this, super curators (who pass is_user_owner_or_allowed() for every collection) triggered ~N round-trips to
get_unpublished_collection_version_from_canonical — one per published collection — causing >120s gateway timeouts when no visibility filter was specified.