### PR TITLE
feat: schema 7.1.0

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -38,7 +38,7 @@ locals {
   backend_wmg_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "${local.backend_wmg_workers}",
     "--bind", "0.0.0.0:5000", "backend.wmg.server.app:app", "--max-requests", "10000", "--timeout", "180",
     "--keep-alive", "61", "--log-level", "info"]    
-  data_load_path               = "s3://${local.secret["s3_buckets"]["env"]["name"]}/database/seed_data_05_09_add_is_pre_analysis.sql"
+  data_load_path               = "s3://${local.secret["s3_buckets"]["env"]["name"]}/database/seed_data_05_11_add_genetic_perturbations.sql"
 
   vpc_id                          = local.secret["cloud_env"]["vpc_id"]
   subnets                         = local.secret["cloud_env"]["private_subnets"]

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -38,7 +38,7 @@ locals {
   backend_wmg_cmd                  = ["gunicorn", "--worker-class", "gevent", "--workers", "${local.backend_wmg_workers}",
     "--bind", "0.0.0.0:5000", "backend.wmg.server.app:app", "--max-requests", "10000", "--timeout", "180",
     "--keep-alive", "61", "--log-level", "info"]    
-  data_load_path               = "s3://${local.secret["s3_buckets"]["env"]["name"]}/database/seed_data_04_2f30f3bcc9aa.sql"
+  data_load_path               = "s3://${local.secret["s3_buckets"]["env"]["name"]}/database/seed_data_05_09_add_is_pre_analysis.sql"
 
   vpc_id                          = local.secret["cloud_env"]["vpc_id"]
   subnets                         = local.secret["cloud_env"]["private_subnets"]

--- a/.happy/terraform/modules/sfn/main.tf
+++ b/.happy/terraform/modules/sfn/main.tf
@@ -162,6 +162,10 @@ resource "aws_sfn_state_machine" "state_machine" {
         "ContainerOverrides": {
           "Environment": [
             {
+              "Name": "MANIFEST",
+              "Value.$": "$.manifest"
+            },
+            {
               "Name": "DATASET_VERSION_ID",
               "Value.$": "$.dataset_version_id"
             },
@@ -214,6 +218,10 @@ resource "aws_sfn_state_machine" "state_machine" {
         "JobQueue.$": "$.job_queue",
         "ContainerOverrides": {
           "Environment": [
+            {
+              "Name": "MANIFEST",
+              "Value.$": "$.manifest"
+            },
             {
               "Name": "DATASET_VERSION_ID",
               "Value.$": "$.dataset_version_id"

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -1167,6 +1167,8 @@ components:
         organism:
           $ref: "#/components/schemas/dataset_organism"
           nullable: true
+        perturbation_types:
+          $ref: "#/components/schemas/perturbation_types"
         processing_status:
           $ref: "#/components/schemas/processing_status_dataset"
         processing_status_detail:
@@ -1276,6 +1278,8 @@ components:
           type: string
         organism:
           $ref: "#/components/schemas/dataset_organism"
+        perturbation_types:
+          $ref: "#/components/schemas/perturbation_types"
         processing_status:
           $ref: "#/components/schemas/processing_status_dataset"
         processing_status_detail:
@@ -1393,6 +1397,8 @@ components:
         organism:
           $ref: "#/components/schemas/dataset_organism"
           nullable: true
+        perturbation_types:
+          $ref: "#/components/schemas/perturbation_types"
         published_at:
           $ref: "#/components/schemas/dataset_version_published_at"
         raw_data_location:
@@ -1488,6 +1494,8 @@ components:
           $ref: "#/components/schemas/dataset_id"
         organism:
           $ref: "#/components/schemas/dataset_organism"
+        perturbation_types:
+          $ref: "#/components/schemas/perturbation_types"
         tissue:
           $ref: "#/components/schemas/dataset_tissue"
         suspension_type:
@@ -1679,6 +1687,16 @@ components:
         published_year:
           type: number
       type: object
+    perturbation_types:
+      description: |
+        List of unique perturbation types present across all observations in the dataset. Values are sourced from
+        obs['perturbation_types'], with 'na' and null values excluded. Items are in ascending lexical order.
+        If the dataset does not contain a 'perturbation_types' obs column, this field is null.
+      type: array
+      items:
+        type: string
+      nullable: true
+      example: ["CRISPR", "ORF"]
     raw_data_location:
       description: Location in dataset's AnnData artifact where raw (i.e. non-normalized) matrix data is stored
       type: string

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -1167,6 +1167,8 @@ components:
         organism:
           $ref: "#/components/schemas/dataset_organism"
           nullable: true
+        genetic_perturbation_strategy:
+          $ref: "#/components/schemas/genetic_perturbation_strategy"
         perturbation_types:
           $ref: "#/components/schemas/perturbation_types"
         processing_status:
@@ -1278,6 +1280,8 @@ components:
           type: string
         organism:
           $ref: "#/components/schemas/dataset_organism"
+        genetic_perturbation_strategy:
+          $ref: "#/components/schemas/genetic_perturbation_strategy"
         perturbation_types:
           $ref: "#/components/schemas/perturbation_types"
         processing_status:
@@ -1397,6 +1401,8 @@ components:
         organism:
           $ref: "#/components/schemas/dataset_organism"
           nullable: true
+        genetic_perturbation_strategy:
+          $ref: "#/components/schemas/genetic_perturbation_strategy"
         perturbation_types:
           $ref: "#/components/schemas/perturbation_types"
         published_at:
@@ -1494,6 +1500,8 @@ components:
           $ref: "#/components/schemas/dataset_id"
         organism:
           $ref: "#/components/schemas/dataset_organism"
+        genetic_perturbation_strategy:
+          $ref: "#/components/schemas/genetic_perturbation_strategy"
         perturbation_types:
           $ref: "#/components/schemas/perturbation_types"
         tissue:
@@ -1687,6 +1695,17 @@ components:
         published_year:
           type: number
       type: object
+    genetic_perturbation_strategy:
+      description: |
+        List of unique genetic perturbation strategies present across all observations in the dataset. Values are
+        sourced from obs['genetic_perturbation_strategy'], with 'no perturbations' and null values excluded. Items
+        are in ascending lexical order. If the dataset does not contain a 'genetic_perturbation_strategy' obs
+        column, this field is null.
+      type: array
+      items:
+        type: string
+      nullable: true
+      example: ["CRISPR", "CRISPRi"]
     perturbation_types:
       description: |
         List of unique perturbation types present across all observations in the dataset. Values are sourced from

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -510,6 +510,34 @@ paths:
         "410":
           $ref: "#/components/responses/410"
 
+  /v1/collections/{collection_id}/datasets/{dataset_id}/genetic_perturbations:
+    get:
+      summary: Fetch the full genetic_perturbations dictionary for a Dataset.
+      description: |
+        Returns the complete `uns['genetic_perturbations']` dictionary for the Dataset, keyed by perturbation ID.
+        If the Dataset was not processed from a file containing `uns['genetic_perturbations']`, the
+        `genetic_perturbations` field in the response will be `null`.
+      operationId: backend.curation.api.v1.curation.collections.collection_id.datasets.dataset_id.genetic_perturbations.actions.get
+      tags:
+        - Collection
+      parameters:
+        - $ref: "#/components/parameters/path_collection_id"
+        - $ref: "#/components/parameters/path_dataset_id"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  genetic_perturbations:
+                    $ref: "#/components/schemas/genetic_perturbations_dict"
+        "404":
+          $ref: "#/components/responses/404"
+        "410":
+          $ref: "#/components/responses/410"
+
   /v1/collections/{collection_id}/datasets/{dataset_id}/manifest:
     get:
       summary: Get manifest for a dataset
@@ -1695,6 +1723,43 @@ components:
         published_year:
           type: number
       type: object
+    genetic_perturbation_entry:
+      description: |
+        Metadata for a single genetic perturbation, as defined in uns['genetic_perturbations'] per the
+        CELLxGENE schema.
+      type: object
+      properties:
+        role:
+          type: string
+          description: The role of the perturbation (e.g. "KO", "overexpression").
+        protospacer_sequence:
+          type: string
+          nullable: true
+          description: The protospacer sequence for CRISPR-based perturbations.
+        protospacer_adjacent_motif:
+          type: string
+          nullable: true
+          description: The PAM sequence for the protospacer.
+        derived_genomic_regions:
+          type: array
+          items:
+            type: string
+          description: Genomic regions derived from this perturbation.
+        derived_features:
+          type: object
+          additionalProperties:
+            type: string
+          description: Map of feature IDs to feature names derived from this perturbation.
+      required:
+        - role
+    genetic_perturbations_dict:
+      description: |
+        The full uns['genetic_perturbations'] dictionary from the dataset, keyed by perturbation ID.
+        Each value is a genetic_perturbation_entry. Null if the dataset has no genetic perturbations data.
+      nullable: true
+      type: object
+      additionalProperties:
+        $ref: "#/components/schemas/genetic_perturbation_entry"
     genetic_perturbation_strategy:
       description: |
         List of unique genetic perturbation strategies present across all observations in the dataset. Values are

--- a/backend/curation/api/curation-api.yml
+++ b/backend/curation/api/curation-api.yml
@@ -733,6 +733,18 @@ paths:
       parameters:
         - $ref: "#/components/parameters/schema_version"
         - $ref: "#/components/parameters/dataset_visibility"
+        - name: analysis
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - pre-analysis
+              - post-analysis
+          description: |
+            Filter datasets by analysis type.
+            - `pre-analysis`: return only datasets belonging to collections where `is_pre_analysis` is True.
+            - `post-analysis`: return only datasets belonging to collections where `is_pre_analysis` is False.
       responses:
         "200":
           description: OK
@@ -847,7 +859,7 @@ components:
           $ref: "#/components/schemas/collection_id"
         collection_url:
           description: |
-            The CELLxGENE Discover URL for the Collection. This points to the canonical link unless it's a revision, 
+            The CELLxGENE Discover URL for the Collection. This points to the canonical link unless it's a revision,
             in which case it points to the unpublished revision version.
           type: string
         collection_version_id:
@@ -871,6 +883,8 @@ components:
           $ref: "#/components/schemas/collection_description"
         doi:
           $ref: "#/components/schemas/doi"
+        is_pre_analysis:
+          $ref: "#/components/schemas/is_pre_analysis"
         links:
           $ref: "#/components/schemas/links"
         name:
@@ -893,6 +907,13 @@ components:
     collection_url:
       description: The CELLxGENE Discover URL for the Collection.
       type: string
+    is_pre_analysis:
+      description: |
+        Indicates whether this Collection contains pre-analysis datasets. When True, the CXG conversion
+        step is skipped and the pre-analysis flag is passed to the validator and label appender.
+        This value is set at collection creation and cannot be changed afterwards.
+      type: boolean
+      default: false
     consortia:
       type: array
       items:
@@ -987,6 +1008,8 @@ components:
           $ref: "#/components/schemas/collection_description"
         doi:
           $ref: "#/components/schemas/doi"
+        is_pre_analysis:
+          $ref: "#/components/schemas/is_pre_analysis"
         links:
           $ref: "#/components/schemas/links"
         name:
@@ -1034,6 +1057,8 @@ components:
           $ref: "#/components/schemas/collection_description"
         doi:
           $ref: "#/components/schemas/doi"
+        is_pre_analysis:
+          $ref: "#/components/schemas/is_pre_analysis"
         links:
           $ref: "#/components/schemas/links"
         name:
@@ -1057,6 +1082,8 @@ components:
           $ref: "#/components/schemas/collection_description"
         doi:
           $ref: "#/components/schemas/doi"
+        is_pre_analysis:
+          $ref: "#/components/schemas/is_pre_analysis"
         links:
           $ref: "#/components/schemas/links"
         name:
@@ -1125,6 +1152,8 @@ components:
           $ref: "#/components/schemas/feature_count"
         feature_reference:
           $ref: "#/components/schemas/feature_reference"
+        is_pre_analysis:
+          $ref: "#/components/schemas/is_pre_analysis"
         is_primary_data:
           $ref: "#/components/schemas/is_primary_data"
         mean_genes_per_cell:
@@ -1233,6 +1262,8 @@ components:
           $ref: "#/components/schemas/donor_id"
         explorer_url:
           $ref: "#/components/schemas/explorer_url"
+        is_pre_analysis:
+          $ref: "#/components/schemas/is_pre_analysis"
         is_primary_data:
           $ref: "#/components/schemas/is_primary_data"
         mean_genes_per_cell:

--- a/backend/curation/api/v1/curation/collections/actions.py
+++ b/backend/curation/api/v1/curation/collections/actions.py
@@ -98,8 +98,12 @@ def post(body: dict, token_info: dict):
         body.get("consortia", []),
     )
 
+    is_pre_analysis = body.get("is_pre_analysis", False)
+
     try:
-        version = get_business_logic().create_collection(token_info["sub"], token_info["curator_name"], metadata)
+        version = get_business_logic().create_collection(
+            token_info["sub"], token_info["curator_name"], metadata, is_pre_analysis=is_pre_analysis
+        )
     except InvalidMetadataException as ex:
         errors.extend(ex.errors)
     except CollectionCreationException as ex:

--- a/backend/curation/api/v1/curation/collections/collection_id/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/actions.py
@@ -51,6 +51,9 @@ def get(collection_id: str, token_info: dict) -> Response:
 def patch(collection_id: str, body: dict, token_info: dict) -> Response:
     user_info = UserInfo(token_info)
 
+    if "is_pre_analysis" in body:
+        raise MethodNotAllowedException(detail="'is_pre_analysis' cannot be modified after collection creation.")
+
     if "links" in body and not body["links"]:
         raise InvalidParametersHTTPException(detail="If provided, the 'links' array may not be empty")
 

--- a/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/actions.py
@@ -38,7 +38,9 @@ def get(collection_id: str, dataset_id: str = None):
     # 2. the collection version is published
     use_canonical_url = collection_version.is_initial_unpublished_version() or collection_version.is_published()
 
-    response_body = reshape_dataset_for_curation_api(dataset_version, use_canonical_url)
+    response_body = reshape_dataset_for_curation_api(
+        dataset_version, use_canonical_url, is_pre_analysis=collection_version.is_pre_analysis
+    )
     return make_response(jsonify(response_body), 200)
 
 

--- a/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/genetic_perturbations/actions.py
+++ b/backend/curation/api/v1/curation/collections/collection_id/datasets/dataset_id/genetic_perturbations/actions.py
@@ -1,0 +1,10 @@
+from flask import jsonify, make_response
+
+from backend.curation.api.v1.curation.collections.common import _get_collection_and_dataset
+from backend.portal.api.providers import get_business_logic
+
+
+def get(collection_id: str, dataset_id: str):
+    _, dataset_version = _get_collection_and_dataset(collection_id, dataset_id)
+    gp_metadata = get_business_logic().get_dataset_genetic_perturbations(dataset_version.version_id)
+    return make_response(jsonify({"genetic_perturbations": gp_metadata.to_dict() if gp_metadata else None}), 200)

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -302,6 +302,8 @@ def reshape_dataset_for_curation_api(
     ds["dataset_id"] = dataset_version.dataset_id.id
     ds["dataset_version_id"] = dataset_version.version_id.id
     ds["is_pre_analysis"] = is_pre_analysis
+    if dataset_version.metadata is not None:
+        ds["perturbation_types"] = ds.get("perturbation_types")
     # Get none preview specific dataset fields
     if not preview:
         ds["assets"] = extract_dataset_assets(dataset_version)
@@ -436,6 +438,7 @@ class EntityColumns:
         "assay",
         "disease",
         "organism",
+        "perturbation_types",
         "suspension_type",
     ]
 
@@ -456,6 +459,7 @@ class EntityColumns:
         "donor_id",
         "citation",
         "spatial",
+        "perturbation_types",
     ]
 
     dataset_metadata_cols = [

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -303,6 +303,7 @@ def reshape_dataset_for_curation_api(
     ds["dataset_version_id"] = dataset_version.version_id.id
     ds["is_pre_analysis"] = is_pre_analysis
     if dataset_version.metadata is not None:
+        ds["genetic_perturbation_strategy"] = ds.get("genetic_perturbation_strategy")
         ds["perturbation_types"] = ds.get("perturbation_types")
     # Get none preview specific dataset fields
     if not preview:
@@ -438,6 +439,7 @@ class EntityColumns:
         "assay",
         "disease",
         "organism",
+        "genetic_perturbation_strategy",
         "perturbation_types",
         "suspension_type",
     ]

--- a/backend/curation/api/v1/curation/collections/common.py
+++ b/backend/curation/api/v1/curation/collections/common.py
@@ -197,6 +197,7 @@ def reshape_for_curation_api(
             preview,
             as_version=reshape_for_version_endpoint,
             is_published=is_published,
+            is_pre_analysis=collection_version.is_pre_analysis,
         ),
         key=lambda d: d["dataset_id"],  # For stable ordering
         reverse=True,  # To stay consistent with Datasets index endpoint sorting
@@ -215,6 +216,7 @@ def reshape_for_curation_api(
         curator_name=collection_version.curator_name,
         description=collection_version.metadata.description,
         doi=doi,
+        is_pre_analysis=collection_version.is_pre_analysis,
         links=links,
         name=collection_version.metadata.name,
         published_at=published_at,
@@ -241,6 +243,7 @@ def reshape_datasets_for_curation_api(
     preview: bool = False,
     as_version: bool = False,
     is_published: bool = False,
+    is_pre_analysis: bool = False,
 ) -> List[dict]:
     business_logic = get_business_logic()
     active_datasets = []
@@ -255,7 +258,12 @@ def reshape_datasets_for_curation_api(
         dataset_versions.extend(business_logic.database_provider.get_dataset_versions_by_id(dataset_version_ids))
     for dv in dataset_versions:
         reshaped_dataset = reshape_dataset_for_curation_api(
-            dv, use_canonical_url, preview, as_canonical=not as_version, is_published=is_published
+            dv,
+            use_canonical_url,
+            preview,
+            as_canonical=not as_version,
+            is_published=is_published,
+            is_pre_analysis=is_pre_analysis,
         )
         active_datasets.append(reshaped_dataset)
     return active_datasets
@@ -268,6 +276,7 @@ def reshape_dataset_for_curation_api(
     index=False,
     as_canonical=True,
     is_published=False,
+    is_pre_analysis: bool = False,
 ) -> dict:
     ds = dict()
     # Determine what columns to include from the dataset
@@ -292,6 +301,7 @@ def reshape_dataset_for_curation_api(
 
     ds["dataset_id"] = dataset_version.dataset_id.id
     ds["dataset_version_id"] = dataset_version.version_id.id
+    ds["is_pre_analysis"] = is_pre_analysis
     # Get none preview specific dataset fields
     if not preview:
         ds["assets"] = extract_dataset_assets(dataset_version)
@@ -340,7 +350,12 @@ def reshape_dataset_for_curation_datasets_index_api(
     # Create base dataset response shape. use_canonical is true only for datasets with a visibility of
     # public; for datasets with a visibility of private, corresponding fields are calculated below.
     is_dataset_visibility_public = visibility == Visibility.PUBLIC.name
-    ds = reshape_dataset_for_curation_api(dataset_version, index=True, use_canonical_url=is_dataset_visibility_public)
+    ds = reshape_dataset_for_curation_api(
+        dataset_version,
+        index=True,
+        use_canonical_url=is_dataset_visibility_public,
+        is_pre_analysis=collection_version.is_pre_analysis,
+    )
 
     # Add visibility and revision-specific fields.
     ds["visibility"] = visibility
@@ -407,6 +422,7 @@ class EntityColumns:
         "datasets",
         "revising_in",
         "consortia",
+        "is_pre_analysis",
     ]
 
     link_cols = [

--- a/backend/curation/api/v1/curation/datasets/actions.py
+++ b/backend/curation/api/v1/curation/datasets/actions.py
@@ -7,13 +7,19 @@ from backend.layers.common.entities import Visibility
 from backend.portal.api.providers import get_business_logic
 
 
-def get(token_info: dict, schema_version: str = None, visibility: str = None):
+def get(token_info: dict, schema_version: str = None, visibility: str = None, analysis: str = None):
     """
     Datasets index endpoint to retrieve full metadata. Only return Dataset data for which the curator is authorized.
     :param token_info: access token info.
     :param schema_version: the schema version to filter the datasets by, PUBLIC Datasets only.
     :param visibility: the Visibility in string form.
+    :param analysis: filter by analysis type: "pre-analysis" (is_pre_analysis=True) or
+                     "post-analysis" (is_pre_analysis=False). If not provided, all datasets are returned.
     """
+    if analysis is not None and analysis not in ("pre-analysis", "post-analysis"):
+        raise InvalidParametersHTTPException(
+            detail="Invalid analysis parameter. Must be 'pre-analysis' or 'post-analysis'."
+        )
 
     # Handle retrieval of private datasets.
     if visibility == Visibility.PRIVATE.name:
@@ -44,9 +50,13 @@ def get(token_info: dict, schema_version: str = None, visibility: str = None):
             schema_version
         )
 
-    # Shape datasets for response.
+    # Shape datasets for response, applying optional analysis filter.
     all_datasets_with_collection_name_and_doi = []
     for collection in collections_with_datasets:
+        if analysis == "pre-analysis" and not collection.is_pre_analysis:
+            continue
+        if analysis == "post-analysis" and collection.is_pre_analysis:
+            continue
         for dataset in collection.datasets:
             dataset_response_obj = reshape_dataset_for_curation_datasets_index_api(visibility, collection, dataset)
             all_datasets_with_collection_name_and_doi.append(dataset_response_obj)

--- a/backend/database/versions/09_add_is_pre_analysis.py
+++ b/backend/database/versions/09_add_is_pre_analysis.py
@@ -1,0 +1,28 @@
+"""add is_pre_analysis flag to CollectionVersion
+
+Revision ID: 09_add_is_pre_analysis
+Revises: 08_92c817dddc7d
+Create Date: 2026-04-07
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "09_add_is_pre_analysis"
+down_revision = "08_92c817dddc7d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "CollectionVersion",
+        sa.Column("is_pre_analysis", sa.BOOLEAN(), nullable=True),
+        schema="persistence_schema",
+    )
+
+
+def downgrade():
+    op.drop_column("CollectionVersion", "is_pre_analysis", schema="persistence_schema")

--- a/backend/database/versions/10_add_genetic_perturbations.py
+++ b/backend/database/versions/10_add_genetic_perturbations.py
@@ -1,0 +1,30 @@
+"""add genetic_perturbations column to DatasetVersion
+
+Revision ID: 10_add_genetic_perturbations
+Revises: 09_add_is_pre_analysis
+Create Date: 2026-04-09
+
+Stores the full uns['genetic_perturbations'] dictionary as a separate nullable JSON column
+to avoid bloating the existing dataset_metadata column (~6.5 MB serialized per perturbation dataset).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "10_add_genetic_perturbations"
+down_revision = "09_add_is_pre_analysis"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "DatasetVersion",
+        sa.Column("genetic_perturbations", sa.JSON(), nullable=True),
+        schema="persistence_schema",
+    )
+
+
+def downgrade():
+    op.drop_column("DatasetVersion", "genetic_perturbations", schema="persistence_schema")

--- a/backend/database/versions/10_add_is_pre_analysis.py
+++ b/backend/database/versions/10_add_is_pre_analysis.py
@@ -1,7 +1,7 @@
 """add is_pre_analysis flag to CollectionVersion
 
-Revision ID: 09_add_is_pre_analysis
-Revises: 08_92c817dddc7d
+Revision ID: 10_add_is_pre_analysis
+Revises: 09_add_artifact_filesize
 Create Date: 2026-04-07
 
 """
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "09_add_is_pre_analysis"
-down_revision = "08_92c817dddc7d"
+revision = "10_add_is_pre_analysis"
+down_revision = "09_add_artifact_filesize"
 branch_labels = None
 depends_on = None
 

--- a/backend/database/versions/11_add_genetic_perturbations.py
+++ b/backend/database/versions/11_add_genetic_perturbations.py
@@ -1,7 +1,7 @@
 """add genetic_perturbations column to DatasetVersion
 
-Revision ID: 10_add_genetic_perturbations
-Revises: 09_add_is_pre_analysis
+Revision ID: 11_add_genetic_perturbations
+Revises: 10_add_is_pre_analysis
 Create Date: 2026-04-09
 
 Stores the full uns['genetic_perturbations'] dictionary as a separate nullable JSON column
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "10_add_genetic_perturbations"
-down_revision = "09_add_is_pre_analysis"
+revision = "11_add_genetic_perturbations"
+down_revision = "10_add_is_pre_analysis"
 branch_labels = None
 depends_on = None
 

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -74,6 +74,7 @@ from backend.layers.common.entities import (
     DatasetValidationStatus,
     DatasetVersion,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
     Link,
     PrivateDatasetVersion,
     PublishedDatasetVersion,
@@ -776,6 +777,22 @@ class BusinessLogic(BusinessLogicInterface):
         Sets the metadata for a dataset version
         """
         self.database_provider.set_dataset_metadata(dataset_version_id, metadata)
+
+    def set_dataset_genetic_perturbations(
+        self, dataset_version_id: DatasetVersionId, genetic_perturbations: Optional[GeneticPerturbationMetadata]
+    ) -> None:
+        """
+        Sets the genetic_perturbations for a dataset version
+        """
+        self.database_provider.set_dataset_genetic_perturbations(dataset_version_id, genetic_perturbations)
+
+    def get_dataset_genetic_perturbations(
+        self, dataset_version_id: DatasetVersionId
+    ) -> Optional[GeneticPerturbationMetadata]:
+        """
+        Returns the genetic_perturbations for a dataset version, or None if not present
+        """
+        return self.database_provider.get_dataset_genetic_perturbations(dataset_version_id)
 
     def update_dataset_artifact_metadata(
         self,

--- a/backend/layers/business/business.py
+++ b/backend/layers/business/business.py
@@ -218,7 +218,11 @@ class BusinessLogic(BusinessLogicInterface):
         return None, None, None
 
     def create_collection(
-        self, owner: str, curator_name: str, collection_metadata: CollectionMetadata
+        self,
+        owner: str,
+        curator_name: str,
+        collection_metadata: CollectionMetadata,
+        is_pre_analysis: bool = False,
     ) -> CollectionVersion:
         """
         Creates a collection using the specified metadata. If a DOI is defined, will also
@@ -244,7 +248,9 @@ class BusinessLogic(BusinessLogicInterface):
         if errors:
             raise CollectionCreationException(errors)
 
-        created_version = self.database_provider.create_canonical_collection(owner, curator_name, collection_metadata)
+        created_version = self.database_provider.create_canonical_collection(
+            owner, curator_name, collection_metadata, is_pre_analysis=is_pre_analysis
+        )
 
         # TODO: can collapse with `create_canonical_collection`
         if publisher_metadata:
@@ -622,8 +628,9 @@ class BusinessLogic(BusinessLogicInterface):
 
         # Validate the URIs
         # TODO: This should be done in the IngestionManifest class
+        _NON_URI_MANIFEST_FIELDS = {"flags", "is_pre_analysis"}
         for key, _url in manifest.model_dump(exclude_none=True).items():
-            if key == "flags":
+            if key in _NON_URI_MANIFEST_FIELDS:
                 continue
             _url = str(_url)
             if not self.uri_provider.validate(_url):
@@ -675,6 +682,10 @@ class BusinessLogic(BusinessLogicInterface):
 
         # Ensure that the collection exists and is not published
         collection = self._assert_collection_version_unpublished(collection_version_id)
+
+        # Propagate collection's is_pre_analysis flag into the manifest so the processing
+        # pipeline can conditionally skip the CXG step and pass the flag to validators.
+        manifest.is_pre_analysis = collection.is_pre_analysis
 
         # Creates a dataset version that the processing pipeline will point to
         new_dataset_version: DatasetVersion

--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -22,6 +22,7 @@ from backend.layers.common.entities import (
     DatasetStatusKey,
     DatasetVersion,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
     PublishedDatasetVersion,
 )
 from backend.layers.common.ingestion_manifest import IngestionManifest
@@ -153,6 +154,16 @@ class BusinessLogicInterface:
         pass
 
     def set_dataset_metadata(self, dataset_version_id: DatasetVersionId, metadata: DatasetMetadata) -> None:
+        pass
+
+    def set_dataset_genetic_perturbations(
+        self, dataset_version_id: DatasetVersionId, genetic_perturbations: Optional[GeneticPerturbationMetadata]
+    ) -> None:
+        pass
+
+    def get_dataset_genetic_perturbations(
+        self, dataset_version_id: DatasetVersionId
+    ) -> Optional[GeneticPerturbationMetadata]:
         pass
 
     def get_dataset_artifacts(self, dataset_version_id: DatasetVersionId) -> Iterable[DatasetArtifact]:

--- a/backend/layers/business/business_interface.py
+++ b/backend/layers/business/business_interface.py
@@ -67,7 +67,11 @@ class BusinessLogicInterface:
         pass
 
     def create_collection(
-        self, owner: str, curator_name: str, collection_metadata: CollectionMetadata
+        self,
+        owner: str,
+        curator_name: str,
+        collection_metadata: CollectionMetadata,
+        is_pre_analysis: bool = False,
     ) -> CollectionVersion:
         pass
 

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -2,7 +2,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
 from dataclasses_json import dataclass_json
@@ -195,6 +195,33 @@ class TissueOntologyTermId(OntologyTermId):
 class SpatialMetadata:
     is_single: bool
     has_fullres: bool
+
+
+@dataclass_json
+@dataclass
+class GeneticPerturbationEntry:
+    role: str
+    protospacer_sequence: Optional[str] = None
+    protospacer_adjacent_motif: Optional[str] = None
+    derived_genomic_regions: List[str] = field(default_factory=list)
+    derived_features: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class GeneticPerturbationMetadata:
+    """
+    Typed container for uns['genetic_perturbations'].
+    Top-level keys are perturbation IDs; values are GeneticPerturbationEntry instances.
+    """
+
+    perturbations: Dict[str, GeneticPerturbationEntry]
+
+    def to_dict(self) -> dict:
+        return {pid: entry.to_dict() for pid, entry in self.perturbations.items()}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "GeneticPerturbationMetadata":
+        return cls(perturbations={pid: GeneticPerturbationEntry.from_dict(v) for pid, v in data.items()})
 
 
 @dataclass_json

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -226,6 +226,7 @@ class DatasetMetadata:
     raw_data_location: Optional[str] = None
     primary_cell_count: Optional[int] = None
     spatial: Optional[SpatialMetadata] = None
+    perturbation_types: Optional[List[str]] = None
 
 
 @dataclass

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -325,6 +325,7 @@ class CollectionVersionBase:
     has_custom_dataset_order: bool
     is_auto_version: Optional[bool]
     data_submission_policy_version: str
+    is_pre_analysis: bool = False
 
     def is_published(self) -> bool:
         """
@@ -351,19 +352,19 @@ class CollectionVersionBase:
 
 @dataclass
 class CollectionVersion(CollectionVersionBase):
-    datasets: List[DatasetVersionId]
+    datasets: List[DatasetVersionId] = field(default_factory=list)
 
 
 @dataclass
 class CollectionVersionWithDatasets(CollectionVersionBase):
-    datasets: List[DatasetVersion]
+    datasets: List[DatasetVersion] = field(default_factory=list)
 
 
 @dataclass
 class CollectionVersionWithPublishedDatasets(CollectionVersionBase):
-    datasets: List[PublishedDatasetVersion]
+    datasets: List[PublishedDatasetVersion] = field(default_factory=list)
 
 
 @dataclass
 class CollectionVersionWithPrivateDatasets(CollectionVersionBase):
-    datasets: List[PrivateDatasetVersion]
+    datasets: List[PrivateDatasetVersion] = field(default_factory=list)

--- a/backend/layers/common/entities.py
+++ b/backend/layers/common/entities.py
@@ -227,6 +227,7 @@ class DatasetMetadata:
     primary_cell_count: Optional[int] = None
     spatial: Optional[SpatialMetadata] = None
     perturbation_types: Optional[List[str]] = None
+    genetic_perturbation_strategy: Optional[List[str]] = None
 
 
 @dataclass

--- a/backend/layers/common/ingestion_manifest.py
+++ b/backend/layers/common/ingestion_manifest.py
@@ -1,7 +1,11 @@
+import json
 import re
 from typing import Optional, Union
 
+import pydantic
 from pydantic import AnyUrl, BaseModel, HttpUrl
+
+_PYDANTIC_V1 = int(pydantic.VERSION.split(".")[0]) < 2
 
 
 class S3Url(AnyUrl):
@@ -36,3 +40,33 @@ class IngestionManifest(BaseModel):
 
     anndata: Union[HttpUrl, S3Url]
     atac_fragment: Optional[Union[HttpUrl, S3Url]] = None  # Optional field
+    is_pre_analysis: bool = False
+
+
+if _PYDANTIC_V1:
+    # Add pydantic v2-compatible methods when running under pydantic v1.
+    # This allows the codebase to use the pydantic v2 API uniformly.
+
+    def _model_dump(self, exclude_none: bool = False, **kwargs):
+        raw = self.dict(**kwargs)
+        if exclude_none:
+            raw = {k: v for k, v in raw.items() if v is not None}
+        return raw
+
+    def _model_dump_json(self, **kwargs) -> str:
+        # Serialize URL types to strings, keep None/bool as-is for valid JSON output
+        d = {}
+        for k, v in self.dict().items():
+            if isinstance(v, bool) or v is None:
+                d[k] = v
+            else:
+                d[k] = str(v)
+        return json.dumps(d, separators=(",", ":"))
+
+    @classmethod
+    def _model_validate_json(cls, json_str: str) -> "IngestionManifest":
+        return cls.parse_raw(json_str)
+
+    IngestionManifest.model_dump = _model_dump
+    IngestionManifest.model_dump_json = _model_dump_json
+    IngestionManifest.model_validate_json = classmethod(_model_validate_json.__func__)

--- a/backend/layers/persistence/orm.py
+++ b/backend/layers/persistence/orm.py
@@ -59,6 +59,7 @@ class DatasetVersionTable:
     collection_id = Column(UUID(as_uuid=True))
     created_at = Column(DateTime)
     dataset_metadata = Column(JSON)
+    genetic_perturbations = Column(JSON)
     artifacts = Column(ARRAY(UUID(as_uuid=True)))
     status = Column(JSON)
 

--- a/backend/layers/persistence/orm.py
+++ b/backend/layers/persistence/orm.py
@@ -37,6 +37,7 @@ class CollectionVersionTable:
     has_custom_dataset_order = Column(BOOLEAN)
     is_auto_version = Column(BOOLEAN)
     data_submission_policy_version = Column(String)
+    is_pre_analysis = Column(BOOLEAN)
 
 
 @mapper_registry.mapped

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -120,6 +120,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             has_custom_dataset_order=row.has_custom_dataset_order,
             is_auto_version=row.is_auto_version,
             data_submission_policy_version=row.data_submission_policy_version,
+            is_pre_analysis=bool(row.is_pre_analysis) if row.is_pre_analysis is not None else False,
         )
 
     def _row_to_collection_version_with_datasets(
@@ -142,6 +143,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             has_custom_dataset_order=row.has_custom_dataset_order,
             is_auto_version=row.is_auto_version,
             data_submission_policy_version=row.data_submission_policy_version,
+            is_pre_analysis=bool(row.is_pre_analysis) if row.is_pre_analysis is not None else False,
         )
 
     def _row_to_canonical_dataset(self, row: Any):
@@ -226,7 +228,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             )
 
     def create_canonical_collection(
-        self, owner: str, curator_name: str, collection_metadata: CollectionMetadata
+        self, owner: str, curator_name: str, collection_metadata: CollectionMetadata, is_pre_analysis: bool = False
     ) -> CollectionVersion:
         """
         Creates a new canonical collection, generating a canonical collection_id and a new version_id.
@@ -253,6 +255,7 @@ class DatabaseProvider(DatabaseProviderInterface):
             has_custom_dataset_order=False,
             is_auto_version=False,
             data_submission_policy_version=None,
+            is_pre_analysis=is_pre_analysis,
         )
 
         with self._manage_session() as session:
@@ -653,6 +656,7 @@ class DatabaseProvider(DatabaseProviderInterface):
                 has_custom_dataset_order=current_version.has_custom_dataset_order,
                 is_auto_version=is_auto_version,
                 data_submission_policy_version=None,
+                is_pre_analysis=current_version.is_pre_analysis,
             )
             session.add(new_version)
             return CollectionVersionId(new_version_id)

--- a/backend/layers/persistence/persistence.py
+++ b/backend/layers/persistence/persistence.py
@@ -36,6 +36,7 @@ from backend.layers.common.entities import (
     DatasetValidationStatus,
     DatasetVersion,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
 )
 from backend.layers.common.helpers import set_revised_at_field, sort_datasets_by_cell_count
 from backend.layers.persistence.constants import SCHEMA_NAME
@@ -1103,6 +1104,26 @@ class DatabaseProvider(DatabaseProviderInterface):
         with self._manage_session() as session:
             dataset_version = session.query(DatasetVersionTable).filter_by(id=version_id.id).one()
             dataset_version.dataset_metadata = metadata.to_dict()
+
+    def set_dataset_genetic_perturbations(
+        self, version_id: DatasetVersionId, genetic_perturbations: Optional[GeneticPerturbationMetadata]
+    ) -> None:
+        """
+        Sets the genetic_perturbations for a dataset version
+        """
+        with self._manage_session() as session:
+            dataset_version = session.query(DatasetVersionTable).filter_by(id=version_id.id).one()
+            dataset_version.genetic_perturbations = genetic_perturbations.to_dict() if genetic_perturbations else None
+
+    def get_dataset_genetic_perturbations(self, version_id: DatasetVersionId) -> Optional[GeneticPerturbationMetadata]:
+        """
+        Returns the genetic_perturbations for a dataset version, or None if not present
+        """
+        with self._manage_session() as session:
+            result = session.query(DatasetVersionTable.genetic_perturbations).filter_by(id=version_id.id).one_or_none()
+        if result is None or result[0] is None:
+            return None
+        return GeneticPerturbationMetadata.from_dict(result[0])
 
     def add_dataset_to_collection_version_mapping(
         self, collection_version_id: CollectionVersionId, dataset_version_id: DatasetVersionId

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -29,7 +29,7 @@ class PersistenceException(Exception):
 
 class DatabaseProviderInterface:
     def create_canonical_collection(
-        self, owner: str, curator_name: str, collection_metadata: CollectionMetadata
+        self, owner: str, curator_name: str, collection_metadata: CollectionMetadata, is_pre_analysis: bool = False
     ) -> CollectionVersion:
         """
         Creates a new canonical collection, generating a canonical collection_id and a new version_id.

--- a/backend/layers/persistence/persistence_interface.py
+++ b/backend/layers/persistence/persistence_interface.py
@@ -20,6 +20,7 @@ from backend.layers.common.entities import (
     DatasetValidationStatus,
     DatasetVersion,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
 )
 
 
@@ -310,6 +311,18 @@ class DatabaseProviderInterface:
     def set_dataset_metadata(self, version_id: DatasetVersionId, metadata: DatasetMetadata) -> None:
         """
         Sets the metadata for a dataset version
+        """
+
+    def set_dataset_genetic_perturbations(
+        self, version_id: DatasetVersionId, genetic_perturbations: Optional[GeneticPerturbationMetadata]
+    ) -> None:
+        """
+        Sets the genetic_perturbations for a dataset version
+        """
+
+    def get_dataset_genetic_perturbations(self, version_id: DatasetVersionId) -> Optional[GeneticPerturbationMetadata]:
+        """
+        Returns the genetic_perturbations for a dataset version, or None if not present
         """
 
     def add_dataset_to_collection_version_mapping(

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -65,7 +65,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
 
     # TODO: add publisher_metadata here?
     def create_canonical_collection(
-        self, owner: str, curator_name: str, collection_metadata: CollectionMetadata
+        self, owner: str, curator_name: str, collection_metadata: CollectionMetadata, is_pre_analysis: bool = False
     ) -> CollectionVersion:
         collection_id = CollectionId()
         version_id = CollectionVersionId()
@@ -85,6 +85,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             has_custom_dataset_order=False,
             is_auto_version=False,
             data_submission_policy_version=None,
+            is_pre_analysis=is_pre_analysis,
         )
         self.collections_versions[version_id.id] = version
         # Don't set mappings here - those will be set when publishing the collection!
@@ -238,6 +239,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
             has_custom_dataset_order=current_version.has_custom_dataset_order,
             is_auto_version=is_auto_version,
             data_submission_policy_version=None,
+            is_pre_analysis=current_version.is_pre_analysis,
         )
         self.collections_versions[new_version_id.id] = collection_version
         return new_version_id

--- a/backend/layers/persistence/persistence_mock.py
+++ b/backend/layers/persistence/persistence_mock.py
@@ -23,6 +23,7 @@ from backend.layers.common.entities import (
     DatasetValidationStatus,
     DatasetVersion,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
 )
 from backend.layers.common.helpers import sort_datasets_by_cell_count
 from backend.layers.persistence.persistence import DatabaseProviderInterface
@@ -55,6 +56,9 @@ class DatabaseProviderMock(DatabaseProviderInterface):
     # Dataset artifacts
     dataset_artifacts: Dict[str, DatasetArtifact]
 
+    # genetic_perturbations keyed by dataset_version_id
+    dataset_genetic_perturbations: Dict[str, Optional[GeneticPerturbationMetadata]]
+
     def __init__(self) -> None:
         super().__init__()
         self.collections = {}  # rename to: active_collections
@@ -62,6 +66,7 @@ class DatabaseProviderMock(DatabaseProviderInterface):
         self.datasets = {}  # rename to: active_datasets
         self.datasets_versions = {}
         self.dataset_artifacts = {}
+        self.dataset_genetic_perturbations = {}
 
     # TODO: add publisher_metadata here?
     def create_canonical_collection(
@@ -614,6 +619,14 @@ class DatabaseProviderMock(DatabaseProviderInterface):
     def set_dataset_metadata(self, version_id: DatasetVersionId, metadata: DatasetMetadata) -> None:
         version = self.datasets_versions[version_id.id]
         version.metadata = copy.deepcopy(metadata)
+
+    def set_dataset_genetic_perturbations(
+        self, version_id: DatasetVersionId, genetic_perturbations: Optional[GeneticPerturbationMetadata]
+    ) -> None:
+        self.dataset_genetic_perturbations[version_id.id] = copy.deepcopy(genetic_perturbations)
+
+    def get_dataset_genetic_perturbations(self, version_id: DatasetVersionId) -> Optional[GeneticPerturbationMetadata]:
+        return copy.deepcopy(self.dataset_genetic_perturbations.get(version_id.id))
 
     def update_dataset_processing_status(self, version_id: DatasetVersionId, status: DatasetProcessingStatus) -> None:
         dataset_version = self.datasets_versions[version_id.id]

--- a/backend/layers/processing/process.py
+++ b/backend/layers/processing/process.py
@@ -107,6 +107,7 @@ class ProcessMain(ProcessingLogic):
         Gets called by the step function at every different step, as defined by `step_name`
         """
         self.logger.info(f"Processing dataset version {dataset_version_id}", extra={"step_name": step_name})
+        is_pre_analysis = manifest.is_pre_analysis if manifest is not None else False
         try:
             if step_name == "validate_anndata":
                 self.process_validate_h5ad.process(dataset_version_id, manifest, artifact_bucket)
@@ -119,12 +120,28 @@ class ProcessMain(ProcessingLogic):
                 )
             elif step_name == "add_labels":
                 self.process_add_labels.process(
-                    collection_version_id, dataset_version_id, artifact_bucket, datasets_bucket
+                    collection_version_id,
+                    dataset_version_id,
+                    artifact_bucket,
+                    datasets_bucket,
+                    is_pre_analysis=is_pre_analysis,
                 )
             elif step_name == "cxg":
-                self.process_cxg.process(dataset_version_id, artifact_bucket, cxg_bucket)
+                if is_pre_analysis:
+                    self.logger.info(f"Skipping CXG conversion for pre-analysis dataset {dataset_version_id}")
+                    self.update_processing_status(
+                        dataset_version_id, DatasetStatusKey.CXG, DatasetConversionStatus.SKIPPED
+                    )
+                else:
+                    self.process_cxg.process(dataset_version_id, artifact_bucket, cxg_bucket)
             elif step_name == "cxg_remaster":
-                self.process_cxg.process(dataset_version_id, artifact_bucket, cxg_bucket, is_reprocess=True)
+                if is_pre_analysis:
+                    self.logger.info(f"Skipping CXG remaster for pre-analysis dataset {dataset_version_id}")
+                    self.update_processing_status(
+                        dataset_version_id, DatasetStatusKey.CXG, DatasetConversionStatus.SKIPPED
+                    )
+                else:
+                    self.process_cxg.process(dataset_version_id, artifact_bucket, cxg_bucket, is_reprocess=True)
             else:
                 self.logger.error(f"Step function configuration error: Unexpected STEP_NAME '{step_name}'")
 

--- a/backend/layers/processing/process_add_labels.py
+++ b/backend/layers/processing/process_add_labels.py
@@ -58,17 +58,22 @@ class ProcessAddLabels(ProcessingLogic):
 
     @logit
     def add_labels(
-        self, collection_version_id: CollectionVersionId, dataset_version_id: DatasetVersionId, local_filename: str
+        self,
+        collection_version_id: CollectionVersionId,
+        dataset_version_id: DatasetVersionId,
+        local_filename: str,
+        is_pre_analysis: bool = False,
     ) -> str:
         """
         labels the specified dataset file and updates the processing status in the database
         :param dataset_version_id: version ID of the dataset to update
         :param collection_version_id: version ID of the collection dataset is being uploaded to
         :param local_filename: file name of the dataset to validate and label
+        :param is_pre_analysis: whether to apply pre-analysis label rules
         :return: file name of labeled dataset, boolean indicating if seurat conversion is possible
         """
         output_filename = CorporaConstants.LABELED_H5AD_ARTIFACT_FILENAME
-        self.schema_validator.add_labels(local_filename, output_filename)
+        self.schema_validator.add_labels(local_filename, output_filename, is_pre_analysis=is_pre_analysis)
         self.populate_dataset_citation(collection_version_id, dataset_version_id, output_filename)
         self.update_processing_status(dataset_version_id, DatasetStatusKey.H5AD, DatasetConversionStatus.CONVERTED)
         return output_filename
@@ -123,6 +128,8 @@ class ProcessAddLabels(ProcessingLogic):
 
         def _get_term_pairs(base_term) -> List[OntologyTermId]:
             base_term_id = base_term + "_ontology_term_id"
+            if base_term not in adata.obs.columns or base_term_id not in adata.obs.columns:
+                return []
             return [
                 OntologyTermId(label=k[0], ontology_term_id=k[1])
                 for k in adata.obs.groupby([base_term, base_term_id]).groups
@@ -198,6 +205,7 @@ class ProcessAddLabels(ProcessingLogic):
         dataset_version_id: DatasetVersionId,
         artifact_bucket: str,
         datasets_bucket: str,
+        is_pre_analysis: bool = False,
     ):
         """
         1. Download the original dataset from URI
@@ -208,6 +216,7 @@ class ProcessAddLabels(ProcessingLogic):
         :param dataset_version_id:
         :param artifact_bucket:
         :param datasets_bucket:
+        :param is_pre_analysis: whether to apply pre-analysis label rules
         :return:
         """
         self.update_processing_status(dataset_version_id, DatasetStatusKey.VALIDATION, DatasetValidationStatus.VALID)
@@ -220,7 +229,10 @@ class ProcessAddLabels(ProcessingLogic):
         # label the dataset
         try:
             file_with_labels = self.add_labels(
-                collection_version_id, dataset_version_id, original_h5ad_artifact_file_name
+                collection_version_id,
+                dataset_version_id,
+                original_h5ad_artifact_file_name,
+                is_pre_analysis=is_pre_analysis,
             )
         except Exception as e:
             self.logger.exception(f"An unexpected error occurred while adding labels to the data set: {e}")

--- a/backend/layers/processing/process_add_labels.py
+++ b/backend/layers/processing/process_add_labels.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import h5py
 import numpy
@@ -14,6 +14,7 @@ from backend.layers.common.entities import (
     DatasetStatusKey,
     DatasetValidationStatus,
     DatasetVersionId,
+    GeneticPerturbationMetadata,
     OntologyTermId,
     SpatialMetadata,
     TissueOntologyTermId,
@@ -111,7 +112,7 @@ class ProcessAddLabels(ProcessingLogic):
         return SpatialMetadata(is_single=bool(is_single), has_fullres=has_fullres)
 
     @logit
-    def extract_metadata(self, filename) -> DatasetMetadata:
+    def extract_metadata(self, filename) -> Tuple[DatasetMetadata, Optional[GeneticPerturbationMetadata]]:
         """Pull metadata out of the AnnData file to insert into the dataset table."""
 
         adata = read_h5ad(filename)
@@ -185,7 +186,13 @@ class ProcessAddLabels(ProcessingLogic):
             values = adata.obs["genetic_perturbation_strategy"].dropna().unique()
             return sorted(v for v in values if v not in _excluded)
 
-        return DatasetMetadata(
+        def _get_genetic_perturbation_metadata() -> Optional[GeneticPerturbationMetadata]:
+            gp = adata.uns.get("genetic_perturbations")
+            if gp is None:
+                return None
+            return GeneticPerturbationMetadata.from_dict(dict(gp))
+
+        dataset_metadata = DatasetMetadata(
             name=adata.uns["title"],
             organism=_get_organism_terms(),
             tissue=_get_tissue_terms(),
@@ -215,6 +222,7 @@ class ProcessAddLabels(ProcessingLogic):
             perturbation_types=_get_perturbation_types(),
             genetic_perturbation_strategy=_get_genetic_perturbation_strategy(),
         )
+        return dataset_metadata, _get_genetic_perturbation_metadata()
 
     def process(
         self,
@@ -255,8 +263,9 @@ class ProcessAddLabels(ProcessingLogic):
             self.logger.exception(f"An unexpected error occurred while adding labels to the data set: {e}")
             raise AddLabelsFailed() from e
         # Process metadata
-        metadata = self.extract_metadata(file_with_labels)
+        metadata, gp_metadata = self.extract_metadata(file_with_labels)
         self.business_logic.set_dataset_metadata(dataset_version_id, metadata)
+        self.business_logic.set_dataset_genetic_perturbations(dataset_version_id, gp_metadata)
         # Upload the labeled dataset to the artifact bucket
         self.create_artifact(
             file_with_labels,

--- a/backend/layers/processing/process_add_labels.py
+++ b/backend/layers/processing/process_add_labels.py
@@ -178,6 +178,13 @@ class ProcessAddLabels(ProcessingLogic):
             filtered = sorted(v for v in values if v not in _excluded)
             return filtered if filtered else []
 
+        def _get_genetic_perturbation_strategy() -> Optional[List[str]]:
+            if "genetic_perturbation_strategy" not in adata.obs.columns:
+                return None
+            _excluded = {"no perturbations"}
+            values = adata.obs["genetic_perturbation_strategy"].dropna().unique()
+            return sorted(v for v in values if v not in _excluded)
+
         return DatasetMetadata(
             name=adata.uns["title"],
             organism=_get_organism_terms(),
@@ -206,6 +213,7 @@ class ProcessAddLabels(ProcessingLogic):
             citation=adata.uns.get("citation"),
             spatial=self.get_spatial_metadata(adata.uns["spatial"]) if "spatial" in adata.uns else None,
             perturbation_types=_get_perturbation_types(),
+            genetic_perturbation_strategy=_get_genetic_perturbation_strategy(),
         )
 
     def process(

--- a/backend/layers/processing/process_add_labels.py
+++ b/backend/layers/processing/process_add_labels.py
@@ -170,6 +170,14 @@ class ProcessAddLabels(ProcessingLogic):
             else:
                 return _get_term_pairs("organism")
 
+        def _get_perturbation_types() -> Optional[List[str]]:
+            if "perturbation_types" not in adata.obs.columns:
+                return None
+            _excluded = {"na", "no perturbations"}
+            values = adata.obs["perturbation_types"].dropna().unique()
+            filtered = sorted(v for v in values if v not in _excluded)
+            return filtered if filtered else []
+
         return DatasetMetadata(
             name=adata.uns["title"],
             organism=_get_organism_terms(),
@@ -197,6 +205,7 @@ class ProcessAddLabels(ProcessingLogic):
             raw_data_location="raw.X" if adata.raw else "X",
             citation=adata.uns.get("citation"),
             spatial=self.get_spatial_metadata(adata.uns["spatial"]) if "spatial" in adata.uns else None,
+            perturbation_types=_get_perturbation_types(),
         )
 
     def process(

--- a/backend/layers/processing/process_validate_h5ad.py
+++ b/backend/layers/processing/process_validate_h5ad.py
@@ -80,11 +80,14 @@ class ProcessValidateH5AD(ProcessingLogic):
         return local_filename
 
     @logit
-    def validate_h5ad_file(self, dataset_version_id: DatasetVersionId, local_filename: str) -> None:
+    def validate_h5ad_file(
+        self, dataset_version_id: DatasetVersionId, local_filename: str, is_pre_analysis: bool = False
+    ) -> None:
         """
         Validates the specified dataset file and updates the processing status in the database
         :param dataset_version_id: version ID of the dataset to update
         :param local_filename: file name of the dataset to validate and label
+        :param is_pre_analysis: whether to apply pre-analysis validation rules
         :return: boolean indicating if seurat conversion is possible
         """
         self.update_processing_status(
@@ -92,7 +95,9 @@ class ProcessValidateH5AD(ProcessingLogic):
         )
 
         try:
-            is_valid, errors, can_convert_to_seurat = self.schema_validator.validate_anndata(local_filename)
+            is_valid, errors, can_convert_to_seurat = self.schema_validator.validate_anndata(
+                local_filename, is_pre_analysis=is_pre_analysis
+            )
         except Exception as e:
             self.logger.exception("validation failed")
             self.update_processing_status(
@@ -131,4 +136,4 @@ class ProcessValidateH5AD(ProcessingLogic):
         local_filename = self.upload_raw_h5ad(dataset_version_id, anndata_uri, artifact_bucket, key_prefix)
 
         # Validate and label the dataset
-        self.validate_h5ad_file(dataset_version_id, local_filename)
+        self.validate_h5ad_file(dataset_version_id, local_filename, is_pre_analysis=manifest.is_pre_analysis)

--- a/backend/layers/thirdparty/schema_validator_provider.py
+++ b/backend/layers/thirdparty/schema_validator_provider.py
@@ -8,7 +8,7 @@ from backend.layers.processing.exceptions import AddLabelsFailed
 
 
 class SchemaValidatorProviderInterface(Protocol):
-    def validate_anndata(self, input_file: str) -> Tuple[bool, list, bool]:
+    def validate_anndata(self, input_file: str, is_pre_analysis: bool = False) -> Tuple[bool, list, bool]:
         pass
 
     def migrate(self, input_file: str, output_file: str, collection_id: str, dataset_id: str) -> List[str]:
@@ -23,9 +23,10 @@ class SchemaValidatorProviderInterface(Protocol):
         """
         pass
 
-    def add_labels(self, input_file: str, output_file: str) -> None:
+    def add_labels(self, input_file: str, output_file: str, is_pre_analysis: bool = False) -> None:
         """
         Adds labels to the provided `input_file` and writes the result to `output_file`.
+        When is_pre_analysis is True, the pre-analysis flag is passed to the label appender.
         """
         pass
 
@@ -48,7 +49,7 @@ class SchemaValidatorProviderInterface(Protocol):
 
 
 class SchemaValidatorProvider(SchemaValidatorProviderInterface):
-    def validate_anndata(self, input_file: str) -> Tuple[bool, list, bool]:
+    def validate_anndata(self, input_file: str, is_pre_analysis: bool = False) -> Tuple[bool, list, bool]:
         """
         Runs `cellxgene-schema validate` on the provided `input_file`.
         Returns a tuple that contains, in order:
@@ -57,7 +58,7 @@ class SchemaValidatorProvider(SchemaValidatorProviderInterface):
         3. A boolean that indicates whether the artifact is Seurat convertible
         """
 
-        return validate.validate(input_file)
+        return validate.validate(input_file, pre_analysis_flag=is_pre_analysis)
 
     def migrate(self, input_file, output_file, collection_id, dataset_id) -> List[str]:
         """
@@ -68,15 +69,16 @@ class SchemaValidatorProvider(SchemaValidatorProviderInterface):
     def get_current_schema_version(self) -> str:
         return get_current_schema_version()
 
-    def add_labels(self, input_file: str, output_file: str) -> None:
+    def add_labels(self, input_file: str, output_file: str, is_pre_analysis: bool = False) -> None:
         """
         Adds labels to the provided `input_file` and writes the result to `output_file`.
+        When is_pre_analysis is True, the pre-analysis flag is passed to the label appender.
         """
         from cellxgene_schema.utils import read_h5ad
         from cellxgene_schema.write_labels import AnnDataLabelAppender
 
         adata = read_h5ad(input_file)
-        anndata_label_adder = AnnDataLabelAppender(adata)
+        anndata_label_adder = AnnDataLabelAppender(adata, pre_analysis=is_pre_analysis)
         if not anndata_label_adder.write_labels(output_file):
             raise AddLabelsFailed(anndata_label_adder.errors)
 

--- a/backend/portal/api/portal-api.yml
+++ b/backend/portal/api/portal-api.yml
@@ -105,6 +105,9 @@ paths:
                   $ref: "#/components/schemas/links"
                 consortia:
                   $ref: "#/components/schemas/consortia"
+                is_pre_analysis:
+                  type: boolean
+                  description: Whether this collection contains pre-analysis datasets.
       responses:
         "201":
           description: A new collection has been created.

--- a/backend/portal/api/portal_api.py
+++ b/backend/portal/api/portal_api.py
@@ -306,6 +306,7 @@ def _collection_to_response(collection: CollectionVersionWithDatasets, access_ty
 
     # Always return consortia
     response["consortia"] = collection.metadata.consortia
+    response["is_pre_analysis"] = collection.is_pre_analysis
     return response
 
 
@@ -407,7 +408,9 @@ def create_collection(body: dict, user: str):
     )
 
     try:
-        version = get_business_logic().create_collection(user, curator_name, metadata)
+        version = get_business_logic().create_collection(
+            user, curator_name, metadata, is_pre_analysis=body.get("is_pre_analysis", False)
+        )
     except (InvalidMetadataException, CollectionCreationException) as ex:
         raise InvalidParametersHTTPException(detail=ex.errors) from None
 

--- a/frontend/src/common/entities.ts
+++ b/frontend/src/common/entities.ts
@@ -91,6 +91,7 @@ export interface Collection {
   contact_name: string;
   description: string;
   id: string;
+  is_pre_analysis?: boolean;
   organs: string[];
   name: string;
   owner: string;

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -106,7 +106,7 @@ const Collection: FC = () => {
   // when React Query is fetching cached `collection` and its outdated
   // `datasets`
   const isPublishable =
-    getIsPublishable(datasets) &&
+    getIsPublishable(datasets, collection.is_pre_analysis) &&
     !isUploadingLink &&
     !isFetching &&
     revisionIsPublishable(collection, isCurator);

--- a/frontend/src/views/Collection/utils.ts
+++ b/frontend/src/views/Collection/utils.ts
@@ -148,11 +148,20 @@ function createLinkTypesToLinks(links: Link[]) {
   return linkTypesToLinks;
 }
 
-export function getIsPublishable(datasets: Array<Dataset>): boolean {
+export function getIsPublishable(
+  datasets: Array<Dataset>,
+  isPreAnalysis = false
+): boolean {
   return (
     datasets?.length > 0 &&
     datasets.every((dataset) => {
       const assets = dataset.dataset_assets;
+      // Pre-analysis datasets intentionally skip CXG conversion, so only H5AD is required
+      if (isPreAnalysis) {
+        return assets.some(
+          (asset) => asset.filetype === DATASET_ASSET_FORMAT.H5AD
+        );
+      }
       const numOfDeployments = dataset.dataset_deployments.length;
       // Assets must contain a cxg and an h5ad. RDS (Seurat) are no longer mandatory for publishing
       return (

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,7 +1,7 @@
 anndata # uses the version supplied by cellxgene-schema
 awscli
 boto3>=1.11.17
-cellxgene-schema==7.0.1
+cellxgene-schema @ git+https://github.com/chanzuckerberg/single-cell-curation.git@cd7ab78f83cc3c8309b1f7ff3b7ccfe517656825#subdirectory=cellxgene_schema_cli
 dask==2024.12.0
 dataclasses-json
 ddtrace==2.1.4

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,7 +1,7 @@
 anndata # uses the version supplied by cellxgene-schema
 awscli
 boto3>=1.11.17
-cellxgene-schema @ git+https://github.com/chanzuckerberg/single-cell-curation.git@a6f618560e1406624ce145a8b3f72ed5b3a386a1#subdirectory=cellxgene_schema_cli
+cellxgene-schema==7.1.0
 dask==2024.12.0
 dataclasses-json
 ddtrace==2.1.4

--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,7 +1,7 @@
 anndata # uses the version supplied by cellxgene-schema
 awscli
 boto3>=1.11.17
-cellxgene-schema @ git+https://github.com/chanzuckerberg/single-cell-curation.git@cd7ab78f83cc3c8309b1f7ff3b7ccfe517656825#subdirectory=cellxgene_schema_cli
+cellxgene-schema @ git+https://github.com/chanzuckerberg/single-cell-curation.git@a6f618560e1406624ce145a8b3f72ed5b3a386a1#subdirectory=cellxgene_schema_cli
 dask==2024.12.0
 dataclasses-json
 ddtrace==2.1.4

--- a/scripts/generate_pre_analysis_fixture.py
+++ b/scripts/generate_pre_analysis_fixture.py
@@ -1,0 +1,53 @@
+"""
+One-time script to generate the pre-analysis h5ad test fixture.
+
+Usage:
+    python scripts/generate_pre_analysis_fixture.py [source.h5ad]
+
+If no source path is given the script downloads the standard functional-test
+example from Dropbox.  The output is written to:
+
+    tests/functional/backend/fixtures/example_pre_analysis.h5ad
+
+Upload that file to Dropbox (dl=1 link) and set PRE_ANALYSIS_DATASET_URI in
+tests/functional/backend/constants.py.
+"""
+
+import sys
+import urllib.request
+from pathlib import Path
+
+import anndata as ad
+
+DROPBOX_DIRECT = (
+    "https://www.dropbox.com/scl/fi/l18zfx8i45j90xejip6qk/example_valid.h5ad"
+    "?rlkey=3p9cnwc0i0ysnfgk8bqy57fev&st=msygclrx&dl=1"
+)
+
+OUTPUT = Path(__file__).parent.parent / "tests/functional/backend/fixtures/example_pre_analysis.h5ad"
+
+
+def main():
+    if len(sys.argv) > 1:
+        source = Path(sys.argv[1])
+        print(f"Reading {source}")
+    else:
+        source = Path("/tmp/example_valid.h5ad")
+        print(f"Downloading example_valid.h5ad → {source}")
+        urllib.request.urlretrieve(DROPBOX_DIRECT, source)
+
+    adata = ad.read_h5ad(source)
+
+    # Strip fields that are not present in pre-analysis datasets.
+    adata.obsm = {}
+    if "cell_type_ontology_term_id" in adata.obs.columns:
+        adata.obs = adata.obs.drop(columns=["cell_type_ontology_term_id"])
+    adata.uns.pop("default_embedding", None)
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    adata.write_h5ad(OUTPUT)
+    print(f"Written → {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional/backend/constants.py
+++ b/tests/functional/backend/constants.py
@@ -19,8 +19,11 @@ DATASET_URI = "https://www.dropbox.com/scl/fi/l18zfx8i45j90xejip6qk/example_vali
 
 VISIUM_DATASET_URI = "https://www.dropbox.com/scl/fi/a871dhnoqzzhkqz0pr3fj/small_visium.h5ad?rlkey=8zv1m79p4lnaqr60nl6hi6yai&st=ibim78id&dl=0"
 
+PRE_ANALYSIS_DATASET_URI = "https://www.dropbox.com/scl/fi/73zdzk3ua5vgcamhqdemx/example_pre_analysis.h5ad?rlkey=brs9qu87n6j48q55o4ymqc7l2&st=2e4rdt1z&dl=0"
+
 DATASET_MANIFEST = {"anndata": DATASET_URI}
 VISIUM_DATASET_MANIFEST = {"anndata": VISIUM_DATASET_URI}
+PRE_ANALYSIS_DATASET_MANIFEST = {"anndata": PRE_ANALYSIS_DATASET_URI, "is_pre_analysis": True}
 ATAC_SEQ_MANIFEST = {
     "anndata": "https://www.dropbox.com/scl/fi/1h9d1usgobiqgnin4s6ld/atac.h5ad?rlkey=o3aokwmez6a8tdip5p4vybv8a&st=nkamyl1n&dl=0",
     "atac_fragment": "https://www.dropbox.com/scl/fi/nexccttzlzwr3lt0oe7eq/fragments_sorted.tsv.gz?rlkey=wrajzdz0f1g5gpx4m1vwmvcfh&st=s3hbbajy&dl=0",

--- a/tests/functional/backend/constants.py
+++ b/tests/functional/backend/constants.py
@@ -21,9 +21,12 @@ VISIUM_DATASET_URI = "https://www.dropbox.com/scl/fi/a871dhnoqzzhkqz0pr3fj/small
 
 PRE_ANALYSIS_DATASET_URI = "https://www.dropbox.com/scl/fi/73zdzk3ua5vgcamhqdemx/example_pre_analysis.h5ad?rlkey=brs9qu87n6j48q55o4ymqc7l2&st=2e4rdt1z&dl=0"
 
+PERTURBATION_DATASET_URI = "https://www.dropbox.com/scl/fi/w59f6s7nd6ws9vwjlbn5z/small_perturbations_example.h5ad?rlkey=hwextcwh3p71oz1b0ulxasswy&st=xzxh91zx&dl=0"
+
 DATASET_MANIFEST = {"anndata": DATASET_URI}
 VISIUM_DATASET_MANIFEST = {"anndata": VISIUM_DATASET_URI}
 PRE_ANALYSIS_DATASET_MANIFEST = {"anndata": PRE_ANALYSIS_DATASET_URI, "is_pre_analysis": True}
+PERTURBATION_DATASET_MANIFEST = {"anndata": PERTURBATION_DATASET_URI, "is_pre_analysis": True}
 ATAC_SEQ_MANIFEST = {
     "anndata": "https://www.dropbox.com/scl/fi/1h9d1usgobiqgnin4s6ld/atac.h5ad?rlkey=o3aokwmez6a8tdip5p4vybv8a&st=nkamyl1n&dl=0",
     "atac_fragment": "https://www.dropbox.com/scl/fi/nexccttzlzwr3lt0oe7eq/fragments_sorted.tsv.gz?rlkey=wrajzdz0f1g5gpx4m1vwmvcfh&st=s3hbbajy&dl=0",

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -9,6 +9,7 @@ from tests.functional.backend.constants import (
     ATAC_SEQ_MANIFEST,
     DATASET_MANIFEST,
     DATASET_URI,
+    PERTURBATION_DATASET_MANIFEST,
     PRE_ANALYSIS_DATASET_MANIFEST,
     VISIUM_DATASET_URI,
 )
@@ -544,3 +545,99 @@ def test_pre_analysis_dataset_upload_and_process(
     res = session.get(f"{api_url}/curation/v1/datasets?analysis=post-analysis", headers=headers)
     assertStatusCode(200, res)
     assert dataset_id not in [d["dataset_id"] for d in res.json()]
+
+
+# --- perturbation_types functional tests ---
+
+
+def test_get_datasets_includes_perturbation_types_field(session, api_url):
+    """Every published dataset returned by GET /curation/v1/datasets includes a perturbation_types field."""
+    res = session.get(f"{api_url}/curation/v1/datasets")
+    assertStatusCode(requests.codes.ok, res)
+    for dataset in res.json():
+        assert "perturbation_types" in dataset
+
+
+@skip_creation_on_prod
+def test_perturbation_dataset_upload_and_process(
+    session,
+    api_url,
+    curation_api_access_token,
+    curator_cookie,
+    request,
+):
+    """
+    Upload a perturbation (pre-analysis) h5ad and verify the full pipeline succeeds and
+    perturbation_types is correctly populated and returned by all GET /collection and
+    GET /dataset endpoints.
+    """
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    headers_dp = {"Cookie": f"cxguser={curator_cookie}", "Content-Type": "application/json"}
+
+    collection_id = create_test_collection(
+        headers_dp,
+        request,
+        session,
+        api_url,
+        {
+            "contact_email": "functest@example.com",
+            "contact_name": "Func Test",
+            "curator_name": "Func Test",
+            "description": "perturbation_types functional test",
+            "name": "test_perturbation_dataset_upload_and_process",
+            "is_pre_analysis": True,
+        },
+    )
+
+    # Create dataset slot and submit manifest.
+    res = session.post(f"{api_url}/curation/v1/collections/{collection_id}/datasets", headers=headers)
+    assertStatusCode(201, res)
+    dataset_id = res.json()["dataset_id"]
+
+    res = session.put(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/manifest",
+        data=json.dumps(PERTURBATION_DATASET_MANIFEST),
+        headers=headers,
+    )
+    assertStatusCode(202, res)
+
+    result = wait_for_dataset_processing_via_curation_api(
+        session, api_url, curation_api_access_token, collection_id, dataset_id
+    )
+    assert not result["errors"], f"Perturbation dataset processing failed: {result['errors']}"
+
+    # --- Verify GET /curation/v1/collections/{id} ---
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers)
+    assertStatusCode(200, res)
+    collection_data = res.json()
+    dataset_entry = next(d for d in collection_data["datasets"] if d["dataset_id"] == dataset_id)
+    assert "perturbation_types" in dataset_entry
+    assert isinstance(dataset_entry["perturbation_types"], list)
+    assert dataset_entry["perturbation_types"] == sorted(dataset_entry["perturbation_types"])
+
+    # --- Verify GET /curation/v1/collections/{id}/datasets/{id} ---
+    res = session.get(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}",
+        headers=headers,
+    )
+    assertStatusCode(200, res)
+    dataset_data = res.json()
+    assert "perturbation_types" in dataset_data
+    assert isinstance(dataset_data["perturbation_types"], list)
+    # Values must exclude 'na'/None and be lexically sorted.
+    assert "na" not in dataset_data["perturbation_types"]
+    assert None not in dataset_data["perturbation_types"]
+    assert dataset_data["perturbation_types"] == sorted(dataset_data["perturbation_types"])
+
+    # --- Publish and verify public GET /curation/v1/collections/{id} ---
+    body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
+    res = session.post(
+        f"{api_url}/dp/v1/collections/{collection_id}/publish", headers=headers_dp, data=json.dumps(body)
+    )
+    assertStatusCode(requests.codes.accepted, res)
+
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}")
+    assertStatusCode(200, res)
+    public_collection = res.json()
+    public_dataset = next(d for d in public_collection["datasets"] if d["dataset_id"] == dataset_id)
+    assert "perturbation_types" in public_dataset

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -5,9 +5,19 @@ import requests
 from requests import HTTPError
 
 from backend.common.constants import DATA_SUBMISSION_POLICY_VERSION
-from tests.functional.backend.constants import ATAC_SEQ_MANIFEST, DATASET_MANIFEST, DATASET_URI, VISIUM_DATASET_URI
+from tests.functional.backend.constants import (
+    ATAC_SEQ_MANIFEST,
+    DATASET_MANIFEST,
+    DATASET_URI,
+    PRE_ANALYSIS_DATASET_MANIFEST,
+    VISIUM_DATASET_URI,
+)
 from tests.functional.backend.skip_reason import skip_creation_on_prod
-from tests.functional.backend.utils import assertStatusCode, create_test_collection
+from tests.functional.backend.utils import (
+    assertStatusCode,
+    create_test_collection,
+    wait_for_dataset_processing_via_curation_api,
+)
 
 
 @skip_creation_on_prod
@@ -335,3 +345,202 @@ def _verify_upload_and_delete_succeeded(
     datasets = data["datasets"]
     dataset_ids = [dataset.get("id") for dataset in datasets]
     assert updated_dataset_id not in dataset_ids
+
+
+# --- is_pre_analysis functional tests ---
+
+
+@skip_creation_on_prod
+def test_pre_analysis_collection_create_and_get(session, api_url, curation_api_access_token, request):
+    """Creating a collection with is_pre_analysis=True via the Curation API stores and returns the flag."""
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    body = {
+        "contact_email": "functest@example.com",
+        "contact_name": "Func Test",
+        "description": "pre-analysis functional test",
+        "name": "test_pre_analysis_collection_create_and_get",
+        "is_pre_analysis": True,
+    }
+    res = session.post(f"{api_url}/curation/v1/collections", data=json.dumps(body), headers=headers)
+    assertStatusCode(requests.codes.created, res)
+    collection_id = res.json()["collection_id"]
+    request.addfinalizer(lambda: session.delete(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers))
+
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers)
+    assertStatusCode(requests.codes.ok, res)
+    data = res.json()
+    assert "is_pre_analysis" in data
+    assert data["is_pre_analysis"] is True
+
+
+@skip_creation_on_prod
+def test_pre_analysis_defaults_false(session, api_url, curation_api_access_token, request):
+    """Creating a collection without is_pre_analysis returns is_pre_analysis=False."""
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    body = {
+        "contact_email": "functest@example.com",
+        "contact_name": "Func Test",
+        "description": "pre-analysis default test",
+        "name": "test_pre_analysis_defaults_false",
+    }
+    res = session.post(f"{api_url}/curation/v1/collections", data=json.dumps(body), headers=headers)
+    assertStatusCode(requests.codes.created, res)
+    collection_id = res.json()["collection_id"]
+    request.addfinalizer(lambda: session.delete(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers))
+
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers)
+    assertStatusCode(requests.codes.ok, res)
+    data = res.json()
+    assert "is_pre_analysis" in data
+    assert data["is_pre_analysis"] is False
+
+
+@skip_creation_on_prod
+def test_pre_analysis_patch_rejected(session, api_url, curation_api_access_token, request):
+    """Attempting to PATCH is_pre_analysis on an existing collection returns 405."""
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    body = {
+        "contact_email": "functest@example.com",
+        "contact_name": "Func Test",
+        "description": "patch rejected test",
+        "name": "test_pre_analysis_patch_rejected",
+    }
+    res = session.post(f"{api_url}/curation/v1/collections", data=json.dumps(body), headers=headers)
+    assertStatusCode(requests.codes.created, res)
+    collection_id = res.json()["collection_id"]
+    request.addfinalizer(lambda: session.delete(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers))
+
+    res = session.patch(
+        f"{api_url}/curation/v1/collections/{collection_id}",
+        data=json.dumps({"is_pre_analysis": True}),
+        headers=headers,
+    )
+    assertStatusCode(405, res)
+
+
+def test_get_datasets_analysis_filter(session, api_url):
+    """GET /curation/v1/datasets with ?analysis= returns only matching datasets."""
+    # pre-analysis filter — all returned datasets must have is_pre_analysis=True
+    res = session.get(f"{api_url}/curation/v1/datasets?analysis=pre-analysis")
+    assertStatusCode(requests.codes.ok, res)
+    for dataset in res.json():
+        assert dataset.get("is_pre_analysis") is True
+
+    # post-analysis filter — all returned datasets must have is_pre_analysis=False
+    res = session.get(f"{api_url}/curation/v1/datasets?analysis=post-analysis")
+    assertStatusCode(requests.codes.ok, res)
+    for dataset in res.json():
+        assert dataset.get("is_pre_analysis") is False
+
+    # invalid value — expect 400
+    res = session.get(f"{api_url}/curation/v1/datasets?analysis=invalid")
+    assertStatusCode(400, res)
+
+
+def test_get_datasets_includes_is_pre_analysis_field(session, api_url):
+    """Every dataset returned by GET /curation/v1/datasets includes is_pre_analysis."""
+    res = session.get(f"{api_url}/curation/v1/datasets")
+    assertStatusCode(requests.codes.ok, res)
+    for dataset in res.json():
+        assert "is_pre_analysis" in dataset
+
+
+# --- pre-analysis upload functional tests ---
+
+
+@skip_creation_on_prod
+def test_pre_analysis_dataset_upload_and_process(
+    session,
+    api_url,
+    curation_api_access_token,
+    curator_cookie,
+    request,
+):
+    """
+    Upload a pre-analysis h5ad to a pre-analysis collection and verify the full
+    pipeline completes (CXG conversion is skipped) and all API responses reflect
+    is_pre_analysis=True.
+
+    The collection is created via the dp/v1 endpoint (cookie auth) so that the same
+    user can later publish it.  Dataset upload uses the curation Bearer token.
+    Status is polled via GET /curation/v1/collections/{id} (processing_status field)
+    rather than the dp/v1 status endpoint, which is cookie-only and unavailable to
+    Bearer-token callers.
+    """
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    headers_dp = {"Cookie": f"cxguser={curator_cookie}", "Content-Type": "application/json"}
+
+    # Create a pre-analysis collection via dp/v1 (cookie auth) so we can publish later.
+    collection_id = create_test_collection(
+        headers_dp,
+        request,
+        session,
+        api_url,
+        {
+            "contact_email": "functest@example.com",
+            "contact_name": "Func Test",
+            "curator_name": "Func Test",
+            "description": "pre-analysis upload functional test",
+            "name": "test_pre_analysis_dataset_upload_and_process",
+            "is_pre_analysis": True,
+        },
+    )
+
+    # Create a dataset slot and submit the manifest.
+    res = session.post(f"{api_url}/curation/v1/collections/{collection_id}/datasets", headers=headers)
+    assertStatusCode(201, res)
+    dataset_id = res.json()["dataset_id"]
+
+    res = session.put(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/manifest",
+        data=json.dumps(PRE_ANALYSIS_DATASET_MANIFEST),
+        headers=headers,
+    )
+    assertStatusCode(202, res)
+
+    # Wait for processing via the curation API (Bearer-token-accessible).
+    result = wait_for_dataset_processing_via_curation_api(
+        session, api_url, curation_api_access_token, collection_id, dataset_id
+    )
+    assert not result["errors"], f"Pre-analysis dataset processing failed: {result['errors']}"
+
+    # Verify is_pre_analysis on the collection and dataset responses.
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers)
+    assertStatusCode(200, res)
+    collection_data = res.json()
+    assert collection_data.get("is_pre_analysis") is True
+    dataset_entry = next(d for d in collection_data["datasets"] if d["dataset_id"] == dataset_id)
+    assert dataset_entry.get("is_pre_analysis") is True
+
+    res = session.get(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}",
+        headers=headers,
+    )
+    assertStatusCode(200, res)
+    assert res.json().get("is_pre_analysis") is True
+
+    # Verify the dataset index filters work correctly.
+    # The collection is still private (unpublished), so visibility=PRIVATE is required.
+    res = session.get(f"{api_url}/curation/v1/datasets?analysis=pre-analysis&visibility=PRIVATE", headers=headers)
+    assertStatusCode(200, res)
+    assert dataset_id in [d["dataset_id"] for d in res.json()]
+
+    res = session.get(f"{api_url}/curation/v1/datasets?analysis=post-analysis&visibility=PRIVATE", headers=headers)
+    assertStatusCode(200, res)
+    assert dataset_id not in [d["dataset_id"] for d in res.json()]
+
+    # Publish the collection, then verify the public analysis filter works without visibility=PRIVATE.
+    body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
+    res = session.post(
+        f"{api_url}/dp/v1/collections/{collection_id}/publish", headers=headers_dp, data=json.dumps(body)
+    )
+    assertStatusCode(requests.codes.accepted, res)
+
+    # After publishing the collection is public, so the filter should work without visibility=PRIVATE.
+    res = session.get(f"{api_url}/curation/v1/datasets?analysis=pre-analysis", headers=headers)
+    assertStatusCode(200, res)
+    assert dataset_id in [d["dataset_id"] for d in res.json()]
+
+    res = session.get(f"{api_url}/curation/v1/datasets?analysis=post-analysis", headers=headers)
+    assertStatusCode(200, res)
+    assert dataset_id not in [d["dataset_id"] for d in res.json()]

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -641,3 +641,101 @@ def test_perturbation_dataset_upload_and_process(
     public_collection = res.json()
     public_dataset = next(d for d in public_collection["datasets"] if d["dataset_id"] == dataset_id)
     assert "perturbation_types" in public_dataset
+
+
+# --- genetic_perturbation_strategy functional tests ---
+
+
+def test_get_datasets_includes_genetic_perturbation_strategy_field(session, api_url):
+    """Every published dataset returned by GET /curation/v1/datasets includes a genetic_perturbation_strategy field."""
+    res = session.get(f"{api_url}/curation/v1/datasets")
+    assertStatusCode(requests.codes.ok, res)
+    for dataset in res.json():
+        assert "genetic_perturbation_strategy" in dataset
+
+
+@skip_creation_on_prod
+def test_genetic_perturbation_strategy_upload_and_process(
+    session,
+    api_url,
+    curation_api_access_token,
+    curator_cookie,
+    request,
+):
+    """
+    Upload a perturbation (pre-analysis) h5ad and verify the full pipeline succeeds and
+    genetic_perturbation_strategy is correctly populated and returned by all GET /collection and
+    GET /dataset endpoints.
+    """
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    headers_dp = {"Cookie": f"cxguser={curator_cookie}", "Content-Type": "application/json"}
+
+    collection_id = create_test_collection(
+        headers_dp,
+        request,
+        session,
+        api_url,
+        {
+            "contact_email": "functest@example.com",
+            "contact_name": "Func Test",
+            "curator_name": "Func Test",
+            "description": "genetic_perturbation_strategy functional test",
+            "name": "test_genetic_perturbation_strategy_upload_and_process",
+            "is_pre_analysis": True,
+        },
+    )
+
+    # Create dataset slot and submit manifest.
+    res = session.post(f"{api_url}/curation/v1/collections/{collection_id}/datasets", headers=headers)
+    assertStatusCode(201, res)
+    dataset_id = res.json()["dataset_id"]
+
+    res = session.put(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/manifest",
+        data=json.dumps(PERTURBATION_DATASET_MANIFEST),
+        headers=headers,
+    )
+    assertStatusCode(202, res)
+
+    result = wait_for_dataset_processing_via_curation_api(
+        session, api_url, curation_api_access_token, collection_id, dataset_id
+    )
+    assert not result["errors"], f"Perturbation dataset processing failed: {result['errors']}"
+
+    # --- Verify GET /curation/v1/collections/{id} ---
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers)
+    assertStatusCode(200, res)
+    collection_data = res.json()
+    dataset_entry = next(d for d in collection_data["datasets"] if d["dataset_id"] == dataset_id)
+    assert "genetic_perturbation_strategy" in dataset_entry
+    gps = dataset_entry["genetic_perturbation_strategy"]
+    assert gps is None or isinstance(gps, list)
+    if isinstance(gps, list):
+        assert gps == sorted(gps)
+
+    # --- Verify GET /curation/v1/collections/{id}/datasets/{id} ---
+    res = session.get(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}",
+        headers=headers,
+    )
+    assertStatusCode(200, res)
+    dataset_data = res.json()
+    assert "genetic_perturbation_strategy" in dataset_data
+    gps = dataset_data["genetic_perturbation_strategy"]
+    assert gps is None or isinstance(gps, list)
+    if isinstance(gps, list):
+        assert None not in gps
+        assert gps == sorted(gps)
+
+    # --- Publish and verify public GET /curation/v1/collections/{id} ---
+    body = {"data_submission_policy_version": DATA_SUBMISSION_POLICY_VERSION}
+    res = session.post(
+        f"{api_url}/dp/v1/collections/{collection_id}/publish", headers=headers_dp, data=json.dumps(body)
+    )
+    assertStatusCode(requests.codes.accepted, res)
+
+    res = session.get(f"{api_url}/curation/v1/collections/{collection_id}")
+    assertStatusCode(200, res)
+    public_collection = res.json()
+    public_dataset = next(d for d in public_collection["datasets"] if d["dataset_id"] == dataset_id)
+    assert "genetic_perturbation_strategy" in public_dataset

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -739,3 +739,111 @@ def test_genetic_perturbation_strategy_upload_and_process(
     public_collection = res.json()
     public_dataset = next(d for d in public_collection["datasets"] if d["dataset_id"] == dataset_id)
     assert "genetic_perturbation_strategy" in public_dataset
+
+
+@skip_creation_on_prod
+def test_genetic_perturbations_dict_endpoint(
+    session,
+    api_url,
+    curation_api_access_token,
+    curator_cookie,
+    request,
+):
+    """
+    Upload a perturbation (pre-analysis) h5ad, process it, then verify
+    GET /curation/v1/collections/{id}/datasets/{id}/genetic_perturbations returns
+    the expected shape (dict keyed by perturbation ID with typed entry fields).
+    Also verifies that a dataset without genetic_perturbations returns null.
+    """
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    headers_dp = {"Cookie": f"cxguser={curator_cookie}", "Content-Type": "application/json"}
+
+    # --- Collection + dataset with perturbations ---
+    collection_id = create_test_collection(
+        headers_dp,
+        request,
+        session,
+        api_url,
+        {
+            "contact_email": "functest@example.com",
+            "contact_name": "Func Test",
+            "curator_name": "Func Test",
+            "description": "genetic_perturbations dict functional test",
+            "name": "test_genetic_perturbations_dict_endpoint",
+            "is_pre_analysis": True,
+        },
+    )
+
+    res = session.post(f"{api_url}/curation/v1/collections/{collection_id}/datasets", headers=headers)
+    assertStatusCode(201, res)
+    dataset_id = res.json()["dataset_id"]
+
+    res = session.put(
+        f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/manifest",
+        data=json.dumps(PERTURBATION_DATASET_MANIFEST),
+        headers=headers,
+    )
+    assertStatusCode(202, res)
+
+    result = wait_for_dataset_processing_via_curation_api(
+        session, api_url, curation_api_access_token, collection_id, dataset_id
+    )
+    assert not result["errors"], f"Perturbation dataset processing failed: {result['errors']}"
+
+    # --- Verify GET .../genetic_perturbations response shape ---
+    gp_url = f"{api_url}/curation/v1/collections/{collection_id}/datasets/{dataset_id}/genetic_perturbations"
+    res = session.get(gp_url, headers=headers)
+    assertStatusCode(200, res)
+    body = res.json()
+
+    assert "genetic_perturbations" in body
+    gp = body["genetic_perturbations"]
+
+    if gp is not None:
+        assert isinstance(gp, dict), "genetic_perturbations should be a dict keyed by perturbation ID"
+        for pid, entry in gp.items():
+            assert isinstance(pid, str), "perturbation ID must be a string"
+            assert "role" in entry, f"entry {pid} missing 'role'"
+            assert "derived_genomic_regions" in entry, f"entry {pid} missing 'derived_genomic_regions'"
+            assert "derived_features" in entry, f"entry {pid} missing 'derived_features'"
+            assert isinstance(entry["derived_genomic_regions"], list)
+            assert isinstance(entry["derived_features"], dict)
+
+    # --- Dataset without genetic_perturbations returns null ---
+    collection_id_plain = create_test_collection(
+        headers_dp,
+        request,
+        session,
+        api_url,
+        {
+            "contact_email": "functest@example.com",
+            "contact_name": "Func Test",
+            "curator_name": "Func Test",
+            "description": "plain dataset for genetic_perturbations null check",
+            "name": "test_genetic_perturbations_dict_endpoint_null",
+        },
+    )
+
+    res = session.post(f"{api_url}/curation/v1/collections/{collection_id_plain}/datasets", headers=headers)
+    assertStatusCode(201, res)
+    plain_dataset_id = res.json()["dataset_id"]
+
+    res = session.put(
+        f"{api_url}/curation/v1/collections/{collection_id_plain}/datasets/{plain_dataset_id}/manifest",
+        data=json.dumps(DATASET_MANIFEST),
+        headers=headers,
+    )
+    assertStatusCode(202, res)
+
+    result = wait_for_dataset_processing_via_curation_api(
+        session, api_url, curation_api_access_token, collection_id_plain, plain_dataset_id
+    )
+    assert not result["errors"], f"Plain dataset processing failed: {result['errors']}"
+
+    gp_url_plain = (
+        f"{api_url}/curation/v1/collections/{collection_id_plain}/datasets/{plain_dataset_id}/genetic_perturbations"
+    )
+    res = session.get(gp_url_plain, headers=headers)
+    assertStatusCode(200, res)
+    plain_body = res.json()
+    assert plain_body["genetic_perturbations"] is None

--- a/tests/functional/backend/utils.py
+++ b/tests/functional/backend/utils.py
@@ -188,7 +188,8 @@ def _wait_for_dataset_status(session, api_url, dataset_id, headers):
     errors = []
     keep_trying = True
     expected_upload_statuses = ["WAITING", "UPLOADING", "UPLOADED"]
-    expected_conversion_statuses = ["CONVERTING", "CONVERTED", "FAILED", "UPLOADING", "UPLOADED", "NA", None]
+    # "SKIPPED" is valid for pre-analysis datasets (cxg is skipped) and for rds (always skipped)
+    expected_conversion_statuses = ["CONVERTING", "CONVERTED", "FAILED", "UPLOADING", "UPLOADED", "NA", "SKIPPED", None]
     timer = time.time()
     while keep_trying:
         res = session.get(f"{api_url}/dp/v1/datasets/{dataset_id}/status", headers=headers)
@@ -212,14 +213,19 @@ def _wait_for_dataset_status(session, api_url, dataset_id, headers):
                 errors.append(f"Atac CONVERSION FAILED. Status: {data}, Check logs for dataset: {dataset_id}")
             if rds_status == "FAILED":
                 errors.append(f"RDS CONVERSION FAILED. Status: {data}, Check logs for dataset: {dataset_id}")
-            if any(
-                [
-                    (cxg_status == h5ad_status == "UPLOADED" or cxg_status == h5ad_status == "CONVERTED")
-                    and rds_status == "SKIPPED"
-                    and atac_status in ["SKIPPED", "UPLOADED", "NA", "COPIED"],
-                    errors,
-                ]
-            ):
+            # Pre-analysis datasets skip CXG conversion; regular datasets expect matching cxg/h5ad statuses.
+            pre_analysis_done = (
+                cxg_status == "SKIPPED"
+                and h5ad_status in ["UPLOADED", "CONVERTED"]
+                and rds_status == "SKIPPED"
+                and atac_status in ["SKIPPED", "NA", None]
+            )
+            regular_done = (
+                (cxg_status == h5ad_status == "UPLOADED" or cxg_status == h5ad_status == "CONVERTED")
+                and rds_status == "SKIPPED"
+                and atac_status in ["SKIPPED", "UPLOADED", "NA", "COPIED"]
+            )
+            if any([pre_analysis_done or regular_done, errors]):
                 keep_trying = False
             if time.time() >= timer + 3600:
                 raise TimeoutError(
@@ -273,3 +279,38 @@ def get_curation_api_access_token(session, api_url, config) -> str:
     )
     assertStatusCode(201, response)
     return response.json()["access_token"]
+
+
+def wait_for_dataset_processing_via_curation_api(
+    session, api_url: str, curation_api_access_token: str, collection_id: str, dataset_id: str
+) -> dict:
+    """
+    Poll GET /curation/v1/collections/{collection_id} until the given dataset reaches
+    a terminal processing_status (SUCCESS or FAILURE/VALIDATION_FAILURE/PIPELINE_FAILURE).
+
+    This is the correct way for curation API callers to wait for processing — the
+    dp/v1 status endpoint only accepts cookie auth and is not available to Bearer-token
+    clients.  Returns {"dataset_id": dataset_id, "errors": [...]}.
+    """
+    headers = {"Authorization": f"Bearer {curation_api_access_token}", "Content-Type": "application/json"}
+    terminal_ok = {"SUCCESS"}
+    terminal_err = {"FAILURE", "VALIDATION_FAILURE", "PIPELINE_FAILURE"}
+    timer = time.time()
+    while True:
+        res = session.get(f"{api_url}/curation/v1/collections/{collection_id}", headers=headers)
+        assertStatusCode(200, res)
+        datasets = res.json().get("datasets", [])
+        dataset = next((d for d in datasets if d["dataset_id"] == dataset_id), None)
+        if dataset is not None:
+            status = dataset.get("processing_status")
+            if status in terminal_ok:
+                return {"dataset_id": dataset_id, "errors": []}
+            if status in terminal_err:
+                detail = dataset.get("processing_status_detail", "")
+                return {"dataset_id": dataset_id, "errors": [f"{status}: {detail}"]}
+        if time.time() >= timer + 3600:
+            raise TimeoutError(
+                f"Dataset processing timed out after 1 h. "
+                f"collection_id={collection_id} dataset_id={dataset_id} last_status={status!r}"
+            )
+        time.sleep(10)

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1054,6 +1054,7 @@ class TestGetCollectionVersionID(BaseAPIPortalTest):
                     "is_primary_data": [True, False],
                     "mean_genes_per_cell": 0.5,
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
+                    "perturbation_types": None,
                     "raw_data_location": "raw.X",
                     "schema_version": "3.0.0",
                     "self_reported_ethnicity": [

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -297,6 +297,7 @@ class TestGetCollections(BaseAPIPortalTest):
         self.expected_dataset_columns = EntityColumns.dataset_metadata_preview_cols + [
             "dataset_id",
             "dataset_version_id",
+            "is_pre_analysis",
         ]
         self.expected_collection_columns = EntityColumns.collections_cols.copy()
         self.expected_collection_columns.remove("tombstone")
@@ -686,6 +687,7 @@ class TestGetCollectionID(BaseAPIPortalTest):
                 "dataset_id": dataset.dataset_id.id,
                 "dataset_version_id": dataset.version_id.id,
                 "tombstone": False,
+                "is_pre_analysis": False,
                 "assets": [  # Filter out disallowed file types + properly construct url
                     {
                         "filesize": -1,
@@ -712,6 +714,7 @@ class TestGetCollectionID(BaseAPIPortalTest):
                 "collection_version_id": collection_version.version_id.id,
                 "datasets": [expect_dataset],
                 "doi": None,
+                "is_pre_analysis": False,
                 "links": links,
                 "publisher_metadata": None,
                 "revision_of": None,
@@ -1047,6 +1050,7 @@ class TestGetCollectionVersionID(BaseAPIPortalTest):
                     "feature_biotype": ["gene"],
                     "feature_count": 400,
                     "feature_reference": ["NCBITaxon:9606"],
+                    "is_pre_analysis": False,
                     "is_primary_data": [True, False],
                     "mean_genes_per_cell": 0.5,
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
@@ -1075,6 +1079,7 @@ class TestGetCollectionVersionID(BaseAPIPortalTest):
             ],
             "description": "described",
             "doi": None,
+            "is_pre_analysis": False,
             "links": [],
             "name": "test_collection",
             "publisher_metadata": None,
@@ -3189,3 +3194,186 @@ class TestAuthToken(BaseAPIPortalTest):
         user_api_key = generate(test_user_id, test_secret)
         response = self.app.post("/curation/v1/auth/token", headers={"x-api-key": user_api_key})
         self.assertEqual(401, response.status_code)
+
+
+class TestPostCollectionIsPreAnalysis(BaseAPIPortalTest):
+    """Tests for the is_pre_analysis field on POST /v1/collections."""
+
+    def setUp(self):
+        super().setUp()
+        self.base_collection = dict(
+            name="collection",
+            description="description",
+            contact_name="john doe",
+            contact_email="johndoe@email.com",
+        )
+
+    def test__post_collection__is_pre_analysis_defaults_false(self):
+        """Creating a collection without is_pre_analysis sets it to False."""
+        response = self.app.post(
+            "/curation/v1/collections",
+            headers=self.make_owner_header(),
+            data=json.dumps(self.base_collection),
+        )
+        self.assertEqual(201, response.status_code)
+        collection_id = response.json["collection_id"]
+        version = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
+        self.assertFalse(version.is_pre_analysis)
+
+    def test__post_collection__is_pre_analysis_true(self):
+        """Creating a collection with is_pre_analysis=True stores the flag correctly."""
+        body = {**self.base_collection, "is_pre_analysis": True}
+        response = self.app.post(
+            "/curation/v1/collections",
+            headers=self.make_owner_header(),
+            data=json.dumps(body),
+        )
+        self.assertEqual(201, response.status_code)
+        collection_id = response.json["collection_id"]
+        version = self.business_logic.get_collection_version_from_canonical(CollectionId(collection_id))
+        self.assertTrue(version.is_pre_analysis)
+
+    def test__get_collection__includes_is_pre_analysis(self):
+        """GET /v1/collections/{id} returns is_pre_analysis in the response."""
+        body = {**self.base_collection, "is_pre_analysis": True}
+        post_resp = self.app.post(
+            "/curation/v1/collections",
+            headers=self.make_owner_header(),
+            data=json.dumps(body),
+        )
+        collection_id = post_resp.json["collection_id"]
+        response = self.app.get(
+            f"/curation/v1/collections/{collection_id}",
+            headers=self.make_owner_header(),
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertIn("is_pre_analysis", response.json)
+        self.assertTrue(response.json["is_pre_analysis"])
+
+    def test__get_collection__is_pre_analysis_false_by_default(self):
+        """GET response includes is_pre_analysis=False for collections created without the flag."""
+        post_resp = self.app.post(
+            "/curation/v1/collections",
+            headers=self.make_owner_header(),
+            data=json.dumps(self.base_collection),
+        )
+        collection_id = post_resp.json["collection_id"]
+        response = self.app.get(
+            f"/curation/v1/collections/{collection_id}",
+            headers=self.make_owner_header(),
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertIn("is_pre_analysis", response.json)
+        self.assertFalse(response.json["is_pre_analysis"])
+
+
+class TestPatchCollectionIsPreAnalysis(BaseAPIPortalTest):
+    """Tests that PATCH /v1/collections/{id} rejects is_pre_analysis updates."""
+
+    def test__patch_collection__rejects_is_pre_analysis(self):
+        """Attempting to update is_pre_analysis via PATCH returns 405."""
+        collection_id = self.generate_unpublished_collection().collection_id
+        response = self.app.patch(
+            f"/curation/v1/collections/{collection_id}",
+            headers=self.make_owner_header(),
+            data=json.dumps({"is_pre_analysis": True}),
+        )
+        self.assertEqual(405, response.status_code)
+
+    def test__patch_collection__name_update_without_is_pre_analysis_ok(self):
+        """PATCH without is_pre_analysis still works normally."""
+        collection_id = self.generate_unpublished_collection().collection_id
+        response = self.app.patch(
+            f"/curation/v1/collections/{collection_id}",
+            headers=self.make_owner_header(),
+            data=json.dumps({"name": "new name"}),
+        )
+        self.assertEqual(200, response.status_code)
+
+
+class TestDatasetsIndexIsPreAnalysis(BaseAPIPortalTest):
+    """Tests for the analysis query parameter on GET /v1/datasets."""
+
+    def _make_pre_analysis_collection(self, add_datasets=1):
+        """Helper: create and publish a pre-analysis collection."""
+        body = dict(
+            name="pre-analysis coll",
+            description="desc",
+            contact_name="Jane",
+            contact_email="jane@example.com",
+            is_pre_analysis=True,
+        )
+        resp = self.app.post(
+            "/curation/v1/collections",
+            headers=self.make_owner_header(),
+            data=json.dumps(body),
+        )
+        collection_id = CollectionId(resp.json["collection_id"])
+        version = self.business_logic.get_collection_version_from_canonical(collection_id)
+        for _ in range(add_datasets):
+            self.generate_dataset(collection_version=version)
+        self.business_logic.publish_collection_version(version.version_id)
+        return self.business_logic.get_collection_version(version.version_id)
+
+    def test__get_datasets__no_analysis_filter_returns_all(self):
+        """Without the analysis param, all public datasets are returned."""
+        pre = self._make_pre_analysis_collection(add_datasets=1)
+        post = self.generate_published_collection(add_datasets=1)
+        response = self.app.get("/curation/v1/datasets")
+        self.assertEqual(200, response.status_code)
+        dataset_ids = {d["dataset_id"] for d in response.json}
+        self.assertIn(pre.datasets[0].dataset_id.id, dataset_ids)
+        self.assertIn(post.datasets[0].dataset_id.id, dataset_ids)
+
+    def test__get_datasets__pre_analysis_filter(self):
+        """analysis=pre-analysis returns only datasets from pre-analysis collections."""
+        pre = self._make_pre_analysis_collection(add_datasets=1)
+        self.generate_published_collection(add_datasets=1)
+        response = self.app.get("/curation/v1/datasets?analysis=pre-analysis")
+        self.assertEqual(200, response.status_code)
+        dataset_ids = {d["dataset_id"] for d in response.json}
+        self.assertIn(pre.datasets[0].dataset_id.id, dataset_ids)
+        for d in response.json:
+            self.assertTrue(d["is_pre_analysis"])
+
+    def test__get_datasets__post_analysis_filter(self):
+        """analysis=post-analysis returns only datasets from non-pre-analysis collections."""
+        self._make_pre_analysis_collection(add_datasets=1)
+        post = self.generate_published_collection(add_datasets=1)
+        response = self.app.get("/curation/v1/datasets?analysis=post-analysis")
+        self.assertEqual(200, response.status_code)
+        dataset_ids = {d["dataset_id"] for d in response.json}
+        self.assertIn(post.datasets[0].dataset_id.id, dataset_ids)
+        for d in response.json:
+            self.assertFalse(d["is_pre_analysis"])
+
+    def test__get_datasets__invalid_analysis_filter_400(self):
+        """Invalid analysis param returns 400."""
+        response = self.app.get("/curation/v1/datasets?analysis=invalid")
+        self.assertEqual(400, response.status_code)
+
+    def test__get_datasets__is_pre_analysis_in_response(self):
+        """Each dataset in the response has an is_pre_analysis field."""
+        self.generate_published_collection(add_datasets=1)
+        response = self.app.get("/curation/v1/datasets")
+        self.assertEqual(200, response.status_code)
+        for dataset in response.json:
+            self.assertIn("is_pre_analysis", dataset)
+
+    def test__get_dataset_in_collection__is_pre_analysis_in_response(self):
+        """GET /v1/collections/{id}/datasets/{id} includes is_pre_analysis."""
+        dataset = self.generate_dataset()
+        url = f"/curation/v1/collections/{dataset.collection_id}/datasets/{dataset.dataset_id}"
+        response = self.app.get(url)
+        self.assertEqual(200, response.status_code)
+        self.assertIn("is_pre_analysis", response.json)
+        self.assertFalse(response.json["is_pre_analysis"])
+
+    def test__get_dataset_in_pre_analysis_collection__is_pre_analysis_true(self):
+        """Dataset from a pre-analysis collection has is_pre_analysis=True."""
+        pre = self._make_pre_analysis_collection(add_datasets=1)
+        dataset = pre.datasets[0]
+        url = f"/curation/v1/collections/{pre.collection_id.id}/datasets/{dataset.dataset_id.id}"
+        response = self.app.get(url)
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(response.json["is_pre_analysis"])

--- a/tests/unit/backend/layers/api/test_curation_api.py
+++ b/tests/unit/backend/layers/api/test_curation_api.py
@@ -1054,6 +1054,7 @@ class TestGetCollectionVersionID(BaseAPIPortalTest):
                     "is_primary_data": [True, False],
                     "mean_genes_per_cell": 0.5,
                     "organism": [{"label": "test_organism_label", "ontology_term_id": "test_organism_term_id"}],
+                    "genetic_perturbation_strategy": None,
                     "perturbation_types": None,
                     "raw_data_location": "raw.X",
                     "schema_version": "3.0.0",

--- a/tests/unit/backend/layers/api/test_portal_api.py
+++ b/tests/unit/backend/layers/api/test_portal_api.py
@@ -196,6 +196,7 @@ class TestCollection(BaseAPIPortalTest):
             ],
             "description": "described",
             "id": mock.ANY,
+            "is_pre_analysis": False,
             "links": [],
             "name": "test_collection",
             "published_at": mock.ANY,

--- a/tests/unit/backend/layers/business/test_business.py
+++ b/tests/unit/backend/layers/business/test_business.py
@@ -624,6 +624,72 @@ class TestGetAllCollections(BaseBusinessLogicTestCase):
             self.assertIsNone(version.published_at)
 
 
+class TestCreateCollectionIsPreAnalysis(BaseBusinessLogicTestCase):
+    """Tests for the is_pre_analysis flag on collection creation."""
+
+    def test_create_collection_is_pre_analysis_defaults_to_false(self):
+        """is_pre_analysis defaults to False when not provided."""
+        collection = self.business_logic.create_collection(
+            test_user_name, test_curator_name, self.sample_collection_metadata
+        )
+        self.assertFalse(collection.is_pre_analysis)
+        collection_from_db = self.database_provider.get_collection_version(collection.version_id)
+        self.assertFalse(collection_from_db.is_pre_analysis)
+
+    def test_create_collection_is_pre_analysis_true(self):
+        """is_pre_analysis=True is persisted and returned."""
+        collection = self.business_logic.create_collection(
+            test_user_name, test_curator_name, self.sample_collection_metadata, is_pre_analysis=True
+        )
+        self.assertTrue(collection.is_pre_analysis)
+        collection_from_db = self.database_provider.get_collection_version(collection.version_id)
+        self.assertTrue(collection_from_db.is_pre_analysis)
+
+    def test_create_collection_revision_inherits_is_pre_analysis(self):
+        """Creating a revision of a pre-analysis collection copies is_pre_analysis to the new version."""
+        collection = self.business_logic.create_collection(
+            test_user_name, test_curator_name, self.sample_collection_metadata, is_pre_analysis=True
+        )
+        # Simulate a minimal publication so that add_collection_version can find the canonical collection.
+        self.database_provider.finalize_collection_version(
+            collection.collection_id,
+            collection.version_id,
+            "3.0.0",
+            DATA_SUBMISSION_POLICY_VERSION,
+        )
+        new_version_id = self.database_provider.add_collection_version(collection.collection_id, is_auto_version=False)
+        revision = self.database_provider.get_collection_version(new_version_id)
+        self.assertTrue(revision.is_pre_analysis)
+
+
+class TestIngestDatasetIsPreAnalysis(BaseBusinessLogicTestCase):
+    """Tests that is_pre_analysis is injected into the manifest when ingesting datasets."""
+
+    def test_ingest_dataset_injects_is_pre_analysis_false(self):
+        """Manifest gets is_pre_analysis=False for normal collections."""
+        import json
+
+        collection = self.business_logic.create_collection(
+            test_user_name, test_curator_name, self.sample_collection_metadata, is_pre_analysis=False
+        )
+        self.business_logic.ingest_dataset(collection.version_id, "http://fake.url", None, None)
+        raw_manifest = self.step_function_provider.start_step_function.call_args[0][2]
+        manifest_dict = json.loads(raw_manifest)
+        self.assertFalse(manifest_dict["is_pre_analysis"])
+
+    def test_ingest_dataset_injects_is_pre_analysis_true(self):
+        """Manifest gets is_pre_analysis=True for pre-analysis collections."""
+        import json
+
+        collection = self.business_logic.create_collection(
+            test_user_name, test_curator_name, self.sample_collection_metadata, is_pre_analysis=True
+        )
+        self.business_logic.ingest_dataset(collection.version_id, "http://fake.url", None, None)
+        raw_manifest = self.step_function_provider.start_step_function.call_args[0][2]
+        manifest_dict = json.loads(raw_manifest)
+        self.assertTrue(manifest_dict["is_pre_analysis"])
+
+
 class TestUpdateCollection(BaseBusinessLogicTestCase):
     """
     Tests operations that can update an unpublished collection version. Also tests that these operations cannot be
@@ -905,7 +971,7 @@ class TestUpdateCollectionDatasets(BaseBusinessLogicTestCase):
         self.step_function_provider.start_step_function.assert_called_once_with(
             revision.version_id,
             new_dataset_version_id,
-            f'{{"anndata":"s3://artifacts/{dataset_version.version_id}/raw.h5ad","atac_fragment":null}}',
+            f'{{"anndata":"s3://artifacts/{dataset_version.version_id}/raw.h5ad","atac_fragment":null,"is_pre_analysis":false}}',
         )
 
     def test_reingest_published_anndata_dataset__not_h5ad(self):
@@ -963,7 +1029,7 @@ class TestUpdateCollectionDatasets(BaseBusinessLogicTestCase):
         self.step_function_provider.start_step_function.assert_called_once_with(
             revision.version_id,
             new_dataset_version_id,
-            f'{{"anndata":"s3://artifacts/{dataset_version.version_id}/raw.h5ad","atac_fragment":"{fragment_url}"}}',
+            f'{{"anndata":"s3://artifacts/{dataset_version.version_id}/raw.h5ad","atac_fragment":"{fragment_url}","is_pre_analysis":false}}',
         )
 
     def test_reingest_published_atac_dataset__not_atac(self):

--- a/tests/unit/backend/layers/common/base_test.py
+++ b/tests/unit/backend/layers/common/base_test.py
@@ -200,12 +200,15 @@ class BaseTest(unittest.TestCase):
         add_datasets: int = 0,
         metadata=None,
         dataset_schema_version="3.0.0",
+        is_pre_analysis: bool = False,
     ) -> CollectionVersion:
         links = links or []
         if not metadata:
             metadata = copy.deepcopy(self.sample_collection_metadata)
             metadata.links = links
-        collection = self.business_logic.create_collection(owner, curator_name, metadata)
+        collection = self.business_logic.create_collection(
+            owner, curator_name, metadata, is_pre_analysis=is_pre_analysis
+        )
 
         for _ in range(add_datasets):
             metadata = copy.deepcopy(self.sample_dataset_metadata)
@@ -237,6 +240,7 @@ class BaseTest(unittest.TestCase):
         curator_name: str = "Jane Smith",
         metadata=None,
         dataset_schema_version="3.0.0",
+        is_pre_analysis: bool = False,
     ) -> CollectionVersionWithDatasets:
         links = links or []
         unpublished_collection = self.generate_unpublished_collection(
@@ -246,6 +250,7 @@ class BaseTest(unittest.TestCase):
             add_datasets=add_datasets,
             metadata=metadata,
             dataset_schema_version=dataset_schema_version,
+            is_pre_analysis=is_pre_analysis,
         )
         self.business_logic.publish_collection_version(unpublished_collection.version_id)
         return self.business_logic.get_collection_version(unpublished_collection.version_id)

--- a/tests/unit/processing/schema_migration/test_dataset_migrate.py
+++ b/tests/unit/processing/schema_migration/test_dataset_migrate.py
@@ -25,7 +25,7 @@ class TestDatasetMigrate:
         assert dataset_version_id != new_dataset_version_id.id
         assert (
             response["manifest"]
-            == f'{{"anndata":"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad","atac_fragment":null}}'
+            == f'{{"anndata":"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad","atac_fragment":null,"is_pre_analysis":false}}'
         )
         assert response["sfn_name"].startswith("migrate_")
         assert new_dataset_version_id.id in response["sfn_name"]
@@ -54,7 +54,7 @@ class TestDatasetMigrate:
         assert dataset_version_id != new_dataset_version_id.id
         assert (
             response["manifest"]
-            == f'{{"anndata":"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad","atac_fragment":null}}'
+            == f'{{"anndata":"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad","atac_fragment":null,"is_pre_analysis":false}}'
         )
         assert response["sfn_name"].startswith("migrate_")
         assert new_dataset_version_id.id in response["sfn_name"]
@@ -83,7 +83,7 @@ class TestDatasetMigrate:
         assert dataset_version_id != new_dataset_version_id.id
         assert (
             response["manifest"]
-            == f'{{"anndata":"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad","atac_fragment":null}}'
+            == f'{{"anndata":"s3://artifact-bucket/{dataset_version_id}/migrated.h5ad","atac_fragment":null,"is_pre_analysis":false}}'
         )
         assert response["sfn_name"].startswith("migrate_")
         assert new_dataset_version_id.id in response["sfn_name"]

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -517,6 +517,38 @@ class TestAddLabels(BaseProcessingTest):
             extracted = self.pal.extract_metadata(f.name)
         self.assertEqual(extracted.perturbation_types, [])
 
+    def test_extract_metadata_genetic_perturbation_strategy_with_column(self):
+        """Unique valid values are returned deduped and in ascending lexical order."""
+        adata = self._make_minimal_adata(
+            extra_obs_cols={
+                "genetic_perturbation_strategy": ["CRISPR", "CRISPRi", "CRISPR", "no perturbations", "ORF"],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertEqual(extracted.genetic_perturbation_strategy, ["CRISPR", "CRISPRi", "ORF"])
+
+    def test_extract_metadata_genetic_perturbation_strategy_without_column(self):
+        """When obs has no genetic_perturbation_strategy column, result is None."""
+        adata = self._make_minimal_adata()
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertIsNone(extracted.genetic_perturbation_strategy)
+
+    def test_extract_metadata_genetic_perturbation_strategy_no_perturbations_excluded(self):
+        """'no perturbations' sentinel values are excluded from the result."""
+        adata = self._make_minimal_adata(
+            extra_obs_cols={
+                "genetic_perturbation_strategy": ["CRISPR", "no perturbations", "no perturbations", "CRISPR", "CRISPR"],
+            },
+        )
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertEqual(extracted.genetic_perturbation_strategy, ["CRISPR"])
+
     def test_get_spatial_metadata__is_single_and_fullres_true(self):
         spatial_dict = {
             "is_single": np.bool_(True),

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -179,6 +179,8 @@ class TestAddLabels(BaseProcessingTest):
 
         self.assertEqual(extracted_metadata.raw_data_location, "X")
         self.assertEqual(extracted_metadata.spatial, None)
+        # No perturbation_types column in obs → should be None
+        self.assertIsNone(extracted_metadata.perturbation_types)
 
     def test_extract_metadata_organism_uns(self):
         # Same setup as before, but organism terms are in uns instead of obs
@@ -446,6 +448,74 @@ class TestAddLabels(BaseProcessingTest):
         self.assertEqual(extracted_metadata.mean_genes_per_cell, 0)
 
         self.assertEqual(extracted_metadata.raw_data_location, "raw.X")
+
+    def _make_minimal_adata(self, extra_obs_cols=None):
+        """Build a minimal AnnData suitable for extract_metadata tests."""
+        n = 5
+        obs_data = {
+            "tissue": ["lung"] * n,
+            "tissue_ontology_term_id": ["UBERON:01"] * n,
+            "tissue_type": ["tissue"] * n,
+            "assay": ["10x"] * n,
+            "assay_ontology_term_id": ["EFO:001"] * n,
+            "disease": ["healthy"] * n,
+            "disease_ontology_term_id": ["MONDO:123"] * n,
+            "sex": ["male"] * n,
+            "sex_ontology_term_id": ["M"] * n,
+            "self_reported_ethnicity": ["unknown"] * n,
+            "self_reported_ethnicity_ontology_term_id": ["unknown"] * n,
+            "development_stage": ["adult"] * n,
+            "development_stage_ontology_term_id": ["HsapDv:0"] * n,
+            "organism": ["Homo sapiens"] * n,
+            "organism_ontology_term_id": ["NCBITaxon:9606"] * n,
+            "is_primary_data": [True] * n,
+            "cell_type": ["B cell"] * n,
+            "cell_type_ontology_term_id": ["CL:001"] * n,
+            "suspension_type": ["cell"] * n,
+            "donor_id": ["D1"] * n,
+        }
+        if extra_obs_cols:
+            obs_data.update(extra_obs_cols)
+        obs = pandas.DataFrame(obs_data, index=[str(i) for i in range(n)])
+        var = pandas.DataFrame(
+            {"feature_biotype": ["gene"] * 3, "feature_reference": ["NCBITaxon:9606"] * 3},
+            index=["A", "B", "C"],
+        )
+        uns = {"title": "minimal dataset", "schema_version": "3.0.0"}
+        X = from_array(np.ones((n, 3), dtype=int))
+        return anndata.AnnData(X=X, obs=obs, var=var, uns=uns)
+
+    def test_extract_metadata_perturbation_types_with_column(self):
+        """perturbation_types with mixed values: excluded sentinels and None dropped, result sorted lexically."""
+        adata = self._make_minimal_adata(
+            extra_obs_cols={
+                "perturbation_types": ["CRISPR", "na", "ORF", "no perturbations", None],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertEqual(extracted.perturbation_types, ["CRISPR", "ORF"])
+
+    def test_extract_metadata_perturbation_types_without_column(self):
+        """When obs has no perturbation_types column, result is None."""
+        adata = self._make_minimal_adata()
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertIsNone(extracted.perturbation_types)
+
+    def test_extract_metadata_perturbation_types_all_excluded(self):
+        """When all perturbation_types values are excluded sentinels or None, result is an empty list."""
+        adata = self._make_minimal_adata(
+            extra_obs_cols={
+                "perturbation_types": ["na", "no perturbations", None, "na", None],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            extracted = self.pal.extract_metadata(f.name)
+        self.assertEqual(extracted.perturbation_types, [])
 
     def test_get_spatial_metadata__is_single_and_fullres_true(self):
         spatial_dict = {

--- a/tests/unit/processing/test_extract_metadata.py
+++ b/tests/unit/processing/test_extract_metadata.py
@@ -6,7 +6,13 @@ import numpy as np
 import pandas
 from dask.array import from_array
 
-from backend.layers.common.entities import OntologyTermId, SpatialMetadata, TissueOntologyTermId
+from backend.layers.common.entities import (
+    GeneticPerturbationEntry,
+    GeneticPerturbationMetadata,
+    OntologyTermId,
+    SpatialMetadata,
+    TissueOntologyTermId,
+)
 from backend.layers.processing.process_add_labels import ProcessAddLabels
 from backend.layers.thirdparty.schema_validator_provider import SchemaValidatorProvider
 from tests.unit.processing.base_processing_test import BaseProcessingTest
@@ -106,7 +112,7 @@ class TestAddLabels(BaseProcessingTest):
 
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted_metadata = self.pal.extract_metadata(f.name)
+            extracted_metadata, _ = self.pal.extract_metadata(f.name)
 
         self.assertEqual(extracted_metadata.organism, [OntologyTermId("Homo sapiens", "NCBITaxon:8505")])
 
@@ -270,7 +276,7 @@ class TestAddLabels(BaseProcessingTest):
 
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted_metadata = self.pal.extract_metadata(f.name)
+            extracted_metadata, _ = self.pal.extract_metadata(f.name)
 
         self.assertEqual(extracted_metadata.organism, [OntologyTermId("Homo sapiens", "NCBITaxon:8505")])
 
@@ -441,7 +447,7 @@ class TestAddLabels(BaseProcessingTest):
 
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted_metadata = self.pal.extract_metadata(f.name)
+            extracted_metadata, _ = self.pal.extract_metadata(f.name)
 
         # Verify that the "my_awesome_wonky_layer" was read and not the default X layer. The layer contains only zeros
         # which should result in a mean_genes_per_cell value of 0 compared to 3 if the X layer was read.
@@ -494,7 +500,7 @@ class TestAddLabels(BaseProcessingTest):
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertEqual(extracted.perturbation_types, ["CRISPR", "ORF"])
 
     def test_extract_metadata_perturbation_types_without_column(self):
@@ -502,7 +508,7 @@ class TestAddLabels(BaseProcessingTest):
         adata = self._make_minimal_adata()
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertIsNone(extracted.perturbation_types)
 
     def test_extract_metadata_perturbation_types_all_excluded(self):
@@ -514,7 +520,7 @@ class TestAddLabels(BaseProcessingTest):
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertEqual(extracted.perturbation_types, [])
 
     def test_extract_metadata_genetic_perturbation_strategy_with_column(self):
@@ -526,7 +532,7 @@ class TestAddLabels(BaseProcessingTest):
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertEqual(extracted.genetic_perturbation_strategy, ["CRISPR", "CRISPRi", "ORF"])
 
     def test_extract_metadata_genetic_perturbation_strategy_without_column(self):
@@ -534,7 +540,7 @@ class TestAddLabels(BaseProcessingTest):
         adata = self._make_minimal_adata()
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertIsNone(extracted.genetic_perturbation_strategy)
 
     def test_extract_metadata_genetic_perturbation_strategy_no_perturbations_excluded(self):
@@ -546,7 +552,7 @@ class TestAddLabels(BaseProcessingTest):
         )
         with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
             adata.write_h5ad(f.name)
-            extracted = self.pal.extract_metadata(f.name)
+            extracted, _ = self.pal.extract_metadata(f.name)
         self.assertEqual(extracted.genetic_perturbation_strategy, ["CRISPR"])
 
     def test_get_spatial_metadata__is_single_and_fullres_true(self):
@@ -576,3 +582,77 @@ class TestAddLabels(BaseProcessingTest):
         self.assertEqual(
             self.pal.get_spatial_metadata(spatial_dict), SpatialMetadata(is_single=False, has_fullres=False)
         )
+
+    # --- GeneticPerturbationMetadata extraction tests ---
+
+    def test_extract_metadata_genetic_perturbation_metadata_absent(self):
+        """Returns None as the second tuple element when uns has no 'genetic_perturbations' key."""
+        adata = self._make_minimal_adata()
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            _, gp_metadata = self.pal.extract_metadata(f.name)
+        self.assertIsNone(gp_metadata)
+
+    def test_extract_metadata_genetic_perturbation_metadata_present(self):
+        """Returns a GeneticPerturbationMetadata with correctly typed entries when uns has 'genetic_perturbations'."""
+        gp_dict = {
+            "p1": {
+                "role": "KO",
+                "protospacer_sequence": "ACGTACGT",
+                "protospacer_adjacent_motif": "NGG",
+                "derived_genomic_regions": ["chr1:100-200"],
+                "derived_features": {"ENSG00000001": "GENE1"},
+            },
+            "p2": {
+                "role": "overexpression",
+                "protospacer_sequence": None,
+                "protospacer_adjacent_motif": None,
+                "derived_genomic_regions": [],
+                "derived_features": {},
+            },
+        }
+        adata = self._make_minimal_adata()
+        adata.uns["genetic_perturbations"] = gp_dict
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            _, gp_metadata = self.pal.extract_metadata(f.name)
+
+        self.assertIsInstance(gp_metadata, GeneticPerturbationMetadata)
+        self.assertIn("p1", gp_metadata.perturbations)
+        self.assertIn("p2", gp_metadata.perturbations)
+
+        p1 = gp_metadata.perturbations["p1"]
+        self.assertIsInstance(p1, GeneticPerturbationEntry)
+        self.assertEqual(p1.role, "KO")
+        self.assertEqual(p1.protospacer_sequence, "ACGTACGT")
+        self.assertEqual(p1.protospacer_adjacent_motif, "NGG")
+        self.assertEqual(p1.derived_genomic_regions, ["chr1:100-200"])
+        self.assertEqual(p1.derived_features, {"ENSG00000001": "GENE1"})
+
+        p2 = gp_metadata.perturbations["p2"]
+        self.assertEqual(p2.role, "overexpression")
+        self.assertEqual(p2.derived_genomic_regions, [])
+        self.assertEqual(p2.derived_features, {})
+
+    def test_extract_metadata_genetic_perturbation_metadata_to_dict_roundtrip(self):
+        """GeneticPerturbationMetadata.to_dict() / from_dict() round-trips correctly."""
+        original = {
+            "p1": {
+                "role": "KO",
+                "protospacer_sequence": "ACGT",
+                "protospacer_adjacent_motif": None,
+                "derived_genomic_regions": ["chr2:500-600"],
+                "derived_features": {"ENSG00000002": "GENE2"},
+            }
+        }
+        gp_metadata = GeneticPerturbationMetadata.from_dict(original)
+        self.assertEqual(gp_metadata.to_dict(), original)
+
+    def test_extract_metadata_returns_tuple(self):
+        """extract_metadata always returns a 2-tuple of (DatasetMetadata, Optional[GeneticPerturbationMetadata])."""
+        adata = self._make_minimal_adata()
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as f:
+            adata.write_h5ad(f.name)
+            result = self.pal.extract_metadata(f.name)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)

--- a/tests/unit/processing/test_process_add_labels.py
+++ b/tests/unit/processing/test_process_add_labels.py
@@ -42,7 +42,7 @@ class ProcessingTest(BaseProcessingTest):
 
         # TODO: ideally use a real h5ad
         processor = ProcessAddLabels(self.business_logic, self.uri_provider, self.s3_provider, self.schema_validator)
-        processor.extract_metadata = Mock()
+        processor.extract_metadata = Mock(return_value=(Mock(), None))
         processor.populate_dataset_citation = Mock()
         processor.process(collection.version_id, dataset_version_id, "fake_bucket_name", "fake_datasets_bucket")
 

--- a/tests/unit/processing/test_processing.py
+++ b/tests/unit/processing/test_processing.py
@@ -72,6 +72,7 @@ class ProcessingTest(BaseProcessingTest):
     @patch("backend.layers.processing.process_cxg.ProcessCxg.make_cxg")
     def test_process_anndata(self, mock_cxg, mock_extract_h5ad, mock_dataset_citation):
         mock_cxg.return_value = "local.cxg"
+        mock_extract_h5ad.return_value = (Mock(), None)
 
         dropbox_uri = "https://www.dropbox.com/s/ow84zm4h0wkl409/test.h5ad?dl=0"
         manifest = IngestionManifest(anndata=dropbox_uri)

--- a/tests/unit/processing/test_processing.py
+++ b/tests/unit/processing/test_processing.py
@@ -268,3 +268,98 @@ class ProcessingTest(BaseProcessingTest):
 
             # Assert upload_directory was called after deletion
             mock_upload_directory.assert_called_once_with("local.cxg", s3_uri)
+
+
+class TestPreAnalysisProcessing(BaseProcessingTest):
+    """Tests for CXG skipping when is_pre_analysis=True in the manifest."""
+
+    def _make_manifest(self, is_pre_analysis: bool) -> IngestionManifest:
+        return IngestionManifest(anndata="https://fake.url/file.h5ad", is_pre_analysis=is_pre_analysis)
+
+    def test_cxg_step_skipped_for_pre_analysis(self):
+        """When is_pre_analysis=True, the cxg step sets status to SKIPPED without running ProcessCxg."""
+        collection = self.generate_unpublished_collection()
+        dataset_version_id, _ = self.business_logic.ingest_dataset(collection.version_id, "http://fake.url", None, None)
+        manifest = self._make_manifest(is_pre_analysis=True)
+        pm = ProcessMain(self.business_logic, self.uri_provider, self.s3_provider, self.schema_validator)
+
+        with patch.object(pm.process_cxg, "process") as mock_cxg:
+            result = pm.process(
+                collection.version_id,
+                dataset_version_id,
+                "cxg",
+                manifest,
+                "fake_bucket",
+                "fake_datasets_bucket",
+                "fake_cxg_bucket",
+            )
+
+        self.assertTrue(result)
+        mock_cxg.assert_not_called()
+        status = self.business_logic.get_dataset_status(dataset_version_id)
+        self.assertEqual(DatasetConversionStatus.SKIPPED, status.cxg_status)
+
+    def test_cxg_remaster_step_skipped_for_pre_analysis(self):
+        """When is_pre_analysis=True, cxg_remaster is also skipped."""
+        collection = self.generate_unpublished_collection()
+        dataset_version_id, _ = self.business_logic.ingest_dataset(collection.version_id, "http://fake.url", None, None)
+        manifest = self._make_manifest(is_pre_analysis=True)
+        pm = ProcessMain(self.business_logic, self.uri_provider, self.s3_provider, self.schema_validator)
+
+        with patch.object(pm.process_cxg, "process") as mock_cxg:
+            result = pm.process(
+                collection.version_id,
+                dataset_version_id,
+                "cxg_remaster",
+                manifest,
+                "fake_bucket",
+                "fake_datasets_bucket",
+                "fake_cxg_bucket",
+            )
+
+        self.assertTrue(result)
+        mock_cxg.assert_not_called()
+        status = self.business_logic.get_dataset_status(dataset_version_id)
+        self.assertEqual(DatasetConversionStatus.SKIPPED, status.cxg_status)
+
+    def test_cxg_step_runs_for_non_pre_analysis(self):
+        """When is_pre_analysis=False, the cxg step runs normally."""
+        collection = self.generate_unpublished_collection()
+        dataset_version_id, _ = self.business_logic.ingest_dataset(collection.version_id, "http://fake.url", None, None)
+        manifest = self._make_manifest(is_pre_analysis=False)
+        pm = ProcessMain(self.business_logic, self.uri_provider, self.s3_provider, self.schema_validator)
+
+        with patch.object(pm.process_cxg, "process") as mock_cxg:
+            pm.process(
+                collection.version_id,
+                dataset_version_id,
+                "cxg",
+                manifest,
+                "fake_bucket",
+                "fake_datasets_bucket",
+                "fake_cxg_bucket",
+            )
+
+        mock_cxg.assert_called_once()
+
+    def test_add_labels_passes_is_pre_analysis(self):
+        """add_labels step passes is_pre_analysis flag to schema_validator."""
+        collection = self.generate_unpublished_collection()
+        dataset_version_id, _ = self.business_logic.ingest_dataset(collection.version_id, "http://fake.url", None, None)
+        manifest = self._make_manifest(is_pre_analysis=True)
+        pm = ProcessMain(self.business_logic, self.uri_provider, self.s3_provider, self.schema_validator)
+
+        with patch.object(pm.process_add_labels, "process") as mock_add_labels:
+            pm.process(
+                collection.version_id,
+                dataset_version_id,
+                "add_labels",
+                manifest,
+                "fake_bucket",
+                "fake_datasets_bucket",
+                "fake_cxg_bucket",
+            )
+
+        mock_add_labels.assert_called_once()
+        call_kwargs = mock_add_labels.call_args[1]
+        self.assertTrue(call_kwargs.get("is_pre_analysis"))


### PR DESCRIPTION
## Summary

Adds support for cellxgene schema 7.1.0 in the data portal.

- Bumps `cellxgene-schema` to `7.1.0` (pinned to the released PyPI version) in `python_dependencies/processing/requirements.txt`
- Supports `is_pre_analysis` dataset submissions (#7730)
- Extracts and exposes `perturbation_types` in dataset metadata (#7731)
- Extracts and exposes `genetic_perturbation_strategy` in dataset metadata (#7733)
- Extracts and stores the `genetic_perturbations` dict as a typed model + exposes it via a dedicated endpoint (#7734)
- Reconciles the migration chain and updates the rdev seed data path for the `11_add_genetic_perturbations` schema version

## Test plan

- [ ] CI passes (unit + functional tests)
- [ ] Processing image builds with `cellxgene-schema==7.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)