### PR TITLE
chore: bump cellxgene-schema to 7.1.1

### DIFF
--- a/python_dependencies/processing/requirements.txt
+++ b/python_dependencies/processing/requirements.txt
@@ -1,7 +1,7 @@
 anndata # uses the version supplied by cellxgene-schema
 awscli
 boto3>=1.11.17
-cellxgene-schema==7.1.0
+cellxgene-schema==7.1.1
 dask==2024.12.0
 dataclasses-json
 ddtrace==2.1.4


### PR DESCRIPTION
Bumps the `cellxgene-schema` pin from 7.1.0 to 7.1.1 in `python_dependencies/processing/requirements.txt`.

This is a patch release; the schema version used at runtime is read dynamically from the validator (`get_current_schema_version()`), so no other code changes are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)