### PR TITLE
chore: migrate runner label from xl-amd64-privileged to lg-amd64-privileged

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   lint:
     if: ${{ ! startsWith(github.head_ref, 'renovate/') }}
-    runs-on: xl-amd64-privileged
+    runs-on: lg-amd64-privileged
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/rdev-tests.yml
+++ b/.github/workflows/rdev-tests.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   functional-test:
-    runs-on: xl-amd64-privileged
+    runs-on: lg-amd64-privileged
     timeout-minutes: 30
     steps:
       - name: Configure AWS Credentials
@@ -40,7 +40,7 @@ jobs:
           DEPLOYMENT_STAGE=rdev STACK_NAME=${{ env.STACK_NAME }} make functional-test
 
   seed-database-e2e-tests:
-    runs-on: xl-amd64-privileged
+    runs-on: lg-amd64-privileged
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -152,7 +152,7 @@ jobs:
     # Merge reports after playwright-tests, even if some shards have failed
     if: always()
     needs: run-e2e-tests
-    runs-on: xl-amd64-privileged
+    runs-on: lg-amd64-privileged
     defaults:
       run:
         working-directory: frontend
@@ -188,7 +188,7 @@ jobs:
   e2e-test:
     if: always()
     name: e2e-test
-    runs-on: xl-amd64-privileged
+    runs-on: lg-amd64-privileged
     needs:
       - run-e2e-tests
     steps:

--- a/.github/workflows/rebuild-processing-image.yml
+++ b/.github/workflows/rebuild-processing-image.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         branch: [main, staging, prod]
-    runs-on: xl-amd64-privileged
+    runs-on: lg-amd64-privileged
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
The `xl-amd64-privileged` runner has been resized to 16 CPU / 64Gi (from 8 CPU / 48Gi). The `lg-amd64-privileged` runner (8 CPU / 32Gi) is the roughly equivalent replacement for workloads that don't need the larger size.